### PR TITLE
i18n: machine translation of new strings

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -313,7 +313,7 @@
   },
   "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks.": {
     "kanji": "タートル・ブロックスはアートと数学を求めるビジュアル・プログラミング言語だ。",
-    "kana": "タートル・ブロックスは アートと すうがくを もとめる ビジュアル・プログラミング げんごだ。"
+    "kana": "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
   },
   "The current version is": {
     "kanji": "ミュージック・ブロックスの最新バージョンは",
@@ -329,7 +329,7 @@
   },
   "You can also type Alt-S to stop.": {
     "kanji": "プログラムは、このボタンをおすかわりに、キーボードで「Altキーと Sキーの同時おし」でも止めることができる。",
-    "kana": "じっこう している プログラムを とめる。 プログラムは、 このボタンを おすかわりに、 キーボードで 「Altキーと  Sキーの どうじおし」でも とめることが できる。"
+    "kana": "You can also type Alt-S to stop."
   },
   "Welcome to Music Blocks": {
     "kanji": "ミュージック・ブロックスへようこそ",
@@ -337,7 +337,7 @@
   },
   "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way.": {
     "kanji": "音楽と算数とプログラミングをむすびつけ、深く楽しむことができるツール。それが、ミュージック・ブロックスだ。",
-    "kana": "おんがくと さんすうと プログラミングを むすびつけ、 ふかく たのしむことができる ツール。 それが、 ミュージック・ブロックスだ。"
+    "kana": "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
   },
   "Meet Mr. Mouse!": {
     "kanji": "ミスター・マウスに会おう！",
@@ -361,7 +361,7 @@
   },
   "A detailed guide to Music Blocks is available.": {
     "kanji": "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。",
-    "kana": "インターネットから、 ミュージック・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
+    "kana": "A detailed guide to Music Blocks is available."
   },
   "Stop the music (and the mice).": {
     "kanji": "実行しているプログラムを止める。",
@@ -473,7 +473,7 @@
   },
   "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes.": {
     "kanji": "メインおよび補助ツールバー、ブロックとキャンバスの右クリックコンテキストメニュー、パレットのヘルプメッセージを表示します。",
-    "kana": "メインおよびほじょツールバー、ブロックとキャンバスのみぎクリックコンテクスト・メニュー、パレットのヘルプ。メッセージをひょうじします。"
+    "kana": "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
   },
   "Run slowly": {
     "kanji": "ゆっくり実行する",
@@ -489,7 +489,7 @@
   },
   "Click to run the project step by step.": {
     "kanji": "クリックをすると、とてもゆっくり、ブロックを１つずつ実行する。プログラムがうまくはたらかず、どのブロックが原因なのかを調べたいときなどに便利だ。",
-    "kana": "クリックをすると、 とてもゆっくり、 ブロックを １つずつ じっこうする。 プログラムが うまく はたらかず、 どのブロックが げんいん なのかを しらべたいとき などに べんりだ。"
+    "kana": "Click to run the project step by step."
   },
   "Display statistics": {
     "kanji": "とうけいを表示する",
@@ -521,7 +521,7 @@
   },
   "You can scroll the blocks on the canvas.": {
     "kanji": "カンバス上をドラッグそうさしたときに、画面をスクロールさせることができる方向を上下だけと上下左右に変える。",
-    "kana": "カンバスじょうを ドラッグそうさ したときに、 がめんを スクロール させることができる ほうこうを じょうげ だけ と じょうげさゆう に かえる。"
+    "kana": "You can scroll the blocks on the canvas."
   },
   "Change theme": {
     "kanji": "テーマを変更",
@@ -569,7 +569,7 @@
   },
   "Restore blocks from the trash.": {
     "kanji": "ゴミ箱にすててしまったブロックを取り出してもどす。ふくすうのブロックをすててあるときは新しい順に、ゴミ箱が空になるまでブロックを拾いもどすことができる。",
-    "kana": "ごみばこに すててしまった ブロックを とりだして もどす。 ふくすうの ブロックを すててある ときは あたらしい じゅんに、 ごみばこが からに なるまで ブロックを ひろいもどすことが できる。"
+    "kana": "Restore blocks from the trash."
   },
   "Switch mode": {
     "kanji": "はってんモード／かんたんモードにする",
@@ -577,7 +577,7 @@
   },
   "Switch between beginner and advance modes.": {
     "kanji": "ミュージック・ブロックスをかんたんモード／はってんモードに切りかえる。モードによって使えるきのうやブロックの種類が変わる。",
-    "kana": "ミュージック・ブロックスを かんたんモード／はってんモード に きりかえる。 モードによって つかえる きのうや ブロックの しゅるいが かわる。"
+    "kana": "Switch between beginner and advance modes."
   },
   "Select language": {
     "kanji": "言語をえらぶ",
@@ -601,7 +601,7 @@
   },
   "To delete a block, right-click on it. Then you will see the delete option.": {
     "kanji": "ブロックを削除するには、ブロックを右クリックします。次に、削除オプションが表示されます。",
-    "kana": "ブロックをさくじょするには、ブロックをみぎクリックします。つぎに、さくじょオプションがひょうじされます。"
+    "kana": "To delete a block, right-click on it. Then you will see the delete option."
   },
   "To copy a block, right-click on it. Then you will see the copy option.": {
     "kanji": "ブロックをコピーするには、ブロックを右クリックします。次に、コピーオプションが表示されます。",
@@ -609,7 +609,7 @@
   },
   "To extract a block, right-click on it. Then you will see the extract option.": {
     "kanji": "ブロックを抽出するには、ブロックを右クリックします。次に、抽出オプションが表示されます。",
-    "kana": "ブロックをちゅうしゅつするには、ブロックをみぎクリックします。つぎに、ちゅうしゅつオプションがひょうじされます。"
+    "kana": "To extract a block, right-click on it. Then you will see the extract option."
   },
   "Tab Navigation": {
     "kanji": "タブのナビゲーション",
@@ -617,7 +617,7 @@
   },
   "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!": {
     "kanji": "キーボードの Tab キーを押すと、ワークスペース、ツールバー、パレットからを魔法のようにジャンプできます。",
-    "kana": "キーボードの Tab キーをおすと、ワークスペース、ツールバー、パレットからをまほうのようにじゃんぷできます。"
+    "kana": "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
   },
   "Contextual Menu for Canvas": {
     "kanji": "キャンバスのコンテキストメニュー",
@@ -649,7 +649,7 @@
   },
   "Collapse the graphics window.": {
     "kanji": "ネズミがいどうしたり、ペンで線をえがいたりできる「カンバス」の表示サイズを しゅくしょうしたり、かくだいしたりする。カンバスをしゅくしょうした場合は、プログラムをふつうのそくどで実行しても、ブロックがかくれない。ふつうの実行そくどでプログラムの動作かくにんをしたいときなどに便利だ。",
-    "kana": "ネズミが いどうしたり、 ペンで せんを えがいたり できる 「カンバス」の ひょうじサイズを しゅくしょう／かくだいする。<br>カンバスを しゅくしょう したばあいは、 プログラムを  ふつうの そくどで じっこう しても、 ブロックが かくれない。 ふつうの じっこうそくどで プログラムの どうさ かくにんを したいときなどに べんりだ。"
+    "kana": "Collapse the graphics window."
   },
   "Home": {
     "kanji": "ホーム",
@@ -673,7 +673,7 @@
   },
   "Expand or collapse start and action stacks.": {
     "kanji": "クリックすると、「スタート」と「アクション」に使われているブロックを、広げて表示したり、折りたたんでかくしたりすることができる。",
-    "kana": "クリックすると、 「スタート」と「アクション」に つかわれている ブロックを、ひろげて ひょうじしたり、おりたたんで かくしたりすることができる。"
+    "kana": "Expand or collapse start and action stacks."
   },
   "Decrease block size": {
     "kanji": "ブロックの表示を小さくする",
@@ -705,15 +705,15 @@
   },
   "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more.": {
     "kanji": "ミュージック・ブロックスの左側には、プログラミングに使うさまざまなブロックをグループ分けした「パレットボタン」がある。",
-    "kana": "ミュージック・ブロックスのひだりがわには、 プログラミングにつかう さまざまな ブロックを グループわけした 「パレットボタン」がある。"
+    "kana": "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
   },
   "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them.": {
     "kanji": "それぞれのパレットボタンをクリックし、「音符（おんぷ）」「アクション」「ペン」などから好きなブロックを選んで、カンバス上にドラッグして置いてみよう。",
-    "kana": " それぞれの パレットボタンを クリックし、 「おんぷ」「アクション」「ペン」などから すきな ブロックをえらんで、 カンバスじょうに ドラッグして おいてみよう。"
+    "kana": "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
   },
   "A detailed guide to Turtle Blocks is available.": {
     "kanji": "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。",
-    "kana": "インターネットから、 タートル・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
+    "kana": "A detailed guide to Turtle Blocks is available."
   },
   "Turtle Blocks Guide": {
     "kanji": "ミュージック・ブロックスガイド",
@@ -725,11 +725,11 @@
   },
   "Turtle Blocks is an open source collection of tools for exploring musical concepts.": {
     "kanji": "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。",
-    "kana": "タートル・ブロックスは、 おんがくの コンセプトを たんきゅうするために つくられた、 オープンソースの ツールだ。"
+    "kana": "Turtle Blocks is an open source collection of tools for exploring musical concepts."
   },
   "A full list of contributors can be found in the Turtle Blocks GitHub repository.": {
     "kanji": "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。",
-    "kana": "タートル・ブロックスに かかわってきた ひとの いちらんは、 GitHub（ギットハブ） の リポジトリで みることができる。"
+    "kana": "A full list of contributors can be found in the Turtle Blocks GitHub repository."
   },
   "Turtle Blocks is licensed under the AGPL.": {
     "kanji": "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。",
@@ -749,11 +749,11 @@
   },
   "Music Blocks is an open source collection of tools for exploring musical concepts.": {
     "kanji": "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。",
-    "kana": "ミュージック・ブロックスは、 おんがくの コンセプトを たんきゅうするために つくられた、 オープンソースの ツールだ。"
+    "kana": "Music Blocks is an open source collection of tools for exploring musical concepts."
   },
   "A full list of contributors can be found in the Music Blocks GitHub repository.": {
     "kanji": "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。",
-    "kana": "ミュージック・ブロックスに かかわってきた ひとの いちらんは、 GitHub（ギットハブ） の リポジトリで みることができる。"
+    "kana": "A full list of contributors can be found in the Music Blocks GitHub repository."
   },
   "Music Blocks is licensed under the AGPL.": {
     "kanji": "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。",
@@ -1085,11 +1085,11 @@
   },
   "Enter the name of a built-in plugin, or leave blank to upload a plugin file:": {
     "kanji": "組み込みプラグインの名前を入力するか、空白のままにしてプラグイン ファイルをアップロードします。",
-    "kana": "くみこみぷらぐいんのなまえをにゅうりょくするか、くうはくのままにしてぷらぐいん ファイルをあっぷろーどします。"
+    "kana": "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
   },
   "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed.": {
     "kanji": "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。",
-    "kana": "プラグインめいがむこうです。えいすうじ、はいふん、あんだーすこあのみがしようできます。"
+    "kana": "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
   },
   "Windows/Linux": {
     "kanji": "Windows/Linux",
@@ -1189,7 +1189,7 @@
   },
   "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context.": {
     "kanji": "コンテキストに応じて、アクティブなブロックの移動、パレットのスクロール、テンポ ウィジェットの調整、またはワークスペースのパンを行います。",
-    "kana": "コンテクストにおうじて、アクティブなブロックのいどう、パレットのスクロール、てんぽ ツールのちょうせい、またはワークスペースのパンをおこないます。"
+    "kana": "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
   },
   "Pan workspace right when horizontal scrolling is enabled.": {
     "kanji": "水平スクロールが有効な場合、ワークスペースを右に移動します。",
@@ -1253,11 +1253,11 @@
   },
   "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together.": {
     "kanji": "ショートカットは状況に依存します。一部の機能は、関連するパネル、ウィジェット、またはモードがアクティブな場合にのみ機能します。 Windows/Linux および Mac の同等のものを一緒に示します。",
-    "kana": "ショートカットは じょうきょうに いぞんします。いちぶのきのうは、かんれんする パネル、ツール、または モードが アクティブな ばあいに のみきのうします。 Windows/Linux および Mac のどうとうの ものを いっしょに しめします。"
+    "kana": "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
   },
   "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field.": {
     "kanji": "クリップボードデータが無効です。ブロックを貼り付けるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストを貼り付けるには、入力フィールド内をクリックします。",
-    "kana": "クリップボードデータがむこうです。ブロックをはりつけるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストをはりつけるには、にゅうりょくフィールドないをクリックします。"
+    "kana": "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
   },
   "Select is enabled.": {
     "kanji": "選択モードが有効です。",
@@ -1449,7 +1449,7 @@
   },
   "Forever loop detected inside a note value block. Unexpected things may happen.": {
     "kanji": "「ずっとくり返す」状態が「音符」の中にある。",
-    "kana": "「ずっとくりかえす」じょうたいが「おんぷ」のなかに ある。"
+    "kana": "Forever loop detected inside a note value block. Unexpected things may happen."
   },
   "There is no block selected.": {
     "kanji": "ブロックが選ばれていません",
@@ -1473,7 +1473,7 @@
   },
   "Failed to initialize Music Blocks core. Please refresh the page.\\n\\nError: %s": {
     "kanji": "ミュージック・ブロックス コアの初期化に失敗しました。ページを更新してください。\\n\\nエラー: %s",
-    "kana": "ミュージック・ブロックス こあのしょきかにしっぱいしました。ページをこうしんしてください。。。エラー: %s"
+    "kana": "Failed to initialize Music Blocks core. Please refresh the page.\\n\\nError: %s"
   },
   "You must select a file.": {
     "kanji": "ファイルをえらんでください。",
@@ -1517,11 +1517,11 @@
   },
   "Error: Unable to save because you ran out of local storage. Try deleting some saved projects.": {
     "kanji": "エラー: ローカル ストレージが不足しているため、保存できません。保存されているプロジェクトをいくつか削除してみてください。",
-    "kana": "エラー: ろーかる すとれーじがふそくしているため、ほぞんできません。ほぞんされているプロジェクトをいくつかさくじょしてみてください。"
+    "kana": "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
   },
   "You must have at least one Partial block inside of a Weighted-partial block": {
     "kanji": "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。",
-    "kana": "「ばいおん ウェート」ブロックの なかに ひとつ いじょうの ばいおん ブロックが はいっている ひつようが あります。"
+    "kana": "You must have at least one Partial block inside of a Weighted-partial block"
   },
   "You can only tie notes of the same pitch. Did you mean to use slur?": {
     "kanji": "同じピッチの音符のみを結ぶことができます。スラーを使うつもりでしたか？",
@@ -2281,7 +2281,7 @@
   },
   "⚠️ Sound is disabled!\\n\\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks.": {
     "kanji": "⚠️ サウンドは無効になっています。\\n\\nブラウザの設定 (サイト設定 > サウンド) を確認して、ミュージック・ブロックスの音声を許可してください。",
-    "kana": "⚠⚠ おんせいは ブロックされています。。。ブラウザーの せってい (サイトの せってい > おんせい) をかくにんして、ミュージック・ブロックスの おんせいを きょかして ください。"
+    "kana": "⚠️ Sound is disabled!\\n\\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
   },
   "Cents Adjustment": {
     "kanji": "セント調整",
@@ -2297,7 +2297,7 @@
   },
   "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code.": {
     "kanji": "このプラグインには、ブラウザで実行されるコードが含まれています。組み込みのプラグイン ディレクトリからロードされていないため、安全でないコードが含まれている可能性があります。",
-    "kana": "このプラグインには、ブラウザーで じっこうされるコードが ふくまれています。くみこみの プラグイン でぃれくとりからロードされていないため、あんぜんでないコードが ふくまれているかの うせいがあります。"
+    "kana": "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
   },
   "Do you want to allow this plugin to run?": {
     "kanji": "このプラグインの実行を許可しますか?",
@@ -2365,11 +2365,11 @@
   },
   "In the example, it is used with the One of block to choose a random phase.": {
     "kanji": "<br><br>図の例は、決まったアクションではなく、２つのうちどちらか１つのアクションをランダムに実行させる。",
-    "kana": "<br><br>ずのれいは、 きまったアクション ではなく、 ２つの うち どちらか １つの アクションを ランダムに じっこうさせる。"
+    "kana": "In the example, it is used with the One of block to choose a random phase."
   },
   "The Listen block is used to listen for an event such as a mouse click.": {
     "kanji": "<h2>イベントブロック（受け取り）</h2><br>特定のイベントに対して、その発生を受け取るたびに実行するアクションを１つ決めておくことができる。",
-    "kana": "<h2>イベントブロック（うけとり）</h2><br>とくていの イベント にたいして、 その はっせい をうけとるたびに じっこうする アクションを １つ きめて おくことが できる。"
+    "kana": "The Listen block is used to listen for an event such as a mouse click."
   },
   "When the event happens, an action is taken.": {
     "kanji": "<br><br>イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。",
@@ -2385,7 +2385,7 @@
   },
   "The Broadcast block is used to trigger an event.": {
     "kanji": "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。",
-    "kana": "<h2>イベントブロック（はっせい）</h2><br>していした なまえの イベントを すべての ネズミに おくる。 イベントの はっせいは、 かくスクリプトが 【イベントのたびにアクション】で してい した アクションの ひきがね として はたらく。"
+    "kana": "The Broadcast block is used to trigger an event."
   },
   "broadcast": {
     "kanji": "イベント発生",
@@ -2397,11 +2397,11 @@
   },
   "All of the Start blocks run at the same time when the Play button is pressed.": {
     "kanji": "[再生] ボタンを押すと、すべての Start ブロックが同時に実行されます。",
-    "kana": "[さいせい] ボタンをおすと、すべての 「スタート」 ブロックがどうじにじっこうされます。"
+    "kana": "All of the Start blocks run at the same time when the Play button is pressed."
   },
   "The Action block is used to group together blocks so that they can be used more than once.": {
     "kanji": "アクション ブロックは、複数のブロックをグループ化して複数回使用できるようにするために使用されます。",
-    "kana": "「 」ブロックは、ふくすうのブロックをグループかしてふくすうかいしようできるようにするためにしようされます。"
+    "kana": "The Action block is used to group together blocks so that they can be used more than once."
   },
   "It is often used for storing a phrase of music that is repeated.": {
     "kanji": "<br><br>何度も実行する音楽のフレーズなどにアクションを作っておくと便利。",
@@ -2445,27 +2445,27 @@
   },
   "The Greater-than block returns True if the top number is greater than the bottom number.": {
     "kanji": "「＞」ブロックは、上の数値が下の数値より大きい場合に True を返します。",
-    "kana": "「＞」ブロックは、うえのすうちがしたのすうちよりおおきいばあいに True をかえします。"
+    "kana": "The Greater-than block returns True if the top number is greater than the bottom number."
   },
   "The Less-than block returns True if the top number is less than the bottom number.": {
     "kanji": "「＜」ブロックは、上の数値が下の数値より小さい場合に True を返します。",
-    "kana": "「＜」ブロックは、うえのすうちがしたのすうちよりちーさいばあいに True をかえします。"
+    "kana": "The Less-than block returns True if the top number is less than the bottom number."
   },
   "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number.": {
     "kanji": "「≦」ブロックは、上の数値が下の数値以下の場合に True を返します。",
-    "kana": "「≦」ブロックは、うえのすうちがしたのすうちいかのばあいに True をかえします。"
+    "kana": "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
   },
   "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number.": {
     "kanji": "「≥」ブロックは、上の数値が下の数値以上である場合に True を返します。",
-    "kana": "「≥」ブロックは、うえのすうちがしたのすうちいじょうであるばあいに True をかえします。"
+    "kana": "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
   },
   "The Equal block returns True if the two numbers are equal.": {
     "kanji": "<h2>しんぎブロック（等しい）</h2><br>２つのすうちをくらべて、同じすうちであるかどうかはんていする。「＝」は、２つのすうちが同じであれば「真（しん）」、同じでなければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。",
-    "kana": "<h2>しんぎブロック（ひとしい）</h2><br>２つの すうちを くらべて、 おなじ すうちで あるかどうか はんてい する。 「＝」は、 ２つの すうちが おなじ であれば 「しん（しん）」、 おなじ でなければ 「にせ（ぎ）」 という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+    "kana": "The Equal block returns True if the two numbers are equal."
   },
   "The Not-equal-to block returns True if the two numbers are not equal to each other.": {
     "kanji": "「≠」ブロックは2つの数字が等しくない場合にTrueを返します。",
-    "kana": "「≠」ブロックは2つのすうじがひとしくないばあいにTrueをかえします。"
+    "kana": "The Not-equal-to block returns True if the two numbers are not equal to each other."
   },
   "The Boolean block is used to specify true or false.": {
     "kanji": "Booleanブロックはtrueまたはfalseを指定するために使われます。",
@@ -2505,7 +2505,7 @@
   },
   "The Subtract-1-from block subtracts one from the value stored in a box.": {
     "kanji": "Subtract-1-fromブロックはボックスに保存された値から1を引きます。",
-    "kana": "「〜から１ひく」ブロックはぼっくすにほぞんされたあたいから1をひきます。"
+    "kana": "The Subtract-1-from block subtracts one from the value stored in a box."
   },
   "subtract 1 from": {
     "kanji": "〜から１引く",
@@ -2549,7 +2549,7 @@
   },
   "The Show-dictionary block displays the contents of the dictionary at the top of the screen.": {
     "kanji": "「辞書を表す」ブロックは、画面の上部に辞書の内容を表示します。",
-    "kana": "「じしょを あらわす」ブロックは、がめんのじょうぶにじしょのないようをひょうじします。"
+    "kana": "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
   },
   "show dictionary": {
     "kanji": "辞書を表す",
@@ -2565,7 +2565,7 @@
   },
   "The Get-dict block returns a value in the dictionary for a specified key.": {
     "kanji": "Get-dictブロックは指定されたキーの辞書の値を返します。",
-    "kana": "Get-dictブロックはしていされたキーのじしょのあたいをかえします。"
+    "kana": "The Get-dict block returns a value in the dictionary for a specified key."
   },
   "get value": {
     "kanji": "数価を表す",
@@ -2593,11 +2593,11 @@
   },
   "The Drum name block is used to select a drum.": {
     "kanji": "<h2>ドラムブロック</h2><br>ドラムの種類を変えるときに使う。クリックで、いろいろなドラムの音を選ぶことができる。",
-    "kana": "<h2>ドラムブロック</h2><br>ドラムの しゅるいを かえるときに つかう。 クリックで、 いろいろな ドラムの おとを えらぶことが できる。"
+    "kana": "The Drum name block is used to select a drum."
   },
   "The Effects name block is used to select a sound effect.": {
     "kanji": "<h2>こうかおんブロック</h2><br>こうかおんの種類を変えるときに使う。クリックで、いろいろなおもしろい音を選ぶことができる。",
-    "kana": "<h2>こうかおんブロック</h2><br>こうかおんの しゅるいを かえるときに つかう。 クリックで、 いろいろな おもしろい おとを えらぶことが できる。"
+    "kana": "The Effects name block is used to select a sound effect."
   },
   "noise": {
     "kanji": "ノイズ",
@@ -2617,7 +2617,7 @@
   },
   "The Set drum block will select a drum sound to replace the pitch of any contained notes.": {
     "kanji": "「ドラムをせってい」ブロックは、含まれているノートのピッチを置き換えるドラム サウンドを選択します。",
-    "kana": "「ドラムをせってい」ブロックは、ふくまれているおんぷの ピッチを おきかえるドラムの おとを せんたくします。"
+    "kana": "The Set drum block will select a drum sound to replace the pitch of any contained notes."
   },
   "In the example above, a kick drum sound will be played instead of sol.": {
     "kanji": "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。",
@@ -2633,7 +2633,7 @@
   },
   "You can use multiple Drum blocks within a Note block.": {
     "kanji": "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。",
-    "kana": "<h2>ドラム ブロック</h2><br>「おんぷブロック」 の なかに いれて つかう。 いろいろな  ドラムの ねいろを えらぶことが できる。 １つの 「おんぷブロック」 の なかで、 ふくすうの ねいろの ドラムを  くみあわせて つかうことが できる。"
+    "kana": "You can use multiple Drum blocks within a Note block."
   },
   "mouse index heap": {
     "kanji": "ネズミヒープに番号をふる",
@@ -2645,11 +2645,11 @@
   },
   "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse.": {
     "kanji": "指定されたマウスの指定された位置のヒープ内の値を返します。",
-    "kana": "していされた ネズミの してい されたいちの ヒープないの あたいをかえします。"
+    "kana": "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
   },
   "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle.": {
     "kanji": "指定されたタートルの指定された位置のヒープ内の値を返します。",
-    "kana": "していされたタートルのしていされたいちのヒープないのあたいをかえします。"
+    "kana": "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
   },
   "Yertle": {
     "kanji": "ヤートル",
@@ -2777,11 +2777,11 @@
   },
   "The Set mouse block sends a stack of blocks to be run by the specified mouse.": {
     "kanji": "指定されたマウスに実行するブロックのスタックを送ります。",
-    "kana": "「ネズミを せってい」ブロックのスタックをおくります。"
+    "kana": "The Set mouse block sends a stack of blocks to be run by the specified mouse."
   },
   "The Set turtle block sends a stack of blocks to be run by the specified turtle.": {
     "kanji": "指定されたタートルに実行するブロックのスタックを送ります。",
-    "kana": "していされたタートルにじっこうするブロックのスタックをおくります。"
+    "kana": "The Set turtle block sends a stack of blocks to be run by the specified turtle."
   },
   "mouse y": {
     "kanji": "ネズミのy座標",
@@ -2821,7 +2821,7 @@
   },
   "The Mouse elapse notes block returns the number of notes played by the specified mouse.": {
     "kanji": "指定されたマウスが演奏したノート数を返します。",
-    "kana": "していされたネズミがえんそうしたおんぷかずをかえします。"
+    "kana": "The Mouse elapse notes block returns the number of notes played by the specified mouse."
   },
   "turtle notes played": {
     "kanji": "タートルの演奏した音符の数",
@@ -2829,7 +2829,7 @@
   },
   "The Turtle elapse notes block returns the number of notes played by the specified turtle.": {
     "kanji": "指定されたタートルが演奏したノート数を返します。",
-    "kana": "していされたタートルがえんそうしたおんぷかずをかえします。"
+    "kana": "The Turtle elapse notes block returns the number of notes played by the specified turtle."
   },
   "mouse pitch number": {
     "kanji": "ネズミの音高数字",
@@ -2837,7 +2837,7 @@
   },
   "The Mouse pitch block returns the current pitch number being played by the specified mouse.": {
     "kanji": "指定されたマウスが現在演奏しているピッチ番号を返します。",
-    "kana": "していされたネズミがげんざいえんそうしているピッチばんごうをかえします。"
+    "kana": "The Mouse pitch block returns the current pitch number being played by the specified mouse."
   },
   "turtle pitch number": {
     "kanji": "タートルの音高数字",
@@ -2845,7 +2845,7 @@
   },
   "The Turtle pitch block returns the current pitch number being played by the specified turtle.": {
     "kanji": "指定されたタートルが現在演奏しているピッチ番号を返します。",
-    "kana": "していされたタートルがげんざいえんそうしているピッチばんごうをかえします。"
+    "kana": "The Turtle pitch block returns the current pitch number being played by the specified turtle."
   },
   "mouse note value": {
     "kanji": "ネズミの音価",
@@ -2873,7 +2873,7 @@
   },
   "The Found mouse block will return true if the specified mouse can be found.": {
     "kanji": "指定されたマウスが見つかった場合にtrueを返します。",
-    "kana": "していされた ネズミが みつかった ばあいに「じつ」を かえします。"
+    "kana": "The Found mouse block will return true if the specified mouse can be found."
   },
   "found mouse": {
     "kanji": "ネズミを見つけた",
@@ -2881,7 +2881,7 @@
   },
   "The Found turtle block will return true if the specified turtle can be found.": {
     "kanji": "指定されたタートルが見つかった場合にtrueを返します。",
-    "kana": "していされた タートルが みつかった ばあいに 「じつ」を かえします。"
+    "kana": "The Found turtle block will return true if the specified turtle can be found."
   },
   "found turtle": {
     "kanji": "タートル見つかった",
@@ -3037,11 +3037,11 @@
   },
   "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window.": {
     "kanji": "このプロジェクトを実行するには、ブラウザでミュージック・ブロックスを開き、このファイルをブラウザ・ウィンドウにドラッグ・アンド・ドロップします。",
-    "kana": "このプロジェクトをじっこうするには、ぶらうざでミュージック・ブロックスをひらき、このファイルをぶらうざ・ウィンドウにドラッグ・アンド・ドロップします。"
+    "kana": "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
   },
   "Alternatively, open the file in Music Blocks using the Load project button.": {
     "kanji": "「ファイルからプロジェクトを読みこむ」ボタンをおして、ファイルをひらいてください。",
-    "kana": "「ファイルから プロジェクトを よみこむ」 ボタンを おして、 ファイルを ひらいて ください。"
+    "kana": "Alternatively, open the file in Music Blocks using the Load project button."
   },
   "Project Code": {
     "kanji": "プロジェクトのコード",
@@ -3049,7 +3049,7 @@
   },
   "This code stores data about the blocks in a project.": {
     "kanji": "このコードは、がいとうする場合、へんしゅうされたバージョンのプロジェクトといっしょに、プロジェクトの中のブロックに関するデータをほぞんします。",
-    "kana": "この コードは、 がいとう する ばあい、 へんしゅう された バージョンの プロジェクトと いっしょに、 プロジェクトの なかの ブロックに かんする データを ほぞん します。"
+    "kana": "This code stores data about the blocks in a project."
   },
   "Copy to Clipboard": {
     "kanji": "クリップボードにコピー",
@@ -3141,7 +3141,7 @@
   },
   "Failed to convert Lilypond to PDF. Please try saving as .ly file instead.": {
     "kanji": "Lilypond を PDF に変換できませんでした。代わりに .ly ファイルとして保存してみてください。",
-    "kana": "Lilypond を PDF にへんかんできませんでした。かわりに .ly ファイルとしてほぞんしてみてください。"
+    "kana": "Failed to convert Lilypond to PDF. Please try saving as .ly file instead."
   },
   "mouse": {
     "kanji": "ネズミ",
@@ -3204,15 +3204,15 @@
     "kana": "「ヒープは から ですか？」ブロックは ヒープが そらの ばあいに「じつ」を かえします。"
   },
   "Pitch index exceeds EDO range": {
-    "kanji": "Pitch index exceeds EDO range",
-    "kana": "Pitch index exceeds EDO range"
+    "kanji": "ピッチインデックスが 平均律 範囲を超えています。",
+    "kana": "ぴっちいんでっくすが へいきんりつ はんいをこえています。"
   },
   "Cannot find project data in this HTML file.": {
-    "kanji": "Cannot find project data in this HTML file.",
-    "kana": "Cannot find project data in this HTML file."
+    "kanji": "このHTMLファイル内にプロジェクトデータが見つかりません。",
+    "kana": "このHTMLふぁいるないにぷろじぇくとでーたがみつかりません。"
   },
   "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%.": {
-    "kanji": "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%.",
+    "kanji": "キャンバスが異常に大きいため、Firefox のパフォーマンスが影響を受ける可能性があります。最高のエクスペリエンスを得るには、ブラウザーのズームを 100% にリセットすることを検討してください。",
     "kana": "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%."
   },
   "unison": {
@@ -3220,12 +3220,12 @@
     "kana": "ユニゾン（同度）"
   },
   "picked up": {
-    "kanji": "picked up",
-    "kana": "picked up"
+    "kanji": "拾った",
+    "kana": "ひろった"
   },
   "You can restore deleted blocks from the trash with the Restore From Trash button.": {
     "kanji": "削除されたブロックは「ゴミ箱から復元」ボタンで復元できます。",
-    "kana": "さくじょされたブロックは「ごみはこからふくげん」ボタンでふくげんできます。"
+    "kana": "You can restore deleted blocks from the trash with the Restore From Trash button."
   },
   "The To frequency block converts a pitch name and octave to Hertz.": {
     "kanji": "トゥーフリクエンシーブロックは音名とオクターブをヘルツに変換します。",
@@ -3245,7 +3245,7 @@
   },
   "In order to copy a sample, you must reload the widget, import the sample again, and export it.": {
     "kanji": "サンプルをコピーするため、ツールを再度試して、またサンプルをロード読み込で、保存することが必要です。",
-    "kana": "サンプルを コピーするため、 ツールを さいどしして、 またサンプルを ロードよみこんで、 ほぞんする ことが ひつようです。"
+    "kana": "In order to copy a sample, you must reload the widget, import the sample again, and export it."
   },
   "double sharp": {
     "kanji": "ダブルシャープ",
@@ -3288,44 +3288,44 @@
     "kana": "ピッチプレビューのキーをせんたくしました。"
   },
   "block sent to trash": {
-    "kanji": "block sent to trash",
-    "kana": "block sent to trash"
+    "kanji": "ブロックがゴミ箱に送られる",
+    "kana": "ぶろっくがごみはこにおくられる"
   },
   "Choose an image": {
-    "kanji": "Choose an image",
-    "kana": "Choose an image"
+    "kanji": "画像を選択してください",
+    "kana": "がぞうをせんたくしてください"
   },
   "Built-in images": {
-    "kanji": "Built-in images",
-    "kana": "Built-in images"
+    "kanji": "内蔵イメージ",
+    "kana": "ないぞういめーじ"
   },
   "Upload from device": {
-    "kanji": "Upload from device",
-    "kana": "Upload from device"
+    "kanji": "デバイスからアップロード",
+    "kana": "でばいすからあっぷろーど"
   },
   "Choose file": {
-    "kanji": "Choose file",
-    "kana": "Choose file"
+    "kanji": "ファイルを選択してください",
+    "kana": "ふぁいるをせんたくしてください"
   },
   "Supports PNG, JPG, SVG, GIF, and other image formats": {
-    "kanji": "Supports PNG, JPG, SVG, GIF, and other image formats",
-    "kana": "Supports PNG, JPG, SVG, GIF, and other image formats"
+    "kanji": "PNG、JPG、SVG、GIF、その他の画像形式をサポート",
+    "kana": "PNG、JPG、SVG、GIF、そのほかのがぞうけいしきをさぽーと"
   },
   "Apply": {
-    "kanji": "Apply",
-    "kana": "Apply"
+    "kanji": "適用する",
+    "kana": "てきようする"
   },
   "Invalid input passed to rational sum": {
-    "kanji": "Invalid input passed to rational sum",
-    "kana": "Invalid input passed to rational sum"
+    "kanji": "無効な入力が有理合計に渡されました",
+    "kana": "むこうなにゅうりょくがゆうりごうけいにわたされました"
   },
   "Note calculation failed: zero denominator": {
-    "kanji": "Note calculation failed: zero denominator",
-    "kana": "Note calculation failed: zero denominator"
+    "kanji": "ノートの計算が失敗しました: 分母がゼロです",
+    "kana": "のーとのけいさんがしっぱいしました: ぶんぼがぜろです"
   },
   "Equal (17EDO)": {
-    "kanji": "Equal (17EDO)",
-    "kana": "Equal (17EDO)"
+    "kanji": "17平均律",
+    "kana": "17へいきんりつ"
   },
   "The Heap block returns the heap.": {
     "kanji": "Heapブロックはヒープを返します。",
@@ -3333,7 +3333,7 @@
   },
   "The Show-heap block displays the contents of the heap at the top of the screen.": {
     "kanji": "「ヒープを表示する」ブロックは、ヒープの内容を画面の上部に表示します。",
-    "kana": "「ヒープをひょうじする」ブロックは、ヒープのないようをがめんのじょうぶにひょうじします。"
+    "kana": "The Show-heap block displays the contents of the heap at the top of the screen."
   },
   "show heap": {
     "kanji": "ヒープを表示する",
@@ -3369,7 +3369,7 @@
   },
   "The Index-heap block returns a value in the heap at a specified location.": {
     "kanji": "Index-heapブロックは指定された位置のヒープの値を返します。",
-    "kana": "「ヒープに ばんごうを ふる」ブロックはしていされたいちのヒープのあたいをかえします。"
+    "kana": "The Index-heap block returns a value in the heap at a specified location."
   },
   "index heap": {
     "kanji": "ヒープに番号をふる",
@@ -3377,7 +3377,7 @@
   },
   "The Set-heap entry block sets a value in the heap at the specified location.": {
     "kanji": "Set-heapエントリーブロックは指定された位置のヒープに値を設定します。",
-    "kana": "「ヒープを せってい する」ブロックはしていされたいちのヒープにあたいをせっていします。"
+    "kana": "The Set-heap entry block sets a value in the heap at the specified location."
   },
   "set heap": {
     "kanji": "ヒープを設定する",
@@ -3401,7 +3401,7 @@
   },
   "The delay (second argument) sets the time delay between chorus voices (milliseconds).": {
     "kanji": "ディレイ(第 2 引数) は、コーラスボイス間の遅延時間 (ミリ秒) を設定します。",
-    "kana": "でぃれい(だい 2 ひきすう) は、こーらすぼいすまのちえんじかん (みりびょう) をせっていします。"
+    "kana": "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
   },
   "synth volume": {
     "kanji": "シンセノ音量",
@@ -3409,7 +3409,7 @@
   },
   "The Synth volume block returns the current volume of the current synthesizer.": {
     "kanji": "Synth volumeブロックは現在のシンセサイザーの音量を返します。",
-    "kana": "「シンセの おんりょう」ブロックは げんざいの シンセサイザーの おんりょうを かえします。"
+    "kana": "The Synth volume block returns the current volume of the current synthesizer."
   },
   "set synth volume": {
     "kanji": "楽器の音量をせってい",
@@ -3425,11 +3425,11 @@
   },
   "The Backward block runs code in reverse order (Musical retrograde).": {
     "kanji": "<h2>実行ブロック（ぎゃく実行）</h2><br>はさまれているブロックを、つうじょうとはぎゃくの順じょで、下から上に向かって実行する。",
-    "kana": "<h2>じっこうブロック（ぎゃくじっこう）</h2><br>はさまれている ブロックを、 つうじょうとは ぎゃくの じゅんじょで、 したから うえにむかって じっこうする。"
+    "kana": "The Backward block runs code in reverse order (Musical retrograde)."
   },
   "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc.": {
     "kanji": "「楽器の音量をせってい」ブロックは、ギター、バイオリン、スネアドラムなどの特定のシンセサイザーの音量を変更します。",
-    "kana": "「シンセの おんりょうを せってい」ブロックは、ギター、バイオリン、スネア・ドラムなどのとくていのシンセサイザーのおんりょうをへんこうします。"
+    "kana": "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
   },
   "backward": {
     "kanji": "ぎゃく向きに実行",
@@ -3441,11 +3441,11 @@
   },
   "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol.": {
     "kanji": "この例の出力は、ソ、ソ、ソ、ソ、レ、レ、レ、レ、ソ、ソ、ソ、ソ です。",
-    "kana": "このれいの しゅつりょくは「ソ、ソ、ソ、ソ、レ、レ、レ、レ、ソ、ソ、ソ、ソ」 です。"
+    "kana": "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
   },
   "The Default block is used inside of a Switch to define the default action.": {
     "kanji": "DefaultブロックはSwitch内でデフォルトの動作を定義するために使われます。",
-    "kana": "「ひょうじゅん」ブロックはSwitchないでデフォルトのどうさをていぎするためにつかわれます。"
+    "kana": "The Default block is used inside of a Switch to define the default action."
   },
   "default": {
     "kanji": "ひょうじゅん",
@@ -3509,7 +3509,7 @@
   },
   "Conditionals lets your program take different actions depending on the condition.": {
     "kanji": "条件付きを使用すると、プログラムは条件に応じてさまざまなアクションを実行できます。",
-    "kana": "じょうけんつきをしようすると、プログラムはじょうけんにおうじてさまざまなをじっこうできます。"
+    "kana": "Conditionals lets your program take different actions depending on the condition."
   },
   "In this example if the mouse button is pressed a snare drum will play.": {
     "kanji": "<br><br>図の例では、もし、パソコンのマウスを長おししていれば「キックドラム」ブロックをえんそうする。",
@@ -3517,7 +3517,7 @@
   },
   "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play.": {
     "kanji": "この例では、マウス ボタンが押されるとスネア ドラムが再生され、そうではない場合はキック ドラムが再生されます。",
-    "kana": "このれいでは、マウス ボタンがおされるとすねあ ドラムがさいせいされ、そうではないばあいはキック ドラムがさいせいされます。"
+    "kana": "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
   },
   "if": {
     "kanji": "もし",
@@ -3533,11 +3533,11 @@
   },
   "The Forever block will repeat the contained blocks forever.": {
     "kanji": "<h2>実行ブロック（くり返し）</h2><br>「ずっとくり返す」のブロックは、実行を停止しないかぎり、はさまれているブロックをくり返し実行する。",
-    "kana": "<h2>じっこうブロック（くりかえし）</h2><br>ずっとくりかえす」の ブロックは、 じっこうを ていし しないかぎり、 はさまれている ブロックを くりかえし じっこうする。"
+    "kana": "The Forever block will repeat the contained blocks forever."
   },
   "In this example of a simple drum machine a kick drum will play 1/4 notes forever.": {
     "kanji": "この単純なドラムマシンの例では、キックドラムは 四分音符を永遠に演奏します。",
-    "kana": "このたんじゅんなドラム・マシンのれいでは、キック・ドラムは よんぶんおんぷをえいえんにえんそうします。"
+    "kana": "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
   },
   "forever": {
     "kanji": "ずっとくり返す",
@@ -3545,7 +3545,7 @@
   },
   "The Repeat block will repeat the contained blocks.": {
     "kanji": "<h2>実行ブロック（くり返し）</h2><br>はさまれているブロックのプログラムを、入力した回数だけくり返す。",
-    "kana": "<h2>じっこうブロック（くりかえし）</h2><br>はさまれている ブロックの プログラムを、 にゅうりょくした かいすう だけ くりかえす。"
+    "kana": "The Repeat block will repeat the contained blocks."
   },
   "In this example the note will be played 4 times.": {
     "kanji": "<br><br>図の例では、「ソ」の音が４回えんそうされる。",
@@ -3569,7 +3569,7 @@
   },
   "The Beat factor block returns the ratio of the note value to the meter note value.": {
     "kanji": "「拍を～倍にするファクター」ブロックは、拍子音符値に対する音符値の比率を返します。",
-    "kana": "「はくを ～ばいにする ファクター」ブロックは、ひょうしおんぷあたいにたいするおんぷあたいのひりつをかえします。"
+    "kana": "The Beat factor block returns the ratio of the note value to the meter note value."
   },
   "The Beats per minute block returns the current beats per minute.": {
     "kanji": "「スピードを決める」ブロックは現在の1分あたりのビート数を返します。",
@@ -3613,7 +3613,7 @@
   },
   "In the figure, it is used to take an action on the first beat of each measure.": {
     "kanji": "図では、各小節の最初の拍でアクションを実行するために使用されます。",
-    "kana": "ずでは、かくしょうせつのさいしょのはくでアクションをじっこうするためにしようされます。"
+    "kana": "In the figure, it is used to take an action on the first beat of each measure."
   },
   "eg 1, 2, 3, or 4.": {
     "kanji": "<br>図の例では、それぞれの小節の１拍（ぱく）目に、特定のアクション・イベントを起こしている。",
@@ -3625,7 +3625,7 @@
   },
   "The Note counter block can be used to count the number of contained notes.": {
     "kanji": "Note counterブロックは含まれる音符の数を数えるために使用できます。",
-    "kana": "「おんぷの ごうけい すう」ブロックはふくまれるおんぷのかずをかぞえるためにしようできます。"
+    "kana": "The Note counter block can be used to count the number of contained notes."
   },
   "note counter": {
     "kanji": "音符の合計数",
@@ -3637,7 +3637,7 @@
   },
   "The Whole notes played block returns the total number of whole notes played.": {
     "kanji": "Whole notes playedブロックは演奏された全音符の総数を返します。",
-    "kana": "「さいせい された ぜんおんぷの かず」ブロックはえんそうされたぜんおんぷのそうすうをかえします。"
+    "kana": "The Whole notes played block returns the total number of whole notes played."
   },
   "notes played": {
     "kanji": "全体の拍の数",
@@ -3657,7 +3657,7 @@
   },
   "The On-weak-beat block lets you specify actions to take on weak (off) beats.": {
     "kanji": "On-weak-beatブロックは弱拍（裏拍）で実行するアクションを指定できます。",
-    "kana": "「On-weak-beat」ブロックはじゃくはく（うらはく）でじっこうするをしていできます。"
+    "kana": "The On-weak-beat block lets you specify actions to take on weak (off) beats."
   },
   "on strong beat": {
     "kanji": "強拍に",
@@ -3665,7 +3665,7 @@
   },
   "The On-strong-beat block lets you specify actions to take on specified beats.": {
     "kanji": "On-strong-beatブロックは指定された強拍で実行するアクションを指定できます。",
-    "kana": "「On-strong-beat」ブロックはしていされたきょうはくでじっこうするをしていできます。"
+    "kana": "The On-strong-beat block lets you specify actions to take on specified beats."
   },
   "beat": {
     "kanji": "拍子",
@@ -3677,7 +3677,7 @@
   },
   "The On-every-beat block lets you specify actions to take on every beat.": {
     "kanji": "On-every-beatブロックはすべての拍で実行するアクションを指定できます。",
-    "kana": "「すべてのびょうしにアクションじっこう」ブロックはすべてのはくでじっこうするをしていできます。"
+    "kana": "The On-every-beat block lets you specify actions to take on every beat."
   },
   "on every note do": {
     "kanji": "全ての音符にアクション実行",
@@ -3685,7 +3685,7 @@
   },
   "The On-every-note block lets you specify actions to take on every note.": {
     "kanji": "On-every-noteブロックはすべての音符で実行するアクションを指定できます。",
-    "kana": "「すべての おんぷに アクションじっこう」ブロックはすべてのおんぷでじっこうするをしていできます。"
+    "kana": "The On-every-note block lets you specify actions to take on every note."
   },
   "master beats per minute": {
     "kanji": "全体のスピードを決める",
@@ -3693,7 +3693,7 @@
   },
   "The Master beats per minute block sets the number of 1/4 notes per minute for every voice.": {
     "kanji": "「全体のスピードを決める」ブロックは、各ボイスの 1 分あたりの 1/4 音符の数を設定します。",
-    "kana": "「ぜんたいの スピードを きめる」ブロックは、かくおんせいの 1 ふんあたりの 1/4 おんぷのかずをせっていします。"
+    "kana": "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
   },
   "bpm": {
     "kanji": "１分あたりの拍の数",
@@ -3713,7 +3713,7 @@
   },
   "The Beats per minute block sets the number of 1/4 notes per minute.": {
     "kanji": "<h2>スピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。",
-    "kana": "<h2>スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくの スピードを きめる。 ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
+    "kana": "The Beats per minute block sets the number of 1/4 notes per minute."
   },
   "pickup": {
     "kanji": "ピックアップ",
@@ -3721,11 +3721,11 @@
   },
   "The Pickup block is used to accommodate any notes that come in before the beat.": {
     "kanji": "「ピックアップ」ブロックは、ビートの前に入力されるノートを収容するために使用されます。",
-    "kana": "「ピックアップ」ブロックは、ビートのまえににゅうりょくされるおんぷをしゅうようするためにしようされます。"
+    "kana": "The Pickup block is used to accommodate any notes that come in before the beat."
   },
   "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure).": {
     "kanji": "音楽のビートは「拍子」ブロックによって決定されます (デフォルトでは、1 小節あたり ４つの1/4音符)。",
-    "kana": "おんがくのビートは「ひょうし」ブロックによってけっていされます (ひょうじゅんでは、1 しょうせつあたり ４つの1/4おんぷ)。"
+    "kana": "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
   },
   "number of beats": {
     "kanji": "拍の数",
@@ -3749,7 +3749,7 @@
   },
   "The Neighbor block rapidly switches between neighboring pitches.": {
     "kanji": "<h2>音を加えるブロック</h2><br>２つの同じ高さの音のあいだに、音を１つ入れることができる。<br>図の例では、ソとソのあいだにラが入り、「ソ、ラ、ソ」とすばやくえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、「ソ」を始まりの音にしたときの「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」のこと。",
-    "kana": "<h2>おとを くわえる ブロック</h2><br>２つの おなじたかさの おとの あいだに、 おとを １つ いれることが できる。<br>ずのれいでは、 ソとソの あいだに ラが はいり、 「ソ、ラ、ソ」 と すばやく えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、 「ソ」 を はじまりのおと に したときの 「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」 の こと。"
+    "kana": "The Neighbor block rapidly switches between neighboring pitches."
   },
   "glide": {
     "kanji": "グリッサンド",
@@ -3765,11 +3765,11 @@
   },
   "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes.": {
     "kanji": "「スラー」ブロックは、指定された音符の長さを全部組み合わせて長くします。",
-    "kana": "「スラー」ブロックは、していされたおんぷのながさをぜんぶくみあわせてながくします。"
+    "kana": "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
   },
   "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes.": {
     "kanji": "「スタッカート」ブロックは、指定された音符の長さを維持しながら、実際の音符の長さを短縮します。",
-    "kana": "「スタッカート」ブロックは、していされたおんぷのながさをいじしながら、じっさいのおんぷのながさをたんしゅくします。"
+    "kana": "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
   },
   "rhythm1": {
     "kanji": "連符（かけ算）",
@@ -3785,7 +3785,7 @@
   },
   "The Rhythm block is used to generate rhythm patterns.": {
     "kanji": "<h2>連符（れんぷ）ブロック（かけ算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つなどくり返して使う。３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。",
-    "kana": "<h2>れんぷブロック（かけざん）</h2><br>まとまった いくつかの おんぷ。 いっていの ながさの おとを  ３つや ５つなど くりかえして つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
+    "kana": "The Rhythm block is used to generate rhythm patterns."
   },
   "1/64 note": {
     "kanji": "６４分音符",
@@ -3821,7 +3821,7 @@
   },
   "The Tuplet block is used to generate a group of notes played in a condensed amount of time.": {
     "kanji": "「～連符」連符ブロックは、凝縮された時間で演奏される音符のグループを生成するために使用されます。",
-    "kana": "「～れんぷ（タプル）」ブロックは、ぎょうしゅくされたじかんでえんそうされるおんぷのグループをせいせいするためにしようされます。"
+    "kana": "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
   },
   "septuplet": {
     "kanji": "７連符",
@@ -3841,11 +3841,11 @@
   },
   "Tuplets are a collection of notes that get scaled to a specific duration.": {
     "kanji": "<h2>連符（れんぷ）ブロック（わり算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つに等分して使う。",
-    "kana": "<h2>れんぷブロック（わりざん）</h2><br>まとまった いくつかの おんぷ。いっていの ながさの おとを  ３つや ５つに とうぶんして つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
+    "kana": "Tuplets are a collection of notes that get scaled to a specific duration."
   },
   "Using tuplets makes it easy to create groups of notes that are not based on a power of 2.": {
     "kanji": "連符を使用すると、2 の累乗に基づいていない音符のグループを簡単に作成できます。",
-    "kana": "れんぷをしようすると、2 のるいじょうにもとづいていないおんぷのグループをかんたんにさくせいできます。"
+    "kana": "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
   },
   "The Input block prompts for keyboard input.": {
     "kanji": "インプットブロックはキーボード入力を促します。",
@@ -3893,11 +3893,11 @@
   },
   "The Cursor over block triggers an event when the cursor is moved over a mouse.": {
     "kanji": "「カーソル（上）」ブロックは、カーソルがマウス上に移動するとイベントをトリガーします。",
-    "kana": "「カーソル（うえ）」ブロックは、カーソルがネズミうえにいどうするとイベントをトリガーします。"
+    "kana": "The Cursor over block triggers an event when the cursor is moved over a mouse."
   },
   "The Cursor over block triggers an event when the cursor is moved over a turtle.": {
     "kanji": "「カーソル（上）」ブロックは、カーソルがタートル上に移動するとイベントをトリガーします。",
-    "kana": "「カーソル（うえ）」ブロックは、カーソルがタートルうえにいどうするとイベントをトリガーします。"
+    "kana": "The Cursor over block triggers an event when the cursor is moved over a turtle."
   },
   "cursor out": {
     "kanji": "カーソル（外）",
@@ -3905,11 +3905,11 @@
   },
   "The Cursor out block triggers an event when the cursor is moved off of a mouse.": {
     "kanji": "「カーソル（外）」ブロックは、カーソルがマウスから離れるとイベントをトリガーします。",
-    "kana": "「カーソル（そと）」ブロックは、カーソルがネズミからはなれるとイベントをトリガーします。"
+    "kana": "The Cursor out block triggers an event when the cursor is moved off of a mouse."
   },
   "The Cursor out block triggers an event when the cursor is moved off of a turtle.": {
     "kanji": "「カーソル（外）」ブロックは、カーソルがタートルから離れるとイベントをトリガーします。",
-    "kana": "「カーソル（そと）」ブロックは、カーソルがタートルからはなれるとイベントをトリガーします。"
+    "kana": "The Cursor out block triggers an event when the cursor is moved off of a turtle."
   },
   "cursor button down": {
     "kanji": "カーソルクリック（下）",
@@ -3917,11 +3917,11 @@
   },
   "The Cursor button down block triggers an event when the cursor button is pressed on a mouse.": {
     "kanji": "「カーソルクリック（下）」ブロックは、マウスのカーソル ボタンが押されたときにイベントをトリガーします。",
-    "kana": "「カーソルクリック（した）」ブロックは、ネズミのカーソル ボタンがおされたときにイベントをトリガーします。"
+    "kana": "The Cursor button down block triggers an event when the cursor button is pressed on a mouse."
   },
   "The Cursor button down block triggers an event when the cursor button is pressed on a turtle.": {
     "kanji": "「カーソルクリック（下）」ブロックは、タートル上でカーソル ボタンが押されたときにイベントをトリガーします。",
-    "kana": "「カーソルクリック（した）」ブロックは、タートルうえでカーソル ボタンがおされたときにイベントをトリガーします。"
+    "kana": "The Cursor button down block triggers an event when the cursor button is pressed on a turtle."
   },
   "cursor button up": {
     "kanji": "カーソルクリック（上）",
@@ -3929,11 +3929,11 @@
   },
   "The Cursor button up block triggers an event when the cursor button is released while over a mouse.": {
     "kanji": "「カーソルクリック（上）」ブロックは、マウスの上でカーソル ボタンが放されるとイベントをトリガーします。",
-    "kana": "「カーソルクリック（うえ）」ブロックは、ネズミのうえでカーソル ボタンがはなされるとイベントをトリガーします。"
+    "kana": "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
   },
   "The Cursor button up block triggers an event when the cursor button is released while over a turtle.": {
     "kanji": "「カーソルクリック（上）」ブロックは、タートルの上でカーソル ボタンが放されるとイベントをトリガーします。",
-    "kana": "「カーソルクリック（うえ）」ブロックは、タートルのうえでカーソル ボタンがはなされるとイベントをトリガーします。"
+    "kana": "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
   },
   "red": {
     "kanji": "赤",
@@ -3957,7 +3957,7 @@
   },
   "The Time block returns the number of seconds that the program has been running.": {
     "kanji": "「時間」ブロックは、プログラムが実行されている秒数を返します。",
-    "kana": "「じかん」ブロックは、プログラムがじっこうされているびょうすうをかえします。"
+    "kana": "The Time block returns the number of seconds that the program has been running."
   },
   "cursor y": {
     "kanji": "yざひょうち（カーソル）",
@@ -3965,7 +3965,7 @@
   },
   "The Cursor Y block returns the vertical position of the mouse.": {
     "kanji": "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルのたて位置を表すｙざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。",
-    "kana": "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの たていち を あらわす ｙざひょうち。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。"
+    "kana": "The Cursor Y block returns the vertical position of the mouse."
   },
   "cursor x": {
     "kanji": "xざひょうち（カーソル）",
@@ -3973,7 +3973,7 @@
   },
   "The Cursor X block returns the horizontal position of the mouse.": {
     "kanji": "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの横位置を表すｘざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。",
-    "kana": "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの よこいち を あらわす ｘざひょうち。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。"
+    "kana": "The Cursor X block returns the horizontal position of the mouse."
   },
   "mouse button": {
     "kanji": "マウスボタン",
@@ -3981,7 +3981,7 @@
   },
   "The Mouse-button block returns True if the mouse button is pressed.": {
     "kanji": "<h2>真偽ブロック（マウスボタン）</h2><br>マウスのボタンがおされているかどうかはんていする。マウスボタンがおされていれば「真（しん）」、おされていなければ「偽（ぎ）」という値になる。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。",
-    "kana": "<h2>しんぎブロック（マウスボタン）</h2><br>マウスの ボタンが おされているか どうか はんてい する。 マウスボタンが おされていれば 「しん（しん）」、 おされていなければ「にせ（ぎ）」と いう あたいになる。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+    "kana": "The Mouse-button block returns True if the mouse button is pressed."
   },
   "to ASCII": {
     "kanji": "ASCIIに",
@@ -3997,11 +3997,11 @@
   },
   "The Get red block returns the red component of the pixel under the mouse.": {
     "kanji": "Get redブロックはマウス下のピクセルの赤成分を返します。",
-    "kana": "「Get red」ブロックはネズミしたのピクセルのあかせいぶんをかえします。"
+    "kana": "The Get red block returns the red component of the pixel under the mouse."
   },
   "The Get red block returns the red component of the pixel under the turtle.": {
     "kanji": "Get redブロックはカメの下のピクセルの赤成分を返します。",
-    "kana": "「Get red」ブロックはかめのしたのピクセルのあかせいぶんをかえします。"
+    "kana": "The Get red block returns the red component of the pixel under the turtle."
   },
   "green": {
     "kanji": "緑",
@@ -4009,11 +4009,11 @@
   },
   "The Get green block returns the green component of the pixel under the mouse.": {
     "kanji": "Get green ブロックは、マウスの下にあるピクセルの緑色コンポーネントを返します。",
-    "kana": "「Get green」ブロックは、ネズミのしたにあるピクセルのりょくしょくこんぽーねんとをかえします。"
+    "kana": "The Get green block returns the green component of the pixel under the mouse."
   },
   "The Get green block returns the green component of the pixel under the turtle.": {
     "kanji": "Get green ブロックは、タートルの下のピクセルの緑色コンポーネントを返します。",
-    "kana": "「Get green」ブロックは、タートルのしたのピクセルのりょくしょくこんぽーねんとをかえします。"
+    "kana": "The Get green block returns the green component of the pixel under the turtle."
   },
   "blue": {
     "kanji": "青",
@@ -4021,11 +4021,11 @@
   },
   "The Get blue block returns the blue component of the pixel under the mouse.": {
     "kanji": "Get blue ブロックは、マウスの下にあるピクセルの青色のコンポーネントを返します。",
-    "kana": "「Get blue」ブロックは、ネズミのしたにあるピクセルのあおいろのこんぽーねんとをかえします。"
+    "kana": "The Get blue block returns the blue component of the pixel under the mouse."
   },
   "The Get blue block returns the blue component of the pixel under the turtle.": {
     "kanji": "Get blue ブロックは、タートルの下のピクセルの青コンポーネントを返します。",
-    "kana": "「Get blue」ブロックは、タートルのしたのピクセルのあおこんぽーねんとをかえします。"
+    "kana": "The Get blue block returns the blue component of the pixel under the turtle."
   },
   "master volume": {
     "kanji": "マスター音量",
@@ -4073,7 +4073,7 @@
   },
   "The Set relative volume block changes the volume of the contained notes.": {
     "kanji": "Set relative volumeブロックは含まれる音符の音量を変更します。",
-    "kana": "「あいたいおんりょうを せってい」ブロックはふくまれるおんぷのおんりょうをへんこうします。"
+    "kana": "The Set relative volume block changes the volume of the contained notes."
   },
   "set relative volume": {
     "kanji": "相対音量を設定",
@@ -4081,11 +4081,11 @@
   },
   "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played.": {
     "kanji": "「デクレッシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ減少させます。",
-    "kana": "「デクレッシェンド」ブロックは、さいせいされるおんぷごとに、ふくまれるおんぷのおんりょうをしていされたりょうだけげんしょうさせます。"
+    "kana": "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
   },
   "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume.": {
     "kanji": "たとえば、値が「5」の「デクレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 低くなります。",
-    "kana": "たとえば、あたいが「5」の「でクレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% ひくくなります。"
+    "kana": "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
   },
   "decrescendo": {
     "kanji": "デクレシェンド",
@@ -4093,11 +4093,11 @@
   },
   "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played.": {
     "kanji": "「クレシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ増加させます。",
-    "kana": "「クレッシェンド」ブロックは、さいせいされるおんぷごとに、ふくまれるおんぷのおんりょうをしていされたりょうだけぞうかさせます。"
+    "kana": "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
   },
   "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume.": {
     "kanji": "たとえば、値が「5」の「クレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 大きくなります。",
-    "kana": "たとえば、あたいが「5」の「クレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% おおきくなります。"
+    "kana": "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
   },
   "crescendo": {
     "kanji": "クレシェンド",
@@ -4121,7 +4121,7 @@
   },
   "The No background block eliminates the background from the saved SVG output.": {
     "kanji": "ノー・バックグラウンドブロックは保存されたSVG出力の背景を削除します。",
-    "kana": "「バックグラウンドなし」ブロックはほぞんされたSVGしゅつりょくのはいけいをさくじょします。"
+    "kana": "The No background block eliminates the background from the saved SVG output."
   },
   "show blocks": {
     "kanji": "ブロックを表示",
@@ -4149,7 +4149,7 @@
   },
   "The Comment block prints a comment at the top of the screen when the program is running in slow mode.": {
     "kanji": "「コメント」ブロックは、プログラムが低速モードで実行されているときに、画面の上部にコメントを出力します。",
-    "kana": "「コメント」ブロックは、プログラムがていそくモードでじっこうされているときに、がめんのじょうぶにメモをしゅつりょくします。"
+    "kana": "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
   },
   "comment": {
     "kanji": "コメント",
@@ -4161,7 +4161,7 @@
   },
   "The Print block displays text at the top of the screen.": {
     "kanji": "<h2>表示ブロック（結果）</h2><br>画面の上部に、指定した実行結果のすうちや文字を表示する。表示したテキストはクリックすると消すことができる。どこでプログラムがまちがっているかをかくにんする際（デバグ）などによく用いられる。",
-    "kana": "<h2>ひょうじ ブロック（けっか）</h2><br>がめんの じょうぶに、 してい した じっこうけっかの すうちや もじを ひょうじする。 ひょうじした テキストは クリックすると けすことが できる。 どこで プログラムが まちがっているかを かくにんするさい（デバグ）などに よく もちいられる。"
+    "kana": "The Print block displays text at the top of the screen."
   },
   "display grid": {
     "kanji": "グリッドを表示",
@@ -4177,43 +4177,43 @@
   },
   "The Debug block adds a debug point in your code. When reached, execution will pause and you can inspect variables.": {
     "kanji": "「デバッガ」ブロックは、コードにデバッグ ポイントを追加します。到達すると、実行が一時停止され、変数を検査できるようになります。",
-    "kana": "「デバッガー」ブロックは、コードにでばっぐ ぽいんとをついかします。とうたつすると、じっこうがいちじていしされ、へんすうをけんさできるようになります。"
+    "kana": "The Debug block adds a debug point in your code. When reached, execution will pause and you can inspect variables."
   },
   "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave.": {
     "kanji": "ピッチ番号をピッチとオクターブにマッピングするためのオフセットを設定するために使われるブロックです。",
-    "kana": "ピッチばんごうをピッチとオクターヴにまっぴんぐするためのおふせっとをせっていするためにつかわれるブロックです。"
+    "kana": "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
   },
   "The Right block returns the position of the right of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスの右のｘざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの みぎはし の ｘざひょうち。 プラスの すうち。カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Right block returns the position of the right of the canvas."
   },
   "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas.": {
     "kanji": "この例では、マウスはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。",
-    "kana": "このれいでは、ネズミはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
+    "kana": "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
   },
   "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas.": {
     "kanji": "この例では、タートルはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。",
-    "kana": "このれいでは、タートルはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
+    "kana": "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
   },
   "The Left block returns the position of the left of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスの左のｘざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上））、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの ひだりはし の ｘざひょうち。 マイナスの すうち。 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Left block returns the position of the left of the canvas."
   },
   "The Top block returns the position of the top of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスの上のｙざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、上（y座標）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの じょうたん の ｙざひょうち。 プラスの すうち。  カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Top block returns the position of the top of the canvas."
   },
   "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas.": {
     "kanji": "この例では、マウスはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。",
-    "kana": "このれいでは、ネズミはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
+    "kana": "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
   },
   "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas.": {
     "kanji": "この例では、タートルはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。",
-    "kana": "このれいでは、タートルはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
+    "kana": "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
   },
   "The Bottom block returns the position of the bottom of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスの下のｙざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの かたん の ｙざひょうち。 マイナスの すうち。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Bottom block returns the position of the bottom of the canvas."
   },
   "The Number to octave block will convert a pitch number to an octave.": {
     "kanji": "Number to octaveブロックはピッチ番号をオクターブに変換します。",
@@ -4221,11 +4221,11 @@
   },
   "The Width block returns the width of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Width block returns the width of the canvas."
   },
   "The Height block returns the height of the canvas.": {
     "kanji": "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。",
-    "kana": "<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+    "kana": "The Height block returns the height of the canvas."
   },
   "stop play": {
     "kanji": "再生を停止",
@@ -4321,7 +4321,7 @@
   },
   "The Show block is used to display text or images on the canvas.": {
     "kanji": "<h2>表示ブロック（スタンプ）</h2><br>スタンプは、実行するとネズミの位置に指定した文字またはがぞうを表示する。ネズミの体の下に表れるので、小さい文字やがぞうだとネズミが移動しないと見えない場合がある。",
-    "kana": "<h2>ひょうじブロック（スタンプ）</h2><br>スタンプは、 じっこうすると ネズミの いちに してい した もじ または がぞう を ひょうじする。 ネズミの からだの したに あらわれるので、 ちいさいもじ や がぞう だと ネズミがいどうしないと みえない ばあいがある。"
+    "kana": "The Show block is used to display text or images on the canvas."
   },
   "show1": {
     "kanji": "スタンプ",
@@ -4329,7 +4329,7 @@
   },
   "The Register block provides an easy way to modify the register (octave) of the notes that follow it.": {
     "kanji": "Registerブロックは後に続く音符のオクターブ（レジスター）を簡単に変更する方法を提供します。",
-    "kana": "「Register」ブロックはのちにつづくおんぷのオクターヴ（れじすたー）をかんたんにへんこうするほうほうをていきょうします。"
+    "kana": "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
   },
   "obj": {
     "kanji": "そざい",
@@ -4337,7 +4337,7 @@
   },
   "The Media block is used to import an image.": {
     "kanji": "<h2>がぞうブロック</h2><br>がぞうのブロック。ブロックのマークをおすと、コンピューター上からがぞうファイルを読み込むことができる。",
-    "kana": "<h2>がぞう ブロック</h2><br>がぞうのブロック。 ブロックの マークを おすと、 コンピューターじょうから がぞうファイルを よみこむことが できる。"
+    "kana": "The Media block is used to import an image."
   },
   "The Text block holds a text string.": {
     "kanji": "<h2>文字ブロック</h2><br>文字を指定するブロック。",
@@ -4381,7 +4381,7 @@
   },
   "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen.": {
     "kanji": "Distanceブロックは2点間の距離を返します。例えば、マウスと画面中央の距離です。",
-    "kana": "「きょり」ブロックは2てんかんのきょりをかえします。たとえば、ネズミとがめんちゅうおうのきょりです。"
+    "kana": "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
   },
   "distance": {
     "kanji": "距離",
@@ -4389,7 +4389,7 @@
   },
   "The Divide block is used to divide.": {
     "kanji": "<h2>すうちブロック（計算）</h2><br>２つのすうちの割り算した計算結果を表すすうちブロック。上につないだすうちを、下につないだすうちで割る。",
-    "kana": "<h2>すうちブロック（けいさん）</h2><br>２つの すうちの わりざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ すうちを、 したに つないだ すうちで わる。"
+    "kana": "The Divide block is used to divide."
   },
   "The Multiply block is used to multiply.": {
     "kanji": "<h2>すうちブロック（計算）</h2><br>２つのすうちを掛け合わせた計算結果を表すすうちブロック。",
@@ -4397,7 +4397,7 @@
   },
   "The Minus block is used to subtract.": {
     "kanji": "<h2>すうちブロック（計算）</h2><br>２つのすうちの引き算した計算結果を表すすうちブロック。上につないだすうちから、下につないだすうちを引く。",
-    "kana": "<h2>すうちブロック（けいさん）</h2><br>２つのすうちの ひきざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ すうちから、 したに つないだ すうちを ひく。"
+    "kana": "The Minus block is used to subtract."
   },
   "The Plus block is used to add.": {
     "kanji": "<h2>すうちブロック（計算）</h2><br>２つのすうちを足し合わせた計算結果を表すすうちブロック。",
@@ -4405,7 +4405,7 @@
   },
   "The One-of block returns one of two choices.": {
     "kanji": "<h2>特殊ブロック（ランダム）</h2><br>つないだ２つのブロックのうち、1つだけをランダムに選ぶ。「すうち」「アクション名」など、さまざまなブロックをつなぐことができる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。",
-    "kana": "<h2>「どちらか ランダム」ブロック</h2><br>つないだ ２つの ブロックのうち、 1つだけを ランダムに えらぶ。 「すうち」「アクションめい」など、 さまざまな ブロックを つなぐことが できる。<br><br>★ランダムとは<br>サイコロの め のように、 なにが でるか わからない すうちのこと。ランダム（random）は にほんごで 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが できる。"
+    "kana": "The One-of block returns one of two choices."
   },
   "one of": {
     "kanji": "どちらかランダム",
@@ -4421,7 +4421,7 @@
   },
   "The Random block returns a random number.": {
     "kanji": "<h2>すうちブロック（ランダム）</h2><br>指定したさいしょうちからさいだいちまでのはんいで、ランダムなすうちになる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。",
-    "kana": "<h2>「ランダム」ブロック</h2><br>してい した さいしょうち から さいだいち までの はんいで、 ランダムな すうちに なる。<br><br>★ランダムとは<br>サイコロの め のように、 なにが でるか わからない すうちのこと。ランダム（random）は にほんごで 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが できる。"
+    "kana": "The Random block returns a random number."
   },
   "random": {
     "kanji": "ランダム",
@@ -4509,7 +4509,7 @@
   },
   "The Set font block sets the font used by the Show block.": {
     "kanji": "フォント設定ブロックはショウブロックで使われるフォントを設定します。",
-    "kana": "「フォントの せってい\"」ブロックはしょうブロックでつかわれるフォントをせっていします。"
+    "kana": "「フォントの せってい」ブロックはしょうブロックでつかわれるフォントをせっていします。"
   },
   "The Background block sets the window background color.": {
     "kanji": "背景ブロックは、カンバスの色をせっていする。",
@@ -4525,7 +4525,7 @@
   },
   "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)": {
     "kanji": "1から始まり、音階の枠組みに関係なく（つまりオクターブが常に8音とは限らない）",
-    "kana": "1からはじまり、おんかいのわくぐみにかんけいなく（つまりオクターヴがつねに8おととはかぎらない）"
+    "kana": "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
   },
   "The Fill block fills in a shape with a color.": {
     "kanji": "<h2>ペンブロック</h2><br>ネズミがえがいた図形の内がわをぬりつぶす。",
@@ -4561,7 +4561,7 @@
   },
   "Scale Degree 1 is always the first pitch in a given scale, regardless of octave.": {
     "kanji": "スケールディグリー1は、オクターブに関係なく常に与えられたスケールの最初の音です。",
-    "kana": "すけーるでぃぐりー1は、オクターヴにかんけいなくつねにあたえられたすけーるのさいしょのおとです。"
+    "kana": "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
   },
   "set translucency": {
     "kanji": "透明度を設定",
@@ -4569,7 +4569,7 @@
   },
   "The Set translucency block changes the opacity of the pen.": {
     "kanji": "<h2>ペンブロック</h2><br>ネズミがえがく線がどのくらいすきとおるかをせっていする。すうちが大きいほど、線がすきとおる。",
-    "kana": "<h2>ペンブロック</h2><br>ネズミが えがく せんが どのくらい すきとおるかを せっていする。 すうちが おおきい ほど、 せんが すきとおる。"
+    "kana": "The Set translucency block changes the opacity of the pen."
   },
   "set hue": {
     "kanji": "色相を設定",
@@ -4601,7 +4601,7 @@
   },
   "The Set-color block changes the pen color.": {
     "kanji": "<h2>ペンブロック</h2><br>ネズミがえがく線の色をせっていする。色は画面上で選ぶほか、それぞれすうちで決めることもできる。色は、0以上で、100より小さいあたいになる。",
-    "kana": "<h2>ペンブロック</h2><br>ネズミが えがく せんのいろを かえる。 いろは がめんじょうで えらぶ ほか、 それぞれ すうちで きめることも できる。 いろは、 0いじょうで、 100より ちいさい あたいになる。"
+    "kana": "The Set-color block changes the pen color."
   },
   "The Load-heap-from-app block loads the heap from a web page.": {
     "kanji": "Load-heap-from-appブロックはウェブページからヒープを読み込みます。",
@@ -4741,7 +4741,7 @@
   },
   "The Run block block runs a block. It accepts two types of arguments: block number or block name.": {
     "kanji": "「ブロックを再生」ブロックはブロックを実行します。ブロック番号またはブロック名の 2 種類の引数を受け入れます。",
-    "kana": "「ブロックをさいせい」ブロックはブロックをじっこうします。ブロックばんごうまたはブロックめいの 2 しゅるいのひきすうをうけいれます。"
+    "kana": "The Run block block runs a block. It accepts two types of arguments: block number or block name."
   },
   "run block": {
     "kanji": "ブロックを再生",
@@ -4801,11 +4801,11 @@
   },
   "Please enter a valid project URL (for example: /index.html?id=123&run=true).": {
     "kanji": "有効なプロジェクト URL (例: /index.html?id=123&run=true) を入力してください。",
-    "kana": "ゆうこうなプロジェクト URL (れい: /index.html?id=123&run=true) をにゅうりょくしてください。"
+    "kana": "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
   },
   "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net).": {
     "kanji": "ミュージック・ブロックス プロジェクトのリンクのみが許可されます (同じサイト、musicblocks.sugarlabs.org、musicblocks.net)。",
-    "kana": "ミュージック・ブロックス プロジェクトの リンクのみが きょかされます (おなじサイト、musicblocks.sugarlabs.org、musicblocks.net)。"
+    "kana": "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
   },
   "Please allow popups for this site": {
     "kanji": "このサイトのポップアップを許可してください",
@@ -4881,7 +4881,7 @@
   },
   "The Meter block opens a tool to select strong beats for the meter.": {
     "kanji": "<h2>拍子ブロック</h2><br>テーブルの数字をクリックして、強い拍（はく）の位置を決める。<br>★拍子（ひょうし）とは<br>拍（はく）がいくつかまとまったもの。<br>★拍（はく）とは<br>くり返されるリズムのこと。",
-    "kana": "<h2>ひょうしブロック</h2><br>テーブルの すうじを クリックして、 つよい はくの いちを きめる。<br>★ひょうし とは<br>はくが いくつか まとまった もの。<br>★はく とは<br>くりかえされる リズムの こと。"
+    "kana": "The Meter block opens a tool to select strong beats for the meter."
   },
   "The oscilloscope block opens a tool to visualize waveforms.": {
     "kanji": "Oscilloscopeブロックは波形を可視化するツールを開きます。",
@@ -4893,7 +4893,7 @@
   },
   "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale).": {
     "kanji": "<h2>モード（音階）ブロック</h2><br>いろいろな音階をさがすツールを表示する。音階は、音と音のかんかくを決めながらさがすことができる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。",
-    "kana": "<h2>モード（おんかい）ブロック</h2><br>いろいろな ちょうを さがす ツールを ひょうじする。おんかいは、 おとと おとの かんかくを きめながら さがすことが できる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+    "kana": "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
   },
   "custom mode": {
     "kanji": "音階",
@@ -4901,7 +4901,7 @@
   },
   "The Tempo block opens a metronome to visualize the beat.": {
     "kanji": "<h2>メトロノームブロック</h2><br>メトロノームを表示する。ボタンをおすと、メトロノームのはやさを変えられる。テーブルには、１分あたりの拍（はく）の数が表示される。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。",
-    "kana": "<h2>メトロノームブロック</h2><br>メトロノームを ひょうじする。 ボタンを おすと、 メトロノームの はやさを かえられる。 テーブルには、 １ぷんあたりの はくのかずが ひょうじされる。<br><br>★はくとは<br>くりかえされる リズムのこと。"
+    "kana": "The Tempo block opens a metronome to visualize the beat."
   },
   "The Arpeggio Widget is used to compose chord sequences.": {
     "kanji": "「アルペジオ」ウィジェットは コード進行 を作るためです。",
@@ -4921,11 +4921,11 @@
   },
   "You must have at least one pitch block and one drum block in the matrix.": {
     "kanji": "フレーズメーカーブロックには、音の高さブロックとドラムブロックを最低1つずつ入れてください。",
-    "kana": "フレーズメーカーブロックには、 おとの たかさブロックと ドラムブロックを さいてい 1つずつ いれて ください。"
+    "kana": "You must have at least one pitch block and one drum block in the matrix."
   },
   "The Pitch slider tool to is used to generate pitches at selected frequencies.": {
     "kanji": "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。また、ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは音の高さを表す周波数。<br>★周波数とは音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。",
-    "kana": "<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを きくことが できる。 つくった おとを データに することが できる。また、 ヘルツの しょきせっていち は じゆうに かえられる。<br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+    "kana": "The Pitch slider tool to is used to generate pitches at selected frequencies."
   },
   "pitch slider": {
     "kanji": "ヘルツスライダー",
@@ -4941,11 +4941,11 @@
   },
   "The Music keyboard block opens a piano keyboard that can be used to create notes.": {
     "kanji": "<h2>キーボードブロック</h2><br>ピアノのキーボードを表示する。作った音をデータ化することができる。<br><br> ",
-    "kana": "<h2>キーボードブロック</h2><br>ピアノの キーボードを ひょうじする。 つくったおとを データに することが できる。"
+    "kana": "The Music keyboard block opens a piano keyboard that can be used to create notes."
   },
   "The Pitch staircase tool to is used to generate pitches from a given ratio.": {
     "kanji": "Pitch staircaseツールは指定された比率からピッチを生成するために使用されます。",
-    "kana": "Pitch staircaseつーるはしていされたひりつからピッチをせいせいするためにしようされます。"
+    "kana": "The Pitch staircase tool to is used to generate pitches from a given ratio."
   },
   "pitch staircase": {
     "kanji": "音高の数列を作る",
@@ -4953,7 +4953,7 @@
   },
   "The Rhythm Maker block opens a tool to create drum machines.": {
     "kanji": "<h2>リズムメーカーブロック</h2><br>音の長さでぶんかつしてリズムを作るテーブルを表示する。作ったリズムをデータ化することができる。<br><br>",
-    "kana": "<h2>リズムメーカー ブロック</h2><br>おとの ながさで ぶんかつして、 リズムを つくる テーブルを ひょうじする。 つくった リズムを データに することが できる。"
+    "kana": "The Rhythm Maker block opens a tool to create drum machines."
   },
   "G major scale": {
     "kanji": "Gメジャー",
@@ -4965,7 +4965,7 @@
   },
   "The Phrase Maker block opens a tool to create musical phrases.": {
     "kanji": "<h2>フレーズメーカーブロック</h2><br>フレーズを作るためのテーブルを表示する。作ったフレーズをデータ化することができる。<br><br>★フレーズとは<br>ひとまとまりの音楽。<br><br>",
-    "kana": "<h2>フレーズメーカーブロック</h2><br>フレーズを つくるための テーブルを  ひょうじする。 つくった フレーズを データに することが できる。<br><br>"
+    "kana": "The Phrase Maker block opens a tool to create musical phrases."
   },
   "phrase maker": {
     "kanji": "フレーズメーカー",
@@ -4977,11 +4977,11 @@
   },
   "You must have at least one pitch block and one rhythm block in the matrix.": {
     "kanji": "フレーズメーカーには、音の高さブロックと音符ブロックを組み合わせてください。",
-    "kana": "フレーズメーカーには、 おとのたかさ ブロックと おんぷブロックを くみあわせて ください。"
+    "kana": "You must have at least one pitch block and one rhythm block in the matrix."
   },
   "The Status block opens a tool for inspecting the status of Music Blocks as it is running.": {
     "kanji": "<h2>実行じょうきょうブロック</h2><br>ブロックの実行じょうきょうをけんさくするテーブルを表示する。<br>",
-    "kana": "<h2>じっこうじょうきょうブロック</h2><br>ブロックのじっこうじょうきょうをけんさくするテーブルをひょうじする。<br>"
+    "kana": "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
   },
   "AI Music": {
     "kanji": "AI音楽",
@@ -4989,7 +4989,7 @@
   },
   "The Reflection block opens a space for you to think about your learning.": {
     "kanji": "「振り返り」ブロックは、学習について考えるためのスペースを開きます。",
-    "kana": "「ふりかえり」ブロックは、がくしゅうについてかんがえるためのすぺーすをひらきます。"
+    "kana": "The Reflection block opens a space for you to think about your learning."
   },
   "reflection": {
     "kanji": "「振り返り」",
@@ -4997,7 +4997,7 @@
   },
   "The LEGO Bricks block opens a widget for designing virtual LEGO creations.": {
     "kanji": "「レゴブロック」ブロックは、仮想 LEGO 作品をデザインするためのウィジェットを開きます。",
-    "kana": "「LEGO ブロック」ブロックは、かそう LEGO さくひんをでざいんするためのツールをひらきます。"
+    "kana": "The LEGO Bricks block opens a widget for designing virtual LEGO creations."
   },
   "LEGO Bricks": {
     "kanji": "レゴブロック",
@@ -5009,7 +5009,7 @@
   },
   "Debug your music blocks project with new possibilities and more understanding.": {
     "kanji": "新たな可能性と理解を深めて、ミュージック・ブロックス プロジェクトをデバッグします。",
-    "kana": "あらたなかのうせいとりかいをふかめて、ミュージック・ブロックス プロジェクトをでばっぐします。"
+    "kana": "Debug your music blocks project with new possibilities and more understanding."
   },
   "set temperament": {
     "kanji": "音律をせってい",
@@ -5017,11 +5017,11 @@
   },
   "The Set temperament block is used to choose the tuning system used by Music Blocks.": {
     "kanji": "「音律をせってい」ブロックは、ミュージック・ブロックスで使用されるチューニング システムを選択するために使用されます。",
-    "kana": "「おんりつをせってい」ブロックは、ミュージック・ブロックスでしようされるカスタム しすてむをせんたくするためにしようされます。"
+    "kana": "The Set temperament block is used to choose the tuning system used by Music Blocks."
   },
   "The Temperament name block is used to select a tuning method.": {
     "kanji": "<h2>音律（おんりつ）ブロック</h2><br>調律（ちょうりつ）のしかたをせっていする。<br>★音律（おんりつ）とは<br>音程（おんてい）（音どうしのへだたり）の決め方。同じ音階でも、音律（おんりつ）によって音の高さが変わる。<br>★調律（ちょうりつ）とは<br>楽器の音の高さを、音律（おんりつ）にしたがって整えること。",
-    "kana": "<hr>おんりつブロック</hr><br>ちょうりつの しかたを せっていする。<br>★おんりつとは<br>おんてい （おとどうしの へだたり） の きめかた。 おなじ おんかい でも、 おんりつに よって おとの たかさが かわる。<br>★ちょうりつとは<br>がっきの おとのたかさを、 おんりつに したがって ととのえること。"
+    "kana": "The Temperament name block is used to select a tuning method."
   },
   "doubly": {
     "kanji": "重",
@@ -5037,7 +5037,7 @@
   },
   "The Interval number block returns the number of scalar steps in the current interval.": {
     "kanji": "「音程を数で表示」ブロックは、現在の音階の数値を返します。",
-    "kana": "「おんていを かずで ひょうじ」ブロックは、げんざいのおんかいのすうちをかえします。"
+    "kana": "The Interval number block returns the number of scalar steps in the current interval."
   },
   "current interval": {
     "kanji": "現在の音階",
@@ -5045,11 +5045,11 @@
   },
   "The Current interval block returns the name of scalar steps in the current interval.": {
     "kanji": "「現在の音階」ブロックは、現在の音階の名前を返します。",
-    "kana": "「げんざいの おんかい」ブロックは、げんざいのおんかいのなまえをかえします。"
+    "kana": "The Current interval block returns the name of scalar steps in the current interval."
   },
   "The Semi-tone interval block measures the distance between two notes in semi-tones.": {
     "kanji": "「半音階的音程」ブロックは、2つの音符間の距離を半音単位で測定します。",
-    "kana": "「はんおんかいてきな おんてい」ブロックは、2つのおんぷまのきょりをはんおんたんいでそくていします。"
+    "kana": "The Semi-tone interval block measures the distance between two notes in semi-tones."
   },
   "semi-tone interval measure": {
     "kanji": "半音階的音程で計る",
@@ -5061,7 +5061,7 @@
   },
   "The Scalar interval block measures the distance between two notes in the current key and mode.": {
     "kanji": "「音階的な音程」ブロックは現在の調とモードで2つの音の距離を測定します。",
-    "kana": "「おんかいてきな おんてい」ブロックはげんざいのちょうとモードで2つのおとのきょりをそくていします。"
+    "kana": "The Scalar interval block measures the distance between two notes in the current key and mode."
   },
   "scalar interval measure": {
     "kanji": "全音階的音程で計る",
@@ -5069,7 +5069,7 @@
   },
   "The Semi-tone interval block calculates a relative interval based on half steps.": {
     "kanji": "「半音階的音程」ブロックは、半音に基づいて相対間隔を計算します。",
-    "kana": "「はんおんかいてきおんてい」ブロックは、はんおんにもとづいてそうたいかんかくをけいさんします。"
+    "kana": "The Semi-tone interval block calculates a relative interval based on half steps."
   },
   "In the figure, we add sol# to sol.": {
     "kanji": "例の画像には<em>ソ</em>が<em>ソ#</em>になります。",
@@ -5077,7 +5077,7 @@
   },
   "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord.": {
     "kanji": "「アルペジオ」ブロックは各「音符」ブロックを複数回実行し、指定されたコードに基づいて移調を追加します。",
-    "kana": "「アルペジオ」ブロックはかく「おんぷ」ブロックをふくすうかいじっこうし、していされたコードにもとづいていちょうをついかします。"
+    "kana": "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
   },
   "The output of the example is: do, mi, sol, sol, ti, mi": {
     "kanji": "例の解決は「ド、ミ、ソ、ソ、シ、ミ」",
@@ -5105,15 +5105,15 @@
   },
   "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode.": {
     "kanji": "「音階的な音程」ブロックは、現在のモードに基づいて相対的な音程を計算し、モード外のピッチをすべてスキップします。",
-    "kana": "「おんかいてきなおんてい」ブロックは、げんざいのモードにもとづいてそうたいてきなおんていをけいさんし、モードそとのピッチをすべてスキップします。"
+    "kana": "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
   },
   "In the figure, we add la to sol.": {
     "kanji": "<br><br>上の図では、ソの「音符（おんぷ）ブロック」をきじゅんにして、「音階の上下ブロック」のすうちを２にせっていしているので、ソと、ソから２音あがったシの音が同時にえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。",
-    "kana": "<br><br>うえのず では、 ソの 「おんぷブロック」 を きじゅんに して、 「おんかいの じょうげブロック」の すうちを ２に せっていしている ので、 ソと、 ソから ２おん あがった シの おとが どうじに えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+    "kana": "In the figure, we add la to sol."
   },
   "The Define mode block allows you to define a custom mode by specifying pitch numbers.": {
     "kanji": "「モードを定義する」ブロックを使用すると、ピッチ番号を指定してカスタム モードを定義できます。",
-    "kana": "「モードをていぎする」ブロックをしようすると、ピッチばんごうをしていしてカスタム モードをていぎできます。"
+    "kana": "The Define mode block allows you to define a custom mode by specifying pitch numbers."
   },
   "define mode": {
     "kanji": "モードを定義する",
@@ -5125,7 +5125,7 @@
   },
   "When Movable do is false, the solfege note names are always tied to specific pitches, eg \\\"do\\\" is always \\\"C-natural\\\" when Movable do is true, the solfege note names are assigned to scale degrees \\\"do\\\" is always the first degree of the major scale.": {
     "kanji": "「移動ド」が「偽」の場合、ソルフェージュ音名は常に特定のピッチに関連付けられます。たとえば、「移動ド」が「真」の場合、「ド」は常に「ド・メジャー」となり、ソルフェージュ音名はスケール度に割り当てられます。「ド」は常に長音階の 1 度です。",
-    "kana": "「いどうど」が「にせ」のばあい、そるふぇーじゅおんめいはつねにとくていのピッチにかんれんづけられます。たとえば、「いどうど」が「まこと」のばあい、「ど」はつねに「ど・めじゃー」となり、そるふぇーじゅおんめいはすけーるどにわりあてられます。「ど」はつねにちょうおんかいの 1 どです。"
+    "kana": "When Movable do is false, the solfege note names are always tied to specific pitches, eg \\\"do\\\" is always \\\"C-natural\\\" when Movable do is true, the solfege note names are assigned to scale degrees \\\"do\\\" is always the first degree of the major scale."
   },
   "mode length": {
     "kanji": "音階の音数",
@@ -5137,7 +5137,7 @@
   },
   "Most Western scales have 7 notes.": {
     "kanji": "西洋のほとんどの音階は、7つの音をもつ。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。",
-    "kana": "<br>せいようの ほとんどの おんかいは、 7つの おとを もつ。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。<br><br>たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+    "kana": "Most Western scales have 7 notes."
   },
   "current mode": {
     "kanji": "現代の音階",
@@ -5153,7 +5153,7 @@
   },
   "The Set key block is used to set the key and mode,": {
     "kanji": "<h2>調をせっていブロック</h2><br>調の部分に音の高さ、音階の部分に音階の種類を選び、調をせっていする。<br><br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。<br>★音階とは<br>順番に並んだ音のまとまり。",
-    "kana": "<h2>ちょうをせっていブロック</h2><br>ちょうの ぶぶんに おとのたかさ、おんかいの ぶぶんに おんかいのしゅるいを えらび、ちょうを せっていする。<br><br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。<br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。"
+    "kana": "The Set key block is used to set the key and mode,"
   },
   "The Set key block is used to set the key and mode, eg C Major": {
     "kanji": "「調をせってい」ブロックは、調と音階(どメジャーなど) を設定するために使用されます。",
@@ -5165,7 +5165,7 @@
   },
   "The Temperament length block returns the number of pitches in the current temperament system. For example, 12 for standard equal temperament or 31 for a 31-tone temperament.": {
     "kanji": "「音律の長さ」ブロックは、現在の音律システムにおけるピッチの数を返します。たとえば、標準平均律の場合は「12」、31音律の場合は「31」です。",
-    "kana": "「おんりつのながさ」ブロックは、げんざいのおんりつしすてむにおけるピッチのかずをかえします。たとえば、ひょうじゅんへいきんりつのばあいは「12」、31おんりつのばあいは「31」です。"
+    "kana": "The Temperament length block returns the number of pitches in the current temperament system. For example, 12 for standard equal temperament or 31 for a 31-tone temperament."
   },
   "transposition": {
     "kanji": "移調",
@@ -5177,7 +5177,7 @@
   },
   "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode.": {
     "kanji": "Scalar step downブロックは現在の調とモードにおける前の音までの半音数を返します。",
-    "kana": "「おんかいうちで~どさがる」ブロックはげんざいのちょうとモードにおけるまえのおとまでのはんおんかずをかえします。"
+    "kana": "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
   },
   "scalar step up": {
     "kanji": "音階内で~度上がる:",
@@ -5185,7 +5185,7 @@
   },
   "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode.": {
     "kanji": "Scalar step upブロックは現在の調とモードにおける次の音までの半音数を返します。",
-    "kana": "「おんかいうちで~どあがる」ブロックはげんざいのちょうとモードにおけるつぎのおとまでのはんおんかずをかえします。"
+    "kana": "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
   },
   "change in pitch": {
     "kanji": "音程の違い",
@@ -5193,7 +5193,7 @@
   },
   "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played.": {
     "kanji": "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半音の値で）の違いです。",
-    "kana": "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半おとの値で）の違いです。"
+    "kana": "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
   },
   "scalar change in pitch": {
     "kanji": "音階のよって音程の違い",
@@ -5205,7 +5205,7 @@
   },
   "The Pitch number block is the value of the pitch of the note currently being played.": {
     "kanji": "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数で表示する。<br>",
-    "kana": "<h2>おとのたかさを かずでひょうじ ブロック</h2><br>おとの たかさを かずで ひょうじする。 たとえば、 「ド_４」 ならば １、 「ソ_４」 ならば ７ 、「シ_３」ならば-１、と ひょうじされる。"
+    "kana": "The Pitch number block is the value of the pitch of the note currently being played."
   },
   "pitch in hertz": {
     "kanji": "音の高さをヘルツで表示",
@@ -5213,7 +5213,7 @@
   },
   "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played.": {
     "kanji": "<h2>音の高さをヘルツで表示ブロック</h2><br>音の高さをヘルツで表示する。<br>たとえば、オクターヴが４のラの音は、４４０ヘルツというすうちで表すことができる。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>",
-    "kana": "<h2>おとの たかさを ヘルツで ひょうじ ブロック</h2><br>おとの たかさを ヘルツで ひょうじ する。<br>たとえば、 オクターヴが４の ラのおとは、 ４４０ヘルツという すうちで あらわすことが できる。<br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+    "kana": "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
   },
   "current pitch": {
     "kanji": "現代の音の高さ",
@@ -5221,11 +5221,11 @@
   },
   "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz.": {
     "kanji": "Current PitchブロックはPitch Converterブロックと共に使用されます。上記の例では、現在のピッチsol 4が392ヘルツとして表示されます。",
-    "kana": "「げんだいの おとの たかさ」ブロックは「Pitch Converter」ブロックとともにしようされます。じょうきのれいでは、げんざいのピッチsol 4が392ヘルツとしてひょうじされます。"
+    "kana": "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
   },
   "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al.": {
     "kanji": "このブロックは最後に演奏された音のピッチ値をヘルツ、音名、ピッチ番号などの異なる形式に変換します。",
-    "kana": "このブロックはさいごにえんそうされたおとのピッチあたいをヘルツ、おんめい、ピッチばんごうなどのことなるけいしきにへんかんします。"
+    "kana": "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
   },
   "alphabet": {
     "kanji": "アルファベット",
@@ -5293,7 +5293,7 @@
   },
   "Y to pitch block will convert a staff y position to corresponding pitch notation.": {
     "kanji": "五線譜のy位置を対応する音高表記に変換するブロック",
-    "kana": "ごせんふのyいちをたいおうするおんこうひょうきにへんかんするブロック"
+    "kana": "Y to pitch block will convert a staff y position to corresponding pitch notation."
   },
   "accidental selector": {
     "kanji": "臨時記号セレクター",
@@ -5301,7 +5301,7 @@
   },
   "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat.": {
     "kanji": "<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）から選ぶことができます。",
-    "kana": "<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）からえらぶことができます。"
+    "kana": "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
   },
   "Pitch can be specified in terms of ni dha pa ma ga re sa.": {
     "kanji": "音の高さを、「sa、re、ga、ma、pa、dha、ni」の７つのインドのソルフェージュでせっていする。",
@@ -5309,7 +5309,7 @@
   },
   "Pitch can be specified in terms of C D E F G A B.": {
     "kanji": "<h2>音の高さブロック</h2><br>音の高さを、CDEFGABの７つのアルファベットでせっていする。たとえば、ドならばＣ、レならばＤであらわされる。",
-    "kana": "<h2>おとのたかさブロック</h2><br>おとのたかさを、 CDEFGABの ７つの アルファベットで せっていする。 たとえば、 ドならばＣ、 レならばＤ で あらわされる。"
+    "kana": "Pitch can be specified in terms of C D E F G A B."
   },
   "solfege": {
     "kanji": "ソルファ",
@@ -5317,7 +5317,7 @@
   },
   "Pitch can be specified in terms of do re mi fa sol la ti.": {
     "kanji": "<h2>音の高さブロック</h2><br>音の高さを、ド、レ、ミ、ファ、ソ、ラ、シの７つのソルフェージュでせっていする。",
-    "kana": "<h2>おとのたかさブロック</h2><br>おとのたかさを、 ド、レ、ミ、ファ、ソ、ラ、シの ７つの ソルフェージュで せっていする。 たとえば、 ドならばＣ、 レならばＤ で あらわされる。"
+    "kana": "Pitch can be specified in terms of do re mi fa sol la ti."
   },
   "The Invert block rotates any contained notes around a target note.": {
     "kanji": "Invertブロックは含まれる音符を対象の音符の周りで反転させます。",
@@ -5345,10 +5345,10 @@
   },
   "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps.": {
     "kanji": "<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。",
-    "kana": "<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。"
+    "kana": "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
   },
-  "In the example shown above, sol is shifted up to sol#.": {
-    "kanji": "In the example shown above, sol is shifted up to sol#.",
+  "In the example shown above, sol is shifted up to sol#. ": {
+    "kanji": "上記の例では、ソ（sol）がソ・シャープ（sol#）に半音上げられています。",
     "kana": "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
   },
   "semi-tone transpose": {
@@ -5357,7 +5357,7 @@
   },
   "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio": {
     "kanji": "「比で移動」ブロックは 音符の中のピッチを比で移動させる。",
-    "kana": "「ひで いどう」ブロックは おんぷの なかの ピッチを ひで いどうさせる。"
+    "kana": "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
   },
   "transpose by ratio": {
     "kanji": "比で移動",
@@ -5397,11 +5397,11 @@
   },
   "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale.": {
     "kanji": "<h2>調を変えるブロック</h2><br>「音符ブロック」内の音の高さを、すべて（音階内で、せっていしたすうち分だけ）上げる、または下げる。",
-    "kana": "<h2>ちょうを かえるブロック</h2><br>「おんぷブロック」 ないの おとのたかさを、 すべて （おんかいないで、 せっていした すうちぶんだけ） あげる、 または さげる。"
+    "kana": "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
   },
   "In the example shown above, sol is shifted up to la.": {
     "kanji": "<br><br>図の例では、ソがラに、ラがシに、シがドに…と置きかえられている。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。",
-    "kana": "<br><br>ずのれいでは、 ソがラに、 ラがシに、 シがドに… と おきかえられている。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。"
+    "kana": "In the example shown above, sol is shifted up to la."
   },
   "scalar transpose": {
     "kanji": "調を変える",
@@ -5417,11 +5417,11 @@
   },
   "The Hertz block (in combination with a Number block) will play a sound at the specified frequency.": {
     "kanji": "<h2>ヘルツブロック</h2><br>音の高さをヘルツ（周波数の単位）でせっていする。「すうちブロック」を組み合わせて使う。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>",
-    "kana": "<h2>ヘルツ ブロック</h2><br>おとのたかさを ヘルツ （しゅうはすうの たんい） で せっていする。 「すうちブロック」 を くみあわせて つかう。<br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+    "kana": "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
   },
   "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G.": {
     "kanji": "Pitch Numberブロックは番号に対応した音高を再生します。例：0はC、7はG。",
-    "kana": "「Pitch Number」ブロックはばんごうにたいおうしたおんこうをさいせいします。れい：0はC、7はG。"
+    "kana": "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
   },
   "nth modal pitch": {
     "kanji": "ピッチ度",
@@ -5429,19 +5429,19 @@
   },
   "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,": {
     "kanji": "nth Modal Pitchはモードの半音単位の音高パターンを取り、各点をモードの度数にします。",
-    "kana": "「ピッチど」はモードのはんおんたんいのおんこうぱたーんをとり、かくてんをモードのどすうにします。"
+    "kana": "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
   },
   "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc.": {
     "kanji": "Nth Modal Pitchは番号を入力として受け取り、指定されたモードのnth度数を表します。0は最初の位置、1は2番目、-1は最初の前の音など。",
-    "kana": "「ピッチど」はばんごうをにゅうりょくとしてうけとり、していされたモードの「なん」どすうをあらわします。0はさいしょのいち、1は2ばんめ、-1はさいしょのまえのおとなど。"
+    "kana": "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
   },
   "The pitches change according to the mode specified without any need for respellings.": {
     "kanji": "音高は指定されたモードに従って変化し、書き換えは不要です。",
-    "kana": "おんこうはしていされたモードにしたがってへんかし、かきかえはふようです。"
+    "kana": "The pitches change according to the mode specified without any need for respellings."
   },
   "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals.": {
     "kanji": "スケールディグリーは音楽で一般的な表記法です。スケール内の7つの位置（1-7）を示し、臨時記号で変更可能です。",
-    "kana": "すけーるでぃぐりーはおんがくでいっぱんてきなひょうきほうです。すけーるないの7つのいち（1-7）をしめし、りんじきごうでへんこうかのうです。"
+    "kana": "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
   },
   "scalar step": {
     "kanji": "音階内を上る／下りる",
@@ -5449,15 +5449,15 @@
   },
   "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,": {
     "kanji": "<h2>音階内を上る／下りるブロック</h2><br>音階内を順番に（ある一定のかんかくで）上りながら、または下りながら音をえんそうする。すうちをせっていすることで、次の音は前の音といくつちがうかが決まる。<br>たとえば、すうちを１にせっていした場合、ソの次にはラ（ソの１音上）、ファの次にはソ（ファの１音上）がえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。",
-    "kana": "<h2>おんかいないをのぼる／おりるブロック</h2><br>おんかいない を じゅんばんに （ある いっていの かんかくで） のぼりながら、 または おりながら おとを えんそう する。 すうちを せっていする ことで、 つぎの おとは まえの おとと いくつちがうか が きまる。"
+    "kana": "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
   },
   "eg if the last note played was sol, Scalar Step 1 will play la.": {
     "kanji": "<br><br>たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>",
-    "kana": "<br><br>たとえば、 すうちを １に せっていした ばあい、 ソの つぎには ラ（ソの １おんうえ）、 ファの つぎには ソ（ファの １おんうえ） が えんそう される。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+    "kana": "eg if the last note played was sol, Scalar Step 1 will play la."
   },
   "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note.": {
     "kanji": "<h2>音の高さブロック</h2><br>音の高さをせっていする。名前とオクターヴの高さを決めて使う。音の周波数も同時に決まる。<br><br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br>★オクターヴの高さとは<br>同じ名前でも高さがちがう音を表すすうち。<br><br>",
-    "kana": "<h2>おとのたかさ ブロック</h2><br>おとのたかさを せってい する。 なまえと オクターヴの たかさを きめて つかう。 おとの しゅうはすうも どうじに  きまる。<br><br>★しゅうはすうとは<br>おとが １びょうかんに なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。<br>★オクターヴの たかさとは<br>おなじ なまえでも たかさがちがう おとを あらわす すうち。"
+    "kana": "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
   },
   "Oscillator": {
     "kanji": "オシレータ―",
@@ -5477,7 +5477,7 @@
   },
   "The Duo synth block is a duo-frequency modulator used to define a timbre.": {
     "kanji": "Duo synthブロックは音色を定義するための二重周波数モジュレータです。",
-    "kana": "「シーケンサーこみ シンセ」ブロックはねいろをていぎするためのにじゅうしゅうはすうモジュレータです。"
+    "kana": "The Duo synth block is a duo-frequency modulator used to define a timbre."
   },
   "vibrato rate": {
     "kanji": "ビブラートエフェクタのレート",
@@ -5509,7 +5509,7 @@
   },
   "The Partial block is used to specify a weight for a specific partial harmonic.": {
     "kanji": "Partialブロックは特定の部分倍音の重みを指定するために使われます。",
-    "kana": "「ばいおん」ブロックはとくていのぶぶんばいおんのおもみをしていするためにつかわれます。"
+    "kana": "The Partial block is used to specify a weight for a specific partial harmonic."
   },
   "Partial weight must be between 0 and 1.": {
     "kanji": "倍音のウェートは０と１の間である必要があります。",
@@ -5521,7 +5521,7 @@
   },
   "The Weighted partials block is used to specify the partials associated with a timbre.": {
     "kanji": "「ウェート倍音」ブロックは、ティンバーに関連付けられた部分音を指定するために使用されます。",
-    "kana": "「ウェートばいおん」ブロックは、ねいろーにかんれんづけられたぶぶんおんをしていするためにしようされます。"
+    "kana": "The Weighted partials block is used to specify the partials associated with a timbre."
   },
   "weighted partials": {
     "kanji": "ウェート倍音",
@@ -5553,11 +5553,11 @@
   },
   "The rate (first argument) controls how fast the sound pulses (cycles per second).": {
     "kanji": "レート (最初の引数) は、サウンドのパルス速度 (1 秒あたりのサイクル数) を制御します。",
-    "kana": "れーと (さいしょのひきすう) は、さうんどのぱるすそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
+    "kana": "The rate (first argument) controls how fast the sound pulses (cycles per second)."
   },
   "The depth (second argument) controls the strength of the pulsing effect (0-100%).": {
     "kanji": "深さ (2 番目の引数) は、パルス効果の強さを制御します (0 ～ 100%)。",
-    "kana": "ふかさ (2 ばんめのひきすう) は、ぱるすこうかのつよさをせいぎょします (0 ～ 100%)。"
+    "kana": "The depth (second argument) controls the strength of the pulsing effect (0-100%)."
   },
   "tremolo": {
     "kanji": "トレモロ",
@@ -5589,15 +5589,15 @@
   },
   "The Chorus block adds a chorus effect.": {
     "kanji": "<h2>コーラスブロック</h2><br>広がりのある音のひびきにする。はやさとずれで、ひびきが残る感じを調節できる。<br>",
-    "kana": "<h2>コーラス ブロック</h2><br>ひろがりの ある おとの ひびきに する。 はやさ と ずれ で、 ひびきが のこる かんじを ちょうせつ できる。"
+    "kana": "The Chorus block adds a chorus effect."
   },
   "The rate (first argument) controls the speed of the chorus modulation (cycles per second).": {
     "kanji": "レート (最初の引数) は、コーラス変調の速度 (1 秒あたりのサイクル数) を制御します。",
-    "kana": "れーと (さいしょのひきすう) は、こーらすへんちょうのそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
+    "kana": "The rate (first argument) controls the speed of the chorus modulation (cycles per second)."
   },
   "The depth (third argument) controls the amount of chorus effect (0-100%).": {
     "kanji": "深さ (3 番目の引数) は、コーラス・エフェクターの量 (0 ～ 100%) を制御します。",
-    "kana": "ふかさ (3 ばんめのひきすう) は、こーらす・えふぇくたーのりょう (0 ～ 100%) をせいぎょします。"
+    "kana": "The depth (third argument) controls the amount of chorus effect (0-100%)."
   },
   "chorus": {
     "kanji": "コーラス",
@@ -5613,11 +5613,11 @@
   },
   "The intensity (first argument) controls how much the pitch varies (semitones).": {
     "kanji": "大きさ (最初の引数) は、ピッチの変化量 (半音) を制御します。",
-    "kana": "おおきさ (さいしょのひきすう) は、ピッチのへんかりょう (はんおん) をせいぎょします。"
+    "kana": "The intensity (first argument) controls how much the pitch varies (semitones)."
   },
   "The rate (second argument) controls the speed of the pitch variation (cycles per second).": {
     "kanji": "レート (2 番目の引数) は、ピッチ変化の速度 (1 秒あたりのサイクル数) を制御します。",
-    "kana": "れーと (2 ばんめのひきすう) は、ピッチへんかのそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
+    "kana": "The rate (second argument) controls the speed of the pitch variation (cycles per second)."
   },
   "vibrato": {
     "kanji": "ビブラート",
@@ -5641,7 +5641,7 @@
   },
   "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice.": {
     "kanji": "音色標準を設定すると、デフォルトの音色が電子シンセから選択した音色に変更されます。",
-    "kana": "ねいろひょうじゅんをせっていすると、デフォルトのねいろがでんししんせからせんたくしたねいろにへんこうされます。"
+    "kana": "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
   },
   "set instrument": {
     "kanji": "音色をせってい",
@@ -5649,7 +5649,7 @@
   },
   "The Set instrument block selects a voice for the synthesizer, eg guitar piano violin or cello.": {
     "kanji": "「音色をせってい」ブロックは、シンセサイザーの音声 (ギター、ピアノ、バイオリン、チェロなど) を選択します。",
-    "kana": "「ねいろをせってい」ブロックは、シンセサイザーのおんせい (ギター、ピアノ、バイオリン、チェロなど) をせんたくします。"
+    "kana": "The Set instrument block selects a voice for the synthesizer, eg guitar piano violin or cello."
   },
   "The Set instrument block selects a voice for the synthesizer,": {
     "kanji": "<h2>音色をせっていブロック</h2><br>中に入っている「音符（おんぷ）ブロック」の音色を設定する。音色は、ギターやピアノなどの中から選ぶことができる。<br><br> ",
@@ -5665,11 +5665,11 @@
   },
   "The Note value block is the value of the duration of the note currently being played.": {
     "kanji": "「音の長さ」ブロックは、現在演奏されている音符の長さの値です。",
-    "kana": "「おとの ながさ」ブロックは、げんざい えんそうされている おんぷの ながさの あたいです。"
+    "kana": "The Note value block is the value of the duration of the note currently being played."
   },
   "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration.": {
     "kanji": "「Milliseconds」ブロックは、音符の長さを指定するために時間 (MS 単位) を使用することを除いて、「音符」ブロックに似ています。",
-    "kana": "「Milliseconds」ブロックは、おんぷのながさをしていするためにじかん (MS たんい) をしようすることをのぞいて、「おんぷ」ブロックににています。"
+    "kana": "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
   },
   "Note value must be greater than 0.": {
     "kanji": "音の長さは、0より大きいあたいをせっていしてください。",
@@ -5681,7 +5681,7 @@
   },
   "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note.": {
     "kanji": "「スイング」ブロックは、音符のペア (音符の値で指定) に作用し、最初の音符に一定の長さ (スイング値で指定) を追加し、2 番目の音符から同じ量を取得します。",
-    "kana": "「スイング」ブロックは、おんぷのぺあ (おんぷのあたいでしてい) にさようし、さいしょのおんぷにいっていのながさ (スイングあたいでしてい) をついかし、2 ばんめのおんぷからおなじりょうをしゅとくします。"
+    "kana": "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
   },
   "swing value": {
     "kanji": "スイングの数値",
@@ -5697,7 +5697,7 @@
   },
   "The Multiply note value block changes the duration of notes by changing their note values.": {
     "kanji": "[音価を～倍にするファクター] ブロックは、音価を変更することで音符の長さを変更します。",
-    "kana": "[おんかを ～ばいにする ファクター] ブロックは、おんかをへんこうすることでおんぷのながさをへんこうします。"
+    "kana": "The Multiply note value block changes the duration of notes by changing their note values."
   },
   "multiply note value": {
     "kanji": "音価を～倍にするファクター",
@@ -5705,7 +5705,7 @@
   },
   "The Tie block works on pairs of notes, combining them into one note.": {
     "kanji": "<h2>タイブロック</h2><br>２つの音をつなげて１つの音にする。「音の高さブロック」を入れて使う。同じ高さの音だけ、つなぐことができる。",
-    "kana": "<h2>タイブロック</h2><br>２つの おとを つなげて １つの おとに する。 「おとのたかさブロック」 を いれて つかう。 おなじ たかさの おとだけ、 つなぐことが できる。"
+    "kana": "The Tie block works on pairs of notes, combining them into one note."
   },
   "tie": {
     "kanji": "タイ",
@@ -5729,7 +5729,7 @@
   },
   "A rest of the specified note value duration can be constructed using a Silence block.": {
     "kanji": "指定した音符の長さの休符は、「休符」ブロックを使用して構築できます。",
-    "kana": "していしたおんぷのながさのきゅうふは、「きゅうふ」ブロックをしようしてこうちくできます。"
+    "kana": "A rest of the specified note value duration can be constructed using a Silence block."
   },
   "note value drum": {
     "kanji": "音符（ドラム）",
@@ -5741,7 +5741,7 @@
   },
   "The Note block is a container for one or more Pitch blocks.": {
     "kanji": "<h2>音符（おんぷ）ブロック</h2><br>音の長さと高さをせっていする。長さを決め、「音の高さブロック」を入れて使う。",
-    "kana": "<h2>おんぷブロック</h2><br>おとの ながさと たかさを せってい する。ながさを きめ、「おとのたかさブロック」 を いれて つかう。"
+    "kana": "The Note block is a container for one or more Pitch blocks."
   },
   "The Note block specifies the duration (note value) of its contents.": {
     "kanji": "<br><br>「音の高さブロック」を２つ以上入れると、音を同時に出すことができる。",
@@ -5765,7 +5765,7 @@
   },
   "The Heading block returns the orientation of the mouse.": {
     "kanji": "<h2>すうちブロック</h2><br>ネズミの向いている角度を表すすうちブロック。向きの値は、０以上で、３６０より小さい値になり、プラスだと右回り、マイナスだと左回りに変化する。",
-    "kana": "<h2>すうち ブロック</h2><br>ネズミの むいている かくどを あらわす すうちブロック。 むきの あたいは、 ０いじょうで、 ３６０より ちいさい あたい になり、 プラスだと みぎまわり、 マイナスだと ひだりまわりに へんかする。"
+    "kana": "The Heading block returns the orientation of the mouse."
   },
   "The Heading block returns the orientation of the turtle.": {
     "kanji": "ヘディングブロックはタートルの向きを返します。",
@@ -5773,7 +5773,7 @@
   },
   "The Y block returns the vertical position of the mouse.": {
     "kanji": "<h2>すうちブロック</h2><br>ネズミのｙざひょう（たて方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。",
-    "kana": "<h2>すうち ブロック</h2><br>ネズミの ｙざひょう（たて ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの めもり（ｙざひょう）を つかって あらわす。"
+    "kana": "The Y block returns the vertical position of the mouse."
   },
   "The Y block returns the vertical position of the turtle.": {
     "kanji": "Yブロックはタートルの垂直位置を返します。",
@@ -5785,7 +5785,7 @@
   },
   "The X block returns the horizontal position of the mouse.": {
     "kanji": "<h2>すうちブロック</h2><br>ネズミのｘざひょう（よこ方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。",
-    "kana": "<h2>すうち ブロック</h2><br>ネズミの ｘざひょう（よこ ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの めもり（ｙざひょう）を つかって あらわす。"
+    "kana": "The X block returns the horizontal position of the mouse."
   },
   "The X block returns the horizontal position of the turtle.": {
     "kanji": "Xブロックはタートルの水平方向の位置を返します。",
@@ -5801,7 +5801,7 @@
   },
   "The Scroll XY block moves the canvas.": {
     "kanji": "<h2>いどうブロック（カンバス）</h2><br>カンバスを上下左右にいどうさせる。カンバスだけがいどうするので結果的に、画面上のすべてのネズミが同時にいどうするように見える。カンバスを右（プラス）にいどうするとネズミは左へ、左（マイナス）にいどうするとネズミは右に動いて見える。同じく、カンバスを上（プラス）にいどうするとネズミは下へ、下（マイナス）にいどうするとネズミは上に動いて見える。",
-    "kana": "<h2>いどう ブロック（カンバス）</h2><br>カンバスを じょうげ さゆうに いどう させる。 カンバスだけが いどう するので けっかてきに、 がめんじょうの すべての ネズミが どうじに いどう するように みえる。 カンバスを みぎ（プラス）に いどう すると ネズミは ひだりへ、 ひだり（マイナス）に いどう すると ネズミは みぎに うごいて みえる。 おなじく、 カンバスを うえ（プラス）に いどう すると ネズミは したへ、 した（マイナス）に いどうすると ネズミは うえに うごいて みえる。"
+    "kana": "The Scroll XY block moves the canvas."
   },
   "x2": {
     "kanji": "よこいどう",
@@ -5813,7 +5813,7 @@
   },
   "The Control-point 2 block sets the second control point for the Bezier curve.": {
     "kanji": "コントロールポイント2ブロックはベジエ曲線の第2コントロールポイントを設定します。",
-    "kana": "「コントロールてん２」ブロックはベジェきょくせんのだい2こんとろーるぽいんとをせっていします。"
+    "kana": "The Control-point 2 block sets the second control point for the Bezier curve."
   },
   "control point 2": {
     "kanji": "コントロール点２",
@@ -5829,7 +5829,7 @@
   },
   "The Control-point 1 block sets the first control point for the Bezier curve.": {
     "kanji": "コントロールポイント1ブロックはベジエ曲線の第1コントロールポイントを設定します。",
-    "kana": "「コントロールてん1」ブロックはベジェきょくせんのだい1こんとろーるぽいんとをせっていします。"
+    "kana": "The Control-point 1 block sets the first control point for the Bezier curve."
   },
   "control point 1": {
     "kanji": "コントロール点１",
@@ -5844,8 +5844,8 @@
     "kana": "ベジェきょくせん"
   },
   "The Arc block moves the mouse in an arc.": {
-    "kanji": "The Arc block moves the mouse in an arc.",
-    "kana": "The Arc block moves the mouse in an arc."
+    "kanji": "アーブロックは、マウスを円弧状に動かします。",
+    "kana": "あーぶろっくは、まうすをえんこじょうにうごかします。"
   },
   "The Arc block moves the turtle in an arc.": {
     "kanji": "アークブロックはタートルを弧を描いて動かします。",
@@ -5881,11 +5881,11 @@
   },
   "The Set XY block moves the mouse to a specific position on the screen.": {
     "kanji": "<h2>いどうブロック</h2><br>ネズミの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。",
-    "kana": "<h2>「していざひょうに いどう」ブロック</h2><br>ネズミの いちを、 してい した ざひょう に いどう させる。<br><br>★ざひょうとは<br>もの の いち を あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ １くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめのように、 よこほうこうの めもり（xざひょう）と たてほうこうの めもり（ｙざひょう）を つかって あらわす。"
+    "kana": "The Set XY block moves the mouse to a specific position on the screen."
   },
   "The Set XY block moves the turtle to a specific position on the screen.": {
     "kanji": "<h2>いどうブロック</h2><br>タートルの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のタートルの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。",
-    "kana": "<h2>「していざひょうに いどう」ブロック</h2><br>タートルのいちを、していしたざひょうにいどうさせる。<br><br>★ざひょうとは<br>もののいちをあらわすためのすうちのこと。ミュージック・ブロックスでは、２つ１くみのすうち（ざひょう）をつかう。がめんじょうのタートルのいちは、ほうがんようしのますめのように、よこほうこうのめもり（xざひょう）とたてほうこうのめもり（ｙざひょう）をつかってあらわす。"
+    "kana": "The Set XY block moves the turtle to a specific position on the screen."
   },
   "set xy": {
     "kanji": "指定ざひょうにいどう",
@@ -5929,7 +5929,7 @@
   },
   "The Back block moves the mouse backward.": {
     "kanji": "<h2>いどうブロック</h2><br>指定したすうち分、ネズミを後ろにもどす。体の向きは変えない。",
-    "kana": "<h2>「うしろへ すすむ」ブロック</h2><br>してい した すうちぶん、 ネズミを うしろに もどす。 からだの むきは かえない。"
+    "kana": "The Back block moves the mouse backward."
   },
   "The Back block moves the turtle backward.": {
     "kanji": "<h2>いどうブロック</h2><br>指定したすうち分、タートルを後ろにもどす。体の向きは変えない。",
@@ -5953,7 +5953,7 @@
   },
   "The Wrap block enables or disables screen wrapping for the graphics actions within it.": {
     "kanji": "「巻きつける」ブロックは、その中のグラフィックス アクションの画面ラッピングを有効または無効にします。",
-    "kana": "「まきつける」ブロックは、そのなかのぐらふぃっくす のがめんらっぴんぐをゆうこうまたはむこうにします。"
+    "kana": "The Wrap block enables or disables screen wrapping for the graphics actions within it."
   },
   "font": {
     "kanji": "フォント",
@@ -6036,8 +6036,8 @@
     "kana": "と"
   },
   "steps": {
-    "kanji": "steps",
-    "kana": "steps"
+    "kanji": "手順",
+    "kana": "てじゅん"
   },
   "Adding missing pitch number 0.": {
     "kanji": "ピッチ数値「0」を加える",
@@ -6049,7 +6049,7 @@
   },
   "Scalar transpositions are equal to Semitone transpositions for custom temperament.": {
     "kanji": "音階的な移調は、カスタム音律の半音移調と同じです。",
-    "kana": "おんかいてきないちょうは、カスタムおんりつのはんおんいちょうとおなじです。"
+    "kana": "Scalar transpositions are equal to Semitone transpositions for custom temperament."
   },
   "Staccato value must be non-zero.": {
     "kanji": "スタッカート値はゼロ以外でなければなりません。",
@@ -6092,8 +6092,8 @@
     "kana": "マイナスの すうちを いれることは できません。"
   },
   "Neighbor note value is too large for the current note duration.": {
-    "kanji": "Neighbor note value is too large for the current note duration.",
-    "kana": "Neighbor note value is too large for the current note duration."
+    "kanji": "ネイバーノートの値が、現在の音符の長さに比べて大きすぎます。",
+    "kana": "ねいばーのーとのあたいが、げんざいのおんぷのながさにくらべておおきすぎます。"
   },
   "Reset Code": {
     "kanji": "コードをリセット",
@@ -6109,7 +6109,7 @@
   },
   "JavaScript block conversion is unavailable because its configuration file failed to load.": {
     "kanji": "JavaScript ブロック変換は、構成ファイルのロードに失敗したため使用できません。",
-    "kana": "JavaScript ブロックへんかんは、こうせいファイルのロードにしっぱいしたためしようできません。"
+    "kana": "JavaScript block conversion is unavailable because its configuration file failed to load."
   },
   "JavaScript block conversion is still loading. Please try again.": {
     "kanji": "JavaScript ブロック変換はまだ読み込み中です。もう一度試してください。",
@@ -6160,7 +6160,7 @@
     "kana": "さーばー エラー: AI ばっくえんどにせつぞくできません。"
   },
   "Could not reach the AI assistant. Please check your connection and try again.": {
-    "kanji": "Could not reach the AI assistant. Please check your connection and try again.",
+    "kanji": "AIアシスタントに接続できませんでした。接続状況を確認し、もう一度お試しください。",
     "kana": "Could not reach the AI assistant. Please check your connection and try again."
   },
   "Before we start": {
@@ -6169,7 +6169,7 @@
   },
   "The AI Debugger will send your current project data to an external server for analysis. Your project blocks and structure will be shared with:": {
     "kanji": "AI デバッガーは、分析のために現在のプロジェクト データを外部サーバーに送信します。プロジェクトのブロックと構造は以下と共有されます。",
-    "kana": "AI デバッガーは、ぶんせきのためにげんざいのプロジェクト データをがいぶさーばーにそうしんします。プロジェクトのブロックとこうぞうはいかときょうゆうされます。"
+    "kana": "The AI Debugger will send your current project data to an external server for analysis. Your project blocks and structure will be shared with:"
   },
   "Analyze my project": {
     "kanji": "私のプロジェクトを分析してください",
@@ -6177,7 +6177,7 @@
   },
   "AI analysis was not started. You can type a question below, but project data will not be sent until you agree.": {
     "kanji": "AI解析は開始されていません。以下に質問を入力できますが、同意するまでプロジェクト データは送信されません。",
-    "kana": "AIかいせきはかいしされていません。いかにしつもんをにゅうりょくできますが、どういするまでプロジェクト データはそうしんされません。"
+    "kana": "AI analysis was not started. You can type a question below, but project data will not be sent until you agree."
   },
   "Debugger error: Invalid project data format.": {
     "kanji": "デバッガー エラー: 無効なプロジェクト データ形式です。",
@@ -6189,7 +6189,7 @@
   },
   "AI Debugger is not available on this host. The backend URL could not be determined.": {
     "kanji": "AI デバッガーはこのホストでは使用できません。バックエンド URL を特定できませんでした。",
-    "kana": "AI デバッガーはこのほすとではしようできません。ばっくえんど URL をとくていできませんでした。"
+    "kana": "AI Debugger is not available on this host. The backend URL could not be determined."
   },
   "Server error: No initial response from AI backend.": {
     "kanji": "サーバー エラー: AI バックエンドからの初期応答がありません。",
@@ -6233,7 +6233,7 @@
   },
   "MIDI loading. This may take some time depending upon the number of notes in the track": {
     "kanji": "「MIDI]を読み込み中です。音符の数とトラックの数によって時間がかかるかもしれません。",
-    "kana": "「MIDI]を よみこみちゅうです。おんぷの かずと トラックの かずによって じかんが かかるかもしれません。"
+    "kana": "MIDI loading. This may take some time depending upon the number of notes in the track"
   },
   "Upload failed: Sample is not a .wav file.": {
     "kanji": "アップロードできませんでした： サンプルは .wavファイルでは ありません。",
@@ -6261,7 +6261,7 @@
   },
   "Please set your Groq API Key using the settings button (wrench icon) first.": {
     "kanji": "まず設定ボタン (レンチアイコン) を使用して Groq API キーを設定してください。",
-    "kana": "まずせっていボタン (レンチ・アイコン) をしようして Groq API キーをせっていしてください。"
+    "kana": "Please set your Groq API Key using the settings button (wrench icon) first."
   },
   "Export": {
     "kanji": "テーブルをほぞん",
@@ -6277,7 +6277,7 @@
   },
   "LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, Instrument)": {
     "kanji": "レゴブロック - %s ピッチ行を含むフレーズ・メーカー (周波数、音声順に並べ替え)",
-    "kana": "レゴ・ブロック - %s ピッチおこなをふくむふれーず・めーかー (しゅうはすう、おんせいじゅんにならべかえ)"
+    "kana": "LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, Instrument)"
   },
   "No color data to save. Please scan an image first.": {
     "kanji": "保存するカラー データがありません。まず画像をスキャンしてください。",
@@ -6308,8 +6308,8 @@
     "kana": "がぞうがせいじょうにプラグインされました"
   },
   "Photo captured": {
-    "kanji": "Photo captured",
-    "kana": "Photo captured"
+    "kanji": "写真を撮影しました",
+    "kana": "しゃしんをさつえいしました"
   },
   "Webcam started": {
     "kanji": "ウェブカメラが開始されました",
@@ -6321,7 +6321,7 @@
   },
   "Eye dropper active - hover over image to preview colors, click to select background color.": {
     "kanji": "スポイトがアクティブ - 画像の上にカーソルを置くと色がプレビューされ、クリックして背景色を選択できます。",
-    "kana": "すぽいとがアクティブ - がぞうのうえにカーソルをおくといろがプレビューされ、クリックしてはいけいしょくをせんたくできます。"
+    "kana": "Eye dropper active - hover over image to preview colors, click to select background color."
   },
   "Background color selected: %s": {
     "kanji": "選択された背景色: %s",
@@ -6525,7 +6525,7 @@
   },
   "Start by dragging a block from the left panel and connect it to the Start block.": {
     "kanji": "はじめに左側のパネルからブロックをドラッグして、それを「スタート」ブロックに接続します。",
-    "kana": "はじめにひだりがわのぱねるからブロックをドラッグして、それを「スタート」ブロックにせつぞくします。"
+    "kana": "Start by dragging a block from the left panel and connect it to the Start block."
   },
   "Next": {
     "kanji": "次",
@@ -6640,8 +6640,8 @@
     "kana": "はんぷく"
   },
   "Please enter a valid ratio (e.g. 3:2) within the octave space.": {
-    "kanji": "Please enter a valid ratio (e.g. 3:2) within the octave space.",
-    "kana": "Please enter a valid ratio (e.g. 3:2) within the octave space."
+    "kanji": "オクターブの範囲内で、有効な比率（例：3:2）を入力してください。",
+    "kana": "おくたーぶのはんいないで、ゆうこうなひりつ（れい：3:2）をにゅうりょくしてください。"
   },
   "Invalid temperament: %s. Skipping to next temperament.": {
     "kanji": "無効な音律: %s。次の音律にスキップします。",
@@ -6700,8 +6700,8 @@
     "kana": "ぷろんぷと"
   },
   "AI Sample Generation": {
-    "kanji": "AI Sample Generation",
-    "kana": "AI Sample Generation"
+    "kanji": "AIによるサンプル生成",
+    "kana": "AIによるさんぷるせいせい"
   },
   "Generating audio... (It may take up to 1 minute)": {
     "kanji": "新しい音声を生成しています... (最大 1 分かかる場合があります)",
@@ -6748,16 +6748,16 @@
     "kana": "まいくあくせすにしっぱいしました: %s"
   },
   "Start": {
-    "kanji": "Start",
-    "kana": "Start"
+    "kanji": "スタート",
+    "kana": "スタート"
   },
   "Detected Pitch:": {
-    "kanji": "Detected Pitch:",
-    "kana": "Detected Pitch:"
+    "kanji": "検出されたピッチ:",
+    "kana": "けんしゅつされたぴっち:"
   },
   "Note:": {
-    "kanji": "Note:",
-    "kana": "Note:"
+    "kanji": "音符:",
+    "kana": "おんぷ:"
   },
   "Synthesizer": {
     "kanji": "シンセサイザー",
@@ -6929,7 +6929,7 @@
   },
   "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct.": {
     "kanji": "このプロジェクトを通報して下さってありがとうございます。モデレータが間もなく、プロジェクトを見ます。",
-    "kana": "このプロジェクトを つうほうして くださって ありがとう ございます。モデレータが まもなく、プロジェクトを みます。"
+    "kana": "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
   },
   "Report Project": {
     "kanji": "プロジェクトを通報する",
@@ -6949,7 +6949,7 @@
   },
   "Feature unavailable - cannot connect to server. Reload Music Blocks to try again.": {
     "kanji": "エラー：サーバに接続できません。ミュージック・ブロックスをリロードし、再度試して下さい。",
-    "kana": "エラー：サーバに せつぞく できません。ブラウザを さいきどう して、さいど ためしてください。"
+    "kana": "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
   },
   "This field is required": {
     "kanji": "この項目は必須項目です",
@@ -7073,7 +7073,7 @@
   },
   "Report projects which violate the <a href=\\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">Sugar Labs Code of Conduct</a>.": {
     "kanji": "<a href=\\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">Sugar Labs 行動規範</a>に違反するプロジェクトを報告します。",
-    "kana": "<a href=\\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">Sugar Labs こうどうきはん</a>にいはんするプロジェクトをほうこくします。"
+    "kana": "Report projects which violate the <a href=\\\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">Sugar Labs Code of Conduct</a>."
   },
   "Reason for reporting project": {
     "kanji": "プロジェクトを通報する理由",

--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -1,6 +1,6 @@
+#
 msgid ""
 msgstr ""
-#
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-05-17 00:31-0400\n"
@@ -46,120 +46,52 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:495 js/SaveInterface.js:25 js/activity.js:5337
 #: js/activity.js:5341 js/activity.js:6060 planet/js/ProjectStorage.js:26
 #: planet/js/GlobalPlanet.js:465 planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/macros.js:170
-#: js/macros.js:266
-#: js/macros.js:267
-#: js/macros.js:276
-#: js/macros.js:828
-#: js/palette.js:1202
-#: js/palette.js:1211
-#: js/palette.js:1220
-#: js/palette.js:1229
-#: js/palette.js:1857
-#: js/palette.js:1868
-#: js/palette.js:1879
-#: js/palette.js:1890
-#: js/palette.js:1909
-#: js/turtledefs.js:131
-#: js/turtledefs.js:229
-#: js/rubrics.js:540
-#: js/block.js:1667
-#: js/block.js:4869
-#: js/blocks.js:1286
-#: js/blocks.js:2984
-#: js/blocks.js:2985
-#: js/blocks.js:3158
-#: js/blocks.js:3574
-#: js/blocks.js:3759
-#: js/blocks.js:4988
-#: js/blocks.js:6243
-#: js/blocks/MeterBlocks.js:750
-#: js/blocks/MeterBlocks.js:803
-#: js/blocks/MeterBlocks.js:866
-#: js/blocks/MeterBlocks.js:927
-#: js/blocks/ActionBlocks.js:251
-#: js/blocks/ActionBlocks.js:328
-#: js/blocks/ActionBlocks.js:639
-#: js/blocks/ActionBlocks.js:739
-#: js/blocks/ActionBlocks.js:984
-#: js/blocks/ActionBlocks.js:1071
-#: js/blocks/ActionBlocks.js:1351
-#: js/blocks/ActionBlocks.js:1354
-#: js/blocks/ActionBlocks.js:1366
-#: js/blocks/ActionBlocks.js:1432
-#: js/widgets/phrasemaker.js:4684
-#: js/widgets/rhythmruler.js:2514
-#: js/widgets/rhythmruler.js:2521
-#: js/widgets/rhythmruler.js:2706
-#: js/widgets/rhythmruler.js:2713
-#: js/widgets/musickeyboard.js:3344
-#: js/macros.js:170
-#: js/macros.js:266
-#: js/macros.js:267
-#: js/macros.js:276
-#: js/macros.js:828
-#: js/palette.js:1202
-#: js/palette.js:1211
-#: js/palette.js:1220
-#: js/palette.js:1229
-#: js/palette.js:1857
-#: js/palette.js:1868
-#: js/palette.js:1879
-#: js/palette.js:1890
-#: js/palette.js:1909
-#: js/turtledefs.js:131
-#: js/turtledefs.js:229
-#: js/rubrics.js:540
-#: js/block.js:1667
-#: js/block.js:4869
-#: js/blocks.js:1286
-#: js/blocks.js:2984
-#: js/blocks.js:2985
-#: js/blocks.js:3158
-#: js/blocks.js:3574
-#: js/blocks.js:3759
-#: js/blocks.js:4988
-#: js/blocks.js:6243
-#: js/blocks/MeterBlocks.js:750
-#: js/blocks/MeterBlocks.js:803
-#: js/blocks/MeterBlocks.js:866
-#: js/blocks/MeterBlocks.js:927
-#: js/blocks/ActionBlocks.js:251
-#: js/blocks/ActionBlocks.js:328
-#: js/blocks/ActionBlocks.js:639
-#: js/blocks/ActionBlocks.js:739
-#: js/blocks/ActionBlocks.js:984
-#: js/blocks/ActionBlocks.js:1071
-#: js/blocks/ActionBlocks.js:1351
-#: js/blocks/ActionBlocks.js:1354
-#: js/blocks/ActionBlocks.js:1366
-#: js/blocks/ActionBlocks.js:1432
-#: js/widgets/phrasemaker.js:4684
-#: js/widgets/rhythmruler.js:2514
-#: js/widgets/rhythmruler.js:2521
-#: js/widgets/rhythmruler.js:2706
-#: js/widgets/rhythmruler.js:2713
+#: planet/js/GlobalPlanet.js:495 js/macros.js:170 js/macros.js:266
+#: js/macros.js:267 js/macros.js:276 js/macros.js:828 js/palette.js:1202
+#: js/palette.js:1211 js/palette.js:1220 js/palette.js:1229 js/palette.js:1857
+#: js/palette.js:1868 js/palette.js:1879 js/palette.js:1890 js/palette.js:1909
+#: js/turtledefs.js:131 js/turtledefs.js:229 js/rubrics.js:540
+#: js/block.js:1667 js/block.js:4869 js/blocks.js:1286 js/blocks.js:2984
+#: js/blocks.js:2985 js/blocks.js:3158 js/blocks.js:3574 js/blocks.js:3759
+#: js/blocks.js:4988 js/blocks.js:6243 js/blocks/MeterBlocks.js:750
+#: js/blocks/MeterBlocks.js:803 js/blocks/MeterBlocks.js:866
+#: js/blocks/MeterBlocks.js:927 js/blocks/ActionBlocks.js:251
+#: js/blocks/ActionBlocks.js:328 js/blocks/ActionBlocks.js:639
+#: js/blocks/ActionBlocks.js:739 js/blocks/ActionBlocks.js:984
+#: js/blocks/ActionBlocks.js:1071 js/blocks/ActionBlocks.js:1351
+#: js/blocks/ActionBlocks.js:1354 js/blocks/ActionBlocks.js:1366
+#: js/blocks/ActionBlocks.js:1432 js/widgets/phrasemaker.js:4684
+#: js/widgets/rhythmruler.js:2514 js/widgets/rhythmruler.js:2521
+#: js/widgets/rhythmruler.js:2706 js/widgets/rhythmruler.js:2713
+#: js/widgets/musickeyboard.js:3344 js/macros.js:170 js/macros.js:266
+#: js/macros.js:267 js/macros.js:276 js/macros.js:828 js/palette.js:1202
+#: js/palette.js:1211 js/palette.js:1220 js/palette.js:1229 js/palette.js:1857
+#: js/palette.js:1868 js/palette.js:1879 js/palette.js:1890 js/palette.js:1909
+#: js/turtledefs.js:131 js/turtledefs.js:229 js/rubrics.js:540
+#: js/block.js:1667 js/block.js:4869 js/blocks.js:1286 js/blocks.js:2984
+#: js/blocks.js:2985 js/blocks.js:3158 js/blocks.js:3574 js/blocks.js:3759
+#: js/blocks.js:4988 js/blocks.js:6243 js/blocks/MeterBlocks.js:750
+#: js/blocks/MeterBlocks.js:803 js/blocks/MeterBlocks.js:866
+#: js/blocks/MeterBlocks.js:927 js/blocks/ActionBlocks.js:251
+#: js/blocks/ActionBlocks.js:328 js/blocks/ActionBlocks.js:639
+#: js/blocks/ActionBlocks.js:739 js/blocks/ActionBlocks.js:984
+#: js/blocks/ActionBlocks.js:1071 js/blocks/ActionBlocks.js:1351
+#: js/blocks/ActionBlocks.js:1354 js/blocks/ActionBlocks.js:1366
+#: js/blocks/ActionBlocks.js:1432 js/widgets/phrasemaker.js:4684
+#: js/widgets/rhythmruler.js:2514 js/widgets/rhythmruler.js:2521
+#: js/widgets/rhythmruler.js:2706 js/widgets/rhythmruler.js:2713
 #: js/widgets/musickeyboard.js:3344
 msgid "action"
 msgstr "アクション"
 
-#: js/macros.js:711
-#: js/utils/musicutils.js:1443
-#: js/utils/synthutils.js:216
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
+#: js/macros.js:711 js/utils/musicutils.js:1443 js/utils/synthutils.js:216
 msgid "duck"
 msgstr "あひる"
 
-#: js/turtle-painter.js:1361
-#: js/turtle-painter.js:1362
-#: js/turtles.js:118
-#: js/lilypond.js:758
-#: js/lilypond.js:915
-#: js/lilypond.js:953
-#: js/block.js:1681
-#: js/logo.js:1607
-#: js/blocks/ActionBlocks.js:1251
+#: js/turtle-painter.js:1361 js/turtle-painter.js:1362 js/turtles.js:118
+#: js/lilypond.js:758 js/lilypond.js:915 js/lilypond.js:953 js/block.js:1681
+#: js/logo.js:1607 js/blocks/ActionBlocks.js:1251
 #: js/blocks/ProgramBlocks.js:1271
 msgid "start"
 msgstr "スタート"
@@ -168,8 +100,7 @@ msgstr "スタート"
 msgid "Saving block artwork"
 msgstr "ブロックの アートを ほぞんちゅう"
 
-#: js/keyboard-controller.js:169
-#: js/turtledefs.js:644
+#: js/keyboard-controller.js:169 js/turtledefs.js:644
 #: planet/js/LocalCard.js:31
 msgid "Copy"
 msgstr "コピー"
@@ -178,107 +109,62 @@ msgstr "コピー"
 msgid "Erase"
 msgstr "けす"
 
-#: js/keyboard-controller.js:178
-#: js/turtledefs.js:430
-#: js/turtledefs.js:466
-#: js/toolbar-ui.js:129
-#: js/toolbar-ui.js:205
-#: js/toolbar-ui.js:262
-#: js/toolbar-ui.js:332
-#: js/widgets/PhraseMakerAudio.js:141
-#: js/widgets/PhraseMakerAudio.js:359
-#: js/widgets/PhraseMakerAudio.js:364
-#: js/widgets/PhraseMakerAudio.js:365
-#: js/widgets/PhraseMakerUI.js:108
-#: js/widgets/PhraseMakerUI.js:109
-#: js/widgets/jseditor.js:407
-#: js/widgets/aiwidget.js:769
-#: js/widgets/aiwidget.js:775
-#: js/widgets/aiwidget.js:776
-#: js/widgets/legobricks.js:339
-#: js/widgets/meterwidget.js:188
-#: js/widgets/modewidget.js:144
-#: js/widgets/phrasemaker.js:628
-#: js/widgets/phrasemaker.js:639
-#: js/widgets/phrasemaker.js:640
-#: js/widgets/pitchstaircase.js:162
-#: js/widgets/pitchstaircase.js:213
-#: js/widgets/pitchstaircase.js:368
-#: js/widgets/rhythmruler.js:813
-#: js/widgets/rhythmruler.js:820
-#: js/widgets/tempo.js:100
-#: js/widgets/tempo.js:101
-#: js/widgets/arpeggio.js:89
-#: js/widgets/arpeggio.js:526
-#: js/widgets/arpeggio.js:527
-#: js/widgets/arpeggio.js:637
-#: js/widgets/arpeggio.js:638
-#: js/widgets/arpeggio.js:769
-#: js/widgets/arpeggio.js:770
-#: js/widgets/musickeyboard.js:316
-#: js/widgets/musickeyboard.js:317
-#: js/widgets/musickeyboard.js:812
-#: js/widgets/pitchdrummatrix.js:150
-#: js/widgets/pitchdrummatrix.js:619
-#: js/widgets/temperament.js:793
-#: js/widgets/temperament.js:796
-#: js/widgets/temperament.js:876
-#: js/widgets/temperament.js:877
-#: js/widgets/temperament.js:2287
-#: js/widgets/temperament.js:2451
-#: js/widgets/sampler.js:223
-#: js/widgets/sampler.js:224
-#: js/widgets/sampler.js:228
-#: js/widgets/sampler.js:229
-#: js/widgets/sampler.js:589
-#: js/widgets/timbre.js:503
-#: js/widgets/timbre.js:504
-#: js/widgets/timbre.js:539
-#: js/widgets/timbre.js:540
-#: js/widgets/timbre.js:822
-#: plugins/rodi.rtp:191
+#: js/keyboard-controller.js:178 js/turtledefs.js:430 js/turtledefs.js:466
+#: js/toolbar-ui.js:129 js/toolbar-ui.js:205 js/toolbar-ui.js:262
+#: js/toolbar-ui.js:332 js/widgets/PhraseMakerAudio.js:141
+#: js/widgets/PhraseMakerAudio.js:359 js/widgets/PhraseMakerAudio.js:364
+#: js/widgets/PhraseMakerAudio.js:365 js/widgets/PhraseMakerUI.js:108
+#: js/widgets/PhraseMakerUI.js:109 js/widgets/jseditor.js:407
+#: js/widgets/aiwidget.js:769 js/widgets/aiwidget.js:775
+#: js/widgets/aiwidget.js:776 js/widgets/legobricks.js:339
+#: js/widgets/meterwidget.js:188 js/widgets/modewidget.js:144
+#: js/widgets/phrasemaker.js:628 js/widgets/phrasemaker.js:639
+#: js/widgets/phrasemaker.js:640 js/widgets/pitchstaircase.js:162
+#: js/widgets/pitchstaircase.js:213 js/widgets/pitchstaircase.js:368
+#: js/widgets/rhythmruler.js:813 js/widgets/rhythmruler.js:820
+#: js/widgets/tempo.js:100 js/widgets/tempo.js:101 js/widgets/arpeggio.js:89
+#: js/widgets/arpeggio.js:526 js/widgets/arpeggio.js:527
+#: js/widgets/arpeggio.js:637 js/widgets/arpeggio.js:638
+#: js/widgets/arpeggio.js:769 js/widgets/arpeggio.js:770
+#: js/widgets/musickeyboard.js:316 js/widgets/musickeyboard.js:317
+#: js/widgets/musickeyboard.js:812 js/widgets/pitchdrummatrix.js:150
+#: js/widgets/pitchdrummatrix.js:619 js/widgets/temperament.js:793
+#: js/widgets/temperament.js:796 js/widgets/temperament.js:876
+#: js/widgets/temperament.js:877 js/widgets/temperament.js:2287
+#: js/widgets/temperament.js:2451 js/widgets/sampler.js:223
+#: js/widgets/sampler.js:224 js/widgets/sampler.js:228
+#: js/widgets/sampler.js:229 js/widgets/sampler.js:589
+#: js/widgets/timbre.js:503 js/widgets/timbre.js:504 js/widgets/timbre.js:539
+#: js/widgets/timbre.js:540 js/widgets/timbre.js:822 plugins/rodi.rtp:191
 msgid "Play"
 msgstr "じっこう"
 
-#: js/keyboard-controller.js:209
-#: js/turtledefs.js:435
-#: js/turtledefs.js:471
-#: js/toolbar-ui.js:130
-#: js/toolbar-ui.js:206
-#: js/toolbar-ui.js:263
-#: js/toolbar-ui.js:333
-#: js/blocks/FlowBlocks.js:647
-#: js/widgets/PhraseMakerAudio.js:34
-#: js/widgets/PhraseMakerUI.js:93
-#: js/widgets/PhraseMakerUI.js:94
-#: js/widgets/meterwidget.js:210
-#: js/widgets/meterwidget.js:211
-#: js/widgets/modewidget.js:155
-#: js/widgets/phrasemaker.js:650
-#: js/widgets/phrasemaker.js:651
-#: js/widgets/pitchstaircase.js:363
-#: js/widgets/pitchstaircase.js:384
-#: js/widgets/pitchstaircase.js:416
-#: js/widgets/arpeggio.js:510
-#: js/widgets/arpeggio.js:511
-#: js/widgets/musickeyboard.js:316
-#: js/widgets/musickeyboard.js:317
-#: js/widgets/pitchdrummatrix.js:619
-#: js/widgets/temperament.js:2279
-#: js/widgets/timbre.js:487
-#: js/widgets/timbre.js:488
-#: plugins/rodi.rtp:29
-#: plugins/rodi.rtp:73
+#: js/keyboard-controller.js:209 js/turtledefs.js:435 js/turtledefs.js:471
+#: js/toolbar-ui.js:130 js/toolbar-ui.js:206 js/toolbar-ui.js:263
+#: js/toolbar-ui.js:333 js/blocks/FlowBlocks.js:647
+#: js/widgets/PhraseMakerAudio.js:34 js/widgets/PhraseMakerUI.js:93
+#: js/widgets/PhraseMakerUI.js:94 js/widgets/meterwidget.js:210
+#: js/widgets/meterwidget.js:211 js/widgets/modewidget.js:155
+#: js/widgets/phrasemaker.js:650 js/widgets/phrasemaker.js:651
+#: js/widgets/pitchstaircase.js:363 js/widgets/pitchstaircase.js:384
+#: js/widgets/pitchstaircase.js:416 js/widgets/arpeggio.js:510
+#: js/widgets/arpeggio.js:511 js/widgets/musickeyboard.js:316
+#: js/widgets/musickeyboard.js:317 js/widgets/pitchdrummatrix.js:619
+#: js/widgets/temperament.js:2279 js/widgets/timbre.js:487
+#: js/widgets/timbre.js:488 plugins/rodi.rtp:29 plugins/rodi.rtp:73
 #: plugins/rodi.rtp:413
 msgid "Stop"
 msgstr "ていし"
 
 #: js/SaveInterface.js:96
-msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-msgstr "このプロジェクトを じっこうするには、ブラウザーでミュージック・ブロックスを ひらき、このファイルを ブラウザー・ウィンドウにド ラッグ・アンド・ドロップします。"
+msgid ""
+"To run this project, open Music Blocks in a web browser and drag and drop "
+"this file into the browser window."
+msgstr ""
+"このプロジェクトを じっこうするには、ブラウザーでミュージック・ブロックスを ひらき、このファイルを ブラウザー・ウィンドウにド "
+"ラッグ・アンド・ドロップします。"
 
-#: js/keyboard-controller.js:213
-#: js/keyboard-controller.js:243
+#: js/keyboard-controller.js:213 js/keyboard-controller.js:243
 msgid "Paste"
 msgstr "はりつけ"
 
@@ -322,8 +208,7 @@ msgstr "ブロックをみぎにうごかしています"
 msgid "Jump to home position."
 msgstr "まんなかにジャンプする"
 
-#: js/keyboard-controller.js:404
-#: js/blocks/ExtrasBlocks.js:276
+#: js/keyboard-controller.js:404 js/blocks/ExtrasBlocks.js:276
 msgid "Hide blocks"
 msgstr "ブロックを ひひょうじ"
 
@@ -347,48 +232,27 @@ msgstr "パレットのかてごり"
 msgid "Toggle Palette"
 msgstr "パレットのきりかえ"
 
-#: js/palette.js:1184
-#: js/palette.js:1313
-#: js/palette.js:1835
-#: js/blocks.js:1485
-#: js/blocks.js:2938
-#: js/blocks.js:3284
-#: js/blocks.js:3326
-#: js/blocks.js:3381
-#: js/blocks.js:3427
-#: js/blocks.js:6269
-#: js/blocks/BoxesBlocks.js:282
-#: js/blocks/BoxesBlocks.js:285
-#: js/blocks/BoxesBlocks.js:405
+#: js/palette.js:1184 js/palette.js:1313 js/palette.js:1835 js/blocks.js:1485
+#: js/blocks.js:2938 js/blocks.js:3284 js/blocks.js:3326 js/blocks.js:3381
+#: js/blocks.js:3427 js/blocks.js:6269 js/blocks/BoxesBlocks.js:282
+#: js/blocks/BoxesBlocks.js:285 js/blocks/BoxesBlocks.js:405
 #: js/blocks/BoxesBlocks.js:598
 msgid "box"
 msgstr "はこ"
 
-#: js/palette.js:1246
-#: js/turtledefs.js:674
-#: js/turtles.js:992
+#: js/palette.js:1246 js/turtledefs.js:674 js/turtles.js:992
 msgid "Grid"
 msgstr "グリッド"
 
-#: js/palette.js:1249
-#: js/blocks.js:2739
-#: js/blocks/MediaBlocks.js:975
+#: js/palette.js:1249 js/blocks.js:2739 js/blocks/MediaBlocks.js:975
 #: js/blocks/MediaBlocks.js:1046
 msgid "text"
 msgstr "もじ そざい"
 
-#: js/palette.js:1252
-#: js/turtledefs.js:129
-#: js/turtledefs.js:227
-#: js/lilypond.js:741
-#: js/lilypond.js:902
-#: js/lilypond.js:943
-#: js/block.js:1758
-#: js/block.js:2832
-#: js/blocks/VolumeBlocks.js:503
-#: js/blocks/DrumBlocks.js:501
-#: js/blocks/RhythmBlocks.js:765
-#: js/widgets/phrasemaker.js:1288
+#: js/palette.js:1252 js/turtledefs.js:129 js/turtledefs.js:227
+#: js/lilypond.js:741 js/lilypond.js:902 js/lilypond.js:943 js/block.js:1758
+#: js/block.js:2832 js/blocks/VolumeBlocks.js:503 js/blocks/DrumBlocks.js:501
+#: js/blocks/RhythmBlocks.js:765 js/widgets/phrasemaker.js:1288
 msgid "drum"
 msgstr "ドラム"
 
@@ -400,11 +264,10 @@ msgstr "こうかおん"
 msgid "sargam"
 msgstr "Sargam (インドの ソルファ)"
 
-#: js/palette.js:1264
-#: js/blocks/PitchBlocks.js:467
-#: js/blocks/PitchBlocks.js:1868
-#: js/blocks/RhythmBlocks.js:922
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical
+#. mode
+#: js/palette.js:1264 js/blocks/PitchBlocks.js:467
+#: js/blocks/PitchBlocks.js:1868 js/blocks/RhythmBlocks.js:922
 msgid "scale degree"
 msgstr "おんど"
 
@@ -420,16 +283,12 @@ msgstr "ちょうを はんてん させる"
 msgid "voice name"
 msgstr "おんめい"
 
-#: js/palette.js:1276
-#: js/blocks/PitchBlocks.js:1257
+#: js/palette.js:1276 js/blocks/PitchBlocks.js:1257
 msgid "custom pitch"
 msgstr "カスタムピッチ"
 
-#: js/palette.js:1280
-#: js/block.js:1674
-#: js/block.js:1793
-#: js/blocks/WidgetBlocks.js:328
-#: js/blocks/IntervalsBlocks.js:63
+#: js/palette.js:1280 js/block.js:1674 js/block.js:1793
+#: js/blocks/WidgetBlocks.js:328 js/blocks/IntervalsBlocks.js:63
 msgid "temperament"
 msgstr "おんりつ"
 
@@ -441,59 +300,38 @@ msgstr "へんかきごう"
 msgid "interval name"
 msgstr "おんていめい"
 
-#: js/palette.js:1293
-#: js/block.js:4223
-#: js/blocks.js:2064
-#: js/blocks.js:2709
-#: js/blocks/SensorsBlocks.js:872
-#: js/blocks/BooleanBlocks.js:77
-#: js/blocks/BooleanBlocks.js:166
-#: js/blocks/BooleanBlocks.js:250
-#: js/blocks/BooleanBlocks.js:334
-#: js/blocks/BooleanBlocks.js:432
-#: js/blocks/BooleanBlocks.js:537
-#: js/blocks/BooleanBlocks.js:637
-#: js/blocks/BooleanBlocks.js:737
-#: js/blocks/BooleanBlocks.js:841
-#: js/blocks/BooleanBlocks.js:942
-#: js/blocks/BooleanBlocks.js:1028
+#: js/palette.js:1293 js/block.js:4223 js/blocks.js:2064 js/blocks.js:2709
+#: js/blocks/SensorsBlocks.js:872 js/blocks/BooleanBlocks.js:77
+#: js/blocks/BooleanBlocks.js:166 js/blocks/BooleanBlocks.js:250
+#: js/blocks/BooleanBlocks.js:334 js/blocks/BooleanBlocks.js:432
+#: js/blocks/BooleanBlocks.js:537 js/blocks/BooleanBlocks.js:637
+#: js/blocks/BooleanBlocks.js:737 js/blocks/BooleanBlocks.js:841
+#: js/blocks/BooleanBlocks.js:942 js/blocks/BooleanBlocks.js:1028
 msgid "true"
 msgstr "真"
 
-#: js/palette.js:1308
-#: js/blocks/PitchBlocks.js:425
+#: js/palette.js:1308 js/blocks/PitchBlocks.js:425
 msgid "pitch converter"
 msgstr "おとのたかさをしょうせつ"
 
-#: js/palette.js:1314
-#: js/palette.js:1319
-#: js/palette.js:1776
-#: js/blocks.js:3616
+#: js/palette.js:1314 js/palette.js:1319 js/palette.js:1776 js/blocks.js:3616
 #: js/blocks/BoxesBlocks.js:595
 msgid "store in"
 msgstr "いれる"
 
-#: js/palette.js:1316
-#: js/palette.js:1317
-#: js/blocks.js:2937
+#: js/palette.js:1316 js/palette.js:1317 js/blocks.js:2937
 #: js/blocks/BoxesBlocks.js:518
 msgid "store in box"
 msgstr "はこに ほぞん"
 
-#: js/palette.js:1328
-#: js/blocks.js:1929
-#: js/blocks/MediaBlocks.js:686
+#: js/palette.js:1328 js/blocks.js:1929 js/blocks/MediaBlocks.js:686
 msgid "open file"
 msgstr "ファイルを ひらく"
 
-#: js/palette.js:1555
-#: js/piemenu-block-context.js:103
-#: js/svgAssetSelector.js:66
-#: js/widgets/widgetWindows.js:219
-#: js/widgets/temperament.js:545
-#: js/widgets/temperament.js:546
-#: js/widgets/temperament.js:1677
-#: js/widgets/temperament.js:1678
+#: js/palette.js:1555 js/piemenu-block-context.js:103
+#: js/svgAssetSelector.js:66 js/widgets/widgetWindows.js:219
+#: js/widgets/temperament.js:545 js/widgets/temperament.js:546
+#: js/widgets/temperament.js:1677 js/widgets/temperament.js:1678
 #: planet/js/StringHelper.js:76
 msgid "Close"
 msgstr "とじる"
@@ -506,8 +344,8 @@ msgstr "テーマが %s モードにきりかわりました。"
 msgid "Music Blocks is already set to this theme."
 msgstr "ミュージック・ブロックスはすでにこのテーマにせっていされています。"
 
+#. TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
 msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
 
@@ -515,183 +353,135 @@ msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
 msgid "Turtle Blocks"
 msgstr "タートル・ブロックス"
 
-#: js/turtledefs.js:121
-#: js/turtledefs.js:219
+#: js/turtledefs.js:121 js/turtledefs.js:219
 msgid "search"
 msgstr "けんさく"
 
-#: js/turtledefs.js:122
-#: js/turtledefs.js:220
-#: js/rubrics.js:533
+#. TRANS: an arrangement of notes based on duration
+#: js/turtledefs.js:122 js/turtledefs.js:220 js/rubrics.js:533
 #: js/blocks/RhythmBlockPaletteBlocks.js:71
-#: js/blocks/RhythmBlockPaletteBlocks.js:249
-#: js/blocks/ProgramBlocks.js:759
-#: js/widgets/rhythmruler.js:2252
-#: js/widgets/rhythmruler.js:2259
-#: js/widgets/rhythmruler.js:2328
-#: js/widgets/rhythmruler.js:2335
+#: js/blocks/RhythmBlockPaletteBlocks.js:249 js/blocks/ProgramBlocks.js:759
+#: js/widgets/rhythmruler.js:2252 js/widgets/rhythmruler.js:2259
+#: js/widgets/rhythmruler.js:2328 js/widgets/rhythmruler.js:2335
 #: js/widgets/rhythmruler.js:2414
-#.TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "おんぷ"
 
-#: js/turtledefs.js:123
-#: js/turtledefs.js:221
-#: js/blocks/MeterBlocks.js:1391
+#. TRANS: musical meter (time signature), e.g., 4:4
+#: js/turtledefs.js:123 js/turtledefs.js:221 js/blocks/MeterBlocks.js:1391
 #: js/blocks/WidgetBlocks.js:616
-#.TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "ひょうし"
 
-#: js/turtledefs.js:124
-#: js/turtledefs.js:222
-#: js/rubrics.js:534
-#: js/block.js:2828
-#: js/blocks/SensorsBlocks.js:186
-#: js/blocks/IntervalsBlocks.js:63
-#: js/blocks/PitchBlocks.js:1930
-#: js/blocks/PitchBlocks.js:1944
-#: js/widgets/phrasemaker.js:1286
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be
+#. CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#: js/turtledefs.js:124 js/turtledefs.js:222 js/rubrics.js:534
+#: js/block.js:2828 js/blocks/SensorsBlocks.js:186
+#: js/blocks/IntervalsBlocks.js:63 js/blocks/PitchBlocks.js:1930
+#: js/blocks/PitchBlocks.js:1944 js/widgets/phrasemaker.js:1286
 #: js/widgets/musickeyboard.js:2218
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "おとの たかさ"
 
-#: js/turtledefs.js:125
-#: js/turtledefs.js:223
+#: js/turtledefs.js:125 js/turtledefs.js:223
 msgid "intervals"
 msgstr "おんてい"
 
-#: js/turtledefs.js:126
-#: js/turtledefs.js:224
-#: js/rubrics.js:535
+#: js/turtledefs.js:126 js/turtledefs.js:224 js/rubrics.js:535
 msgid "tone"
 msgstr "ねいろ"
 
-#: js/turtledefs.js:127
-#: js/turtledefs.js:225
+#: js/turtledefs.js:127 js/turtledefs.js:225
 msgid "ornament"
 msgstr "そうしょく"
 
-#: js/turtledefs.js:128
-#: js/turtledefs.js:226
-#: js/blocks/VolumeBlocks.js:362
-#: js/blocks/VolumeBlocks.js:503
-#: js/blocks/VolumeBlocks.js:546
+#: js/turtledefs.js:128 js/turtledefs.js:226 js/blocks/VolumeBlocks.js:362
+#: js/blocks/VolumeBlocks.js:503 js/blocks/VolumeBlocks.js:546
 #: js/blocks/ProgramBlocks.js:1305
 msgid "volume"
 msgstr "おんりょう"
 
-#: js/turtledefs.js:130
-#: js/turtledefs.js:228
-#: js/rubrics.js:539
+#: js/turtledefs.js:130 js/turtledefs.js:228 js/rubrics.js:539
 msgid "flow"
 msgstr "じっこうてじゅん"
 
-#: js/turtledefs.js:132
-#: js/turtledefs.js:230
+#: js/turtledefs.js:132 js/turtledefs.js:230
 msgid "boxes"
 msgstr "かずの はこ"
 
-#: js/turtledefs.js:133
-#: js/turtledefs.js:231
+#: js/turtledefs.js:133 js/turtledefs.js:231
 msgid "widgets"
 msgstr "ツール"
 
-#: js/turtledefs.js:134
-#: js/turtledefs.js:232
-#: js/widgets/phrasemaker.js:1289
+#: js/turtledefs.js:134 js/turtledefs.js:232 js/widgets/phrasemaker.js:1289
 msgid "graphics"
 msgstr "ネズミの うごき"
 
-#: js/turtledefs.js:135
-#: js/turtledefs.js:233
-#: js/rubrics.js:537
+#: js/turtledefs.js:135 js/turtledefs.js:233 js/rubrics.js:537
 #: js/widgets/phrasemaker.js:1290
 msgid "pen"
 msgstr "ペン"
 
-#: js/turtledefs.js:136
-#: js/turtledefs.js:234
-#: js/rubrics.js:538
-#: js/blocks/NumberBlocks.js:928
-#: js/blocks/PitchBlocks.js:1794
+#: js/turtledefs.js:136 js/turtledefs.js:234 js/rubrics.js:538
+#: js/blocks/NumberBlocks.js:928 js/blocks/PitchBlocks.js:1794
 #: js/blocks/PitchBlocks.js:1840
 msgid "number"
 msgstr "すうち"
 
-#: js/turtledefs.js:137
-#: js/turtledefs.js:235
+#: js/turtledefs.js:137 js/turtledefs.js:235
 msgid "boolean"
 msgstr "くらべる"
 
-#: js/turtledefs.js:138
-#: js/turtledefs.js:236
-#: js/rubrics.js:542
-#: js/blocks/MediaBlocks.js:1013
-#: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
+#: js/turtledefs.js:138 js/turtledefs.js:236 js/rubrics.js:542
+#: js/blocks/MediaBlocks.js:1013 planet/js/GlobalTag.js:44
 msgid "media"
 msgstr "メディア"
 
-#: js/turtledefs.js:139
-#: js/turtledefs.js:237
-#: js/rubrics.js:541
+#. TRANS: On the Planet, we use labels to tag projects.
+#: js/turtledefs.js:139 js/turtledefs.js:237 js/rubrics.js:541
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "sensors"
 msgstr "センサー"
 
-#: js/turtledefs.js:140
-#: js/turtledefs.js:238
-#: js/blocks/HeapBlocks.js:59
+#: js/turtledefs.js:140 js/turtledefs.js:238 js/blocks/HeapBlocks.js:59
 #: js/widgets/status.js:150
 msgid "heap"
 msgstr "ヒープ"
 
-#: js/turtledefs.js:141
-#: js/turtledefs.js:239
-#: js/blocks/DictBlocks.js:142
+#: js/turtledefs.js:141 js/turtledefs.js:239 js/blocks/DictBlocks.js:142
 #: js/blocks/ProgramBlocks.js:500
 msgid "dictionary"
 msgstr "じしょ"
 
-#: js/turtledefs.js:142
-#: js/turtledefs.js:240
+#: js/turtledefs.js:142 js/turtledefs.js:240
 msgid "ensemble"
 msgstr "がっそう"
 
-#: js/turtledefs.js:143
-#: js/turtledefs.js:241
+#: js/turtledefs.js:143 js/turtledefs.js:241
 msgid "extras"
 msgstr "そのた"
 
-#: js/turtledefs.js:145
-#: js/turtledefs.js:242
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
+#: js/turtledefs.js:145 js/turtledefs.js:242
 msgid "program"
 msgstr "プログラム"
 
-#: js/turtledefs.js:146
-#: js/turtledefs.js:243
+#: js/turtledefs.js:146 js/turtledefs.js:243
 msgid "my blocks"
 msgstr "わたしの ブロック"
 
-#: js/turtledefs.js:185
-#: js/turtledefs.js:269
+#: js/turtledefs.js:185 js/turtledefs.js:269
 msgid "artwork"
 msgstr "アート"
 
-#: js/turtledefs.js:185
-#: js/turtledefs.js:269
+#: js/turtledefs.js:185 js/turtledefs.js:269
 msgid "logic"
 msgstr "ろんり"
 
-#: js/turtledefs.js:185
-#: js/turtledefs.js:269
-#: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
+#: js/turtledefs.js:185 js/turtledefs.js:269 planet/js/GlobalTag.js:32
 msgid "Music"
 msgstr "おんがく"
 
@@ -704,18 +494,17 @@ msgid "Welcome to Turtle Blocks"
 msgstr "タートル・ブロックへようこそ"
 
 #: js/turtledefs.js:424
-msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
+msgid ""
+"Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with "
+"snap-together visual-programming blocks."
 msgstr "タートル・ブロックスは アートと すうがくを もとめる ビジュアル・プログラミング げんごだ。"
 
-#: js/turtledefs.js:426
-#: js/turtledefs.js:446
-#: js/turtledefs.js:755
+#: js/turtledefs.js:426 js/turtledefs.js:446 js/turtledefs.js:755
 #: js/turtledefs.js:780
 msgid "The current version is"
 msgstr "タートル・ブロックスの さいしんバージョンは"
 
-#: js/turtledefs.js:431
-#: js/turtledefs.js:467
+#: js/turtledefs.js:431 js/turtledefs.js:467
 msgid "Click the run button to run the project in fast mode."
 msgstr "クリックをすると、 ふつうの スピードで プログラムを じっこうすることが できる。"
 
@@ -723,22 +512,23 @@ msgstr "クリックをすると、 ふつうの スピードで プログラム
 msgid "Stop the turtle."
 msgstr "タータルを とめる"
 
-#: js/turtledefs.js:436
-#: js/turtledefs.js:472
+#: js/turtledefs.js:436 js/turtledefs.js:472
 msgid "You can also type Alt-S to stop."
-msgstr "じっこう している プログラムを とめる。 プログラムは、 このボタンを おすかわりに、 キーボードで 「Altキーと  Sキーの どうじおし」でも とめることが できる。"
+msgstr ""
+"じっこう している プログラムを とめる。 プログラムは、 このボタンを おすかわりに、 キーボードで 「Altキーと  Sキーの どうじおし」でも "
+"とめることが できる。"
 
-#: js/turtledefs.js:443
-#: js/widgets/help.js:548
+#: js/turtledefs.js:443 js/widgets/help.js:548
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへ ようこそ"
 
 #: js/turtledefs.js:444
-msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
+msgid ""
+"Music Blocks is a collection of tools for exploring fundamental musical "
+"concepts in a fun way."
 msgstr "おんがくと さんすうと プログラミングを むすびつけ、 ふかく たのしむことができる ツール。 それが、 ミュージック・ブロックスだ。"
 
-#: js/turtledefs.js:450
-#: js/widgets/help.js:549
+#: js/turtledefs.js:450 js/widgets/help.js:549
 msgid "Meet Mr. Mouse!"
 msgstr "ミスター・マウスに あおう！"
 
@@ -754,18 +544,16 @@ msgstr "ミスター・マウスと いっしょに、 ミュージック・ブ�
 msgid "Let us start our tour!"
 msgstr " では、 ツアーを はじめよう。"
 
-#: js/turtledefs.js:459
-#: js/turtledefs.js:737
-#: js/widgets/help.js:550
+#: js/turtledefs.js:459 js/turtledefs.js:737 js/widgets/help.js:550
 msgid "Guide"
 msgstr "もっとくわしく しるには"
 
 #: js/turtledefs.js:460
 msgid "A detailed guide to Music Blocks is available."
-msgstr "インターネットから、 ミュージック・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
+msgstr ""
+"インターネットから、 ミュージック・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
 
-#: js/turtledefs.js:463
-#: js/SaveInterface.js:93
+#: js/turtledefs.js:463 js/SaveInterface.js:93
 msgid "Music Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
 
@@ -773,11 +561,8 @@ msgstr "ミュージック・ブロックスガイド"
 msgid "Stop the music (and the mice)."
 msgstr "じっこうしているプログラムを止める。"
 
-#: js/turtledefs.js:479
-#: js/toolbar-ui.js:131
-#: js/toolbar-ui.js:207
-#: js/toolbar-ui.js:264
-#: js/toolbar-ui.js:334
+#: js/turtledefs.js:479 js/toolbar-ui.js:131 js/toolbar-ui.js:207
+#: js/toolbar-ui.js:264 js/toolbar-ui.js:334
 msgid "Record"
 msgstr "ろくおん"
 
@@ -785,11 +570,8 @@ msgstr "ろくおん"
 msgid "Record your project as video."
 msgstr "さいせい されている ビデオを ろくおんする"
 
-#: js/turtledefs.js:485
-#: js/toolbar-ui.js:134
-#: js/toolbar-ui.js:210
-#: js/toolbar-ui.js:267
-#: js/toolbar-ui.js:337
+#: js/turtledefs.js:485 js/toolbar-ui.js:134 js/toolbar-ui.js:210
+#: js/toolbar-ui.js:267 js/toolbar-ui.js:337
 msgid "Toggle Fullscreen"
 msgstr "フルスクリーンの きりかえ"
 
@@ -797,12 +579,8 @@ msgstr "フルスクリーンの きりかえ"
 msgid "Toggle Fullscreen mode."
 msgstr "フルスクリーンの きりかえ"
 
-#: js/turtledefs.js:490
-#: js/toolbar-ui.js:135
-#: js/toolbar-ui.js:211
-#: js/toolbar-ui.js:268
-#: js/toolbar-ui.js:338
-#: js/toolbar-ui.js:592
+#: js/turtledefs.js:490 js/toolbar-ui.js:135 js/toolbar-ui.js:211
+#: js/toolbar-ui.js:268 js/toolbar-ui.js:338 js/toolbar-ui.js:592
 #: planet/js/StringHelper.js:32
 msgid "New project"
 msgstr "あたらしい プロジェクト"
@@ -811,11 +589,8 @@ msgstr "あたらしい プロジェクト"
 msgid "Initialize a new project."
 msgstr "あたらしい プロジェクトを つくる。"
 
-#: js/turtledefs.js:495
-#: js/toolbar-ui.js:136
-#: js/toolbar-ui.js:212
-#: js/toolbar-ui.js:269
-#: js/toolbar-ui.js:339
+#: js/turtledefs.js:495 js/toolbar-ui.js:136 js/toolbar-ui.js:212
+#: js/toolbar-ui.js:269 js/toolbar-ui.js:339
 msgid "Load project from file"
 msgstr "プロジェクトを よみこむ"
 
@@ -823,54 +598,31 @@ msgstr "プロジェクトを よみこむ"
 msgid "You can also load projects from the file system."
 msgstr "コンピューターに ほぞん してある ファイルから、 ミュージック・ブロックスの プロジェクトを よみこんで ひらく。"
 
-#: js/turtledefs.js:501
-#: js/turtledefs.js:509
-#: js/turtledefs.js:528
-#: js/toolbar-ui.js:137
-#: js/toolbar-ui.js:213
-#: js/toolbar-ui.js:214
-#: js/toolbar-ui.js:270
-#: js/toolbar-ui.js:340
+#: js/turtledefs.js:501 js/turtledefs.js:509 js/turtledefs.js:528
+#: js/toolbar-ui.js:137 js/toolbar-ui.js:213 js/toolbar-ui.js:214
+#: js/toolbar-ui.js:270 js/toolbar-ui.js:340
 msgid "Save project"
 msgstr "プロジェクトを ほぞん"
 
-#: js/turtledefs.js:502
-#: js/turtledefs.js:529
-#: js/toolbar-ui.js:138
-#: js/toolbar-ui.js:163
-#: js/toolbar-ui.js:165
-#: js/toolbar-ui.js:239
-#: js/toolbar-ui.js:250
-#: js/toolbar-ui.js:252
-#: js/toolbar-ui.js:271
-#: js/toolbar-ui.js:295
-#: js/toolbar-ui.js:297
-#: js/toolbar-ui.js:341
-#: js/toolbar-ui.js:365
-#: js/toolbar-ui.js:367
+#: js/turtledefs.js:502 js/turtledefs.js:529 js/toolbar-ui.js:138
+#: js/toolbar-ui.js:163 js/toolbar-ui.js:165 js/toolbar-ui.js:239
+#: js/toolbar-ui.js:250 js/toolbar-ui.js:252 js/toolbar-ui.js:271
+#: js/toolbar-ui.js:295 js/toolbar-ui.js:297 js/toolbar-ui.js:341
+#: js/toolbar-ui.js:365 js/toolbar-ui.js:367
 msgid "Save project as HTML"
 msgstr "HTMLをほぞん"
 
-#: js/turtledefs.js:502
-#: js/toolbar-ui.js:164
-#: js/toolbar-ui.js:168
+#: js/turtledefs.js:502 js/toolbar-ui.js:164 js/toolbar-ui.js:168
 #: js/toolbar-ui.js:242
 msgid "Save mouse artwork as PNG"
 msgstr "PNGでほぞん"
 
-#: js/turtledefs.js:508
-#: js/SaveInterface.js:256
-#: js/widgets/legobricks.js:350
-#: js/widgets/meterwidget.js:229
-#: js/widgets/modewidget.js:161
-#: js/widgets/phrasemaker.js:662
-#: js/widgets/pitchslider.js:184
-#: js/widgets/pitchstaircase.js:777
-#: js/widgets/reflection.js:154
-#: js/widgets/arpeggio.js:98
-#: js/widgets/musickeyboard.js:827
-#: js/widgets/pitchdrummatrix.js:166
-#: js/widgets/temperament.js:2559
+#: js/turtledefs.js:508 js/SaveInterface.js:256 js/widgets/legobricks.js:350
+#: js/widgets/meterwidget.js:229 js/widgets/modewidget.js:161
+#: js/widgets/phrasemaker.js:662 js/widgets/pitchslider.js:184
+#: js/widgets/pitchstaircase.js:777 js/widgets/reflection.js:154
+#: js/widgets/arpeggio.js:98 js/widgets/musickeyboard.js:827
+#: js/widgets/pitchdrummatrix.js:166 js/widgets/temperament.js:2559
 #: js/widgets/timbre.js:829
 msgid "Save"
 msgstr "ほぞん する"
@@ -879,9 +631,7 @@ msgstr "ほぞん する"
 msgid "Save your project to a file."
 msgstr "げんざい ひらいている プロジェクトを ほぞんする。"
 
-#: js/turtledefs.js:513
-#: js/toolbar-ui.js:253
-#: js/toolbar-ui.js:298
+#: js/turtledefs.js:513 js/toolbar-ui.js:253 js/toolbar-ui.js:298
 #: js/toolbar-ui.js:368
 msgid "Save turtle artwork as SVG"
 msgstr "アートを SVGで ほぞん"
@@ -890,12 +640,8 @@ msgstr "アートを SVGで ほぞん"
 msgid "Save graphics from your project to as SVG."
 msgstr "プロジェクトの グラフィックを SVGで ほぞん"
 
-#: js/turtledefs.js:517
-#: js/toolbar-ui.js:251
-#: js/toolbar-ui.js:254
-#: js/toolbar-ui.js:296
-#: js/toolbar-ui.js:299
-#: js/toolbar-ui.js:366
+#: js/turtledefs.js:517 js/toolbar-ui.js:251 js/toolbar-ui.js:254
+#: js/toolbar-ui.js:296 js/toolbar-ui.js:299 js/toolbar-ui.js:366
 #: js/toolbar-ui.js:369
 msgid "Save turtle artwork as PNG"
 msgstr "アートを PNGで ほぞん"
@@ -904,12 +650,8 @@ msgstr "アートを PNGで ほぞん"
 msgid "Save graphics from your project as PNG."
 msgstr "プロジェクトの グラフィックを PNGで ほぞん"
 
-#: js/turtledefs.js:521
-#: js/toolbar-ui.js:173
-#: js/toolbar-ui.js:246
-#: js/toolbar-ui.js:255
-#: js/toolbar-ui.js:300
-#: js/toolbar-ui.js:370
+#: js/turtledefs.js:521 js/toolbar-ui.js:173 js/toolbar-ui.js:246
+#: js/toolbar-ui.js:255 js/toolbar-ui.js:300 js/toolbar-ui.js:370
 msgid "Save block artwork as SVG"
 msgstr "ブロックの アートを ほぞん"
 
@@ -917,15 +659,11 @@ msgstr "ブロックの アートを ほぞん"
 msgid "Save block artwork as an SVG file."
 msgstr "ブロックの グラフィックを SVGで ほぞん"
 
-#: js/turtledefs.js:531
-#: js/toolbar-ui.js:166
-#: js/toolbar-ui.js:240
+#: js/turtledefs.js:531 js/toolbar-ui.js:166 js/toolbar-ui.js:240
 msgid "Save project as MIDI"
 msgstr "プロジェクトをMIDIとしてほぞん"
 
-#: js/turtledefs.js:533
-#: js/toolbar-ui.js:169
-#: js/toolbar-ui.js:243
+#: js/turtledefs.js:533 js/toolbar-ui.js:169 js/toolbar-ui.js:243
 msgid "Save music as WAV"
 msgstr "WAVでほぞん"
 
@@ -953,25 +691,20 @@ msgstr "オプションツールバーをひょうじ"
 msgid "Click this button to expand or collapse the auxiliary toolbar."
 msgstr "このボタンを クリックすると 「サブメニュー」を  ひらいたりおりたたんだり することが できる。"
 
-#: js/turtledefs.js:553
-#: js/toolbar-ui.js:143
-#: js/toolbar-ui.js:219
-#: js/toolbar-ui.js:276
-#: js/toolbar-ui.js:346
-#: js/piemenu-block-context.js:113
+#: js/turtledefs.js:553 js/toolbar-ui.js:143 js/toolbar-ui.js:219
+#: js/toolbar-ui.js:276 js/toolbar-ui.js:346 js/piemenu-block-context.js:113
 #: js/widgets/jseditor.js:380
 msgid "Help"
 msgstr "せつめい"
 
 #: js/turtledefs.js:554
-msgid "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
+msgid ""
+"Displays help messages for the main and auxiliary toolbar, right-click "
+"contextual menu for blocks and canvas, and palettes."
 msgstr "メインおよびほじょツールバー、ブロックとキャンバスのみぎクリックコンテクスト・メニュー、パレットのヘルプ。メッセージをひょうじします。"
 
-#: js/turtledefs.js:560
-#: js/toolbar-ui.js:145
-#: js/toolbar-ui.js:221
-#: js/toolbar-ui.js:278
-#: js/toolbar-ui.js:348
+#: js/turtledefs.js:560 js/toolbar-ui.js:145 js/toolbar-ui.js:221
+#: js/toolbar-ui.js:278 js/toolbar-ui.js:348
 msgid "Run slowly"
 msgstr "ゆっくり じっこう する"
 
@@ -979,23 +712,19 @@ msgstr "ゆっくり じっこう する"
 msgid "Click to run the project in slow mode."
 msgstr "クリックをすると、 ゆっくりとした スピードで プログラムを じっこうすることが できる。"
 
-#: js/turtledefs.js:565
-#: js/toolbar-ui.js:146
-#: js/toolbar-ui.js:222
-#: js/toolbar-ui.js:279
-#: js/toolbar-ui.js:349
+#: js/turtledefs.js:565 js/toolbar-ui.js:146 js/toolbar-ui.js:222
+#: js/toolbar-ui.js:279 js/toolbar-ui.js:349
 msgid "Run step by step"
 msgstr "ブロックを ひとつずつ じっこうする"
 
 #: js/turtledefs.js:566
 msgid "Click to run the project step by step."
-msgstr "クリックをすると、 とてもゆっくり、 ブロックを １つずつ じっこうする。 プログラムが うまく はたらかず、 どのブロックが げんいん なのかを しらべたいとき などに べんりだ。"
+msgstr ""
+"クリックをすると、 とてもゆっくり、 ブロックを １つずつ じっこうする。 プログラムが うまく はたらかず、 どのブロックが げんいん なのかを "
+"しらべたいとき などに べんりだ。"
 
-#: js/turtledefs.js:571
-#: js/toolbar-ui.js:147
-#: js/toolbar-ui.js:223
-#: js/toolbar-ui.js:280
-#: js/toolbar-ui.js:350
+#: js/turtledefs.js:571 js/toolbar-ui.js:147 js/toolbar-ui.js:223
+#: js/toolbar-ui.js:280 js/toolbar-ui.js:350
 msgid "Display statistics"
 msgstr "とうけいを ひょうじ する"
 
@@ -1003,11 +732,8 @@ msgstr "とうけいを ひょうじ する"
 msgid "Display statistics about your Music project."
 msgstr "プロジェクトに ふくまれている ブロックの しゅるい、 わりあい など、 とうけいてきな じょうほうを ひょうじする。"
 
-#: js/turtledefs.js:576
-#: js/toolbar-ui.js:148
-#: js/toolbar-ui.js:224
-#: js/toolbar-ui.js:281
-#: js/toolbar-ui.js:351
+#: js/turtledefs.js:576 js/toolbar-ui.js:148 js/toolbar-ui.js:224
+#: js/toolbar-ui.js:281 js/toolbar-ui.js:351
 msgid "Load plugin"
 msgstr "プラグインをよみこむ"
 
@@ -1015,11 +741,8 @@ msgstr "プラグインをよみこむ"
 msgid "Load a selected plugin."
 msgstr "せんたくしたプラグインをよみこみます。"
 
-#: js/turtledefs.js:581
-#: js/toolbar-ui.js:149
-#: js/toolbar-ui.js:225
-#: js/toolbar-ui.js:282
-#: js/toolbar-ui.js:352
+#: js/turtledefs.js:581 js/toolbar-ui.js:149 js/toolbar-ui.js:225
+#: js/toolbar-ui.js:282 js/toolbar-ui.js:352
 msgid "Delete plugin"
 msgstr "プラグインを けす"
 
@@ -1033,14 +756,11 @@ msgstr "じゆうなほうこうに／たてほうこうにスクロール"
 
 #: js/turtledefs.js:587
 msgid "You can scroll the blocks on the canvas."
-msgstr "カンバスじょうを ドラッグそうさ したときに、 がめんを スクロール させることができる ほうこうを じょうげ だけ と じょうげさゆう に かえる。"
+msgstr ""
+"カンバスじょうを ドラッグそうさ したときに、 がめんを スクロール させることができる ほうこうを じょうげ だけ と じょうげさゆう に かえる。"
 
-#: js/turtledefs.js:592
-#: js/toolbar-ui.js:152
-#: js/toolbar-ui.js:228
-#: js/toolbar-ui.js:285
-#: js/toolbar-ui.js:355
-#: js/widgets/jseditor.js:442
+#: js/turtledefs.js:592 js/toolbar-ui.js:152 js/toolbar-ui.js:228
+#: js/toolbar-ui.js:285 js/toolbar-ui.js:355 js/widgets/jseditor.js:442
 msgid "Change theme"
 msgstr "テーマをへんこう"
 
@@ -1048,14 +768,9 @@ msgstr "テーマをへんこう"
 msgid "Switch between dark and light mode."
 msgstr "ダークモードとライトモードをきりかえます。"
 
-#: js/turtledefs.js:597
-#: js/toolbar-ui.js:156
-#: js/toolbar-ui.js:232
-#: js/toolbar-ui.js:289
-#: js/toolbar-ui.js:359
-#: planet/js/GlobalCard.js:56
-#: planet/js/LocalCard.js:64
-#: planet/js/StringHelper.js:78
+#: js/turtledefs.js:597 js/toolbar-ui.js:156 js/toolbar-ui.js:232
+#: js/toolbar-ui.js:289 js/toolbar-ui.js:359 planet/js/GlobalCard.js:56
+#: planet/js/LocalCard.js:64 planet/js/StringHelper.js:78
 msgid "Merge with current project"
 msgstr "プロジェクトを くみあわせる"
 
@@ -1071,9 +786,7 @@ msgstr "アートを つつむ"
 msgid "Turn Turtle wrapping On or Off."
 msgstr "アートつつむか・つつまない"
 
-#: js/turtledefs.js:607
-#: js/toolbar-ui.js:157
-#: js/toolbar-ui.js:233
+#: js/turtledefs.js:607 js/toolbar-ui.js:157 js/toolbar-ui.js:233
 msgid "Set Pitch Preview"
 msgstr "へんかきごうをせってい"
 
@@ -1081,11 +794,8 @@ msgstr "へんかきごうをせってい"
 msgid "Click to set the current pitch."
 msgstr "クリックしてげんざいのおんこうをせっていします。"
 
-#: js/turtledefs.js:613
-#: js/toolbar-ui.js:158
-#: js/toolbar-ui.js:234
-#: js/toolbar-ui.js:290
-#: js/toolbar-ui.js:360
+#: js/turtledefs.js:613 js/toolbar-ui.js:158 js/toolbar-ui.js:234
+#: js/toolbar-ui.js:290 js/toolbar-ui.js:360
 msgid "JavaScript Editor"
 msgstr "ジャバスクリプト エディタ"
 
@@ -1093,17 +803,16 @@ msgstr "ジャバスクリプト エディタ"
 msgid "Converts Music Block programs to JavaScript."
 msgstr "ミュージック・ブロックスのプログラムをJavaScriptにへんかんします。"
 
-#: js/turtledefs.js:619
-#: js/toolbar-ui.js:159
-#: js/toolbar-ui.js:235
-#: js/toolbar-ui.js:291
-#: js/toolbar-ui.js:361
+#: js/turtledefs.js:619 js/toolbar-ui.js:159 js/toolbar-ui.js:235
+#: js/toolbar-ui.js:291 js/toolbar-ui.js:361
 msgid "Restore"
 msgstr "すてた ブロックを もどす"
 
 #: js/turtledefs.js:620
 msgid "Restore blocks from the trash."
-msgstr "ごみばこに すててしまった ブロックを とりだして もどす。 ふくすうの ブロックを すててある ときは あたらしい じゅんに、 ごみばこが からに なるまで ブロックを ひろいもどすことが できる。"
+msgstr ""
+"ごみばこに すててしまった ブロックを とりだして もどす。 ふくすうの ブロックを すててある ときは あたらしい じゅんに、 ごみばこが からに "
+"なるまで ブロックを ひろいもどすことが できる。"
 
 #: js/turtledefs.js:624
 msgid "Switch mode"
@@ -1111,14 +820,11 @@ msgstr "モードを せってい"
 
 #: js/turtledefs.js:625
 msgid "Switch between beginner and advance modes."
-msgstr "ミュージック・ブロックスを かんたんモード／はってんモード に きりかえる。 モードによって つかえる きのうや ブロックの しゅるいが かわる。"
+msgstr ""
+"ミュージック・ブロックスを かんたんモード／はってんモード に きりかえる。 モードによって つかえる きのうや ブロックの しゅるいが かわる。"
 
-#: js/turtledefs.js:629
-#: js/toolbar-ui.js:162
-#: js/toolbar-ui.js:238
-#: js/toolbar-ui.js:249
-#: js/toolbar-ui.js:294
-#: js/toolbar-ui.js:364
+#: js/turtledefs.js:629 js/toolbar-ui.js:162 js/toolbar-ui.js:238
+#: js/toolbar-ui.js:249 js/toolbar-ui.js:294 js/toolbar-ui.js:364
 msgid "Select language"
 msgstr "げんごを えらぶ"
 
@@ -1126,8 +832,7 @@ msgstr "げんごを えらぶ"
 msgid "Select your language preference."
 msgstr "ブロックの なまえなどに ひょうじ される げんごを えらぶ。"
 
-#: js/turtledefs.js:634
-#: js/widgets/help.js:565
+#: js/turtledefs.js:634 js/widgets/help.js:565
 msgid "Contextual Menu for Blocks"
 msgstr "ブロックのコンテクスト・メニュー"
 
@@ -1135,39 +840,39 @@ msgstr "ブロックのコンテクスト・メニュー"
 msgid "Right-click on a block to access common actions."
 msgstr "ブロックをみぎクリックしてきょうつうそうさにあくせすします。"
 
-#: js/turtledefs.js:639
-#: planet/js/StringHelper.js:48
+#: js/turtledefs.js:639 planet/js/StringHelper.js:48
 msgid "Delete"
 msgstr "けす"
 
 #: js/turtledefs.js:640
-msgid "To delete a block, right-click on it. Then you will see the delete option."
+msgid ""
+"To delete a block, right-click on it. Then you will see the delete option."
 msgstr "ブロックをさくじょするには、ブロックをみぎクリックします。つぎに、さくじょオプションがひょうじされます。"
 
 #: js/turtledefs.js:645
 msgid "To copy a block, right-click on it. Then you will see the copy option."
 msgstr "ブロックをコピーするには、ブロックをみぎクリックします。つぎに、「コピー」オプションがひょうじされます。"
 
-#: js/turtledefs.js:649
-#: js/piemenu-block-context.js:101
+#: js/turtledefs.js:649 js/piemenu-block-context.js:101
 msgid "Extract"
 msgstr "とりだす"
 
 #: js/turtledefs.js:650
-msgid "To extract a block, right-click on it. Then you will see the extract option."
+msgid ""
+"To extract a block, right-click on it. Then you will see the extract option."
 msgstr "ブロックをちゅうしゅつするには、ブロックをみぎクリックします。つぎに、ちゅうしゅつオプションがひょうじされます。"
 
-#: js/turtledefs.js:659
-#: js/widgets/help.js:564
+#: js/turtledefs.js:659 js/widgets/help.js:564
 msgid "Tab Navigation"
 msgstr "たぶのなびげーしょん"
 
 #: js/turtledefs.js:660
-msgid "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
+msgid ""
+"Press the Tab key on your keyboard to magically jump between the workspace, "
+"toolbar, and palette!"
 msgstr "キーボードの Tab キーをおすと、ワークスペース、ツールバー、パレットからをまほうのようにじゃんぷできます。"
 
-#: js/turtledefs.js:668
-#: js/widgets/help.js:566
+#: js/turtledefs.js:668 js/widgets/help.js:566
 msgid "Contextual Menu for Canvas"
 msgstr "キャンバスのコンテクスト・メニュー"
 
@@ -1183,20 +888,13 @@ msgstr "でかるとざひょうまたはきょくざひょうグリッドのせ
 msgid "Turn on/off music staffs."
 msgstr "ごせんふのひょうじ/ひひょうじをきりかえます。"
 
-#: js/turtledefs.js:681
-#: js/turtles.js:1009
-#: js/blocks/GraphicsBlocks.js:369
-#: js/widgets/legobricks.js:374
-#: js/widgets/modewidget.js:164
-#: js/widgets/phrasemaker.js:676
-#: js/widgets/pitchstaircase.js:800
-#: js/widgets/rhythmruler.js:760
-#: js/widgets/arpeggio.js:109
-#: js/widgets/musickeyboard.js:835
-#: js/widgets/pitchdrummatrix.js:178
-#: js/widgets/temperament.js:387
-#: js/widgets/temperament.js:418
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
+#: js/turtledefs.js:681 js/turtles.js:1009 js/blocks/GraphicsBlocks.js:369
+#: js/widgets/legobricks.js:374 js/widgets/modewidget.js:164
+#: js/widgets/phrasemaker.js:676 js/widgets/pitchstaircase.js:800
+#: js/widgets/rhythmruler.js:760 js/widgets/arpeggio.js:109
+#: js/widgets/musickeyboard.js:835 js/widgets/pitchdrummatrix.js:178
+#: js/widgets/temperament.js:387 js/widgets/temperament.js:418
 msgid "Clear"
 msgstr "しょうきょ"
 
@@ -1204,17 +902,18 @@ msgstr "しょうきょ"
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr "ネズミを もとのいちに もどし、 ペンで えがいた せんを すべて けす。"
 
-#: js/turtledefs.js:686
-#: js/turtles.js:1030
+#: js/turtledefs.js:686 js/turtles.js:1030
 msgid "Collapse"
 msgstr "カンバスを しゅくしょう"
 
 #: js/turtledefs.js:687
 msgid "Collapse the graphics window."
-msgstr "ネズミが いどうしたり、 ペンで せんを えがいたり できる 「カンバス」の ひょうじサイズを しゅくしょう／かくだいする。<br>カンバスを しゅくしょう したばあいは、 プログラムを  ふつうの そくどで じっこう しても、 ブロックが かくれない。 ふつうの じっこうそくどで プログラムの どうさ かくにんを したいときなどに べんりだ。"
+msgstr ""
+"ネズミが いどうしたり、 ペンで せんを えがいたり できる 「カンバス」の ひょうじサイズを しゅくしょう／かくだいする。<br>カンバスを "
+"しゅくしょう したばあいは、 プログラムを  ふつうの そくどで じっこう しても、 ブロックが かくれない。 ふつうの じっこうそくどで プログラムの"
+" どうさ かくにんを したいときなどに べんりだ。"
 
-#: js/turtledefs.js:691
-#: js/context-menu-controller.js:191
+#: js/turtledefs.js:691 js/context-menu-controller.js:191
 msgid "Home"
 msgstr "ホーム"
 
@@ -1222,8 +921,7 @@ msgstr "ホーム"
 msgid "Return all blocks to the center of the screen."
 msgstr "すべての ブロックを、 カンバスの まんなかに はいち する。"
 
-#: js/turtledefs.js:696
-#: js/context-menu-controller.js:208
+#: js/turtledefs.js:696 js/context-menu-controller.js:208
 msgid "Show/hide blocks"
 msgstr "ブロックを ひょうじ／ひひょうじ"
 
@@ -1231,17 +929,16 @@ msgstr "ブロックを ひょうじ／ひひょうじ"
 msgid "Hide or show the blocks and the palettes."
 msgstr "クリックすると、 パレットボタンと プログラムの ブロックを がめんじょうに ひょうじさせたり、かくしたりすることができる。"
 
-#: js/turtledefs.js:701
-#: js/context-menu-controller.js:224
+#: js/turtledefs.js:701 js/context-menu-controller.js:224
 msgid "Expand/collapse blocks"
 msgstr "ブロックを ひろげる/おりたたむ"
 
 #: js/turtledefs.js:702
 msgid "Expand or collapse start and action stacks."
-msgstr "クリックすると、 「スタート」と「アクション」に つかわれている ブロックを、ひろげて ひょうじしたり、おりたたんで かくしたりすることができる。"
+msgstr ""
+"クリックすると、 「スタート」と「アクション」に つかわれている ブロックを、ひろげて ひょうじしたり、おりたたんで かくしたりすることができる。"
 
-#: js/turtledefs.js:706
-#: js/context-menu-controller.js:240
+#: js/turtledefs.js:706 js/context-menu-controller.js:240
 msgid "Decrease block size"
 msgstr "ブロックのひょうじを ちいさくする"
 
@@ -1249,8 +946,7 @@ msgstr "ブロックのひょうじを ちいさくする"
 msgid "Decrease the size of the blocks."
 msgstr "がめんに ひょうじされる ブロックの サイズを ちいさくする。"
 
-#: js/turtledefs.js:711
-#: js/context-menu-controller.js:255
+#: js/turtledefs.js:711 js/context-menu-controller.js:255
 msgid "Increase block size"
 msgstr "ブロックのひょうじを おおきくする"
 
@@ -1271,33 +967,42 @@ msgid "Palette buttons"
 msgstr "パレットボタン"
 
 #: js/turtledefs.js:725
-msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
+msgid ""
+"This toolbar contains the palette buttons including Rhythm Pitch Tone Action"
+" and more."
 msgstr "ミュージック・ブロックスのひだりがわには、 プログラミングにつかう さまざまな ブロックを グループわけした 「パレットボタン」がある。"
 
 #: js/turtledefs.js:729
-msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
-msgstr " それぞれの パレットボタンを クリックし、 「おんぷ」「アクション」「ペン」などから すきな ブロックをえらんで、 カンバスじょうに ドラッグして おいてみよう。"
+msgid ""
+"Click to show the palettes of blocks and drag blocks from the palettes onto "
+"the canvas to use them."
+msgstr ""
+" それぞれの パレットボタンを クリックし、 「おんぷ」「アクション」「ペン」などから すきな ブロックをえらんで、 カンバスじょうに ドラッグして "
+"おいてみよう。"
 
 #: js/turtledefs.js:738
 msgid "A detailed guide to Turtle Blocks is available."
-msgstr "インターネットから、 タートル・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
+msgstr ""
+"インターネットから、 タートル・ブロックスの さらに くわしい ガイドページを みることが できる。 つぎの リンクさきを ひらいて みよう。"
 
 #: js/turtledefs.js:741
 msgid "Turtle Blocks Guide"
 msgstr "タートル・ブロックス ガイド"
 
-#: js/turtledefs.js:744
-#: js/turtledefs.js:769
-#: js/widgets/help.js:551
+#: js/turtledefs.js:744 js/turtledefs.js:769 js/widgets/help.js:551
 msgid "About"
 msgstr "タートル・ブロックスに ついて"
 
 #: js/turtledefs.js:745
-msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
+msgid ""
+"Turtle Blocks is an open source collection of tools for exploring musical "
+"concepts."
 msgstr "タートル・ブロックスは、 おんがくの コンセプトを たんきゅうするために つくられた、 オープンソースの ツールだ。"
 
 #: js/turtledefs.js:749
-msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
+msgid ""
+"A full list of contributors can be found in the Turtle Blocks GitHub "
+"repository."
 msgstr "タートル・ブロックスに かかわってきた ひとの いちらんは、 GitHub（ギットハブ） の リポジトリで みることができる。"
 
 #: js/turtledefs.js:753
@@ -1308,9 +1013,7 @@ msgstr "タートル・ブロックスの プログラムは、 だれでもじ�
 msgid "Turtle Blocks GitHub repository"
 msgstr "タートル・ブロックスのリポジトリ"
 
-#: js/turtledefs.js:763
-#: js/widgets/help.js:495
-#: js/widgets/help.js:552
+#: js/turtledefs.js:763 js/widgets/help.js:495 js/widgets/help.js:552
 msgid "Congratulations."
 msgstr "おめでとうございます！"
 
@@ -1319,11 +1022,15 @@ msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr "ツアーは ここで おわり。タータル・ブロックスを じゆうに たのしもう。"
 
 #: js/turtledefs.js:770
-msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
+msgid ""
+"Music Blocks is an open source collection of tools for exploring musical "
+"concepts."
 msgstr "ミュージック・ブロックスは、 おんがくの コンセプトを たんきゅうするために つくられた、 オープンソースの ツールだ。"
 
 #: js/turtledefs.js:774
-msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
+msgid ""
+"A full list of contributors can be found in the Music Blocks GitHub "
+"repository."
 msgstr "ミュージック・ブロックスに かかわってきた ひとの いちらんは、 GitHub（ギットハブ） の リポジトリで みることができる。"
 
 #: js/turtledefs.js:778
@@ -1334,8 +1041,7 @@ msgstr "ミュージック・ブロックスの プログラムは、 だれで�
 msgid "Music Blocks GitHub repository"
 msgstr "ミュージック・ブロックスのリポジトリ"
 
-#: js/turtledefs.js:786
-#: js/widgets/help.js:553
+#: js/turtledefs.js:786 js/widgets/help.js:553
 msgid "Congratulations!"
 msgstr "おめでとうございます！"
 
@@ -1347,20 +1053,14 @@ msgstr "ミスター・マウスの ツアーは ここでおわり。 ミュー
 msgid "Expand"
 msgstr "カンバスを かくだい"
 
-#: js/SaveInterface.js:25
-#: js/project-manager.js:262
-#: js/project-manager.js:266
-#: js/project-manager.js:360
-#: planet/js/GlobalPlanet.js:464
-#: planet/js/GlobalPlanet.js:466
-#: planet/js/GlobalPlanet.js:494
+#: js/SaveInterface.js:25 js/project-manager.js:262 js/project-manager.js:266
+#: js/project-manager.js:360 planet/js/GlobalPlanet.js:464
+#: planet/js/GlobalPlanet.js:466 planet/js/GlobalPlanet.js:494
 #: planet/js/ProjectStorage.js:26
 msgid "My Project"
 msgstr "じぶんの プロジェクト"
 
-#: js/SaveInterface.js:26
-#: js/blocks.js:4607
-#: js/blocks/MediaBlocks.js:971
+#: js/SaveInterface.js:26 js/blocks.js:4607 js/blocks/MediaBlocks.js:971
 msgid "Show"
 msgstr "プロジェクトの コードを ひょうじ する"
 
@@ -1385,11 +1085,15 @@ msgid "For more information, please consult the"
 msgstr "もっと くわしく しりたい ばあいは、 ミュージック・ブロックスの ガイドを さんしょう して ください。"
 
 #: js/SaveInterface.js:96
-msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
-msgstr "このプロジェクトをじっこうするには、ぶらうざでミュージック・ブロックスをひらき、このファイルをぶらうざ・ウィンドウにドラッグ・アンド・ドロップします。"
+msgid ""
+"To run this project, open Music Blocks in a web browser and drag and drop "
+"this file into the browser window."
+msgstr ""
+"このプロジェクトをじっこうするには、ぶらうざでミュージック・ブロックスをひらき、このファイルをぶらうざ・ウィンドウにドラッグ・アンド・ドロップします。"
 
 #: js/SaveInterface.js:100
-msgid "Alternatively, open the file in Music Blocks using the Load project button."
+msgid ""
+"Alternatively, open the file in Music Blocks using the Load project button."
 msgstr "「ファイルから プロジェクトを よみこむ」 ボタンを おして、 ファイルを ひらいて ください。"
 
 #: js/SaveInterface.js:102
@@ -1398,7 +1102,9 @@ msgstr "プロジェクトの コード"
 
 #: js/SaveInterface.js:104
 msgid "This code stores data about the blocks in a project."
-msgstr "この コードは、 がいとう する ばあい、 へんしゅう された バージョンの プロジェクトと いっしょに、 プロジェクトの なかの ブロックに かんする データを ほぞん します。"
+msgstr ""
+"この コードは、 がいとう する ばあい、 へんしゅう された バージョンの プロジェクトと いっしょに、 プロジェクトの なかの ブロックに かんする"
+" データを ほぞん します。"
 
 #: js/SaveInterface.js:109
 msgid "Copy to Clipboard"
@@ -1432,25 +1138,18 @@ msgstr "ファイルがほぞんされました!ダウンロードをかくに�
 msgid "Save file"
 msgstr "ファイルをほぞん"
 
-#: js/SaveInterface.js:254
-#: js/SaveInterface.js:261
+#: js/SaveInterface.js:254 js/SaveInterface.js:261
 msgid "Filename:"
 msgstr "ファイルめい："
 
-#: js/SaveInterface.js:257
-#: js/project-manager.js:706
-#: js/toolbar-ui.js:612
-#: js/activity.js:782
-#: js/svgAssetSelector.js:172
-#: js/widgets/aidebugger.js:581
-#: planet/js/Planet.js:176
-#: planet/js/StringHelper.js:42
+#: js/SaveInterface.js:257 js/project-manager.js:706 js/toolbar-ui.js:612
+#: js/activity.js:782 js/svgAssetSelector.js:172 js/widgets/aidebugger.js:581
+#: planet/js/Planet.js:176 planet/js/StringHelper.js:42
 #: planet/js/StringHelper.js:49
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: js/SaveInterface.js:325
-#: planet/js/SaveInterface.js:90
+#: js/SaveInterface.js:325 planet/js/SaveInterface.js:90
 msgid "No description provided"
 msgstr "きにゅうが ありません"
 
@@ -1458,64 +1157,52 @@ msgstr "きにゅうが ありません"
 msgid "Your recording is in progress."
 msgstr "ろくおんちゅう"
 
-#: js/SaveInterface.js:639
-#: js/SaveInterface.js:679
-#: js/logo.js:2333
+#: js/SaveInterface.js:639 js/SaveInterface.js:679 js/logo.js:2333
 msgid "Error generating ABC output."
 msgstr "ABC しゅつりょくのせいせいなかにエラーがはっせいしました。"
 
+#. TRANS: File name prompt for save as Lilypond
 #: js/SaveInterface.js:742
-#.TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ファイルめい"
 
-#: js/SaveInterface.js:744
-#: planet/js/StringHelper.js:38
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
+#: js/SaveInterface.js:744 planet/js/StringHelper.js:38
 msgid "Project title"
 msgstr "きょくめい"
 
+#. TRANS: Project title prompt for save as Lilypond
 #: js/SaveInterface.js:746
-#.TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "さっきょくか"
 
+#. TRANS: MIDI prompt for save as Lilypond
 #: js/SaveInterface.js:748
-#.TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDIのアウトプット がくふにも まとめましょうか？"
 
+#. TRANS: Guitar prompt for save as Lilypond
 #: js/SaveInterface.js:750
-#.TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "ギターの TABも がくふに まとめましょうか？"
 
+#. TRANS: Lilypond is a scripting language for generating sheet music
 #: js/SaveInterface.js:752
-#.TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondがくふの フォーマットで ほぞん"
 
-#: js/SaveInterface.js:764
-#: js/SaveInterface.js:767
-#: js/blocks/EnsembleBlocks.js:115
-#: js/blocks/EnsembleBlocks.js:177
-#: js/blocks/EnsembleBlocks.js:238
-#: js/blocks/EnsembleBlocks.js:320
-#: js/blocks/EnsembleBlocks.js:366
-#: js/blocks/EnsembleBlocks.js:407
-#: js/blocks/EnsembleBlocks.js:461
-#: js/blocks/EnsembleBlocks.js:512
-#: js/blocks/EnsembleBlocks.js:557
-#: js/blocks/EnsembleBlocks.js:605
-#: js/blocks/EnsembleBlocks.js:659
-#: js/blocks/EnsembleBlocks.js:778
-#: js/blocks/EnsembleBlocks.js:865
-#: js/blocks/EnsembleBlocks.js:925
-#: js/blocks/EnsembleBlocks.js:970
-#: js/blocks/EnsembleBlocks.js:1238
+#. TRANS: default project title when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
+#: js/SaveInterface.js:764 js/SaveInterface.js:767
+#: js/blocks/EnsembleBlocks.js:115 js/blocks/EnsembleBlocks.js:177
+#: js/blocks/EnsembleBlocks.js:238 js/blocks/EnsembleBlocks.js:320
+#: js/blocks/EnsembleBlocks.js:366 js/blocks/EnsembleBlocks.js:407
+#: js/blocks/EnsembleBlocks.js:461 js/blocks/EnsembleBlocks.js:512
+#: js/blocks/EnsembleBlocks.js:557 js/blocks/EnsembleBlocks.js:605
+#: js/blocks/EnsembleBlocks.js:659 js/blocks/EnsembleBlocks.js:778
+#: js/blocks/EnsembleBlocks.js:865 js/blocks/EnsembleBlocks.js:925
+#: js/blocks/EnsembleBlocks.js:970 js/blocks/EnsembleBlocks.js:1238
 #: js/blocks/EnsembleBlocks.js:1306
-#.TRANS: default project title when saving as Lilypond
-#.TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "ミスター・マウス"
 
@@ -1607,8 +1294,8 @@ msgstr "プラグインは さいせいするときえるよ"
 msgid "show Cartesian"
 msgstr "ほうがん（ざひょう）を ひょうじ"
 
-#. TRANS: a numeric mapping of the notes in an octave based on the musical
-#. mode
+#.  TRANS: a numeric mapping of the notes in an octave based on the musical
+#.  mode
 #: js/activity.js:3331 js/palette.js:1258 js/blocks/RhythmBlocks.js:925
 #: js/blocks/PitchBlocks.js:462 js/blocks/PitchBlocks.js:1831
 msgid "scale degree"
@@ -1742,9 +1429,7 @@ msgstr "ブロックをしたにうごかしています"
 msgid "Moving block left."
 msgstr "ブロックをひだりにうごかしています"
 
-#: js/SaveInterface.js:871
-#: js/SaveInterface.js:930
-#: js/logo.js:2319
+#: js/SaveInterface.js:871 js/SaveInterface.js:930 js/logo.js:2319
 msgid "Error generating Lilypond output."
 msgstr "Lilypond しゅつりょくのせいせいなかにエラーがはっせいしました。"
 
@@ -1753,21 +1438,20 @@ msgid "The Lilypond code is copied to clipboard. You can paste it here:"
 msgstr "Lilypond コードがクリップボードにコピーされます。ここにはりつけることができます:"
 
 #: js/SaveInterface.js:1017
-msgid "Failed to convert Lilypond to PDF. Please try saving as .ly file instead."
+msgid ""
+"Failed to convert Lilypond to PDF. Please try saving as .ly file instead."
 msgstr "Lilypond を PDF にへんかんできませんでした。かわりに .ly ファイルとしてほぞんしてみてください。"
 
 #: js/block-drag-controller.js:534
 msgid "Consider breaking this stack into parts."
 msgstr "この ながい スタックを べつべつの スタックに した ほうが いい"
 
-#: js/context-menu-controller.js:438
-#: js/trash-controller.js:57
+#: js/context-menu-controller.js:438 js/trash-controller.js:57
 #: js/trash-controller.js:75
 msgid "Trash can is empty."
 msgstr "ごみはこはそらです。"
 
-#: js/context-menu-controller.js:444
-#: js/trash-controller.js:79
+#: js/context-menu-controller.js:444 js/trash-controller.js:79
 #: js/trash-controller.js:215
 msgid "Item restored from the trash."
 msgstr "ごみはこから アイテムを ふくげんしました。"
@@ -1789,15 +1473,17 @@ msgid "Loading Complete!"
 msgstr "よみこみかんりょう！"
 
 #: js/activity.js:7068
-msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
+msgid ""
+"Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "くみこみプラグインのなまえをにゅうりょくするか、くうはくのままにしてプラグイン ファイルをプラグインします。"
 
 #: js/activity.js:7080
-msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
+msgid ""
+"Invalid plugin name. Only alphanumeric characters, hyphens, and underscores "
+"are allowed."
 msgstr "プラグインめいがむこうです。えいすうじ、はいふん、あんだーすこあのみがしようできます。"
 
-#: js/activity.js:7538
-#: js/help-controller.js:92
+#: js/activity.js:7538 js/help-controller.js:92
 msgid "Windows/Linux"
 msgstr "Windows/Linux"
 
@@ -1809,13 +1495,11 @@ msgstr "まっく"
 msgid "Workspace"
 msgstr "ワークスペース"
 
-#: js/help-controller.js:100
-#: js/toolbar-ui.js:493
+#: js/help-controller.js:100 js/toolbar-ui.js:493
 msgid "Play project"
 msgstr "プロジェクトをさいせい"
 
-#: js/help-controller.js:104
-#: js/toolbar-ui.js:555
+#: js/help-controller.js:104 js/toolbar-ui.js:555
 msgid "Stop project"
 msgstr "プロジェクトをていしする"
 
@@ -1895,14 +1579,16 @@ msgstr "なびげーしょん"
 msgid "Move focus between the toolbar, palettes, and workspace."
 msgstr "ツールバー、パレット、ワークスペースのなかからフォーカスをいどうします。"
 
-#: js/help-controller.js:185
-#: js/help-controller.js:248
+#: js/help-controller.js:185 js/help-controller.js:248
 msgid "Arrow keys"
 msgstr "やじるしキー"
 
 #: js/help-controller.js:186
-msgid "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
-msgstr "コンテクストにおうじて、アクティブなブロックのいどう、パレットのスクロール、てんぽ ツールのちょうせい、またはワークスペースのパンをおこないます。"
+msgid ""
+"Move the active block, scroll palettes, adjust the tempo widget, or pan the "
+"workspace depending on context."
+msgstr ""
+"コンテクストにおうじて、アクティブなブロックのいどう、パレットのスクロール、てんぽ ツールのちょうせい、またはワークスペースのパンをおこないます。"
 
 #: js/help-controller.js:192
 msgid "Pan workspace right when horizontal scrolling is enabled."
@@ -1916,10 +1602,8 @@ msgstr "すいへいスクロールがゆうこうなばあい、ワークスペ
 msgid "Toolbar"
 msgstr "ツールバー"
 
-#: js/help-controller.js:205
-#: js/help-controller.js:206
-#: js/help-controller.js:242
-#: js/help-controller.js:243
+#: js/help-controller.js:205 js/help-controller.js:206
+#: js/help-controller.js:242 js/help-controller.js:243
 msgid "Arrow Left / Arrow Right"
 msgstr "ひだりやじるし / みぎやじるし"
 
@@ -1967,23 +1651,21 @@ msgstr "ヘルプがひらいているときにヘルプ・ページのなかか
 msgid "Adjust pitch by semitone when Pitch Slider is open."
 msgstr "ピッチ・スライダーがひらいているときにはんおんたんいでピッチをちょうせいします。"
 
-#: js/help-controller.js:257
-#: js/help-controller.js:280
-#: js/toolbar-ui.js:144
-#: js/toolbar-ui.js:220
-#: js/toolbar-ui.js:277
-#: js/toolbar-ui.js:347
+#: js/help-controller.js:257 js/help-controller.js:280 js/toolbar-ui.js:144
+#: js/toolbar-ui.js:220 js/toolbar-ui.js:277 js/toolbar-ui.js:347
 msgid "Keyboard shortcuts"
 msgstr "キーボードのショートカット"
 
 #: js/help-controller.js:284
-msgid "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
-msgstr "ショートカットは じょうきょうに いぞんします。いちぶのきのうは、かんれんする パネル、ツール、または モードが アクティブな ばあいに のみきのうします。 Windows/Linux および Mac のどうとうの ものを いっしょに しめします。"
+msgid ""
+"Shortcuts are context-sensitive. Some only work when a related panel, "
+"widget, or mode is active. Windows/Linux and Mac equivalents are shown "
+"together."
+msgstr ""
+"ショートカットは じょうきょうに いぞんします。いちぶのきのうは、かんれんする パネル、ツール、または モードが アクティブな ばあいに "
+"のみきのうします。 Windows/Linux および Mac のどうとうの ものを いっしょに しめします。"
 
-#: js/lilypond.js:619
-#: js/lilypond.js:909
-#: js/lilypond.js:912
-#: js/lilypond.js:950
+#: js/lilypond.js:619 js/lilypond.js:909 js/lilypond.js:912 js/lilypond.js:950
 #: js/rubrics.js:536
 msgid "mouse"
 msgstr "ネズミ"
@@ -2032,11 +1714,8 @@ msgstr "モモンガ"
 msgid "bat"
 msgstr "こうもり"
 
-#: js/lilypond.js:758
-#: js/lilypond.js:915
-#: js/lilypond.js:953
-#: js/blocks/ActionBlocks.js:1284
-#: js/blocks/ExtrasBlocks.js:561
+#: js/lilypond.js:758 js/lilypond.js:915 js/lilypond.js:953
+#: js/blocks/ActionBlocks.js:1284 js/blocks/ExtrasBlocks.js:561
 msgid "start drum"
 msgstr "ドラム・スタート"
 
@@ -2047,6 +1726,8 @@ msgstr "えらばれた おんめいが てきせつでは ありません。"
 #: js/logoconstants.js:44
 msgid "Pitch index exceeds EDO range"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/project-manager.js:60
 msgid "Catching mice"
@@ -2100,31 +1781,23 @@ msgstr "MIDIをいんぽーとする"
 msgid "Set the max blocks to generate:"
 msgstr "せいせいするさいだいブロックをせっていします。"
 
-#: js/project-manager.js:686
-#: js/toolbar-ui.js:175
-#: js/toolbar-ui.js:248
-#: js/toolbar-ui.js:257
-#: js/toolbar-ui.js:302
-#: js/toolbar-ui.js:372
-#: js/toolbar-ui.js:607
-#: js/activity.js:766
-#: planet/js/Planet.js:160
+#: js/project-manager.js:686 js/toolbar-ui.js:175 js/toolbar-ui.js:248
+#: js/toolbar-ui.js:257 js/toolbar-ui.js:302 js/toolbar-ui.js:372
+#: js/toolbar-ui.js:607 js/activity.js:766 planet/js/Planet.js:160
 msgid "Confirm"
 msgstr "さくせいする"
 
-#: js/project-manager.js:775
-#: js/project-manager.js:832
-#: js/project-manager.js:854
-#: js/project-manager.js:891
-#: js/project-manager.js:940
-#: js/project-manager.js:957
+#: js/project-manager.js:775 js/project-manager.js:832
+#: js/project-manager.js:854 js/project-manager.js:891
+#: js/project-manager.js:940 js/project-manager.js:957
 msgid "Cannot load project from the file. Please check the file type."
 msgstr "プロジェクトを よみこめません。 ファイルの しゅるいを かくにん してください。"
 
-#: js/project-manager.js:787
-#: js/project-manager.js:902
+#: js/project-manager.js:787 js/project-manager.js:902
 msgid "Cannot find project data in this HTML file."
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/project-manager.js:1076
 msgid "Something went wrong reading JSON-encoded project data."
@@ -2138,116 +1811,84 @@ msgstr "むこうな パラメータ"
 msgid "mice"
 msgstr "ネズミたちのかんけい"
 
-#: js/search-ui.js:127
-#: js/activity.js:581
+#: js/search-ui.js:127 js/activity.js:581
 msgid "Search for blocks"
 msgstr "ブロックをさがす"
 
-#: js/toolbar-ui.js:128
-#: js/toolbar-ui.js:204
+#: js/toolbar-ui.js:128 js/toolbar-ui.js:204
 msgid "About Music Blocks"
 msgstr "ミュージック・ブロックスに ついて"
 
-#: js/toolbar-ui.js:132
-#: js/toolbar-ui.js:133
-#: js/toolbar-ui.js:208
-#: js/toolbar-ui.js:209
-#: js/toolbar-ui.js:265
-#: js/toolbar-ui.js:266
-#: js/toolbar-ui.js:335
-#: js/toolbar-ui.js:336
+#: js/toolbar-ui.js:132 js/toolbar-ui.js:133 js/toolbar-ui.js:208
+#: js/toolbar-ui.js:209 js/toolbar-ui.js:265 js/toolbar-ui.js:266
+#: js/toolbar-ui.js:335 js/toolbar-ui.js:336
 msgid "Enter Fullscreen"
 msgstr "ぜんがめんひょうじにいる"
 
-#: js/toolbar-ui.js:139
-#: js/toolbar-ui.js:215
-#: js/toolbar-ui.js:272
+#: js/toolbar-ui.js:139 js/toolbar-ui.js:215 js/toolbar-ui.js:272
 #: js/toolbar-ui.js:342
 msgid "Find and share projects"
 msgstr "みんなの さくひん"
 
-#: js/toolbar-ui.js:140
-#: js/toolbar-ui.js:216
-#: js/toolbar-ui.js:273
+#: js/toolbar-ui.js:140 js/toolbar-ui.js:216 js/toolbar-ui.js:273
 #: js/toolbar-ui.js:343
 msgid "Offline. Sharing is unavailable"
 msgstr "オフライン。シェア きのうが つかえません"
 
-#: js/toolbar-ui.js:141
-#: js/toolbar-ui.js:217
-#: js/toolbar-ui.js:274
+#: js/toolbar-ui.js:141 js/toolbar-ui.js:217 js/toolbar-ui.js:274
 #: js/toolbar-ui.js:344
 msgid "Auxiliary menu"
 msgstr "サブメニュー"
 
-#: js/toolbar-ui.js:142
-#: js/toolbar-ui.js:218
-#: js/toolbar-ui.js:275
+#: js/toolbar-ui.js:142 js/toolbar-ui.js:218 js/toolbar-ui.js:275
 #: js/toolbar-ui.js:345
 msgid "Help and shortcuts"
 msgstr "ヘルプとショートカット"
 
-#: js/toolbar-ui.js:150
-#: js/toolbar-ui.js:226
-#: js/toolbar-ui.js:283
+#: js/toolbar-ui.js:150 js/toolbar-ui.js:226 js/toolbar-ui.js:283
 #: js/toolbar-ui.js:353
 msgid "Enable horizontal scrolling"
 msgstr "じゆうな ほうこうに スクロール"
 
-#: js/toolbar-ui.js:151
-#: js/toolbar-ui.js:227
-#: js/toolbar-ui.js:284
+#: js/toolbar-ui.js:151 js/toolbar-ui.js:227 js/toolbar-ui.js:284
 #: js/toolbar-ui.js:354
 msgid "Disable horizontal scrolling"
 msgstr "たて ほうこうに スクロール"
 
-#: js/toolbar-ui.js:153
-#: js/toolbar-ui.js:229
-#: js/toolbar-ui.js:286
+#: js/toolbar-ui.js:153 js/toolbar-ui.js:229 js/toolbar-ui.js:286
 #: js/toolbar-ui.js:356
 msgid "Light Mode"
 msgstr "ライトモード"
 
-#: js/toolbar-ui.js:154
-#: js/toolbar-ui.js:230
-#: js/toolbar-ui.js:287
+#: js/toolbar-ui.js:154 js/toolbar-ui.js:230 js/toolbar-ui.js:287
 #: js/toolbar-ui.js:357
 msgid "Dark Mode"
 msgstr "ダークモード"
 
-#: js/toolbar-ui.js:155
-#: js/toolbar-ui.js:231
-#: js/toolbar-ui.js:288
+#: js/toolbar-ui.js:155 js/toolbar-ui.js:231 js/toolbar-ui.js:288
 #: js/toolbar-ui.js:358
 msgid "High-contrast Mode"
 msgstr "ハイコントラストモード"
 
-#: js/toolbar-ui.js:160
-#: js/toolbar-ui.js:236
-#: js/toolbar-ui.js:292
+#: js/toolbar-ui.js:160 js/toolbar-ui.js:236 js/toolbar-ui.js:292
 #: js/toolbar-ui.js:362
 msgid "Switch to beginner mode"
 msgstr "かんたん モードに する"
 
-#: js/toolbar-ui.js:161
-#: js/toolbar-ui.js:237
-#: js/toolbar-ui.js:293
+#: js/toolbar-ui.js:161 js/toolbar-ui.js:237 js/toolbar-ui.js:293
 #: js/toolbar-ui.js:363
 msgid "Switch to advanced mode"
 msgstr "はってん モードに する"
 
-#: js/toolbar-ui.js:167
-#: js/toolbar-ui.js:241
+#: js/toolbar-ui.js:167 js/toolbar-ui.js:241
 msgid "Save mouse artwork as SVG"
 msgstr "SVGでほぞん"
 
-#: js/toolbar-ui.js:170
-#: js/toolbar-ui.js:244
+#: js/toolbar-ui.js:170 js/toolbar-ui.js:244
 msgid "Save sheet music as ABC"
 msgstr "ABCのフォーマットでほぞん"
 
-#: js/toolbar-ui.js:171
-#: js/toolbar-ui.js:245
+#: js/toolbar-ui.js:171 js/toolbar-ui.js:245
 msgid "Save sheet music as Lilypond"
 msgstr "がくふ (Lilypondの フォーマット)で ほぞん"
 
@@ -2255,16 +1896,12 @@ msgstr "がくふ (Lilypondの フォーマット)で ほぞん"
 msgid "Save sheet music as MusicXML"
 msgstr "プロジェクトを MusicXMLがくふで ほぞん"
 
-#: js/toolbar-ui.js:174
-#: js/toolbar-ui.js:247
-#: js/toolbar-ui.js:256
-#: js/toolbar-ui.js:301
-#: js/toolbar-ui.js:371
+#: js/toolbar-ui.js:174 js/toolbar-ui.js:247 js/toolbar-ui.js:256
+#: js/toolbar-ui.js:301 js/toolbar-ui.js:371
 msgid "Save block artwork as PNG"
 msgstr "ブロックのアートワークをPNGでほぞん"
 
-#: js/toolbar-ui.js:261
-#: js/toolbar-ui.js:331
+#: js/toolbar-ui.js:261 js/toolbar-ui.js:331
 msgid "About Turtle Blocks"
 msgstr "タートル・ブロックスについて"
 
@@ -2272,17 +1909,12 @@ msgstr "タートル・ブロックスについて"
 msgid "Are you sure you want to create a new project?"
 msgstr "あたらしいプロジェクトをさくせいしてもよろしいですか？"
 
-#: js/toolbar-ui.js:792
-#: js/toolbar-ui.js:803
-#: js/toolbar-ui.js:814
-#: js/toolbar-ui.js:845
-#: js/toolbar-ui.js:856
+#: js/toolbar-ui.js:792 js/toolbar-ui.js:803 js/toolbar-ui.js:814
+#: js/toolbar-ui.js:845 js/toolbar-ui.js:856
 msgid "Turtle Wrap Off"
 msgstr "がめんの きょうかいを むししない"
 
-#: js/toolbar-ui.js:804
-#: js/toolbar-ui.js:813
-#: js/toolbar-ui.js:846
+#: js/toolbar-ui.js:804 js/toolbar-ui.js:813 js/toolbar-ui.js:846
 #: js/toolbar-ui.js:855
 msgid "Turtle Wrap On"
 msgstr "がめんの きょうかいを むしする"
@@ -2295,9 +1927,10 @@ msgstr "さきの アイテムを ふくげん"
 msgid "Restore all items"
 msgstr "すべての アイテムを ふくげん"
 
+#. TRANS: partials are weighted components in a harmonic series
 #: js/turtle-singer.js:1576
-#.TRANS: partials are weighted components in a harmonic series
-msgid "You must have at least one Partial block inside of a Weighted-partial block"
+msgid ""
+"You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「ばいおん ウェート」ブロックの なかに ひとつ いじょうの ばいおん ブロックが はいっている ひつようが あります。"
 
 #: js/turtle-singer.js:1793
@@ -2329,19 +1962,25 @@ msgid "plugins will be removed upon restart."
 msgstr "プラグインは さいせいするときえるよ"
 
 #: js/activity.js:1753
-msgid "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%."
+msgid ""
+"Firefox performance may be affected because the canvas is unusually large. "
+"For the best experience, consider resetting the browser zoom to 100%."
 msgstr ""
+"きゃんばすがいじょうにおおきいため、Firefox "
+"のぱふぉーまんすがえいきょうをうけるかのうせいがあります。さいこうのえくすぺりえんすをえるには、ぶらうざーのずーむを 100% "
+"にりせっとすることをけんとうしてください。"
 
 #: js/activity.js:2554
-msgid "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
-msgstr "クリップボードデータがむこうです。ブロックをはりつけるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストをはりつけるには、にゅうりょくフィールドないをクリックします。"
+msgid ""
+"Invalid clipboard data. To paste blocks, first copy them from the Music "
+"Blocks canvas. To paste text, click inside an input field."
+msgstr ""
+"クリップボードデータがむこうです。ブロックをはりつけるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストをはりつけるには、にゅうりょくフィールドないをクリックします。"
 
-#: js/block.js:1475
-#: js/piemenus.js:3357
-#: js/utils/musicutils.js:1284
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
+#: js/block.js:1475 js/piemenus.js:3357 js/utils/musicutils.js:1284
 #: js/blocks/PitchBlocks.js:1440
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "ユニゾン（同度）"
 
@@ -2349,9 +1988,7 @@ msgstr "ユニゾン（同度）"
 msgid "matrix"
 msgstr "フレーズメーカー"
 
-#: js/block.js:1695
-#: js/blocks/WidgetBlocks.js:1787
-#: plugins/rodi.rtp:324
+#: js/block.js:1695 js/blocks/WidgetBlocks.js:1787 plugins/rodi.rtp:324
 msgid "status"
 msgstr "じっこう じょうきょう"
 
@@ -2363,9 +2000,8 @@ msgstr "ドラム・ピッチぎょうれつ"
 msgid "ruler"
 msgstr "リズムメーカー"
 
-#: js/block.js:1716
-#: js/blocks/WidgetBlocks.js:483
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
+#: js/block.js:1716 js/blocks/WidgetBlocks.js:483
 msgid "timbre"
 msgstr "ねいろ"
 
@@ -2373,17 +2009,14 @@ msgstr "ねいろ"
 msgid "stair"
 msgstr "かいだん"
 
-#: js/block.js:1730
-#: js/blocks/ProgramBlocks.js:1279
+#. TRANS: the speed at music is should be played.
+#: js/block.js:1730 js/blocks/ProgramBlocks.js:1279
 #: js/blocks/WidgetBlocks.js:825
-#.TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "メトロノーム"
 
-#: js/block.js:1737
-#: js/block.js:1800
-#: js/blocks/IntervalsBlocks.js:1527
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
+#: js/block.js:1737 js/block.js:1800 js/blocks/IntervalsBlocks.js:1527
 msgid "mode"
 msgstr "おんかい"
 
@@ -2391,83 +2024,61 @@ msgstr "おんかい"
 msgid "slider"
 msgstr "スライダー"
 
-#: js/block.js:1751
-#: js/blocks/SensorsBlocks.js:963
+#: js/block.js:1751 js/blocks/SensorsBlocks.js:963
 msgid "keyboard"
 msgstr "キーボード"
 
-#: js/block.js:1765
-#: js/blocks/WidgetBlocks.js:1366
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
+#: js/block.js:1765 js/blocks/WidgetBlocks.js:1366
 #: js/blocks/WidgetBlocks.js:1405
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
 
-#: js/block.js:1772
-#: js/block.js:2640
-#: js/block.js:2697
-#: js/blocks/MeterBlocks.js:1415
-#: js/blocks/OrnamentBlocks.js:220
-#: js/blocks/OrnamentBlocks.js:312
-#: js/blocks/RhythmBlockPaletteBlocks.js:89
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
+#: js/block.js:1772 js/block.js:2640 js/block.js:2697
+#: js/blocks/MeterBlocks.js:1415 js/blocks/OrnamentBlocks.js:220
+#: js/blocks/OrnamentBlocks.js:312 js/blocks/RhythmBlockPaletteBlocks.js:89
 #: js/blocks/RhythmBlockPaletteBlocks.js:267
 #: js/blocks/RhythmBlockPaletteBlocks.js:532
 #: js/blocks/RhythmBlockPaletteBlocks.js:600
 #: js/blocks/RhythmBlockPaletteBlocks.js:651
-#: js/blocks/RhythmBlockPaletteBlocks.js:902
-#: js/blocks/RhythmBlocks.js:33
-#: js/blocks/RhythmBlocks.js:357
-#: js/blocks/RhythmBlocks.js:765
-#: js/blocks/RhythmBlocks.js:805
-#: js/turtleactions/DictActions.js:85
-#: js/widgets/phrasemaker.js:1162
-#: js/widgets/phrasemaker.js:2930
-#: js/widgets/phrasemaker.js:2979
-#: js/widgets/phrasemaker.js:3098
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#: js/blocks/RhythmBlockPaletteBlocks.js:902 js/blocks/RhythmBlocks.js:33
+#: js/blocks/RhythmBlocks.js:357 js/blocks/RhythmBlocks.js:765
+#: js/blocks/RhythmBlocks.js:805 js/turtleactions/DictActions.js:85
+#: js/widgets/phrasemaker.js:1162 js/widgets/phrasemaker.js:2930
+#: js/widgets/phrasemaker.js:2979 js/widgets/phrasemaker.js:3098
 msgid "note value"
 msgstr "おとの ながさ"
 
-#: js/block.js:1779
-#: js/blocks/OrnamentBlocks.js:312
+#. TRANS: calculate a relative step between notes based on semi-tones
+#: js/block.js:1779 js/blocks/OrnamentBlocks.js:312
 #: js/blocks/IntervalsBlocks.js:1127
-#.TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "おんかいの じょうげ"
 
-#: js/block.js:1786
-#: js/blocks/RhythmBlocks.js:159
+#: js/block.js:1786 js/blocks/RhythmBlocks.js:159
 msgid "milliseconds"
 msgstr "ミリびょう"
 
-#: js/block.js:2565
-#: js/block.js:2588
+#: js/block.js:2565 js/block.js:2588
 msgid "scalar interval %s"
 msgstr "おんかいのじょうげ %s"
 
-#: js/block.js:2638
-#: js/block.js:2642
-#: js/block.js:2695
-#: js/block.js:2834
-#: js/blocks/ProgramBlocks.js:1275
-#: js/blocks/RhythmBlocks.js:711
-#: js/widgets/rhythmruler.js:1396
-#: js/widgets/rhythmruler.js:1552
+#: js/block.js:2638 js/block.js:2642 js/block.js:2695 js/block.js:2834
+#: js/blocks/ProgramBlocks.js:1275 js/blocks/RhythmBlocks.js:711
+#: js/widgets/rhythmruler.js:1396 js/widgets/rhythmruler.js:1552
 msgid "silence"
 msgstr "きゅうふ"
 
-#: js/block.js:2734
-#: js/block.js:3876
-#: js/block.js:3893
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#: js/block.js:2734 js/block.js:3876 js/block.js:3893
 #: js/utils/musicutils.js:7340
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
-#: js/block.js:2822
-#: js/blocks/IntervalsBlocks.js:639
-#.TRANS: scalar step
+#. TRANS: scalar step
+#: js/block.js:2822 js/blocks/IntervalsBlocks.js:639
 msgid "down"
 msgstr "した"
 
@@ -2491,97 +2102,71 @@ msgstr "じつ"
 
 #: js/block.js:3314
 msgid "picked up"
-msgstr ""
+msgstr "ひろった"
 
-#: js/block.js:3563
-#: js/piemenu-block-context.js:160
-msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
+#: js/block.js:3563 js/piemenu-block-context.js:160
+msgid ""
+"You can restore deleted blocks from the trash with the Restore From Trash "
+"button."
 msgstr "さくじょされたブロックは「ごみはこからふくげん」ボタンでふくげんできます。"
 
-#: js/block.js:4223
-#: js/blocks.js:2066
-#: js/blocks.js:2711
-#: js/blocks/SensorsBlocks.js:874
-#: js/blocks/BooleanBlocks.js:79
-#: js/blocks/BooleanBlocks.js:168
-#: js/blocks/BooleanBlocks.js:252
-#: js/blocks/BooleanBlocks.js:336
-#: js/blocks/BooleanBlocks.js:434
-#: js/blocks/BooleanBlocks.js:539
-#: js/blocks/BooleanBlocks.js:639
-#: js/blocks/BooleanBlocks.js:739
-#: js/blocks/BooleanBlocks.js:843
+#: js/block.js:4223 js/blocks.js:2066 js/blocks.js:2711
+#: js/blocks/SensorsBlocks.js:874 js/blocks/BooleanBlocks.js:79
+#: js/blocks/BooleanBlocks.js:168 js/blocks/BooleanBlocks.js:252
+#: js/blocks/BooleanBlocks.js:336 js/blocks/BooleanBlocks.js:434
+#: js/blocks/BooleanBlocks.js:539 js/blocks/BooleanBlocks.js:639
+#: js/blocks/BooleanBlocks.js:739 js/blocks/BooleanBlocks.js:843
 #: js/blocks/BooleanBlocks.js:944
 msgid "false"
 msgstr "にせ（ぎ）"
 
-#: js/block.js:4233
-#: js/block.js:4237
-#: js/blocks/ExtrasBlocks.js:620
+#: js/block.js:4233 js/block.js:4237 js/blocks/ExtrasBlocks.js:620
 msgid "Cartesian"
 msgstr "うがん（ざひょう）をひょうじ"
 
-#: js/block.js:4233
-#: js/block.js:4238
-#: js/blocks/ExtrasBlocks.js:624
+#: js/block.js:4233 js/block.js:4238 js/blocks/ExtrasBlocks.js:624
 msgid "polar"
 msgstr "きょくざひょう をひょうじ"
 
-#: js/block.js:4233
-#: js/block.js:4239
-#: js/blocks/ExtrasBlocks.js:628
+#: js/block.js:4233 js/block.js:4239 js/blocks/ExtrasBlocks.js:628
 msgid "Cartesian/Polar"
 msgstr "ちゅうしんのかくどとほうがん（ざひょう）をひょうじ"
 
-#: js/block.js:4233
-#: js/block.js:4246
-#: js/blocks/ExtrasBlocks.js:657
+#: js/block.js:4233 js/block.js:4246 js/blocks/ExtrasBlocks.js:657
 msgid "none"
 msgstr "なし"
 
-#: js/block.js:4240
-#: js/blocks/ExtrasBlocks.js:633
+#: js/block.js:4240 js/blocks/ExtrasBlocks.js:633
 msgid "treble"
 msgstr "トレブルきごう"
 
-#: js/block.js:4241
-#: js/blocks/ExtrasBlocks.js:637
+#: js/block.js:4241 js/blocks/ExtrasBlocks.js:637
 msgid "grand staff"
 msgstr "トレブルとバスきごう"
 
-#: js/block.js:4242
-#: js/blocks/ExtrasBlocks.js:641
+#: js/block.js:4242 js/blocks/ExtrasBlocks.js:641
 msgid "mezzo-soprano"
 msgstr "メゾソプラノきごう"
 
-#: js/block.js:4243
-#: js/blocks/ExtrasBlocks.js:645
+#: js/block.js:4243 js/blocks/ExtrasBlocks.js:645
 msgid "alto"
 msgstr "アルトきごう"
 
-#: js/block.js:4244
-#: js/blocks/ExtrasBlocks.js:649
+#: js/block.js:4244 js/blocks/ExtrasBlocks.js:649
 msgid "tenor"
 msgstr "テノールきごう"
 
-#: js/block.js:4245
-#: js/utils/musicutils.js:1393
-#: js/utils/synthutils.js:88
-#: js/blocks/ExtrasBlocks.js:653
-#: js/widgets/legobricks.js:1955
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/block.js:4245 js/utils/musicutils.js:1393 js/utils/synthutils.js:88
+#: js/blocks/ExtrasBlocks.js:653 js/widgets/legobricks.js:1955
 msgid "bass"
 msgstr "コントラバス"
 
-#: js/block.js:4290
-#: js/blocks.js:2057
-#: js/blocks.js:2702
+#: js/block.js:4290 js/blocks.js:2057 js/blocks.js:2702
 msgid "on2"
 msgstr "オン"
 
-#: js/block.js:4292
-#: js/blocks.js:2059
-#: js/blocks.js:2704
+#: js/block.js:4292 js/blocks.js:2059 js/blocks.js:2704
 msgid "off"
 msgstr "オフ"
 
@@ -2606,11 +2191,13 @@ msgid "Failed to load Music Blocks. Please refresh the page."
 msgstr "ミュージック・ブロックスのよみこみにしっぱいしました。ページをこうしんしてください。"
 
 #: js/loader.js:565
-msgid "Failed to initialize Music Blocks core. Please refresh the page.\n\nError: %s"
+msgid ""
+"Failed to initialize Music Blocks core. Please refresh the page.\n"
+"\n"
+"Error: %s"
 msgstr "ミュージック・ブロックス こあのしょきかにしっぱいしました。ページをこうしんしてください。。。エラー: %s"
 
-#: js/logo.js:694
-#: js/blocks/ProgramBlocks.js:259
+#: js/logo.js:694 js/blocks/ProgramBlocks.js:259
 #: js/blocks/ProgramBlocks.js:431
 msgid "You must select a file."
 msgstr "ファイルを えらんで ください。"
@@ -2619,35 +2206,29 @@ msgstr "ファイルを えらんで ください。"
 msgid "Infinite loop detected. Execution stopped to prevent browser freeze."
 msgstr "むげんループが けんしゅつ されました。ブラウザーの フレーズを ふせぐために じっこうが ていしされました。"
 
-#: js/logo.js:2037
-#: js/blocks/MediaBlocks.js:338
+#: js/logo.js:2037 js/blocks/MediaBlocks.js:338
 msgid "width"
 msgstr "カンバスの よこはば"
 
-#: js/logo.js:2038
-#: js/blocks/MediaBlocks.js:395
+#: js/logo.js:2038 js/blocks/MediaBlocks.js:395
 msgid "height"
 msgstr "カンバスの たてはば"
 
-#: js/logo.js:2039
-#: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
+#: js/logo.js:2039 js/blocks/MediaBlocks.js:35
 msgid "right (screen)"
 msgstr "ざひょうち（みぎ）"
 
-#: js/logo.js:2040
-#: js/blocks/MediaBlocks.js:111
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
+#: js/logo.js:2040 js/blocks/MediaBlocks.js:111
 msgid "left (screen)"
 msgstr "ざひょうち （ひだり）"
 
-#: js/logo.js:2041
-#: js/blocks/MediaBlocks.js:186
+#: js/logo.js:2041 js/blocks/MediaBlocks.js:186
 msgid "top (screen)"
 msgstr "ざひょうち（うえ）"
 
-#: js/logo.js:2042
-#: js/blocks/MediaBlocks.js:261
+#: js/logo.js:2042 js/blocks/MediaBlocks.js:261
 msgid "bottom (screen)"
 msgstr "ざひょうち（した）"
 
@@ -2655,8 +2236,7 @@ msgstr "ざひょうち（した）"
 msgid "Playback is ready."
 msgstr "コンパイル かんりょう"
 
-#: js/piemenu-block-context.js:100
-#: js/blocks/FlowBlocks.js:136
+#: js/piemenu-block-context.js:100 js/blocks/FlowBlocks.js:136
 msgid "Duplicate"
 msgstr "複製する"
 
@@ -2669,94 +2249,69 @@ msgid "Save stack"
 msgstr "スタックを ほぞん"
 
 #: js/piemenu-block-context.js:138
-msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
+msgid ""
+"In order to copy a sample, you must reload the widget, import the sample "
+"again, and export it."
 msgstr "サンプルを コピーするため、 ツールを さいどしして、 またサンプルを ロードよみこんで、 ほぞんする ことが ひつようです。"
 
-#: js/piemenus.js:447
-#: js/utils/musicutils.js:1468
-#: js/utils/musicutils.js:1488
-#: js/widgets/phrasemaker.js:2202
-#: js/widgets/musickeyboard.js:2680
+#. TRANS: double sharp is a music term related to pitch
+#: js/piemenus.js:447 js/utils/musicutils.js:1468 js/utils/musicutils.js:1488
+#: js/widgets/phrasemaker.js:2202 js/widgets/musickeyboard.js:2680
 #: js/widgets/sampler.js:1681
-#.TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ダブルシャープ"
 
-#: js/piemenus.js:448
-#: js/utils/musicutils.js:1466
-#: js/utils/musicutils.js:1489
-#: js/blocks/PitchBlocks.js:1595
-#: js/turtleactions/PitchActions.js:441
-#: js/widgets/phrasemaker.js:2203
-#: js/widgets/musickeyboard.js:2681
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
+#: js/piemenus.js:448 js/utils/musicutils.js:1466 js/utils/musicutils.js:1489
+#: js/blocks/PitchBlocks.js:1595 js/turtleactions/PitchActions.js:441
+#: js/widgets/phrasemaker.js:2203 js/widgets/musickeyboard.js:2681
 #: js/widgets/sampler.js:1682
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "シャープ"
 
-#: js/piemenus.js:449
-#: js/utils/musicutils.js:1464
-#: js/utils/musicutils.js:1490
-#: js/widgets/phrasemaker.js:2204
-#: js/widgets/musickeyboard.js:2682
+#. TRANS: natural is a music term related to pitch
+#: js/piemenus.js:449 js/utils/musicutils.js:1464 js/utils/musicutils.js:1490
+#: js/widgets/phrasemaker.js:2204 js/widgets/musickeyboard.js:2682
 #: js/widgets/sampler.js:1683
-#.TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "ナチュラル"
 
-#: js/piemenus.js:450
-#: js/utils/musicutils.js:1462
-#: js/utils/musicutils.js:1491
-#: js/blocks/PitchBlocks.js:1555
-#: js/turtleactions/PitchActions.js:444
-#: js/widgets/phrasemaker.js:2205
-#: js/widgets/musickeyboard.js:2683
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
+#: js/piemenus.js:450 js/utils/musicutils.js:1462 js/utils/musicutils.js:1491
+#: js/blocks/PitchBlocks.js:1555 js/turtleactions/PitchActions.js:444
+#: js/widgets/phrasemaker.js:2205 js/widgets/musickeyboard.js:2683
 #: js/widgets/sampler.js:1684
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "フラット"
 
-#: js/piemenus.js:451
-#: js/utils/musicutils.js:1460
-#: js/utils/musicutils.js:1492
-#: js/widgets/phrasemaker.js:2206
-#: js/widgets/musickeyboard.js:2684
+#. TRANS: double flat is a music term related to pitch
+#: js/piemenus.js:451 js/utils/musicutils.js:1460 js/utils/musicutils.js:1492
+#: js/widgets/phrasemaker.js:2206 js/widgets/musickeyboard.js:2684
 #: js/widgets/sampler.js:1685
-#.TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "ダブルフラット"
 
-#: js/piemenus.js:3517
-#: js/piemenus.js:3591
-#: js/utils/musicutils.js:1292
-#: js/utils/musicutils.js:1470
-#: js/utils/musicutils.js:1701
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
+#: js/piemenus.js:3517 js/piemenus.js:3591 js/utils/musicutils.js:1292
+#: js/utils/musicutils.js:1470 js/utils/musicutils.js:1701
 msgid "major"
 msgstr "メジャー"
 
-#: js/piemenus.js:3517
-#: js/piemenus.js:3591
-#: js/utils/musicutils.js:1310
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
+#: js/piemenus.js:3517 js/piemenus.js:3591 js/utils/musicutils.js:1310
 msgid "ionian"
 msgstr "アイオニアン おんかい"
 
-#: js/piemenus.js:3519
-#: js/piemenus.js:3595
-#: js/utils/musicutils.js:1290
-#: js/utils/musicutils.js:1471
-#: js/utils/musicutils.js:1698
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
+#: js/piemenus.js:3519 js/piemenus.js:3595 js/utils/musicutils.js:1290
+#: js/utils/musicutils.js:1471 js/utils/musicutils.js:1698
 msgid "minor"
 msgstr "マイナー（短）"
 
-#: js/piemenus.js:3519
-#: js/piemenus.js:3595
-#: js/utils/musicutils.js:1320
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
+#: js/piemenus.js:3519 js/piemenus.js:3595 js/utils/musicutils.js:1320
 msgid "aeolian"
 msgstr "エオリアンおんかい"
 
@@ -2769,123 +2324,104 @@ msgid "project undefined"
 msgstr "プロジェクトみていぎ"
 
 #: js/planetInterface.js:279
-msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
+msgid ""
+"Error: Unable to save because you ran out of local storage. Try deleting "
+"some saved projects."
 msgstr "エラー: ろーかる すとれーじがふそくしているため、ほぞんできません。ほぞんされているプロジェクトをいくつかさくじょしてみてください。"
 
-#: js/blocks.js:1936
-#: js/blocks.js:1944
+#: js/blocks.js:1936 js/blocks.js:1944
 msgid "audio file"
 msgstr "オーディオファイル"
 
-#: js/blocks.js:2942
-#: js/blocks.js:3347
-#: js/blocks.js:3393
-#: js/blocks.js:3439
-#: js/blocks.js:5492
-#: js/blocks.js:5516
-#: js/blocks/BoxesBlocks.js:776
+#: js/blocks.js:2942 js/blocks.js:3347 js/blocks.js:3393 js/blocks.js:3439
+#: js/blocks.js:5492 js/blocks.js:5516 js/blocks/BoxesBlocks.js:776
 msgid "box1"
 msgstr "はこ１"
 
-#: js/blocks.js:2944
-#: js/blocks.js:3349
-#: js/blocks.js:3395
-#: js/blocks.js:3441
-#: js/blocks.js:5494
-#: js/blocks.js:5518
-#: js/blocks/BoxesBlocks.js:667
+#: js/blocks.js:2944 js/blocks.js:3349 js/blocks.js:3395 js/blocks.js:3441
+#: js/blocks.js:5494 js/blocks.js:5518 js/blocks/BoxesBlocks.js:667
 msgid "box2"
 msgstr "はこ２"
 
-#: js/blocks.js:3616
-#: js/blocks/DictBlocks.js:215
-#: js/blocks/DictBlocks.js:289
-#: js/blocks/EnsembleBlocks.js:409
-#: js/blocks/EnsembleBlocks.js:420
-#: js/blocks/BoxesBlocks.js:599
-#: js/blocks/MediaBlocks.js:829
-#: js/blocks/ProgramBlocks.js:394
-#: js/blocks/ProgramBlocks.js:500
-#: js/blocks/ProgramBlocks.js:664
-#: js/blocks/PitchBlocks.js:695
-#: js/blocks/PitchBlocks.js:1001
-#: js/blocks/PitchBlocks.js:1960
+#: js/blocks.js:3616 js/blocks/DictBlocks.js:215 js/blocks/DictBlocks.js:289
+#: js/blocks/EnsembleBlocks.js:409 js/blocks/EnsembleBlocks.js:420
+#: js/blocks/BoxesBlocks.js:599 js/blocks/MediaBlocks.js:829
+#: js/blocks/ProgramBlocks.js:394 js/blocks/ProgramBlocks.js:500
+#: js/blocks/ProgramBlocks.js:664 js/blocks/PitchBlocks.js:695
+#: js/blocks/PitchBlocks.js:1001 js/blocks/PitchBlocks.js:1960
 #: js/blocks/ToneBlocks.js:1058
 msgid "name"
 msgstr "なまえ"
 
-#: js/blocks.js:3616
-#: js/blocks/DictBlocks.js:289
-#: js/blocks/DictBlocks.js:430
-#: js/blocks/HeapBlocks.js:544
-#: js/blocks/BoxesBlocks.js:75
-#: js/blocks/BoxesBlocks.js:599
-#: js/blocks/RhythmBlocks.js:1124
+#: js/blocks.js:3616 js/blocks/DictBlocks.js:289 js/blocks/DictBlocks.js:430
+#: js/blocks/HeapBlocks.js:544 js/blocks/BoxesBlocks.js:75
+#: js/blocks/BoxesBlocks.js:599 js/blocks/RhythmBlocks.js:1124
 msgid "value"
 msgstr "あたい"
 
 #: js/blocks.js:3954
-msgid "Forever loop detected inside a note value block. Unexpected things may happen."
+msgid ""
+"Forever loop detected inside a note value block. Unexpected things may "
+"happen."
 msgstr "「ずっとくりかえす」じょうたいが「おんぷ」のなかに ある。"
 
 #: js/blocks.js:4501
 msgid "There is no block selected."
 msgstr "ブロックが えらばれて いません。"
 
-#: js/blocks.js:4613
-#: js/blocks/MediaBlocks.js:886
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
+#: js/blocks.js:4613 js/blocks/MediaBlocks.js:886
 msgid "avatar"
 msgstr "ネズミへんこう"
 
-#: js/blocks.js:4616
-#: js/utils/synthutils.js:3854
-#: js/blocks/ToneBlocks.js:1043
+#. TRANS: The sound sample that the user uploads.
+#: js/blocks.js:4616 js/utils/synthutils.js:3854 js/blocks/ToneBlocks.js:1043
 #: js/widgets/sampler.js:1921
-#.TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "ねいろ サンプル"
 
 #: js/blocks.js:6720
 msgid "block sent to trash"
-msgstr ""
+msgstr "ぶろっくがごみはこにおくられる"
 
 #: js/svgAssetSelector.js:63
 msgid "Choose an image"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/svgAssetSelector.js:83
 msgid "Built-in images"
-msgstr ""
+msgstr "ないぞういめーじ"
 
 #: js/svgAssetSelector.js:92
 msgid "Upload from device"
-msgstr ""
+msgstr "でばいすからあっぷろーど"
 
 #: js/svgAssetSelector.js:156
 msgid "Choose file"
-msgstr ""
+msgstr "ふぁいるをせんたくしてください"
 
 #: js/svgAssetSelector.js:160
 msgid "Supports PNG, JPG, SVG, GIF, and other image formats"
-msgstr ""
+msgstr "PNG、JPG、SVG、GIF、そのほかのがぞうけいしきをさぽーと"
 
 #: js/svgAssetSelector.js:176
 msgid "Apply"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/utils/utils-logic.js:324
 msgid "Invalid input passed to rational sum"
-msgstr ""
+msgstr "むこうなにゅうりょくがゆうりごうけいにわたされました"
 
 #: js/utils/utils-logic.js:331
 msgid "Note calculation failed: zero denominator"
-msgstr ""
+msgstr "のーとのけいさんがしっぱいしました: ぶんぼがぜろです"
 
-#: js/utils/musicutils.js:595
-#: js/utils/musicutils.js:735
-#: js/widgets/musickeyboard.js:3244
-#: js/widgets/pitchdrummatrix.js:235
+#: js/utils/musicutils.js:595 js/utils/musicutils.js:735
+#: js/widgets/musickeyboard.js:3244 js/widgets/pitchdrummatrix.js:235
 msgid "rest"
 msgstr "きゅうふ"
 
@@ -3065,36 +2601,32 @@ msgstr "ちょう１３ど"
 msgid "Diminished seventh, plus an octave"
 msgstr "げん１４ど"
 
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 #: js/utils/musicutils.js:927
-#.TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１ど 2ど 3ど 4ど 5ど 6ど 7ど 8ど 9ど 10ど 11ど 12ど"
 
-#: js/utils/musicutils.js:1286
-#: js/utils/musicutils.js:1472
+#. TRANS: augmented is a music term related to intervals
+#: js/utils/musicutils.js:1286 js/utils/musicutils.js:1472
 #: js/utils/musicutils.js:1700
-#.TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "オーギュメント（ぞう）"
 
-#: js/utils/musicutils.js:1288
-#: js/utils/musicutils.js:1473
+#. TRANS: diminished is a music term related to intervals and mode
+#: js/utils/musicutils.js:1288 js/utils/musicutils.js:1473
 #: js/utils/musicutils.js:1699
-#.TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（げん）"
 
-#: js/utils/musicutils.js:1294
-#: js/utils/musicutils.js:1697
-#: js/blocks/IntervalsBlocks.js:673
-#: js/turtleactions/IntervalsActions.js:163
+#. TRANS: perfect is a music term related to intervals
+#: js/utils/musicutils.js:1294 js/utils/musicutils.js:1697
+#: js/blocks/IntervalsBlocks.js:673 js/turtleactions/IntervalsActions.js:163
 #: js/turtleactions/IntervalsActions.js:167
-#.TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "パーフェクト（かんぜん）"
 
+#. TRANS: twelve semi-tone scale for music
 #: js/utils/musicutils.js:1296
-#.TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック おんかい"
 
@@ -3106,63 +2638,63 @@ msgstr "アルジェリア おんかい"
 msgid "spanish"
 msgstr "スペイン おんかい"
 
+#. TRANS: modal scale in music
 #: js/utils/musicutils.js:1300
-#.TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
+#. TRANS: harmonic major scale in music
 #: js/utils/musicutils.js:1302
-#.TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長おんかい）"
 
+#. TRANS: natural minor scales in music
 #: js/utils/musicutils.js:1304
-#.TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "しぜんたん おんかい"
 
+#. TRANS: harmonic minor scale in music
 #: js/utils/musicutils.js:1306
-#.TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "わせいたん おんかい"
 
+#. TRANS: melodic minor scale in music
 #: js/utils/musicutils.js:1308
-#.TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "せんりつたん おんかい"
 
+#. TRANS: modal scale for music
 #: js/utils/musicutils.js:1312
-#.TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン おんかい"
 
+#. TRANS: modal scale for music
 #: js/utils/musicutils.js:1314
-#.TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン おんかい"
 
+#. TRANS: modal scale for music
 #: js/utils/musicutils.js:1316
-#.TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン おんかい"
 
+#. TRANS: modal scale for music
 #: js/utils/musicutils.js:1318
-#.TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン おんかい"
 
+#. TRANS: modal scale for music
 #: js/utils/musicutils.js:1322
-#.TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン おんかい"
 
+#. TRANS: minor jazz scale for music
 #: js/utils/musicutils.js:1324
-#.TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード おんかい"
 
+#. TRANS: bebop scale for music
 #: js/utils/musicutils.js:1326
-#.TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ おんかい"
 
@@ -3174,8 +2706,8 @@ msgstr "アラビア おんかい"
 msgid "byzantine"
 msgstr "ビザンティン"
 
+#. TRANS: musical scale for music by Verdi
 #: js/utils/musicutils.js:1330
-#.TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディのおんかい"
 
@@ -3183,8 +2715,8 @@ msgstr "ヴェルディのおんかい"
 msgid "ethiopian"
 msgstr "エチオピアおんかい"
 
+#. TRANS: Ethiopic scale for music
 #: js/utils/musicutils.js:1333
-#.TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ おんかい"
 
@@ -3196,8 +2728,8 @@ msgstr "ヒンドゥー おんかい"
 msgid "hungarian"
 msgstr "ハンガリー おんかい"
 
+#. TRANS: minor Romanian scale for music
 #: js/utils/musicutils.js:1337
-#.TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー おんかい"
 
@@ -3205,18 +2737,18 @@ msgstr "ルーマニア・マイナー おんかい"
 msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー おんかい"
 
+#. TRANS: musical scale for Mid-Eastern music
 #: js/utils/musicutils.js:1340
-#.TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム おんかい"
 
+#. TRANS: minor blues scale for music
 #: js/utils/musicutils.js:1342
-#.TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース おんかい"
 
+#. TRANS: major blues scale for music
 #: js/utils/musicutils.js:1344
-#.TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース おんかい"
 
@@ -3224,13 +2756,15 @@ msgstr "メジャー・ブルース おんかい"
 msgid "whole tone"
 msgstr "ホールトーン おんかい"
 
+#. TRANS: pentatonic is a general term that means "five note scale". This
+#. scale is typically known as "minor pentatonic"
 #: js/utils/musicutils.js:1347
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック おんかい"
 
+#. TRANS: pentatonic is a general term that means "five note scale". This
+#. scale is typically known as "major pentatonic"
 #: js/utils/musicutils.js:1349
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニックおんかい"
 
@@ -3242,8 +2776,9 @@ msgstr "ちゅうごく おんかい"
 msgid "egyptian"
 msgstr "エジプト おんかい"
 
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three
+#. different versions of this scale
 #: js/utils/musicutils.js:1353
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "ひらじょうし"
 
@@ -3251,288 +2786,237 @@ msgstr "ひらじょうし"
 msgid "Japan"
 msgstr "にほん"
 
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and
+#. https://en.wikipedia.org/wiki/Sakura_Sakura
 #: js/utils/musicutils.js:1356
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "いんおんかい"
 
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 #: js/utils/musicutils.js:1358
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "みんよ おんかい"
 
+#. TRANS: Italian mathematician
 #: js/utils/musicutils.js:1360
-#.TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ おんかい"
 
-#: js/utils/musicutils.js:1361
-#: js/utils/musicutils.js:1415
-#: js/utils/musicutils.js:1458
-#: js/utils/musicutils.js:1480
-#: js/utils/musicutils.js:1972
-#: js/utils/synthutils.js:148
-#: js/blocks/VolumeBlocks.js:411
-#: js/blocks/WidgetBlocks.js:485
-#: js/blocks/WidgetBlocks.js:490
-#: js/blocks/IntervalsBlocks.js:1182
-#: js/blocks/ToneBlocks.js:979
-#: js/turtleactions/VolumeActions.js:231
+#. TRANS: customize voice
+#: js/utils/musicutils.js:1361 js/utils/musicutils.js:1415
+#: js/utils/musicutils.js:1458 js/utils/musicutils.js:1480
+#: js/utils/musicutils.js:1972 js/utils/synthutils.js:148
+#: js/blocks/VolumeBlocks.js:411 js/blocks/WidgetBlocks.js:485
+#: js/blocks/WidgetBlocks.js:490 js/blocks/IntervalsBlocks.js:1182
+#: js/blocks/ToneBlocks.js:979 js/turtleactions/VolumeActions.js:231
 #: js/widgets/modewidget.js:917
-#.TRANS: customize voice
 msgid "custom"
 msgstr "オリジナル"
 
-#: js/utils/musicutils.js:1363
-#: js/utils/musicutils.js:1919
+#. TRANS: highpass filter
+#: js/utils/musicutils.js:1363 js/utils/musicutils.js:1919
 #: js/blocks/WidgetBlocks.js:244
-#.TRANS: highpass filter
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
-#: js/utils/musicutils.js:1365
-#: js/utils/musicutils.js:1920
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
+#: js/utils/musicutils.js:1365 js/utils/musicutils.js:1920
 msgid "lowpass"
 msgstr "ローパス・フィルター"
 
-#: js/utils/musicutils.js:1367
-#: js/utils/musicutils.js:1921
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
+#: js/utils/musicutils.js:1367 js/utils/musicutils.js:1921
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
-#: js/utils/musicutils.js:1369
-#: js/utils/musicutils.js:1922
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
+#: js/utils/musicutils.js:1369 js/utils/musicutils.js:1922
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
 
-#: js/utils/musicutils.js:1371
-#: js/utils/musicutils.js:1923
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
+#: js/utils/musicutils.js:1371 js/utils/musicutils.js:1923
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
-#: js/utils/musicutils.js:1373
-#: js/utils/musicutils.js:1924
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
+#: js/utils/musicutils.js:1373 js/utils/musicutils.js:1924
 msgid "notch"
 msgstr "ノッチ・フィルター"
 
-#: js/utils/musicutils.js:1375
-#: js/utils/musicutils.js:1925
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
+#: js/utils/musicutils.js:1375 js/utils/musicutils.js:1925
 msgid "allpass"
 msgstr "オールパスフィルター"
 
-#: js/utils/musicutils.js:1377
-#: js/utils/musicutils.js:1926
-#.TRANS: peaking filter
+#. TRANS: peaking filter
+#: js/utils/musicutils.js:1377 js/utils/musicutils.js:1926
 msgid "peaking"
 msgstr "ピーク・フィルタ"
 
-#: js/utils/musicutils.js:1378
-#: js/utils/musicutils.js:1934
-#: js/utils/synthutils.js:140
-#: js/blocks/PitchBlocks.js:85
+#. TRANS: sine wave
+#: js/utils/musicutils.js:1378 js/utils/musicutils.js:1934
+#: js/utils/synthutils.js:140 js/blocks/PitchBlocks.js:85
 #: js/widgets/legobricks.js:1964
-#.TRANS: sine wave
 msgid "sine"
 msgstr "サインは"
 
-#: js/utils/musicutils.js:1379
-#: js/utils/musicutils.js:1935
-#: js/utils/synthutils.js:142
-#: js/blocks/PitchBlocks.js:39
+#. TRANS: square wave
+#: js/utils/musicutils.js:1379 js/utils/musicutils.js:1935
+#: js/utils/synthutils.js:142 js/blocks/PitchBlocks.js:39
 #: js/widgets/legobricks.js:1965
-#.TRANS: square wave
 msgid "square"
 msgstr "しかくの なみ"
 
-#: js/utils/musicutils.js:1380
-#: js/utils/musicutils.js:1936
-#: js/utils/synthutils.js:146
-#: js/blocks/PitchBlocks.js:62
-#: js/blocks/ToneBlocks.js:39
-#: js/widgets/legobricks.js:1967
-#.TRANS: triangle wave
+#. TRANS: triangle wave
+#: js/utils/musicutils.js:1380 js/utils/musicutils.js:1936
+#: js/utils/synthutils.js:146 js/blocks/PitchBlocks.js:62
+#: js/blocks/ToneBlocks.js:39 js/widgets/legobricks.js:1967
 msgid "triangle"
 msgstr "さんかくの なみ"
 
-#: js/utils/musicutils.js:1381
-#: js/utils/musicutils.js:1937
-#: js/utils/synthutils.js:144
-#: js/blocks/PitchBlocks.js:108
+#. TRANS: sawtooth wave
+#: js/utils/musicutils.js:1381 js/utils/musicutils.js:1937
+#: js/utils/synthutils.js:144 js/blocks/PitchBlocks.js:108
 #: js/widgets/legobricks.js:1966
-#.TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの なみ"
 
-#: js/utils/musicutils.js:1383
-#: js/utils/musicutils.js:1687
-#: js/blocks/PitchBlocks.js:998
-#: js/blocks/PitchBlocks.js:1004
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
+#: js/utils/musicutils.js:1383 js/utils/musicutils.js:1687
+#: js/blocks/PitchBlocks.js:998 js/blocks/PitchBlocks.js:1004
 #: js/turtleactions/PitchActions.js:587
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "ぐうすう"
 
-#: js/utils/musicutils.js:1385
-#: js/utils/musicutils.js:1688
-#: js/blocks/PitchBlocks.js:1004
-#: js/turtleactions/PitchActions.js:589
-#.TRANS: odd numbers
+#. TRANS: odd numbers
+#: js/utils/musicutils.js:1385 js/utils/musicutils.js:1688
+#: js/blocks/PitchBlocks.js:1004 js/turtleactions/PitchActions.js:589
 msgid "odd"
 msgstr "きすう"
 
-#: js/utils/musicutils.js:1386
-#: js/utils/musicutils.js:1689
-#: js/blocks/PitchBlocks.js:1004
-#: js/turtleactions/PitchActions.js:591
+#: js/utils/musicutils.js:1386 js/utils/musicutils.js:1689
+#: js/blocks/PitchBlocks.js:1004 js/turtleactions/PitchActions.js:591
 msgid "scalar"
 msgstr "おんかいてき"
 
-#: js/utils/musicutils.js:1387
-#: js/utils/synthutils.js:80
-#: js/blocks/VolumeBlocks.js:47
-#: js/widgets/legobricks.js:1948
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1387 js/utils/synthutils.js:80
+#: js/blocks/VolumeBlocks.js:47 js/widgets/legobricks.js:1948
 msgid "piano"
 msgstr "ピアノ"
 
-#: js/utils/musicutils.js:1388
-#: js/utils/synthutils.js:82
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1388 js/utils/synthutils.js:82
 #: js/widgets/legobricks.js:1952
-#.TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
 
-#: js/utils/musicutils.js:1389
-#: js/utils/synthutils.js:84
+#. TRANS: viola musical instrument
+#: js/utils/musicutils.js:1389 js/utils/synthutils.js:84
 #: js/widgets/legobricks.js:1953
-#.TRANS: viola musical instrument
 msgid "viola"
 msgstr "ビオラ"
 
-#: js/utils/musicutils.js:1390
-#: js/utils/synthutils.js:128
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
+#: js/utils/musicutils.js:1390 js/utils/synthutils.js:128
 msgid "xylophone"
 msgstr "もっきん"
 
-#: js/utils/musicutils.js:1391
-#: js/utils/synthutils.js:150
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
+#: js/utils/musicutils.js:1391 js/utils/synthutils.js:150
 msgid "vibraphone"
 msgstr "てっきん"
 
-#: js/utils/musicutils.js:1392
-#: js/utils/synthutils.js:86
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1392 js/utils/synthutils.js:86
 #: js/widgets/legobricks.js:1954
-#.TRANS: musical instrument
 msgid "cello"
 msgstr "チェロ"
 
-#: js/utils/musicutils.js:1394
-#: js/utils/synthutils.js:90
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
+#: js/utils/musicutils.js:1394 js/utils/synthutils.js:90
 msgid "double bass"
 msgstr "ダブルベース"
 
-#: js/utils/musicutils.js:1395
-#: js/utils/synthutils.js:98
-#: js/widgets/legobricks.js:1949
-#: js/widgets/rhythmruler.js:2706
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1395 js/utils/synthutils.js:98
+#: js/widgets/legobricks.js:1949 js/widgets/rhythmruler.js:2706
 msgid "guitar"
 msgstr "ギター"
 
-#: js/utils/musicutils.js:1396
-#: js/utils/synthutils.js:92
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
+#: js/utils/musicutils.js:1396 js/utils/synthutils.js:92
 msgid "sitar"
 msgstr "したーる"
 
-#: js/utils/musicutils.js:1397
-#: js/utils/synthutils.js:94
-#.TRANS: harmonium musical instrument
+#. TRANS: harmonium musical instrument
+#: js/utils/musicutils.js:1397 js/utils/synthutils.js:94
 msgid "harmonium"
 msgstr "はるもにうむ"
 
-#: js/utils/musicutils.js:1398
-#: js/utils/synthutils.js:96
-#.TRANS: mandolin musical instrument
+#. TRANS: mandolin musical instrument
+#: js/utils/musicutils.js:1398 js/utils/synthutils.js:96
 msgid "mandolin"
 msgstr "まんどりん"
 
-#: js/utils/musicutils.js:1399
-#: js/utils/synthutils.js:100
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1399 js/utils/synthutils.js:100
 #: js/widgets/legobricks.js:1950
-#.TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "アコースティック"
 
-#: js/utils/musicutils.js:1400
-#: js/utils/synthutils.js:102
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1400 js/utils/synthutils.js:102
 #: js/widgets/legobricks.js:1956
-#.TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
 
-#: js/utils/musicutils.js:1401
-#: js/utils/synthutils.js:104
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1401 js/utils/synthutils.js:104
 #: js/widgets/legobricks.js:1957
-#.TRANS: musical instrument
 msgid "clarinet"
 msgstr "クラリネット"
 
-#: js/utils/musicutils.js:1402
-#: js/utils/synthutils.js:106
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1402 js/utils/synthutils.js:106
 #: js/widgets/legobricks.js:1958
-#.TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
 
-#: js/utils/musicutils.js:1403
-#: js/utils/synthutils.js:108
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1403 js/utils/synthutils.js:108
 #: js/widgets/legobricks.js:1962
-#.TRANS: musical instrument
 msgid "tuba"
 msgstr "チューバ"
 
-#: js/utils/musicutils.js:1404
-#: js/utils/synthutils.js:110
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1404 js/utils/synthutils.js:110
 #: js/widgets/legobricks.js:1959
-#.TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
 
-#: js/utils/musicutils.js:1405
-#: js/utils/synthutils.js:112
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1405 js/utils/synthutils.js:112
 #: js/widgets/legobricks.js:1961
-#.TRANS: musical instrument
 msgid "oboe"
 msgstr "オーボエ"
 
-#: js/utils/musicutils.js:1406
-#: js/utils/synthutils.js:114
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1406 js/utils/synthutils.js:114
 #: js/widgets/legobricks.js:1960
-#.TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
 
-#: js/utils/musicutils.js:1407
-#: js/utils/synthutils.js:130
+#. TRANS: polytone synthesizer
+#: js/utils/musicutils.js:1407 js/utils/synthutils.js:130
 #: js/widgets/legobricks.js:1947
-#.TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
-#: js/utils/musicutils.js:1408
-#: js/utils/synthutils.js:132
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
+#: js/utils/musicutils.js:1408 js/utils/synthutils.js:132
 msgid "simple 1"
 msgstr "シンプル１"
 
@@ -3548,84 +3032,70 @@ msgstr "シンプル３"
 msgid "simple 4"
 msgstr "シンプル４"
 
-#: js/utils/musicutils.js:1412
-#: js/utils/synthutils.js:66
+#. TRANS: white noise synthesizer
+#: js/utils/musicutils.js:1412 js/utils/synthutils.js:66
 #: js/blocks/DrumBlocks.js:200
-#.TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ホワイト ノイズ"
 
-#: js/utils/musicutils.js:1413
-#: js/utils/synthutils.js:68
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
+#: js/utils/musicutils.js:1413 js/utils/synthutils.js:68
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
-#: js/utils/musicutils.js:1414
-#: js/utils/synthutils.js:70
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
+#: js/utils/musicutils.js:1414 js/utils/synthutils.js:70
 msgid "pink noise"
 msgstr "ピンクノイズ"
 
-#: js/utils/musicutils.js:1416
-#: js/utils/synthutils.js:162
-#: js/widgets/rhythmruler.js:2252
-#: js/widgets/rhythmruler.js:2514
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1416 js/utils/synthutils.js:162
+#: js/widgets/rhythmruler.js:2252 js/widgets/rhythmruler.js:2514
 msgid "snare drum"
 msgstr "スネアドラム"
 
-#: js/utils/musicutils.js:1417
-#: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1417 js/utils/synthutils.js:164
 msgid "kick drum"
 msgstr "キックドラム"
 
-#: js/utils/musicutils.js:1418
-#: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1418 js/utils/synthutils.js:166
 msgid "tom tom"
 msgstr "タムタム"
 
-#: js/utils/musicutils.js:1419
-#: js/utils/synthutils.js:168
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1419 js/utils/synthutils.js:168
 msgid "floor tom"
 msgstr "フロアタム"
 
-#: js/utils/musicutils.js:1420
-#: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1420 js/utils/synthutils.js:170
 msgid "bass drum"
 msgstr "バスドラム"
 
-#: js/utils/musicutils.js:1421
-#: js/utils/synthutils.js:172
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
+#: js/utils/musicutils.js:1421 js/utils/synthutils.js:172
 msgid "cup drum"
 msgstr "カップドラム"
 
-#: js/utils/musicutils.js:1422
-#: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1422 js/utils/synthutils.js:174
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
-#: js/utils/musicutils.js:1423
-#: js/utils/synthutils.js:178
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1423 js/utils/synthutils.js:178
 msgid "hi hat"
 msgstr "ハイハット"
 
-#: js/utils/musicutils.js:1424
-#: js/utils/synthutils.js:180
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
+#: js/utils/musicutils.js:1424 js/utils/synthutils.js:180
 msgid "ride bell"
 msgstr "ライドベル"
 
-#: js/utils/musicutils.js:1425
-#: js/utils/synthutils.js:182
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1425 js/utils/synthutils.js:182
 msgid "cow bell"
 msgstr "カウベル"
 
@@ -3633,162 +3103,137 @@ msgstr "カウベル"
 msgid "japanese drum"
 msgstr "たいこ"
 
-#: js/utils/musicutils.js:1427
-#: js/utils/synthutils.js:188
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1427 js/utils/synthutils.js:188
 msgid "japanese bell"
 msgstr "しょう"
 
-#: js/utils/musicutils.js:1428
-#: js/utils/synthutils.js:184
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1428 js/utils/synthutils.js:184
 msgid "triangle bell"
 msgstr "トライアングル"
 
-#: js/utils/musicutils.js:1429
-#: js/utils/synthutils.js:186
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1429 js/utils/synthutils.js:186
 msgid "finger cymbals"
 msgstr "フィンガー シンバル"
 
-#: js/utils/musicutils.js:1430
-#: js/utils/synthutils.js:190
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
+#: js/utils/musicutils.js:1430 js/utils/synthutils.js:190
 msgid "chime"
 msgstr "チャイム"
 
-#: js/utils/musicutils.js:1431
-#: js/utils/synthutils.js:192
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
+#: js/utils/musicutils.js:1431 js/utils/synthutils.js:192
 msgid "gong"
 msgstr "ドラ"
 
-#: js/utils/musicutils.js:1432
-#: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1432 js/utils/synthutils.js:194
 msgid "clang"
 msgstr "カチャカチャ"
 
-#: js/utils/musicutils.js:1433
-#: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1433 js/utils/synthutils.js:196
 msgid "crash"
 msgstr "クラッシュ"
 
-#: js/utils/musicutils.js:1434
-#: js/utils/synthutils.js:198
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1434 js/utils/synthutils.js:198
 msgid "bottle"
 msgstr "あきびん"
 
-#: js/utils/musicutils.js:1435
-#: js/utils/synthutils.js:200
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1435 js/utils/synthutils.js:200
 msgid "clap"
 msgstr "てびょうし"
 
-#: js/utils/musicutils.js:1436
-#: js/utils/synthutils.js:202
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1436 js/utils/synthutils.js:202
 msgid "slap"
 msgstr "ピシャリ"
 
-#: js/utils/musicutils.js:1437
-#: js/utils/synthutils.js:204
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1437 js/utils/synthutils.js:204
 msgid "splash"
 msgstr "しぶき"
 
-#: js/utils/musicutils.js:1438
-#: js/utils/synthutils.js:206
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1438 js/utils/synthutils.js:206
 msgid "bubbles"
 msgstr "あわ"
 
-#: js/utils/musicutils.js:1439
-#: js/utils/synthutils.js:208
-#.TRANS: sound effect
+#. TRANS: sound effect
+#: js/utils/musicutils.js:1439 js/utils/synthutils.js:208
 msgid "raindrop"
 msgstr "あめのしずく"
 
-#: js/utils/musicutils.js:1440
-#: js/utils/synthutils.js:210
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
+#: js/utils/musicutils.js:1440 js/utils/synthutils.js:210
 msgid "cat"
 msgstr "ねこ"
 
-#: js/utils/musicutils.js:1441
-#: js/utils/synthutils.js:212
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
+#: js/utils/musicutils.js:1441 js/utils/synthutils.js:212
 msgid "cricket"
 msgstr "こおろぎ"
 
-#: js/utils/musicutils.js:1442
-#: js/utils/synthutils.js:214
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
+#: js/utils/musicutils.js:1442 js/utils/synthutils.js:214
 msgid "dog"
 msgstr "いぬ"
 
-#: js/utils/musicutils.js:1444
-#: js/utils/synthutils.js:116
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1444 js/utils/synthutils.js:116
 #: js/widgets/legobricks.js:1963
-#.TRANS: musical instrument
 msgid "banjo"
 msgstr "バンジョー"
 
-#: js/utils/musicutils.js:1445
-#: js/utils/synthutils.js:118
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1445 js/utils/synthutils.js:118
 msgid "koto"
 msgstr "こと"
 
-#: js/utils/musicutils.js:1446
-#: js/utils/synthutils.js:120
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1446 js/utils/synthutils.js:120
 msgid "dulcimer"
 msgstr "ダルシマー"
 
-#: js/utils/musicutils.js:1447
-#: js/utils/synthutils.js:122
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1447 js/utils/synthutils.js:122
 #: js/widgets/legobricks.js:1951
-#.TRANS: musical instrument
 msgid "electric guitar"
 msgstr "エレクトリック"
 
-#: js/utils/musicutils.js:1448
-#: js/utils/synthutils.js:124
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1448 js/utils/synthutils.js:124
 msgid "bassoon"
 msgstr "バスーン"
 
-#: js/utils/musicutils.js:1449
-#: js/utils/synthutils.js:126
-#.TRANS: musical instrument
+#. TRANS: musical instrument
+#: js/utils/musicutils.js:1449 js/utils/synthutils.js:126
 msgid "celeste"
 msgstr "セレスタ"
 
-#: js/utils/musicutils.js:1451
-#: js/widgets/temperament.js:996
-#.TRANS: musical temperament
+#. TRANS: musical temperament
+#: js/utils/musicutils.js:1451 js/widgets/temperament.js:996
 msgid "equal"
 msgstr "へいきん おんりつ"
 
+#. TRANS: musical temperament
 #: js/utils/musicutils.js:1453
-#.TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス おんりつ "
 
+#. TRANS: musical temperament
 #: js/utils/musicutils.js:1455
-#.TRANS: musical temperament
 msgid "just intonation"
 msgstr "じゅんせいりつ"
 
-#: js/utils/musicutils.js:1457
-#: js/utils/musicutils.js:1953
-#: js/utils/musicutils.js:1954
-#: js/utils/musicutils.js:1970
+#. TRANS: musical temperament
+#: js/utils/musicutils.js:1457 js/utils/musicutils.js:1953
+#: js/utils/musicutils.js:1954 js/utils/musicutils.js:1970
 #: js/utils/musicutils.js:1971
-#.TRANS: musical temperament
 msgid "Meantone"
 msgstr "ちゅうぜんおんりつ"
 
@@ -3816,97 +3261,91 @@ msgstr "げんしちのわおん（ディミニッシュト・セブンス）"
 msgid "half-diminished 7th"
 msgstr "げんごたんしちのわおん（ハーフ・ディミニッシュト）"
 
-#: js/utils/musicutils.js:1945
-#: js/utils/musicutils.js:1962
+#: js/utils/musicutils.js:1945 js/utils/musicutils.js:1962
 msgid "Equal (12EDO)"
 msgstr "１２へいきんりつ"
 
-#: js/utils/musicutils.js:1946
-#: js/utils/musicutils.js:1963
+#: js/utils/musicutils.js:1946 js/utils/musicutils.js:1963
 msgid "Equal (5EDO)"
 msgstr "5へいきんりつ"
 
-#: js/utils/musicutils.js:1947
-#: js/utils/musicutils.js:1964
+#: js/utils/musicutils.js:1947 js/utils/musicutils.js:1964
 msgid "Equal (7EDO)"
 msgstr "7へいきんりつ"
 
-#: js/utils/musicutils.js:1948
-#: js/utils/musicutils.js:1965
+#: js/utils/musicutils.js:1948 js/utils/musicutils.js:1965
 msgid "Equal (17EDO)"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
-#: js/utils/musicutils.js:1949
-#: js/utils/musicutils.js:1966
+#: js/utils/musicutils.js:1949 js/utils/musicutils.js:1966
 msgid "Equal (19EDO)"
 msgstr "19へいきんりつ"
 
-#: js/utils/musicutils.js:1950
-#: js/utils/musicutils.js:1967
+#: js/utils/musicutils.js:1950 js/utils/musicutils.js:1967
 msgid "Equal (31EDO)"
 msgstr "31へいきんりつ"
 
-#: js/utils/musicutils.js:1951
-#: js/utils/musicutils.js:1968
+#: js/utils/musicutils.js:1951 js/utils/musicutils.js:1968
 msgid "5-limit Just Intonation"
 msgstr "５げんかい　じゅんせいりつ"
 
-#: js/utils/musicutils.js:1952
-#: js/utils/musicutils.js:1969
+#: js/utils/musicutils.js:1952 js/utils/musicutils.js:1969
 msgid "Pythagorean (3-limit JI)"
 msgstr "ピタゴラスおんりつ"
 
-#: js/utils/musicutils.js:4915
-#: js/widgets/temperament.js:2569
+#: js/utils/musicutils.js:4915 js/widgets/temperament.js:2569
 msgid "Invalid temperament. Falling back to equal temperament."
 msgstr "むこうなきしつ。へいきんりつにもどります。"
 
-#: js/utils/musicutils.js:7511
-#: js/utils/musicutils.js:7554
+#: js/utils/musicutils.js:7511 js/utils/musicutils.js:7554
 msgid "current"
 msgstr "げんざいの"
 
-#: js/utils/musicutils.js:7514
-#: js/utils/musicutils.js:7545
+#: js/utils/musicutils.js:7514 js/utils/musicutils.js:7545
 msgid "next"
 msgstr "このつぎの"
 
-#: js/utils/musicutils.js:7517
-#: js/utils/musicutils.js:7550
+#: js/utils/musicutils.js:7517 js/utils/musicutils.js:7550
 msgid "previous"
 msgstr "このまえの"
 
+#. TRANS: simple monotone synthesizer
 #: js/utils/synthutils.js:134
-#.TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
+#. TRANS: simple monotone synthesizer
 #: js/utils/synthutils.js:136
-#.TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
+#. TRANS: simple monotone synthesizer
 #: js/utils/synthutils.js:138
-#.TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
+#. TRANS: musical instrument
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
 msgid "taiko"
 msgstr "たいこ"
 
 #: js/utils/synthutils.js:2260
-msgid "⚠️ Sound is disabled!\n\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
-msgstr "⚠⚠ おんせいは ブロックされています。。。ブラウザーの せってい (サイトの せってい > おんせい) をかくにんして、ミュージック・ブロックスの おんせいを きょかして ください。"
+msgid ""
+"⚠️ Sound is disabled!\n"
+"\n"
+"Please check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
+msgstr ""
+"⚠⚠ おんせいは ブロックされています。。。ブラウザーの せってい (サイトの せってい > おんせい) をかくにんして、ミュージック・ブロックスの "
+"おんせいを きょかして ください。"
 
 #: js/utils/synthutils.js:3787
 msgid "Cents Adjustment"
 msgstr "セント ちょうせい"
 
-#: js/utils/synthutils.js:3816
-#: js/widgets/sampler.js:1925
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
+#: js/utils/synthutils.js:3816 js/widgets/sampler.js:1925
 msgid "reference tone"
 msgstr "さんしょうピッチ"
 
@@ -3915,8 +3354,12 @@ msgid "Security Warning"
 msgstr "せきゅりてぃけいこく"
 
 #: js/utils/utils.js:476
-msgid "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
-msgstr "このプラグインには、ブラウザーで じっこうされるコードが ふくまれています。くみこみの プラグイン でぃれくとりからロードされていないため、あんぜんでないコードが ふくまれているかの うせいがあります。"
+msgid ""
+"This plugin contains code that will be executed in your browser. It has not "
+"been loaded from the built-in plugins directory and may contain unsafe code."
+msgstr ""
+"このプラグインには、ブラウザーで じっこうされるコードが ふくまれています。くみこみの プラグイン "
+"でぃれくとりからロードされていないため、あんぜんでないコードが ふくまれているかの うせいがあります。"
 
 #: js/utils/utils.js:480
 msgid "Do you want to allow this plugin to run?"
@@ -3926,32 +3369,27 @@ msgstr "このプラグインのじっこうをきょかしますか?"
 msgid "Source: %s"
 msgstr "ソース: %s"
 
-#: js/utils/utils.js:482
-#: js/blocks/ExtrasBlocks.js:696
-#: js/blocks/ExtrasBlocks.js:715
-#: js/blocks/ExtrasBlocks.js:738
-#: js/blocks/ExtrasBlocks.js:761
-#: js/blocks/ExtrasBlocks.js:779
-#: js/blocks/ExtrasBlocks.js:798
-#: js/blocks/ExtrasBlocks.js:817
+#: js/utils/utils.js:482 js/blocks/ExtrasBlocks.js:696
+#: js/blocks/ExtrasBlocks.js:715 js/blocks/ExtrasBlocks.js:738
+#: js/blocks/ExtrasBlocks.js:761 js/blocks/ExtrasBlocks.js:779
+#: js/blocks/ExtrasBlocks.js:798 js/blocks/ExtrasBlocks.js:817
 #: js/blocks/ExtrasBlocks.js:836
 msgid "unknown"
 msgstr "ふめい"
 
 #: js/blocks/DictBlocks.js:62
-msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+msgid ""
+"The Show-dictionary block displays the contents of the dictionary at the top"
+" of the screen."
 msgstr "「じしょを あらわす」ブロックは、がめんのじょうぶにじしょのないようをひょうじします。"
 
 #: js/blocks/DictBlocks.js:77
 msgid "show dictionary"
 msgstr "じしょを あらわす"
 
-#: js/blocks/DictBlocks.js:80
-#: js/blocks/DictBlocks.js:145
-#: js/blocks/DictBlocks.js:216
-#: js/blocks/DictBlocks.js:290
-#: js/blocks/ProgramBlocks.js:400
-#: js/blocks/ProgramBlocks.js:506
+#: js/blocks/DictBlocks.js:80 js/blocks/DictBlocks.js:145
+#: js/blocks/DictBlocks.js:216 js/blocks/DictBlocks.js:290
+#: js/blocks/ProgramBlocks.js:400 js/blocks/ProgramBlocks.js:506
 #: js/blocks/ProgramBlocks.js:670
 msgid "My Dictionary"
 msgstr "わたしの じしょ"
@@ -3960,47 +3398,37 @@ msgstr "わたしの じしょ"
 msgid "The Dictionary block returns a dictionary."
 msgstr "「じしょ」ブロックはじしょをかえします。"
 
-#: js/blocks/DictBlocks.js:197
-#: js/blocks/DictBlocks.js:339
-msgid "The Get-dict block returns a value in the dictionary for a specified key."
+#: js/blocks/DictBlocks.js:197 js/blocks/DictBlocks.js:339
+msgid ""
+"The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックはしていされたキーのじしょのあたいをかえします。"
 
-#: js/blocks/DictBlocks.js:212
-#: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
+#: js/blocks/DictBlocks.js:212 js/blocks/DictBlocks.js:354
 msgid "get value"
 msgstr "あたいを あらわす"
 
-#: js/blocks/DictBlocks.js:215
-#: js/blocks/DictBlocks.js:216
-#: js/blocks/DictBlocks.js:289
-#: js/blocks/DictBlocks.js:290
-#: js/blocks/DictBlocks.js:357
-#: js/blocks/DictBlocks.js:430
+#: js/blocks/DictBlocks.js:215 js/blocks/DictBlocks.js:216
+#: js/blocks/DictBlocks.js:289 js/blocks/DictBlocks.js:290
+#: js/blocks/DictBlocks.js:357 js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 msgid "key2"
 msgstr "キーワード"
 
-#: js/blocks/DictBlocks.js:215
-#: js/blocks/DictBlocks.js:216
-#: js/blocks/DictBlocks.js:289
-#: js/blocks/DictBlocks.js:290
-#: js/blocks/DictBlocks.js:357
-#: js/blocks/DictBlocks.js:430
-#: js/blocks/DictBlocks.js:431
-#: js/blocks/IntervalsBlocks.js:1525
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
+#: js/blocks/DictBlocks.js:215 js/blocks/DictBlocks.js:216
+#: js/blocks/DictBlocks.js:289 js/blocks/DictBlocks.js:290
+#: js/blocks/DictBlocks.js:357 js/blocks/DictBlocks.js:430
+#: js/blocks/DictBlocks.js:431 js/blocks/IntervalsBlocks.js:1525
 msgid "key"
 msgstr "ちょう"
 
-#: js/blocks/DictBlocks.js:271
-#: js/blocks/DictBlocks.js:411
+#: js/blocks/DictBlocks.js:271 js/blocks/DictBlocks.js:411
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックはしていされたキーにじしょのあたいをせっていします。"
 
-#: js/blocks/DictBlocks.js:286
-#: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
+#: js/blocks/DictBlocks.js:286 js/blocks/DictBlocks.js:427
 msgid "set value"
 msgstr "あたいを せってい"
 
@@ -4009,7 +3437,9 @@ msgid "The Heap block returns the heap."
 msgstr "「ヒープ」ブロックはヒープをかえします。"
 
 #: js/blocks/HeapBlocks.js:118
-msgid "The Show-heap block displays the contents of the heap at the top of the screen."
+msgid ""
+"The Show-heap block displays the contents of the heap at the top of the "
+"screen."
 msgstr "「ヒープをひょうじする」ブロックは、ヒープのないようをがめんのじょうぶにひょうじします。"
 
 #: js/blocks/HeapBlocks.js:133
@@ -4028,8 +3458,8 @@ msgstr "ヒープの ながさ"
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "「ヒープは から ですか？」ブロックはヒープがそらのばあいにtrueをかえします。"
 
+#. TRANS: Is the heap empty?
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ヒープは から ですか？"
 
@@ -4037,9 +3467,8 @@ msgstr "ヒープは から ですか？"
 msgid "The Empty-heap block empties the heap."
 msgstr "「ヒープは から ですか？」ブロックはヒープをそらにします。"
 
-#: js/blocks/HeapBlocks.js:327
-#: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
+#: js/blocks/HeapBlocks.js:327 js/blocks/HeapBlocks.js:647
 msgid "empty heap"
 msgstr "からの ヒープ"
 
@@ -4047,55 +3476,53 @@ msgstr "からの ヒープ"
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "「ヒープを ぎゃくに する」ブロックはヒープのじゅんじょをぎゃくにします。"
 
+#. TRANS: reverse the order of the heap
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ヒープを ぎゃくに する"
 
 #: js/blocks/HeapBlocks.js:428
-msgid "The Index-heap block returns a value in the heap at a specified location."
+msgid ""
+"The Index-heap block returns a value in the heap at a specified location."
 msgstr "「ヒープに ばんごうを ふる」ブロックはしていされたいちのヒープのあたいをかえします。"
 
 #: js/blocks/ActionBlocks.js:1308
-msgid "The Action block is used to group together blocks so that they can be used more than once."
+msgid ""
+"The Action block is used to group together blocks so that they can be used "
+"more than once."
 msgstr "「アクション」ブロックは、ふくすうのブロックをグループかしてふくすうかいしようできるようにするためにしようされます。"
 
+#. TRANS: retrieve a value from the heap at index position in the heap
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ヒープに ばんごうを ふる"
 
-#: js/blocks/HeapBlocks.js:474
-#: js/blocks/HeapBlocks.js:572
-#: js/blocks/EnsembleBlocks.js:145
-#: js/blocks/EnsembleBlocks.js:1223
+#: js/blocks/HeapBlocks.js:474 js/blocks/HeapBlocks.js:572
+#: js/blocks/EnsembleBlocks.js:145 js/blocks/EnsembleBlocks.js:1223
 msgid "Index must be > 0."
 msgstr "インデクス ばんごうは 0 より おおきい ひつようが あります。"
 
-#: js/blocks/HeapBlocks.js:479
-#: js/blocks/HeapBlocks.js:577
+#: js/blocks/HeapBlocks.js:479 js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:150
 msgid "Maximum heap size is 1000."
 msgstr "ヒープの おおきさは、 さいだい 1000です。"
 
 #: js/blocks/HeapBlocks.js:523
-msgid "The Set-heap entry block sets a value in the heap at the specified location."
+msgid ""
+"The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "「ヒープを せってい する」ブロックはしていされたいちのヒープにあたいをせっていします。"
 
-#: js/blocks/HeapBlocks.js:539
-#: js/blocks/ProgramBlocks.js:301
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
+#: js/blocks/HeapBlocks.js:539 js/blocks/ProgramBlocks.js:301
 msgid "set heap"
 msgstr "ヒープを せってい する"
 
-#: js/blocks/HeapBlocks.js:544
-#: js/blocks/EnsembleBlocks.js:117
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
+#: js/blocks/HeapBlocks.js:544 js/blocks/EnsembleBlocks.js:117
 msgid "index"
 msgstr "インデックス"
 
-#: js/blocks/HeapBlocks.js:544
-#: js/blocks/BoxesBlocks.js:75
+#: js/blocks/HeapBlocks.js:544 js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:599
 msgid "value1"
 msgstr "すうち"
@@ -4117,27 +3544,43 @@ msgid "xor"
 msgstr "XOR"
 
 #: js/blocks/BooleanBlocks.js:391
-msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+msgid ""
+"The Greater-than block returns True if the top number is greater than the "
+"bottom number."
 msgstr "「＞」ブロックは、うえの すうちが したの すうちより おおきいばあいに 「じつ」を かえします。"
 
 #: js/blocks/BooleanBlocks.js:496
-msgid "The Less-than block returns True if the top number is less than the bottom number."
+msgid ""
+"The Less-than block returns True if the top number is less than the bottom "
+"number."
 msgstr "「＜」ブロックは、うえの すうちが したの すうちより ちいさい ばあいに 「じつ」を かえします。"
 
 #: js/blocks/BooleanBlocks.js:596
-msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
+msgid ""
+"The Less-than-or-equal-to block returns True if the top number is less than "
+"or equal to the bottom number."
 msgstr "「≦」ブロックは、うえの すうちが したの すうちいかの ばあいに  「じつ」を かえします。"
 
 #: js/blocks/BooleanBlocks.js:696
-msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
+msgid ""
+"The Greater-than-or-equal-to block returns True if the top number is greater"
+" than or equal to the bottom number."
 msgstr "「≥」ブロックは、うえの すうちが したの すうち いじょう であるばあいに 「じつ」を かえします。"
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
-msgstr "<h2>しんぎブロック（ひとしい）</h2><br>２つの すうちを くらべて、 おなじ すうちで あるかどうか はんてい する。 「＝」は、 ２つの すうちが おなじ であれば 「しん（しん）」、 おなじ でなければ 「にせ（ぎ）」 という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+msgstr ""
+"<h2>しんぎブロック（ひとしい）</h2><br>２つの すうちを くらべて、 おなじ すうちで あるかどうか はんてい する。 「＝」は、 ２つの "
+"すうちが おなじ であれば 「しん（しん）」、 おなじ でなければ 「にせ（ぎ）」 という "
+"けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような "
+"ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを "
+"じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの "
+"けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
 
 #: js/blocks/BooleanBlocks.js:901
-msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
+msgid ""
+"The Not-equal-to block returns True if the two numbers are not equal to each"
+" other."
 msgstr "「≠」ブロックは 2つの すうじが ひとしくない ばあいに「じつ」を かえします。"
 
 #: js/blocks/BooleanBlocks.js:1001
@@ -4178,7 +3621,8 @@ msgid "add 1 to"
 msgstr "はこに １を たす"
 
 #: js/blocks/BoxesBlocks.js:211
-msgid "The Subtract-1-from block subtracts one from the value stored in a box."
+msgid ""
+"The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "「〜から１ひく」ブロックはぼっくすにほぞんされたあたいから1をひきます。"
 
 #: js/blocks/BoxesBlocks.js:222
@@ -4223,7 +3667,9 @@ msgid "store in box1"
 msgstr "はこ１に すうちを いれる"
 
 #: js/blocks/DictBlocks.js:62
-msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
+msgid ""
+"The Show-dictionary block displays the contents of the dictionary at the top"
+" of the screen."
 msgstr "「じしょを あらわす」ブロックは、がめんのじょうぶにじしょのないようをひょうじします。"
 
 #: js/blocks/DictBlocks.js:77
@@ -4242,10 +3688,11 @@ msgid "The Dictionary block returns a dictionary."
 msgstr "「じしょ」ブロックはじしょをかえします。"
 
 #: js/blocks/DictBlocks.js:197 js/blocks/DictBlocks.js:339
-msgid "The Get-dict block returns a value in the dictionary for a specified key."
+msgid ""
+"The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックはしていされたキーのじしょのあたいをかえします。"
 
-#. TRANS: retrieve a value from the dictionary with a given key
+#.  TRANS: retrieve a value from the dictionary with a given key
 #: js/blocks/DictBlocks.js:212 js/blocks/DictBlocks.js:354
 msgid "get value"
 msgstr "あたいを あらわす"
@@ -4257,7 +3704,7 @@ msgstr "あたいを あらわす"
 msgid "key2"
 msgstr "キーワード"
 
-#. TRANS: key, e.g., C in C Major
+#.  TRANS: key, e.g., C in C Major
 #: js/blocks/DictBlocks.js:215 js/blocks/DictBlocks.js:216
 #: js/blocks/DictBlocks.js:289 js/blocks/DictBlocks.js:290
 #: js/blocks/DictBlocks.js:357 js/blocks/DictBlocks.js:430
@@ -4269,7 +3716,7 @@ msgstr "ちょう"
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックはしていされたキーにじしょのあたいをせっていします。"
 
-#. TRANS: set a value in the dictionary for a given key
+#.  TRANS: set a value in the dictionary for a given key
 #: js/blocks/DictBlocks.js:286 js/blocks/DictBlocks.js:427
 msgid "set value"
 msgstr "あたいを せってい"
@@ -4280,11 +3727,14 @@ msgstr "「ノイズめい」ブロックはのいずシンセサイザーをせ
 
 #: js/blocks/DrumBlocks.js:102
 msgid "The Drum name block is used to select a drum."
-msgstr "<h2>ドラムブロック</h2><br>ドラムの しゅるいを かえるときに つかう。 クリックで、 いろいろな ドラムの おとを えらぶことが できる。"
+msgstr ""
+"<h2>ドラムブロック</h2><br>ドラムの しゅるいを かえるときに つかう。 クリックで、 いろいろな ドラムの おとを えらぶことが できる。"
 
 #: js/blocks/DrumBlocks.js:146
 msgid "The Effects name block is used to select a sound effect."
-msgstr "<h2>こうかおんブロック</h2><br>こうかおんの しゅるいを かえるときに つかう。 クリックで、 いろいろな おもしろい おとを えらぶことが できる。"
+msgstr ""
+"<h2>こうかおんブロック</h2><br>こうかおんの しゅるいを かえるときに つかう。 クリックで、 いろいろな おもしろい おとを えらぶことが"
+" できる。"
 
 #: js/blocks/DrumBlocks.js:163
 msgid "noise"
@@ -4298,13 +3748,15 @@ msgstr "「ノイズさいせい」ブロックはほわいとのいず、ぴん
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラムおとにおきかえます。"
 
-#. TRANS: map a pitch to a drum sound
+#.  TRANS: map a pitch to a drum sound
 #: js/blocks/DrumBlocks.js:343
 msgid "map pitch to drum"
 msgstr "ドラムを おんぷに かえる"
 
 #: js/blocks/DrumBlocks.js:397 js/blocks/DrumBlocks.js:406
-msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+msgid ""
+"The Set drum block will select a drum sound to replace the pitch of any "
+"contained notes."
 msgstr "「ドラムをせってい」ブロックは、ふくまれているおんぷの ピッチを おきかえるドラムの おとを せんたくします。"
 
 #: js/blocks/DrumBlocks.js:410
@@ -4315,8 +3767,8 @@ msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>
 msgid "The Pop block removes the value at the top of the heap."
 msgstr "「ポップ」ブロックはヒープのせんとうのあたいをさくじょします。"
 
+#. TRANS: pop a value off the top of the heap
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ポップ"
 
@@ -4324,8 +3776,8 @@ msgstr "ポップ"
 msgid "The Push block adds a value to the top of the heap."
 msgstr "「プッシュ」ブロックはあたいをヒープのせんとうについかします。"
 
+#. TRANS: push a value onto the top of the heap
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "プッシュ"
 
@@ -4338,40 +3790,34 @@ msgid "turtle index heap"
 msgstr "タートル ヒープに ばんごうを ふる"
 
 #: js/blocks/EnsembleBlocks.js:98
-msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
+msgid ""
+"The Mouse index heap block returns a value in the heap at a specified "
+"location for a specified mouse."
 msgstr "していされた ネズミの してい されたいちの ヒープないの あたいをかえします。"
 
 #: js/blocks/EnsembleBlocks.js:105
-msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
+msgid ""
+"The Turtle index heap block returns a value in the heap at a specified "
+"location for a specified turtle."
 msgstr "していされたタートルのしていされたいちのヒープないのあたいをかえします。"
 
-#: js/blocks/EnsembleBlocks.js:115
-#: js/blocks/EnsembleBlocks.js:190
-#: js/blocks/EnsembleBlocks.js:252
-#: js/blocks/EnsembleBlocks.js:334
-#: js/blocks/EnsembleBlocks.js:380
-#: js/blocks/EnsembleBlocks.js:418
-#: js/blocks/EnsembleBlocks.js:476
-#: js/blocks/EnsembleBlocks.js:526
-#: js/blocks/EnsembleBlocks.js:571
-#: js/blocks/EnsembleBlocks.js:621
-#: js/blocks/EnsembleBlocks.js:675
-#: js/blocks/EnsembleBlocks.js:788
-#: js/blocks/EnsembleBlocks.js:879
-#: js/blocks/EnsembleBlocks.js:943
-#: js/blocks/EnsembleBlocks.js:983
-#: js/blocks/EnsembleBlocks.js:1245
+#: js/blocks/EnsembleBlocks.js:115 js/blocks/EnsembleBlocks.js:190
+#: js/blocks/EnsembleBlocks.js:252 js/blocks/EnsembleBlocks.js:334
+#: js/blocks/EnsembleBlocks.js:380 js/blocks/EnsembleBlocks.js:418
+#: js/blocks/EnsembleBlocks.js:476 js/blocks/EnsembleBlocks.js:526
+#: js/blocks/EnsembleBlocks.js:571 js/blocks/EnsembleBlocks.js:621
+#: js/blocks/EnsembleBlocks.js:675 js/blocks/EnsembleBlocks.js:788
+#: js/blocks/EnsembleBlocks.js:879 js/blocks/EnsembleBlocks.js:943
+#: js/blocks/EnsembleBlocks.js:983 js/blocks/EnsembleBlocks.js:1245
 #: js/blocks/EnsembleBlocks.js:1319
 msgid "Yertle"
 msgstr "ヤートル"
 
-#: js/blocks/EnsembleBlocks.js:117
-#: js/blocks/EnsembleBlocks.js:1106
+#: js/blocks/EnsembleBlocks.js:117 js/blocks/EnsembleBlocks.js:1106
 msgid "mouse name"
 msgstr "ネズミの なまえ"
 
-#: js/blocks/EnsembleBlocks.js:117
-#: js/blocks/EnsembleBlocks.js:1115
+#: js/blocks/EnsembleBlocks.js:117 js/blocks/EnsembleBlocks.js:1115
 msgid "turtle name"
 msgstr "ネズミの名前"
 
@@ -4391,26 +3837,18 @@ msgstr "タートルをとめる"
 msgid "The Stop turtle block stops the specified turtle."
 msgstr "していされたタートルをていしします。"
 
-#: js/blocks/EnsembleBlocks.js:207
-#: js/blocks/EnsembleBlocks.js:267
-#: js/blocks/EnsembleBlocks.js:431
-#: js/blocks/EnsembleBlocks.js:490
-#: js/blocks/EnsembleBlocks.js:732
-#: js/blocks/EnsembleBlocks.js:833
-#: js/blocks/EnsembleBlocks.js:895
-#: js/blocks/EnsembleBlocks.js:1216
+#: js/blocks/EnsembleBlocks.js:207 js/blocks/EnsembleBlocks.js:267
+#: js/blocks/EnsembleBlocks.js:431 js/blocks/EnsembleBlocks.js:490
+#: js/blocks/EnsembleBlocks.js:732 js/blocks/EnsembleBlocks.js:833
+#: js/blocks/EnsembleBlocks.js:895 js/blocks/EnsembleBlocks.js:1216
 #: js/blocks/EnsembleBlocks.js:1279
 msgid "Cannot find mouse"
 msgstr "ネズミが みつかりません。"
 
-#: js/blocks/EnsembleBlocks.js:209
-#: js/blocks/EnsembleBlocks.js:269
-#: js/blocks/EnsembleBlocks.js:433
-#: js/blocks/EnsembleBlocks.js:492
-#: js/blocks/EnsembleBlocks.js:734
-#: js/blocks/EnsembleBlocks.js:835
-#: js/blocks/EnsembleBlocks.js:897
-#: js/blocks/EnsembleBlocks.js:1218
+#: js/blocks/EnsembleBlocks.js:209 js/blocks/EnsembleBlocks.js:269
+#: js/blocks/EnsembleBlocks.js:433 js/blocks/EnsembleBlocks.js:492
+#: js/blocks/EnsembleBlocks.js:734 js/blocks/EnsembleBlocks.js:835
+#: js/blocks/EnsembleBlocks.js:897 js/blocks/EnsembleBlocks.js:1218
 #: js/blocks/EnsembleBlocks.js:1281
 msgid "Cannot find turtle"
 msgstr "タートルが みつかりません。"
@@ -4443,8 +3881,8 @@ msgstr "タートルは すでに うごいています。"
 msgid "Cannot find start block"
 msgstr "「スタート」ブロックが みつかりません。"
 
+#. TRANS: pen color for this mouse
 #: js/blocks/EnsembleBlocks.js:310
-#.TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの いろ"
 
@@ -4452,8 +3890,8 @@ msgstr "ネズミの いろ"
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "していされたネズミのぺんのいろをかえします。"
 
+#. TRANS: pen color for this turtle
 #: js/blocks/EnsembleBlocks.js:324
-#.TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルのいろ"
 
@@ -4461,8 +3899,8 @@ msgstr "タートルのいろ"
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "していされたタートルのぺんのいろをかえします。"
 
+#. TRANS: heading (compass direction) for this mouse
 #: js/blocks/EnsembleBlocks.js:356
-#.TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの すすむ かくど"
 
@@ -4470,8 +3908,8 @@ msgstr "ネズミの すすむ かくど"
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "していされたネズミのむきをかえします。"
 
+#. TRANS: heading (compass direction) for this turtle
 #: js/blocks/EnsembleBlocks.js:370
-#.TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルのすすむかくど"
 
@@ -4479,58 +3917,51 @@ msgstr "タートルのすすむかくど"
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr "していされたタートルのむきをかえします。"
 
-#: js/blocks/EnsembleBlocks.js:402
-#: js/blocks/EnsembleBlocks.js:459
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
+#: js/blocks/EnsembleBlocks.js:402 js/blocks/EnsembleBlocks.js:459
 msgid "set mouse"
 msgstr "ネズミを せってい"
 
-#: js/blocks/EnsembleBlocks.js:409
-#: js/blocks/EnsembleBlocks.js:420
+#: js/blocks/EnsembleBlocks.js:409 js/blocks/EnsembleBlocks.js:420
 #: js/blocks/BoxesBlocks.js:599
 msgid "name1"
 msgstr "はこへ"
 
-#: js/blocks/EnsembleBlocks.js:409
-#: js/blocks/EnsembleBlocks.js:420
-#: js/blocks/ProgramBlocks.js:895
-#: js/blocks/GraphicsBlocks.js:238
-#: js/blocks/GraphicsBlocks.js:316
-#: js/blocks/GraphicsBlocks.js:432
-#: js/blocks/GraphicsBlocks.js:483
-#: js/blocks/GraphicsBlocks.js:530
+#: js/blocks/EnsembleBlocks.js:409 js/blocks/EnsembleBlocks.js:420
+#: js/blocks/ProgramBlocks.js:895 js/blocks/GraphicsBlocks.js:238
+#: js/blocks/GraphicsBlocks.js:316 js/blocks/GraphicsBlocks.js:432
+#: js/blocks/GraphicsBlocks.js:483 js/blocks/GraphicsBlocks.js:530
 #: js/blocks/GraphicsBlocks.js:761
 msgid "x"
 msgstr "xざひょう（よこ）"
 
-#: js/blocks/EnsembleBlocks.js:409
-#: js/blocks/EnsembleBlocks.js:420
-#: js/blocks/ProgramBlocks.js:895
-#: js/blocks/GraphicsBlocks.js:152
-#: js/blocks/GraphicsBlocks.js:316
-#: js/blocks/GraphicsBlocks.js:432
-#: js/blocks/GraphicsBlocks.js:483
-#: js/blocks/GraphicsBlocks.js:530
+#: js/blocks/EnsembleBlocks.js:409 js/blocks/EnsembleBlocks.js:420
+#: js/blocks/ProgramBlocks.js:895 js/blocks/GraphicsBlocks.js:152
+#: js/blocks/GraphicsBlocks.js:316 js/blocks/GraphicsBlocks.js:432
+#: js/blocks/GraphicsBlocks.js:483 js/blocks/GraphicsBlocks.js:530
 #: js/blocks/GraphicsBlocks.js:761
 msgid "y"
 msgstr "yざひょう（たて）"
 
-#: js/blocks/EnsembleBlocks.js:413
-#: js/blocks/EnsembleBlocks.js:474
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
+#: js/blocks/EnsembleBlocks.js:413 js/blocks/EnsembleBlocks.js:474
 msgid "set turtle"
 msgstr "タートルをせってい"
 
 #: js/blocks/EnsembleBlocks.js:451
-msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
+msgid ""
+"The Set mouse block sends a stack of blocks to be run by the specified "
+"mouse."
 msgstr "「ネズミを せってい」ブロックのスタックをおくります。"
 
 #: js/blocks/EnsembleBlocks.js:466
-msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
+msgid ""
+"The Set turtle block sends a stack of blocks to be run by the specified "
+"turtle."
 msgstr "していされたタートルにじっこうするブロックのスタックをおくります。"
 
+#. TRANS: y position for this mouse
 #: js/blocks/EnsembleBlocks.js:502
-#.TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミの yざひょう"
 
@@ -4538,8 +3969,8 @@ msgstr "ネズミの yざひょう"
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "「ネズミの yざひょう」していされたネズミのYざひょうをかえします。"
 
+#. TRANS: y position for this turtle
 #: js/blocks/EnsembleBlocks.js:516
-#.TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "ネズミののy座標"
 
@@ -4547,8 +3978,8 @@ msgstr "ネズミののy座標"
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "していされたタートルのYざひょうをかえします。"
 
+#. TRANS: x position for this mouse
 #: js/blocks/EnsembleBlocks.js:547
-#.TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミの xざひょう"
 
@@ -4556,8 +3987,8 @@ msgstr "ネズミの xざひょう"
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "していされたネズミのXざひょうをかえします。"
 
+#. TRANS: x position for this turtle
 #: js/blocks/EnsembleBlocks.js:561
-#.TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "ネズミのx座標"
 
@@ -4565,55 +3996,62 @@ msgstr "ネズミのx座標"
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "していされたタートルのXざひょうをかえします。"
 
+#. TRANS: notes played by this mouse
 #: js/blocks/EnsembleBlocks.js:593
-#.TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの えんそうした おんぷの かず"
 
 #: js/blocks/EnsembleBlocks.js:595
-msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
+msgid ""
+"The Mouse elapse notes block returns the number of notes played by the "
+"specified mouse."
 msgstr "していされたネズミがえんそうしたおんぷかずをかえします。"
 
+#. TRANS: notes played by this turtle
 #: js/blocks/EnsembleBlocks.js:609
-#.TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルのえんそうしたおんぷのかず"
 
 #: js/blocks/EnsembleBlocks.js:611
-msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
+msgid ""
+"The Turtle elapse notes block returns the number of notes played by the "
+"specified turtle."
 msgstr "していされたタートルがえんそうしたおんぷかずをかえします。"
 
+#. TRANS: convert current note for this turtle to piano key (1-88)
 #: js/blocks/EnsembleBlocks.js:647
-#.TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
 
 #: js/blocks/EnsembleBlocks.js:649
-msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
+msgid ""
+"The Mouse pitch block returns the current pitch number being played by the "
+"specified mouse."
 msgstr "していされたネズミがげんざいえんそうしているピッチばんごうをかえします。"
 
+#. TRANS: convert current note for this turtle to piano key (1-88)
 #: js/blocks/EnsembleBlocks.js:663
-#.TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルのピッチすうじ"
 
 #: js/blocks/EnsembleBlocks.js:665
-msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
+msgid ""
+"The Turtle pitch block returns the current pitch number being played by the "
+"specified turtle."
 msgstr "していされたタートルがげんざいえんそうしているピッチばんごうをかえします。"
 
-#: js/blocks/EnsembleBlocks.js:772
-#: js/blocks/EnsembleBlocks.js:844
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
+#: js/blocks/EnsembleBlocks.js:772 js/blocks/EnsembleBlocks.js:844
 msgid "mouse note value"
 msgstr "ネズミの おんか"
 
+#. TRANS: note value is the duration of the note played by this turtle
 #: js/blocks/EnsembleBlocks.js:782
-#.TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルのおんか"
 
+#. TRANS: sync is short for synchronization
 #: js/blocks/EnsembleBlocks.js:855
-#.TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを どうき させる"
 
@@ -4621,8 +4059,8 @@ msgstr "ネズミを どうき させる"
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "ネズミまのビートかずをどうきさせるブロックです。"
 
+#. TRANS: sync is short for synchronization
 #: js/blocks/EnsembleBlocks.js:869
-#.TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルをどうきさせる"
 
@@ -4631,7 +4069,8 @@ msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr "タートルまのビートかずをどうきさせるブロックです。"
 
 #: js/blocks/EnsembleBlocks.js:911
-msgid "The Found mouse block will return true if the specified mouse can be found."
+msgid ""
+"The Found mouse block will return true if the specified mouse can be found."
 msgstr "していされた ネズミが みつかった ばあいに「じつ」を かえします。"
 
 #: js/blocks/EnsembleBlocks.js:919
@@ -4639,7 +4078,9 @@ msgid "found mouse"
 msgstr "ネズミを みつけた"
 
 #: js/blocks/EnsembleBlocks.js:929
-msgid "The Found turtle block will return true if the specified turtle can be found."
+msgid ""
+"The Found turtle block will return true if the specified turtle can be "
+"found."
 msgstr "していされた タートルが みつかった ばあいに 「じつ」を かえします。"
 
 #: js/blocks/EnsembleBlocks.js:937
@@ -4718,18 +4159,15 @@ msgstr "なんびきめの タートルの なまえ"
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr "「なんびきめの タートルの なまえ」ブロックはえぬばんめのタートルのなまえをかえします。"
 
-#: js/blocks/EnsembleBlocks.js:1231
-#: js/blocks/EnsembleBlocks.js:1291
+#: js/blocks/EnsembleBlocks.js:1231 js/blocks/EnsembleBlocks.js:1291
 msgid "set name"
 msgstr "ネズミに なまえを つける"
 
-#: js/blocks/EnsembleBlocks.js:1240
-#: js/blocks/EnsembleBlocks.js:1247
+#: js/blocks/EnsembleBlocks.js:1240 js/blocks/EnsembleBlocks.js:1247
 msgid "source"
 msgstr "ソース"
 
-#: js/blocks/EnsembleBlocks.js:1240
-#: js/blocks/EnsembleBlocks.js:1247
+#: js/blocks/EnsembleBlocks.js:1240 js/blocks/EnsembleBlocks.js:1247
 msgid "target"
 msgstr "ターゲット"
 
@@ -4743,7 +4181,9 @@ msgstr "<h2>「タートルに なまえを つける」ブロック</h2><br>タ
 
 #: js/blocks/FlowBlocks.js:41
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
-msgstr "<h2>じっこうブロック（ぎゃくじっこう）</h2><br>はさまれている ブロックを、 つうじょうとは ぎゃくの じゅんじょで、 したから うえにむかって じっこうする。"
+msgstr ""
+"<h2>じっこうブロック（ぎゃくじっこう）</h2><br>はさまれている ブロックを、 つうじょうとは ぎゃくの じゅんじょで、 したから "
+"うえにむかって じっこうする。"
 
 #: js/blocks/FlowBlocks.js:48
 msgid "backward"
@@ -4754,19 +4194,21 @@ msgid "The Duplicate block will run each block multiple times."
 msgstr "Duplicateブロックはかくブロックをふくすうかいじっこうします。"
 
 #: js/blocks/FlowBlocks.js:126
-msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
+msgid ""
+"The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, "
+"Sol, Sol."
 msgstr "このれいの しゅつりょくは「ソ、ソ、ソ、ソ、レ、レ、レ、レ、ソ、ソ、ソ、ソ」 です。"
 
 #: js/blocks/FlowBlocks.js:372
-msgid "The Default block is used inside of a Switch to define the default action."
+msgid ""
+"The Default block is used inside of a Switch to define the default action."
 msgstr "「ひょうじゅん」ブロックはSwitchないでデフォルトのどうさをていぎするためにつかわれます。"
 
 #: js/blocks/FlowBlocks.js:380
 msgid "default"
 msgstr "ひょうじゅん"
 
-#: js/blocks/FlowBlocks.js:399
-#: js/blocks/FlowBlocks.js:456
+#: js/blocks/FlowBlocks.js:399 js/blocks/FlowBlocks.js:456
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr "ケースブロックは スイッチ ブロックの なかに ある ひつようが あります。"
 
@@ -4810,17 +4252,13 @@ msgstr "「までに」ブロックは じょうけんが まことに なるま
 msgid "until"
 msgstr "までに"
 
-#: js/blocks/FlowBlocks.js:790
-#: js/blocks/FlowBlocks.js:873
+#: js/blocks/FlowBlocks.js:790 js/blocks/FlowBlocks.js:873
 msgid "do2"
 msgstr "～する"
 
-#: js/blocks/FlowBlocks.js:790
-#: js/blocks/FlowBlocks.js:873
-#: js/blocks/MeterBlocks.js:804
-#: js/blocks/ActionBlocks.js:411
-#: js/blocks/ActionBlocks.js:632
-#: js/blocks/ActionBlocks.js:982
+#: js/blocks/FlowBlocks.js:790 js/blocks/FlowBlocks.js:873
+#: js/blocks/MeterBlocks.js:804 js/blocks/ActionBlocks.js:411
+#: js/blocks/ActionBlocks.js:632 js/blocks/ActionBlocks.js:982
 #: js/blocks/ActionBlocks.js:1070
 msgid "do"
 msgstr "アクション"
@@ -4833,30 +4271,29 @@ msgstr "「のあいだに」ブロックはじょうけんがまことである
 msgid "while"
 msgstr "のあいだに"
 
-#: js/blocks/FlowBlocks.js:953
-#: js/blocks/FlowBlocks.js:964
-#: js/blocks/FlowBlocks.js:1018
-#: js/blocks/FlowBlocks.js:1029
-msgid "Conditionals lets your program take different actions depending on the condition."
+#: js/blocks/FlowBlocks.js:953 js/blocks/FlowBlocks.js:964
+#: js/blocks/FlowBlocks.js:1018 js/blocks/FlowBlocks.js:1029
+msgid ""
+"Conditionals lets your program take different actions depending on the "
+"condition."
 msgstr "じょうけんつきをしようすると、プログラムはじょうけんにおうじてさまざまなをじっこうできます。"
 
-#: js/blocks/FlowBlocks.js:957
-#: js/blocks/FlowBlocks.js:1022
+#: js/blocks/FlowBlocks.js:957 js/blocks/FlowBlocks.js:1022
 #: js/blocks/FlowBlocks.js:1033
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr "<br><br>ずのれい では、 もし、 パソコンのマウスを ながおし していれば 「スネアドラム」ブロックを えんそうする。"
 
 #: js/blocks/FlowBlocks.js:968
-msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
+msgid ""
+"In this example if the mouse button is pressed a snare drum will play, else "
+"a kick drum will play."
 msgstr "このれいでは、マウス ボタンがおされるとすねあ ドラムがさいせいされ、そうではないばあいはキック ドラムがさいせいされます。"
 
-#: js/blocks/FlowBlocks.js:979
-#: js/blocks/FlowBlocks.js:1042
+#: js/blocks/FlowBlocks.js:979 js/blocks/FlowBlocks.js:1042
 msgid "if"
 msgstr "もし"
 
-#: js/blocks/FlowBlocks.js:981
-#: js/blocks/FlowBlocks.js:1044
+#: js/blocks/FlowBlocks.js:981 js/blocks/FlowBlocks.js:1044
 msgid "then"
 msgstr "ならば"
 
@@ -4866,10 +4303,14 @@ msgstr "でなければ"
 
 #: js/blocks/FlowBlocks.js:1079
 msgid "The Forever block will repeat the contained blocks forever."
-msgstr "<h2>じっこうブロック（くりかえし）</h2><br>ずっとくりかえす」の ブロックは、 じっこうを ていし しないかぎり、 はさまれている ブロックを くりかえし じっこうする。"
+msgstr ""
+"<h2>じっこうブロック（くりかえし）</h2><br>ずっとくりかえす」の ブロックは、 じっこうを ていし しないかぎり、 はさまれている "
+"ブロックを くりかえし じっこうする。"
 
 #: js/blocks/FlowBlocks.js:1081
-msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
+msgid ""
+"In this example of a simple drum machine a kick drum will play 1/4 notes "
+"forever."
 msgstr "このたんじゅんなドラム・マシンのれいでは、キック・ドラムは よんぶんおんぷをえいえんにえんそうします。"
 
 #: js/blocks/FlowBlocks.js:1091
@@ -4878,7 +4319,8 @@ msgstr "ずっと くりかえす"
 
 #: js/blocks/FlowBlocks.js:1127
 msgid "The Repeat block will repeat the contained blocks."
-msgstr "<h2>じっこうブロック（くりかえし）</h2><br>はさまれている ブロックの プログラムを、 にゅうりょくした かいすう だけ くりかえす。"
+msgstr ""
+"<h2>じっこうブロック（くりかえし）</h2><br>はさまれている ブロックの プログラムを、 にゅうりょくした かいすう だけ くりかえす。"
 
 #: js/blocks/FlowBlocks.js:1129
 msgid "In this example the note will be played 4 times."
@@ -4892,36 +4334,35 @@ msgstr "～かい くりかえす"
 msgid "duplicate factor"
 msgstr "複製ファクター"
 
+#. TRANS: musical meter (time signature), e.g., 4:4
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "げんだいの びょうし"
 
+#. TRANS: number of beats per minute
 #: js/blocks/MeterBlocks.js:88
-#.TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "はくを ～ばいにする ファクター"
 
 #: js/blocks/MeterBlocks.js:96
-msgid "The Beat factor block returns the ratio of the note value to the meter note value."
+msgid ""
+"The Beat factor block returns the ratio of the note value to the meter note "
+"value."
 msgstr "「はくを ～ばいにする ファクター」ブロックは、ひょうしおんぷあたいにたいするおんぷあたいのひりつをかえします。"
 
 #: js/blocks/MeterBlocks.js:167
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr "「１ぷんあたりの はくのかず」ブロックはげんざいの1ふんあたりのビートかずをかえします。"
 
-#: js/blocks/MeterBlocks.js:176
-#: js/widgets/status.js:155
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
+#: js/blocks/MeterBlocks.js:176 js/widgets/status.js:155
 msgid "beats per minute2"
 msgstr "１ぷんあたりの はくのかず"
 
-#: js/blocks/MeterBlocks.js:176
-#: js/blocks/MeterBlocks.js:1101
-#: js/blocks/MeterBlocks.js:1183
-#: js/blocks/MeterBlocks.js:1260
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
+#: js/blocks/MeterBlocks.js:176 js/blocks/MeterBlocks.js:1101
+#: js/blocks/MeterBlocks.js:1183 js/blocks/MeterBlocks.js:1260
 msgid "beats per minute"
 msgstr "スピードを きめる"
 
@@ -4937,8 +4378,8 @@ msgstr "BPM はすくなくとも 30 であるひつようがあり、30 にこ�
 msgid "BPM must be at most 1000, clamping to 1000."
 msgstr "BPM はさいだい 1000 にするひつようがあり、1000 にこていされます。"
 
+#. TRANS: count of current musical measure in meter
 #: js/blocks/MeterBlocks.js:256
-#.TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "「しょうせつの かず」"
 
@@ -4946,57 +4387,54 @@ msgstr "「しょうせつの かず」"
 msgid "The Measure count block returns the current measure."
 msgstr "「しょうせつの かず」ブロックはげんざいのしょうせつかずをかえします。"
 
+#. TRANS: count of current beat in the meter
 #: js/blocks/MeterBlocks.js:316
-#.TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "はくの いち"
 
-#: js/blocks/MeterBlocks.js:326
-#: js/blocks/MeterBlocks.js:337
-#: js/blocks/MeterBlocks.js:597
-#: js/blocks/MeterBlocks.js:608
+#: js/blocks/MeterBlocks.js:326 js/blocks/MeterBlocks.js:337
+#: js/blocks/MeterBlocks.js:597 js/blocks/MeterBlocks.js:608
 msgid "The Beat count block is the number of the current beat,"
 msgstr "<h2>はくの いちブロック</h2><br>しょうせつの なかで なんぱくめかを あらわす かず。"
 
-#: js/blocks/MeterBlocks.js:328
-#: js/blocks/MeterBlocks.js:341
-#: js/blocks/MeterBlocks.js:599
-#: js/blocks/MeterBlocks.js:612
-msgid "In the figure, it is used to take an action on the first beat of each measure."
+#: js/blocks/MeterBlocks.js:328 js/blocks/MeterBlocks.js:341
+#: js/blocks/MeterBlocks.js:599 js/blocks/MeterBlocks.js:612
+msgid ""
+"In the figure, it is used to take an action on the first beat of each "
+"measure."
 msgstr "ずでは、かくしょうせつのさいしょのはくでアクションをじっこうするためにしようされます。"
 
-#: js/blocks/MeterBlocks.js:339
-#: js/blocks/MeterBlocks.js:610
+#: js/blocks/MeterBlocks.js:339 js/blocks/MeterBlocks.js:610
 msgid "eg 1, 2, 3, or 4."
 msgstr " たとえば、 かくしょうせつの ３はくめに なにか アクション・イベントを おこしたいときなどに つかう。"
 
+#. TRANS: count the number of notes
 #: js/blocks/MeterBlocks.js:397
-#.TRANS: count the number of notes
 msgid "sum note values"
 msgstr "おとの ながさを たす"
 
-#: js/blocks/MeterBlocks.js:405
-#: js/blocks/MeterBlocks.js:469
-msgid "The Note counter block can be used to count the number of contained notes."
+#: js/blocks/MeterBlocks.js:405 js/blocks/MeterBlocks.js:469
+msgid ""
+"The Note counter block can be used to count the number of contained notes."
 msgstr "「おんぷの ごうけい すう」ブロックはふくまれるおんぷのかずをかぞえるためにしようできます。"
 
+#. TRANS: count the number of notes
 #: js/blocks/MeterBlocks.js:461
-#.TRANS: count the number of notes
 msgid "note counter"
 msgstr "おんぷの ごうけい すう"
 
+#. TRANS: number of whole notes that have been played
 #: js/blocks/MeterBlocks.js:525
-#.TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "さいせい された ぜんおんぷの かず"
 
 #: js/blocks/MeterBlocks.js:534
-msgid "The Whole notes played block returns the total number of whole notes played."
+msgid ""
+"The Whole notes played block returns the total number of whole notes played."
 msgstr "「さいせい された ぜんおんぷの かず」ブロックはえんそうされたぜんおんぷのそうすうをかえします。"
 
-#: js/blocks/MeterBlocks.js:587
-#: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
+#: js/blocks/MeterBlocks.js:587 js/turtleactions/DictActions.js:83
 msgid "notes played"
 msgstr "ぜんたいの はくの かず"
 
@@ -5008,8 +4446,8 @@ msgstr "「えんを えがいて いどう」ブロックは タートルを �
 msgid "The No clock block decouples the notes from the master clock."
 msgstr "<em>クロックなし</em>ブロックはそれぞれの動作の順番をリズムより優先します。"
 
+#. TRANS: don't lock notes to master clock
 #: js/blocks/MeterBlocks.js:696
-#.TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "クロックなし"
 
@@ -5018,7 +4456,8 @@ msgid "on weak beat do"
 msgstr "弱拍に～する"
 
 #: js/blocks/MeterBlocks.js:740
-msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
+msgid ""
+"The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr "「On-weak-beat」ブロックはじゃくはく（うらはく）でじっこうするをしていできます。"
 
 #: js/blocks/MeterBlocks.js:785
@@ -5026,17 +4465,17 @@ msgid "on strong beat"
 msgstr "強拍に"
 
 #: js/blocks/MeterBlocks.js:793
-msgid "The On-strong-beat block lets you specify actions to take on specified beats."
+msgid ""
+"The On-strong-beat block lets you specify actions to take on specified "
+"beats."
 msgstr "「On-strong-beat」ブロックはしていされたきょうはくでじっこうするをしていできます。"
 
 #: js/blocks/MeterBlocks.js:804
 msgid "beat"
 msgstr "びょうし"
 
-#: js/blocks/MeterBlocks.js:804
-#: js/blocks/ActionBlocks.js:411
-#: js/blocks/ActionBlocks.js:632
-#: js/blocks/ActionBlocks.js:982
+#: js/blocks/MeterBlocks.js:804 js/blocks/ActionBlocks.js:411
+#: js/blocks/ActionBlocks.js:632 js/blocks/ActionBlocks.js:982
 #: js/blocks/ActionBlocks.js:1070
 msgid "do1"
 msgstr "アクション じっこう"
@@ -5046,7 +4485,8 @@ msgid "on every beat do"
 msgstr "すべてのびょうしにアクションじっこう"
 
 #: js/blocks/MeterBlocks.js:856
-msgid "The On-every-beat block lets you specify actions to take on every beat."
+msgid ""
+"The On-every-beat block lets you specify actions to take on every beat."
 msgstr "「すべてのびょうしにアクションじっこう」ブロックはすべてのはくでじっこうするをしていできます。"
 
 #: js/blocks/MeterBlocks.js:909
@@ -5054,58 +4494,62 @@ msgid "on every note do"
 msgstr "すべての おんぷに アクションじっこう"
 
 #: js/blocks/MeterBlocks.js:917
-msgid "The On-every-note block lets you specify actions to take on every note."
+msgid ""
+"The On-every-note block lets you specify actions to take on every note."
 msgstr "「すべての おんぷに アクションじっこう」ブロックはすべてのおんぷでじっこうするをしていできます。"
 
-#: js/blocks/MeterBlocks.js:963
-#: js/blocks/MeterBlocks.js:1039
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
+#: js/blocks/MeterBlocks.js:963 js/blocks/MeterBlocks.js:1039
 msgid "master beats per minute"
 msgstr "ぜんたいの スピードを きめる"
 
 #: js/blocks/MeterBlocks.js:975
-msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+msgid ""
+"The Master beats per minute block sets the number of 1/4 notes per minute "
+"for every voice."
 msgstr "「ぜんたいの スピードを きめる」ブロックは、かくぼいすの 1 ふんあたりの 1/4 おんぷのかずをせっていします。"
 
-#: js/blocks/MeterBlocks.js:987
-#: js/blocks/MeterBlocks.js:1123
+#: js/blocks/MeterBlocks.js:987 js/blocks/MeterBlocks.js:1123
 #: js/blocks/MeterBlocks.js:1185
 msgid "bpm"
 msgstr "１ぷんあたりの はくのかず"
 
-#: js/blocks/MeterBlocks.js:987
-#: js/blocks/MeterBlocks.js:1123
+#: js/blocks/MeterBlocks.js:987 js/blocks/MeterBlocks.js:1123
 #: js/blocks/MeterBlocks.js:1185
 msgid "beat value"
 msgstr "１ぱく"
 
-#: js/blocks/MeterBlocks.js:1070
-#: js/blocks/MeterBlocks.js:1217
+#: js/blocks/MeterBlocks.js:1070 js/blocks/MeterBlocks.js:1217
 #: js/blocks/MeterBlocks.js:1290
 msgid "Beats per minute must be > 30."
 msgstr "１ぷん あたりの はくの かずは ３０より おおきい あたいを せってい して ください。"
 
-#: js/blocks/MeterBlocks.js:1073
-#: js/blocks/MeterBlocks.js:1220
+#: js/blocks/MeterBlocks.js:1073 js/blocks/MeterBlocks.js:1220
 #: js/blocks/MeterBlocks.js:1293
 msgid "Maximum beats per minute is 1000."
 msgstr "１ぷん あたりの はくの かずは さいだい １０００です。"
 
 #: js/blocks/MeterBlocks.js:1113
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
-msgstr "<h2>スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくの スピードを きめる。 ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
+msgstr ""
+"<h2>スピードを きめるブロック</h2><br>１ぷんあたりの はくの かずを せってい することで、 きょくの スピードを きめる。 "
+"ひょうじゅんは ４ぶおんぷ ９０こ。<br><br>★はくとは<br>くりかえされる リズムのこと。"
 
+#. TRANS: anacrusis
 #: js/blocks/MeterBlocks.js:1327
-#.TRANS: anacrusis
 msgid "pickup"
 msgstr "ピックアップ"
 
 #: js/blocks/MeterBlocks.js:1334
-msgid "The Pickup block is used to accommodate any notes that come in before the beat."
+msgid ""
+"The Pickup block is used to accommodate any notes that come in before the "
+"beat."
 msgstr "「ピックアップ」ブロックは、ビートのまえににゅうりょくされるおんぷをしゅうようするためにしようされます。"
 
 #: js/blocks/MeterBlocks.js:1400
-msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
+msgid ""
+"The beat of the music is determined by the Meter block (by default, 4 1/4 "
+"notes per measure)."
 msgstr "おんがくのビートは「ひょうし」ブロックによってけっていされます (ひょうじゅんでは、1 しょうせつあたり ４つの1/4おんぷ)。"
 
 #: js/blocks/MeterBlocks.js:1415
@@ -5120,49 +4564,54 @@ msgstr "スタッカートの ながさ ファクター"
 msgid "slur factor"
 msgstr "スラーの ながさ ファクター"
 
-#: js/blocks/OrnamentBlocks.js:217
-#: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of
+#. C
+#: js/blocks/OrnamentBlocks.js:217 js/blocks/OrnamentBlocks.js:309
 msgid "neighbor"
 msgstr "おとを くわえる"
 
-#: js/blocks/OrnamentBlocks.js:220
-#: js/blocks/IntervalsBlocks.js:708
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
+#: js/blocks/OrnamentBlocks.js:220 js/blocks/IntervalsBlocks.js:708
 msgid "semi-tone interval"
 msgstr "半おんかい的音程"
 
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
-msgstr "<h2>おとを くわえる ブロック</h2><br>２つの おなじたかさの おとの あいだに、 おとを １つ いれることが できる。<br>ずのれいでは、 ソとソの あいだに ラが はいり、 「ソラソ」 と すばやく えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+msgstr ""
+"<h2>おとを くわえる ブロック</h2><br>２つの おなじたかさの おとの あいだに、 おとを １つ いれることが "
+"できる。<br>ずのれいでは、 ソとソの あいだに ラが はいり、 「ソラソ」 と すばやく "
+"えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの "
+"「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/OrnamentBlocks.js:364
 msgid "glide"
 msgstr "グリッサンド"
 
-#: js/blocks/OrnamentBlocks.js:472
-#: js/blocks/OrnamentBlocks.js:636
+#: js/blocks/OrnamentBlocks.js:472 js/blocks/OrnamentBlocks.js:636
 msgid "slur"
 msgstr "スラー"
 
-#: js/blocks/OrnamentBlocks.js:551
-#: js/blocks/OrnamentBlocks.js:703
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
+#: js/blocks/OrnamentBlocks.js:551 js/blocks/OrnamentBlocks.js:703
 msgid "staccato"
 msgstr "スタッカート"
 
 #: js/blocks/OrnamentBlocks.js:619
-msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+msgid ""
+"The Slur block lengthens the sustain of notes while maintaining the "
+"specified rhythmic value of the notes."
 msgstr "「スラー」ブロックは、していされたおんぷのながさをぜんぶくみあわせてながくします。"
 
 #: js/blocks/OrnamentBlocks.js:685
-msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+msgid ""
+"The Staccato block shortens the length of the actual note while maintaining "
+"the specified rhythmic value of the notes."
 msgstr "「スタッカート」ブロックは、していされたおんぷのながさをいじしながら、じっさいのおんぷのながさをたんしゅくします。"
 
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 #: js/blocks/RhythmBlockPaletteBlocks.js:69
 #: js/blocks/RhythmBlockPaletteBlocks.js:248
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "れんぷ（かけ算）"
 
@@ -5180,74 +4629,78 @@ msgstr "ポリリズム"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:234
 msgid "The Rhythm block is used to generate rhythm patterns."
-msgstr "<h2>れんぷブロック（かけざん）</h2><br>まとまった いくつかの おんぷ。 いっていの ながさの おとを  ３つや ５つなど くりかえして つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
+msgstr ""
+"<h2>れんぷブロック（かけざん）</h2><br>まとまった いくつかの おんぷ。 いっていの ながさの おとを  ３つや ５つなど くりかえして "
+"つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:296
 #: js/blocks/RhythmBlockPaletteBlocks.js:301
-#.TRANS: Do not modify the following line
 msgid "1/64 note"
 msgstr "６４ぶん おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:327
 #: js/blocks/RhythmBlockPaletteBlocks.js:332
-#.TRANS: Do not modify the following line
 msgid "1/32 note"
 msgstr "３２ぶん おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:361
 #: js/blocks/RhythmBlockPaletteBlocks.js:366
-#.TRANS: Do not modify the following line
 msgid "1/16 note"
 msgstr "１６ぶん おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:395
-#.TRANS: Do not modify the following line
 msgid "eighth note"
 msgstr "８ぶん おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:423
-#.TRANS: Do not modify the following line
 msgid "quarter note"
 msgstr "４ぶ おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:451
 #: js/blocks/RhythmBlockPaletteBlocks.js:456
-#.TRANS: Do not modify the following line
 msgid "half note"
 msgstr "２ぶ おんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:485
 #: js/blocks/RhythmBlockPaletteBlocks.js:490
-#.TRANS: Do not modify the following line
 msgid "whole note"
 msgstr "ぜんおんぷ"
 
+#. TRANS: Do not modify the following line
+#. TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:529
 #: js/blocks/RhythmBlockPaletteBlocks.js:597
 #: js/blocks/RhythmBlockPaletteBlocks.js:648
-#.TRANS: Do not modify the following line
-#.TRANS: A tuplet is a note value divided into irregular time values.
-#.TRANS: Do not modify the following line
 msgid "tuplet"
 msgstr "～れんぷ（タプル）"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:637
-#.TRANS: Do not modify the following line
-msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
+msgid ""
+"The Tuplet block is used to generate a group of notes played in a condensed "
+"amount of time."
 msgstr "「～れんぷ（タプル）」ブロックは、ぎょうしゅくされたじかんでえんそうされるおんぷのグループをせいせいするためにしようされます。"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:795
-#.TRANS: Do not modify the following line
 msgid "septuplet"
 msgstr "７れんぷ"
 
+#. TRANS: Do not modify the following line
 #: js/blocks/RhythmBlockPaletteBlocks.js:823
-#.TRANS: Do not modify the following line
 msgid "quintuplet"
 msgstr "５れんぷ"
 
+#. TRANS: A tuplet divided into 3 time values.
 #: js/blocks/RhythmBlockPaletteBlocks.js:851
-#.TRANS: A tuplet divided into 3 time values.
 msgid "triplet"
 msgstr "３れんぷ"
 
@@ -5256,11 +4709,16 @@ msgid "simple tuplet"
 msgstr "れんぷ（わり算）"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:888
-msgid "Tuplets are a collection of notes that get scaled to a specific duration."
-msgstr "<h2>れんぷブロック（わりざん）</h2><br>まとまった いくつかの おんぷ。いっていの ながさの おとを  ３つや ５つに とうぶんして つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
+msgid ""
+"Tuplets are a collection of notes that get scaled to a specific duration."
+msgstr ""
+"<h2>れんぷブロック（わりざん）</h2><br>まとまった いくつかの おんぷ。いっていの ながさの おとを  ３つや ５つに とうぶんして "
+"つかう。３れんぷ や ５れんぷ など、 ２のばいすう ではない おんぷの かずで グループを つくりやすくなる。"
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:890
-msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
+msgid ""
+"Using tuplets makes it easy to create groups of notes that are not based on "
+"a power of 2."
 msgstr "れんぷをしようすると、2 のるいじょうにもとづいていないおんぷのグループをかんたんにさくせいできます。"
 
 #: js/blocks/SensorsBlocks.js:36
@@ -5303,32 +4761,40 @@ msgstr "「クリック」ブロックはネズミがクリックされたばあ
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr "「クリック」ブロックはかめがクリックされたばあいにイベントをトリガーします。"
 
+#. TRANS: The mouse cursor is over the mouse icon
 #: js/blocks/SensorsBlocks.js:350
-#.TRANS: The mouse cursor is over the mouse icon
 msgid "cursor over"
 msgstr "カーソル（うえ）"
 
 #: js/blocks/SensorsBlocks.js:355
-msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
+msgid ""
+"The Cursor over block triggers an event when the cursor is moved over a "
+"mouse."
 msgstr "「カーソル（うえ）」ブロックは、カーソルがネズミうえにいどうするとイベントをトリガーします。"
 
 #: js/blocks/SensorsBlocks.js:364
-msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
+msgid ""
+"The Cursor over block triggers an event when the cursor is moved over a "
+"turtle."
 msgstr "「カーソル（うえ）」ブロックは、カーソルがタートルうえにいどうするとイベントをトリガーします。"
 
+#. TRANS: The cursor is "out" -- it is no longer over the mouse.
 #: js/blocks/SensorsBlocks.js:395
-#.TRANS: The cursor is "out" -- it is no longer over the mouse.
 msgid "cursor out"
 msgstr "カーソル（外）"
 
+#. TRANS: hover
 #: js/blocks/SensorsBlocks.js:401
-#.TRANS: hover
-msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
+msgid ""
+"The Cursor out block triggers an event when the cursor is moved off of a "
+"mouse."
 msgstr "「カーソル（そと）」ブロックは、カーソルがネズミからはなれるとイベントをトリガーします。"
 
+#. TRANS: hover
 #: js/blocks/SensorsBlocks.js:411
-#.TRANS: hover
-msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
+msgid ""
+"The Cursor out block triggers an event when the cursor is moved off of a "
+"turtle."
 msgstr "「カーソル（そと）」ブロックは、カーソルがタートルからはなれるとイベントをトリガーします。"
 
 #: js/blocks/SensorsBlocks.js:441
@@ -5336,11 +4802,15 @@ msgid "cursor button down"
 msgstr "カーソルクリック（した）"
 
 #: js/blocks/SensorsBlocks.js:446
-msgid "The Cursor button down block triggers an event when the cursor button is pressed on a mouse."
+msgid ""
+"The Cursor button down block triggers an event when the cursor button is "
+"pressed on a mouse."
 msgstr "「カーソルクリック（した）」ブロックは、ネズミのカーソル ボタンがおされたときにイベントをトリガーします。"
 
 #: js/blocks/SensorsBlocks.js:455
-msgid "The Cursor button down block triggers an event when the cursor button is pressed on a turtle."
+msgid ""
+"The Cursor button down block triggers an event when the cursor button is "
+"pressed on a turtle."
 msgstr "「カーソルクリック（した）」ブロックは、タートルうえでカーソル ボタンがおされたときにイベントをトリガーします。"
 
 #: js/blocks/SensorsBlocks.js:485
@@ -5348,22 +4818,23 @@ msgid "cursor button up"
 msgstr "カーソルクリック（うえ）"
 
 #: js/blocks/SensorsBlocks.js:490
-msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
+msgid ""
+"The Cursor button up block triggers an event when the cursor button is "
+"released while over a mouse."
 msgstr "「カーソルクリック（うえ）」ブロックは、ネズミのうえでカーソル ボタンがはなされるとイベントをトリガーします。"
 
 #: js/blocks/SensorsBlocks.js:499
-msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
+msgid ""
+"The Cursor button up block triggers an event when the cursor button is "
+"released while over a turtle."
 msgstr "「カーソルクリック（うえ）」ブロックは、タートルのうえでカーソル ボタンがはなされるとイベントをトリガーします。"
 
-#: js/blocks/SensorsBlocks.js:529
-#: js/blocks/SensorsBlocks.js:1004
-#: js/blocks/PenBlocks.js:112
-#: plugins/rodi.rtp:217
+#: js/blocks/SensorsBlocks.js:529 js/blocks/SensorsBlocks.js:1004
+#: js/blocks/PenBlocks.js:112 plugins/rodi.rtp:217
 msgid "red"
 msgstr "あか"
 
-#: js/blocks/SensorsBlocks.js:574
-#: plugins/rodi.rtp:216
+#: js/blocks/SensorsBlocks.js:574 plugins/rodi.rtp:216
 msgid "pixel color"
 msgstr "ピクセルの いろ"
 
@@ -5380,7 +4851,9 @@ msgid "time"
 msgstr "じかん"
 
 #: js/blocks/SensorsBlocks.js:727
-msgid "The Time block returns the number of seconds that the program has been running."
+msgid ""
+"The Time block returns the number of seconds that the program has been "
+"running."
 msgstr "「じかん」ブロックは、プログラムがじっこうされているびょうすうをかえします。"
 
 #: js/blocks/SensorsBlocks.js:766
@@ -5389,7 +4862,10 @@ msgstr "yざひょうち（カーソル）"
 
 #: js/blocks/SensorsBlocks.js:771
 msgid "The Cursor Y block returns the vertical position of the mouse."
-msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの たていち を あらわす ｙざひょうち。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。"
+msgstr ""
+"<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの たていち を あらわす ｙざひょうち。<br>ずのれいは、 ネズミを つかって "
+"がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを "
+"おしているときだけ ペンをおろし、 せんをえがく。"
 
 #: js/blocks/SensorsBlocks.js:807
 msgid "cursor x"
@@ -5397,7 +4873,10 @@ msgstr "xざひょうち（カーソル）"
 
 #: js/blocks/SensorsBlocks.js:812
 msgid "The Cursor X block returns the horizontal position of the mouse."
-msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの よこいち を あらわす ｘざひょうち。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。"
+msgstr ""
+"<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの よこいち を あらわす ｘざひょうち。<br>ずのれいは、 ネズミを つかって "
+"がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを "
+"おしているときだけ ペンをおろし、 せんをえがく。"
 
 #: js/blocks/SensorsBlocks.js:848
 msgid "mouse button"
@@ -5405,7 +4884,14 @@ msgstr "マウスボタン"
 
 #: js/blocks/SensorsBlocks.js:850
 msgid "The Mouse-button block returns True if the mouse button is pressed."
-msgstr "<h2>しんぎブロック（マウスボタン）</h2><br>マウスの ボタンが おされているか どうか はんてい する。 マウスボタンが おされていれば 「しん（しん）」、 おされていなければ「にせ（ぎ）」と いう あたいになる。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 せんをえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+msgstr ""
+"<h2>しんぎブロック（マウスボタン）</h2><br>マウスの ボタンが おされているか どうか はんてい する。 マウスボタンが おされていれば "
+"「しん（しん）」、 おされていなければ「にせ（ぎ）」と いう あたいになる。<br>ずのれいは、 ネズミを つかって がめんじょうに じゆうに せんを "
+"えがける プログラム。 ネズミが パソコンの マウスカーソルの いち に いどうしつづけつつ、 マウスを おしているときだけ ペンをおろし、 "
+"せんをえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような "
+"ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを "
+"じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの "
+"けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
 
 #: js/blocks/SensorsBlocks.js:896
 msgid "to ASCII"
@@ -5420,39 +4906,45 @@ msgid "The Keyboard block returns computer keyboard input."
 msgstr "「キーボード」ブロックはこんぴゅーたのキーボードにゅうりょくをかえします。"
 
 #: js/blocks/SensorsBlocks.js:1006
-msgid "The Get red block returns the red component of the pixel under the mouse."
+msgid ""
+"The Get red block returns the red component of the pixel under the mouse."
 msgstr "「Get red」ブロックはネズミしたのピクセルのあかせいぶんをかえします。"
 
 #: js/blocks/SensorsBlocks.js:1009
-msgid "The Get red block returns the red component of the pixel under the turtle."
+msgid ""
+"The Get red block returns the red component of the pixel under the turtle."
 msgstr "「Get red」ブロックはかめのしたのピクセルのあかせいぶんをかえします。"
 
-#: js/blocks/SensorsBlocks.js:1015
-#: js/blocks/PenBlocks.js:64
+#: js/blocks/SensorsBlocks.js:1015 js/blocks/PenBlocks.js:64
 #: plugins/rodi.rtp:218
 msgid "green"
 msgstr "みどり"
 
 #: js/blocks/SensorsBlocks.js:1017
-msgid "The Get green block returns the green component of the pixel under the mouse."
+msgid ""
+"The Get green block returns the green component of the pixel under the "
+"mouse."
 msgstr "「Get green」ブロックは、ネズミのしたにあるピクセルのりょくしょくこんぽーねんとをかえします。"
 
 #: js/blocks/SensorsBlocks.js:1020
-msgid "The Get green block returns the green component of the pixel under the turtle."
+msgid ""
+"The Get green block returns the green component of the pixel under the "
+"turtle."
 msgstr "「Get green」ブロックは、タートルのしたのピクセルのりょくしょくこんぽーねんとをかえします。"
 
-#: js/blocks/SensorsBlocks.js:1026
-#: js/blocks/PenBlocks.js:48
+#: js/blocks/SensorsBlocks.js:1026 js/blocks/PenBlocks.js:48
 #: plugins/rodi.rtp:219
 msgid "blue"
 msgstr "あお"
 
 #: js/blocks/SensorsBlocks.js:1028
-msgid "The Get blue block returns the blue component of the pixel under the mouse."
+msgid ""
+"The Get blue block returns the blue component of the pixel under the mouse."
 msgstr "「Get blue」ブロックは、ネズミのしたにあるピクセルのあおいろのこんぽーねんとをかえします。"
 
 #: js/blocks/SensorsBlocks.js:1031
-msgid "The Get blue block returns the blue component of the pixel under the turtle."
+msgid ""
+"The Get blue block returns the blue component of the pixel under the turtle."
 msgstr "「Get blue」ブロックは、タートルのしたのピクセルのあおこんぽーねんとをかえします。"
 
 #: js/blocks/VolumeBlocks.js:35
@@ -5460,7 +4952,9 @@ msgid "synth volume"
 msgstr "シンセのおんりょう"
 
 #: js/blocks/VolumeBlocks.js:39
-msgid "The Synth volume block returns the current volume of the current synthesizer."
+msgid ""
+"The Synth volume block returns the current volume of the current "
+"synthesizer."
 msgstr "「シンセのおんりょう」ブロックはげんざいのシンセサイザーのおんりょうをかえします。"
 
 #: js/blocks/VolumeBlocks.js:105
@@ -5471,20 +4965,16 @@ msgstr "マスター おんりょう"
 msgid "The Master volume block returns the master volume."
 msgstr "「マスター おんりょう」ブロックはマスター・ボリュームをかえします。"
 
-#: js/blocks/VolumeBlocks.js:355
-#: js/blocks/VolumeBlocks.js:525
+#: js/blocks/VolumeBlocks.js:355 js/blocks/VolumeBlocks.js:525
 msgid "set synth volume"
 msgstr "がっきの おんりょうを せってい"
 
-#: js/blocks/VolumeBlocks.js:362
-#: js/blocks/VolumeBlocks.js:546
+#: js/blocks/VolumeBlocks.js:362 js/blocks/VolumeBlocks.js:546
 msgid "synth"
 msgstr "がっき"
 
-#: js/blocks/VolumeBlocks.js:403
-#: js/blocks/VolumeBlocks.js:578
-#: js/blocks/VolumeBlocks.js:741
-#: js/turtleactions/VolumeActions.js:174
+#: js/blocks/VolumeBlocks.js:403 js/blocks/VolumeBlocks.js:578
+#: js/blocks/VolumeBlocks.js:741 js/turtleactions/VolumeActions.js:174
 msgid "Setting volume to 0."
 msgstr "おんりょうを 「0」に せってい します。"
 
@@ -5497,7 +4987,9 @@ msgid "set drum volume"
 msgstr "ドラムの おんりょうを せってい"
 
 #: js/blocks/VolumeBlocks.js:531
-msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
+msgid ""
+"The Set synth volume block will change the volume of a particular synth, eg "
+"guitar violin snare drum etc."
 msgstr "「がっきのおんりょうをせってい」ブロックは、ギター、バイオリン、スネア・ドラムなどのとくていのシンセサイザーのおんりょうをへんこうします。"
 
 #: js/blocks/VolumeBlocks.js:535
@@ -5520,8 +5012,7 @@ msgstr "「ステレオをせってい」ブロックはすべてのしんせの
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr "ワーニング：おとはみぎかひだりだけのスピーカーからでている"
 
-#: js/blocks/VolumeBlocks.js:648
-#: js/blocks/VolumeBlocks.js:696
+#: js/blocks/VolumeBlocks.js:648 js/blocks/VolumeBlocks.js:696
 msgid "set master volume"
 msgstr "ぜんたいのおんりょうを せってい"
 
@@ -5530,7 +5021,8 @@ msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr "<h2>ぜんたいのおんりょうを せっていブロック</h2><br>ぜんたいの おんりょうを せっていする。"
 
 #: js/blocks/VolumeBlocks.js:784
-msgid "The Set relative volume block changes the volume of the contained notes."
+msgid ""
+"The Set relative volume block changes the volume of the contained notes."
 msgstr "「あいたいおんりょうを せってい」ブロックはふくまれるおんぷのおんりょうをへんこうします。"
 
 #: js/blocks/VolumeBlocks.js:791
@@ -5538,24 +5030,38 @@ msgid "set relative volume"
 msgstr "あいたいおんりょうを せってい"
 
 #: js/blocks/VolumeBlocks.js:843
-msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
+msgid ""
+"The Decrescendo block will decrease the volume of the contained notes by a "
+"specified amount for every note played."
 msgstr "「デクレッシェンド」ブロックは、さいせいされるおんぷごとに、ふくまれるおんぷのおんりょうをしていされたりょうだけげんしょうさせます。"
 
 #: js/blocks/VolumeBlocks.js:847
-msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
-msgstr "たとえば、あたいが「5」の「でクレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% ひくくなります。"
+msgid ""
+"For example if you have 7 notes in sequence contained in a Decrescendo block"
+" with a value of 5 the final note will be at 35% less than the starting "
+"volume."
+msgstr ""
+"たとえば、あたいが「5」の「でクレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% "
+"ひくくなります。"
 
 #: js/blocks/VolumeBlocks.js:857
 msgid "decrescendo"
 msgstr "デクレシェンド"
 
 #: js/blocks/VolumeBlocks.js:907
-msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
+msgid ""
+"The Crescendo block will increase the volume of the contained notes by a "
+"specified amount for every note played."
 msgstr "「クレッシェンド」ブロックは、さいせいされるおんぷごとに、ふくまれるおんぷのおんりょうをしていされたりょうだけぞうかさせます。"
 
 #: js/blocks/VolumeBlocks.js:911
-msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
-msgstr "たとえば、あたいが「5」の「クレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% おおきくなります。"
+msgid ""
+"For example if you have 7 notes in sequence contained in a Crescendo block "
+"with a value of 5 the final note will be at 35% more than the starting "
+"volume."
+msgstr ""
+"たとえば、あたいが「5」の「クレッシェンド」ブロックに 7つのおんぷがれんぞくしてふくまれているばあい、さいごのおんぷはかいしおんりょうより 35% "
+"おおきくなります。"
 
 #: js/blocks/VolumeBlocks.js:921
 msgid "crescendo"
@@ -5577,61 +5083,56 @@ msgstr "「URLに もどります」ブロックはあたいをウェブペー�
 msgid "return to URL"
 msgstr "URLに もどります"
 
-#: js/blocks/ActionBlocks.js:178
-#: js/blocks/ProgramBlocks.js:86
+#: js/blocks/ActionBlocks.js:178 js/blocks/ProgramBlocks.js:86
 #: js/blocks/ProgramBlocks.js:181
 msgid "Invalid URL"
 msgstr "むこうな URL"
 
-#: js/blocks/ActionBlocks.js:230
-#: js/blocks/ActionBlocks.js:311
-#: js/blocks/ActionBlocks.js:522
-#: js/blocks/ActionBlocks.js:711
+#: js/blocks/ActionBlocks.js:230 js/blocks/ActionBlocks.js:311
+#: js/blocks/ActionBlocks.js:522 js/blocks/ActionBlocks.js:711
 msgid "The Calculate block returns a value calculated by an action."
 msgstr "「けいさん する」ブロックはでけいさんされたあたいをかえします。"
 
 #: js/blocks/GraphicsBlocks.js:1200
-msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+msgid ""
+"The Wrap block enables or disables screen wrapping for the graphics actions "
+"within it."
 msgstr "「まきつける」ブロックは、そのなかの グラフィックスの がめんラッピングを ゆうこう または むこうに します。"
 
-#: js/blocks/ActionBlocks.js:248
-#: js/blocks/ActionBlocks.js:538
+#: js/blocks/ActionBlocks.js:248 js/blocks/ActionBlocks.js:538
 #: js/blocks/ActionBlocks.js:730
 msgid "calculate"
 msgstr "けいさん する"
 
-#: js/blocks/ActionBlocks.js:397
-#: js/blocks/ActionBlocks.js:615
-#: js/blocks/ActionBlocks.js:965
-#: js/blocks/ActionBlocks.js:1417
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
+#: js/blocks/ActionBlocks.js:397 js/blocks/ActionBlocks.js:615
+#: js/blocks/ActionBlocks.js:965 js/blocks/ActionBlocks.js:1417
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（してい）</h2><br>していした アクションブロックを じっこうする。"
 
-#: js/blocks/ActionBlocks.js:814
-#: js/blocks/ActionBlocks.js:888
+#: js/blocks/ActionBlocks.js:814 js/blocks/ActionBlocks.js:888
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr "「ひきすう」ブロックはにわたされたひきすうのあたいをふくみます。"
 
-#: js/blocks/ActionBlocks.js:829
-#: js/blocks/ActionBlocks.js:901
+#: js/blocks/ActionBlocks.js:829 js/blocks/ActionBlocks.js:901
 msgid "arg"
 msgstr "ひきすう"
 
-#: js/blocks/ActionBlocks.js:859
-#: js/blocks/ActionBlocks.js:923
+#: js/blocks/ActionBlocks.js:859 js/blocks/ActionBlocks.js:923
 #: js/blocks/ActionBlocks.js:931
 msgid "Invalid argument"
 msgstr "むこうな ぎろん"
 
 #: js/blocks/ActionBlocks.js:967
-msgid "In the example, it is used with the One of block to choose a random phase."
+msgid ""
+"In the example, it is used with the One of block to choose a random phase."
 msgstr "<br><br>ずのれいは、 きまったアクション ではなく、 ２つの うち どちらか １つの アクションを ランダムに じっこうさせる。"
 
-#: js/blocks/ActionBlocks.js:1041
-#: js/blocks/ActionBlocks.js:1048
+#: js/blocks/ActionBlocks.js:1041 js/blocks/ActionBlocks.js:1048
 msgid "The Listen block is used to listen for an event such as a mouse click."
-msgstr "<h2>イベントブロック（うけとり）</h2><br>とくていの イベント にたいして、 その はっせい をうけとるたびに じっこうする アクションを １つ きめて おくことが できる。"
+msgstr ""
+"<h2>イベントブロック（うけとり）</h2><br>とくていの イベント にたいして、 その はっせい をうけとるたびに じっこうする アクションを "
+"１つ きめて おくことが できる。"
 
 #: js/blocks/ActionBlocks.js:1050
 msgid "When the event happens, an action is taken."
@@ -5641,15 +5142,16 @@ msgstr "<br><br>イベントの発生は、各スクリプトが【イベント�
 msgid "on"
 msgstr "のとき"
 
-#: js/blocks/ActionBlocks.js:1070
-#: js/blocks/ActionBlocks.js:1071
+#: js/blocks/ActionBlocks.js:1070 js/blocks/ActionBlocks.js:1071
 #: js/blocks/ActionBlocks.js:1180
 msgid "event"
 msgstr "イベント"
 
 #: js/blocks/ActionBlocks.js:1160
 msgid "The Broadcast block is used to trigger an event."
-msgstr "<h2>イベントブロック（はっせい）</h2><br>していした なまえの イベントを すべての ネズミに おくる。 イベントの はっせいは、 かくスクリプトが 【イベントのたびにアクション】で してい した アクションの ひきがね として はたらく。"
+msgstr ""
+"<h2>イベントブロック（はっせい）</h2><br>していした なまえの イベントを すべての ネズミに おくる。 イベントの はっせいは、 "
+"かくスクリプトが 【イベントのたびにアクション】で してい した アクションの ひきがね として はたらく。"
 
 #: js/blocks/ActionBlocks.js:1178
 msgid "broadcast"
@@ -5660,11 +5162,15 @@ msgid "Each Start block is a separate voice."
 msgstr "<h2>スタートブロック</h2><br>じっこうボタンが おされると、 スタートブロックが じっこうされる。"
 
 #: js/blocks/ActionBlocks.js:1238
-msgid "All of the Start blocks run at the same time when the Play button is pressed."
+msgid ""
+"All of the Start blocks run at the same time when the Play button is "
+"pressed."
 msgstr "[さいせい] ボタンをおすと、すべての 「スタート」 ブロックがどうじにじっこうされます。"
 
 #: js/blocks/ActionBlocks.js:1329
-msgid "The Action block is used to group together blocks so that they can be used more than once."
+msgid ""
+"The Action block is used to group together blocks so that they can be used "
+"more than once."
 msgstr "「 」ブロックは、ふくすうのブロックをグループかしてふくすうかいしようできるようにするためにしようされます。"
 
 #: js/blocks/ActionBlocks.js:1333
@@ -5708,35 +5214,50 @@ msgid "xor"
 msgstr "XOR"
 
 #: js/blocks/BooleanBlocks.js:391
-msgid "The Greater-than block returns True if the top number is greater than the bottom number."
+msgid ""
+"The Greater-than block returns True if the top number is greater than the "
+"bottom number."
 msgstr "「＞」ブロックは、うえのすうちがしたのすうちよりおおきいばあいに True をかえします。"
 
 #: js/blocks/BooleanBlocks.js:496
-msgid "The Less-than block returns True if the top number is less than the bottom number."
+msgid ""
+"The Less-than block returns True if the top number is less than the bottom "
+"number."
 msgstr "「＜」ブロックは、うえのすうちがしたのすうちよりちーさいばあいに True をかえします。"
 
 #: js/blocks/BooleanBlocks.js:596
-msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
+msgid ""
+"The Less-than-or-equal-to block returns True if the top number is less than "
+"or equal to the bottom number."
 msgstr "「≦」ブロックは、うえのすうちがしたのすうちいかのばあいに True をかえします。"
 
 #: js/blocks/BooleanBlocks.js:696
-msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
+msgid ""
+"The Greater-than-or-equal-to block returns True if the top number is greater"
+" than or equal to the bottom number."
 msgstr "「≥」ブロックは、うえのすうちがしたのすうちいじょうであるばあいに True をかえします。"
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
-msgstr "<h2>しんぎブロック（ひとしい）</h2><br>２つの すうちを くらべて、 おなじ すうちで あるかどうか はんてい する。 「＝」は、 ２つの すうちが おなじ であれば 「しん（しん）」、 おなじ でなければ 「にせ（ぎ）」 という けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
+msgstr ""
+"<h2>しんぎブロック（ひとしい）</h2><br>２つの すうちを くらべて、 おなじ すうちで あるかどうか はんてい する。 「＝」は、 ２つの "
+"すうちが おなじ であれば 「しん（しん）」、 おなじ でなければ 「にせ（ぎ）」 という "
+"けっかになる。<br><br>★しんぎブロックとは<br>「もし～ならば」などの じょうけんブロックを うごかすために ひつような "
+"ブロック。<br>「もし～ならば」は、 せいかくに ひょうげんすると、 「もし～という じょうけんが ただしい ならば、 つぎの ブロックを "
+"じっこうする」という いみ である。 しんぎブロックは ふとうしき などによる ひかくが 「ただしい（しん）」か、 「ただしくない（にせ）」かの "
+"けっかを あらわし、 「もし～ならば」に つづく ブロックを じっこうするか どうか きめる。"
 
 #: js/blocks/BooleanBlocks.js:901
-msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
+msgid ""
+"The Not-equal-to block returns True if the two numbers are not equal to each"
+" other."
 msgstr "「≠」ブロックは2つのすうじがひとしくないばあいにTrueをかえします。"
 
 #: js/blocks/BooleanBlocks.js:1003
 msgid "The Boolean block is used to specify true or false."
 msgstr "Booleanブロックはtrueまたはfalseをしていするためにつかわれます。"
 
-#: js/blocks/BoxesBlocks.js:53
-#: js/blocks/BoxesBlocks.js:59
+#: js/blocks/BoxesBlocks.js:53 js/blocks/BoxesBlocks.js:59
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr "<h2>かずのはこ（あたいをかえる）</h2><br>してい した はこに、 すきな すうちを たす。"
 
@@ -5748,8 +5269,7 @@ msgstr "<br><br> マイナスの すうちを つかうと ひきざん にな�
 msgid "add"
 msgstr "たす"
 
-#: js/blocks/BoxesBlocks.js:75
-#: js/widgets/temperament.js:1081
+#: js/blocks/BoxesBlocks.js:75 js/widgets/temperament.js:1081
 msgid "to"
 msgstr "はこへ"
 
@@ -5766,20 +5286,19 @@ msgid "add 1 to"
 msgstr "はこに １を たす"
 
 #: js/blocks/BoxesBlocks.js:211
-msgid "The Subtract-1-from block subtracts one from the value stored in a box."
+msgid ""
+"The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "「〜から１ひく」ブロックはぼっくすにほぞんされたあたいから1をひきます。"
 
 #: js/blocks/BoxesBlocks.js:222
 msgid "subtract 1 from"
 msgstr "〜から１ひく"
 
-#: js/blocks/BoxesBlocks.js:270
-#: js/blocks/BoxesBlocks.js:387
+#: js/blocks/BoxesBlocks.js:270 js/blocks/BoxesBlocks.js:387
 msgid "The Box block returns the value stored in a box."
 msgstr "<h2>すうちブロック</h2><br>すうちブロック として、 はこの すうちを つかう。"
 
-#: js/blocks/BoxesBlocks.js:504
-#: js/blocks/BoxesBlocks.js:580
+#: js/blocks/BoxesBlocks.js:504 js/blocks/BoxesBlocks.js:580
 msgid "The Store in block will store a value in a box."
 msgstr "<h2>かずのはこ（あたいをいれる）</h2><br>してい した はこに、 してい した すうちを いれる。"
 
@@ -5819,8 +5338,7 @@ msgstr "しょうすうからぶんすう"
 msgid "save as ABC"
 msgstr "ABCフォーマットでほぞん"
 
-#: js/blocks/ExtrasBlocks.js:96
-#: js/blocks/ExtrasBlocks.js:132
+#: js/blocks/ExtrasBlocks.js:96 js/blocks/ExtrasBlocks.js:132
 #: js/blocks/ExtrasBlocks.js:168
 msgid "title"
 msgstr "めい"
@@ -5842,7 +5360,8 @@ msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "「ヒープは から ですか？」ブロックは ヒープが そらの ばあいに「じつ」を かえします。"
 
 #: js/blocks/ExtrasBlocks.js:220
-msgid "The No background block eliminates the background from the saved SVG output."
+msgid ""
+"The No background block eliminates the background from the saved SVG output."
 msgstr "「バックグラウンドなし」ブロックはほぞんされたSVGしゅつりょくのはいけいをさくじょします。"
 
 #: js/blocks/ExtrasBlocks.js:248
@@ -5857,8 +5376,7 @@ msgstr "「ブロックを ひょうじ」ブロックはブロックをひょ�
 msgid "The Hide blocks block hides the blocks."
 msgstr "「ブロックを ひひょうじ」ブロックはブロックをひひょうじにします。"
 
-#: js/blocks/ExtrasBlocks.js:307
-#: js/blocks/ExtrasBlocks.js:340
+#: js/blocks/ExtrasBlocks.js:307 js/blocks/ExtrasBlocks.js:340
 msgid "The Space block is used to add space between blocks."
 msgstr "<h2>スペースブロック</h2><br>ブロックと ブロックの あいだに スペースを いれたいときに つかう。"
 
@@ -5871,11 +5389,12 @@ msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr "「まつ」ブロックはしていされたびょうすうだけプログラムをいちじていしします。"
 
 #: js/blocks/ExtrasBlocks.js:427
-msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
+msgid ""
+"The Comment block prints a comment at the top of the screen when the program"
+" is running in slow mode."
 msgstr "「コメント」ブロックは、プログラムがていそくモードでじっこうされているときに、がめんのじょうぶにメモをしゅつりょくします。"
 
-#: js/blocks/ExtrasBlocks.js:435
-#: plugins/facebook.rtp:30
+#: js/blocks/ExtrasBlocks.js:435 plugins/facebook.rtp:30
 msgid "comment"
 msgstr "コメント"
 
@@ -5885,7 +5404,10 @@ msgstr "けっかを ひょうじ"
 
 #: js/blocks/ExtrasBlocks.js:478
 msgid "The Print block displays text at the top of the screen."
-msgstr "<h2>ひょうじ ブロック（けっか）</h2><br>がめんの じょうぶに、 してい した じっこうけっかの すうちや もじを ひょうじする。 ひょうじした テキストは クリックすると けすことが できる。 どこで プログラムが まちがっているかを かくにんするさい（デバグ）などに よく もちいられる。"
+msgstr ""
+"<h2>ひょうじ ブロック（けっか）</h2><br>がめんの じょうぶに、 してい した じっこうけっかの すうちや もじを ひょうじする。 "
+"ひょうじした テキストは クリックすると けすことが できる。 どこで プログラムが まちがっているかを かくにんするさい（デバグ）などに よく "
+"もちいられる。"
 
 #: js/blocks/ExtrasBlocks.js:587
 msgid "display grid"
@@ -5895,71 +5417,91 @@ msgstr "グリッドをひょうじ"
 msgid "The Display Grid Block changes the grid type"
 msgstr "「グリッドをひょうじ」ブロックのグリッド たいぷのへんこう"
 
-#: js/blocks/ExtrasBlocks.js:858
-#: js/blocks/ExtrasBlocks.js:870
+#: js/blocks/ExtrasBlocks.js:858 js/blocks/ExtrasBlocks.js:870
 #: js/blocks/WidgetBlocks.js:2155
 msgid "debugger"
 msgstr "デバッガー"
 
 #: js/blocks/ExtrasBlocks.js:861
-msgid "The Debug block adds a debug point in your code. When reached, execution will pause and you can inspect variables."
-msgstr "「デバッガー」ブロックは、コードにでばっぐ ぽいんとをついかします。とうたつすると、じっこうがいちじていしされ、へんすうをけんさできるようになります。"
+msgid ""
+"The Debug block adds a debug point in your code. When reached, execution "
+"will pause and you can inspect variables."
+msgstr ""
+"「デバッガー」ブロックは、コードにでばっぐ ぽいんとをついかします。とうたつすると、じっこうがいちじていしされ、へんすうをけんさできるようになります。"
 
-#: js/blocks/MediaBlocks.js:45
-#: js/blocks/MediaBlocks.js:56
+#: js/blocks/MediaBlocks.js:45 js/blocks/MediaBlocks.js:56
 msgid "The Right block returns the position of the right of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの みぎはし の ｘざひょうち。 プラスの すうち。カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの みぎはし の ｘざひょうち。 プラスの すうち。カンバスの たてはば、 よこはば、 "
+"ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
-#: js/blocks/MediaBlocks.js:47
-#: js/blocks/MediaBlocks.js:123
-msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-msgstr "このれいでは、ネズミはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
+#: js/blocks/MediaBlocks.js:47 js/blocks/MediaBlocks.js:123
+msgid ""
+"In this example, the mouse moves right until it reaches the right edge of "
+"the canvas; then it reappears at the left of the canvas."
+msgstr ""
+"このれいでは、ネズミはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
 
-#: js/blocks/MediaBlocks.js:58
-#: js/blocks/MediaBlocks.js:134
-msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
-msgstr "このれいでは、タートルはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
+#: js/blocks/MediaBlocks.js:58 js/blocks/MediaBlocks.js:134
+msgid ""
+"In this example, the turtle moves right until it reaches the right edge of "
+"the canvas; then it reappears at the left of the canvas."
+msgstr ""
+"このれいでは、タートルはキャンバスのみぎはしにとうたつするまでみぎにいどうします。そののち、キャンバスのひだりがわにふたたびひょうじされます。"
 
-#: js/blocks/MediaBlocks.js:121
-#: js/blocks/MediaBlocks.js:132
+#: js/blocks/MediaBlocks.js:121 js/blocks/MediaBlocks.js:132
 msgid "The Left block returns the position of the left of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの ひだりはし の ｘざひょうち。 マイナスの すうち。 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの ひだりはし の ｘざひょうち。 マイナスの すうち。 カンバスの たてはば、 よこはば、"
+" ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
-#: js/blocks/MediaBlocks.js:196
-#: js/blocks/MediaBlocks.js:207
+#: js/blocks/MediaBlocks.js:196 js/blocks/MediaBlocks.js:207
 msgid "The Top block returns the position of the top of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの じょうたん の ｙざひょうち。 プラスの すうち。  カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの じょうたん の ｙざひょうち。 プラスの すうち。  カンバスの じょうほうを もつ "
+"すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの "
+"６しゅるいが ある。"
 
-#: js/blocks/MediaBlocks.js:198
-#: js/blocks/MediaBlocks.js:273
-msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-msgstr "このれいでは、ネズミはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
+#: js/blocks/MediaBlocks.js:198 js/blocks/MediaBlocks.js:273
+msgid ""
+"In this example, the mouse moves upward until it reaches the top edge of the"
+" canvas; then it reappears at the bottom of the canvas."
+msgstr ""
+"このれいでは、ネズミはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
 
-#: js/blocks/MediaBlocks.js:209
-#: js/blocks/MediaBlocks.js:284
-msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
-msgstr "このれいでは、タートルはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
+#: js/blocks/MediaBlocks.js:209 js/blocks/MediaBlocks.js:284
+msgid ""
+"In this example, the turtle moves upward until it reaches the top edge of "
+"the canvas; then it reappears at the bottom of the canvas."
+msgstr ""
+"このれいでは、タートルはキャンバスのじょうたんにとうたつするまでうわむきにいどうします。そののち、キャンバスのかぶにふたたびひょうじされます。"
 
-#: js/blocks/MediaBlocks.js:271
-#: js/blocks/MediaBlocks.js:282
+#: js/blocks/MediaBlocks.js:271 js/blocks/MediaBlocks.js:282
 msgid "The Bottom block returns the position of the bottom of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの かたん の ｙざひょうち。 マイナスの すうち。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの かたん の ｙざひょうち。 マイナスの すうち。 カンバスの じょうほうを もつ "
+"すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの "
+"６しゅるいが ある。"
 
 #: js/blocks/MediaBlocks.js:347
 msgid "The Width block returns the width of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 "
+"カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
 #: js/blocks/MediaBlocks.js:404
 msgid "The Height block returns the height of the canvas."
-msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
+msgstr ""
+"<h2>すうちブロック（カンバス）</h2><br>カンバスの たてはば の すうちを あらわす。 カンバスの じょうほうを もつ すうちブロックは、 "
+"カンバスの たてはば、 よこはば、 ざひょうち（うえ）、 ざひょうち（した）、 ざひょうち（ひだり）、 ざひょうち（みぎ） などの ６しゅるいが ある。"
 
+#. TRANS: stops playback of an audio recording
 #: js/blocks/MediaBlocks.js:453
-#.TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "ていし"
 
+#. TRANS: Erases the images and text
 #: js/blocks/MediaBlocks.js:488
-#.TRANS: Erases the images and text
 msgid "erase media"
 msgstr "メディアを けす"
 
@@ -5967,8 +5509,8 @@ msgstr "メディアを けす"
 msgid "The Erase Media block erases text and images."
 msgstr "「メディアを けす」ブロックは もじと がぞうを けします。"
 
+#. TRANS: play an audio recording
 #: js/blocks/MediaBlocks.js:523
-#.TRANS: play an audio recording
 msgid "play back"
 msgstr "プレーバック"
 
@@ -6008,32 +5550,25 @@ msgstr "メデイアを ていし"
 msgid "The Stop media block stops audio or video playback."
 msgstr "「メデイアを ていし」ブロックはおんせいまたはどうがのさいせいをていしします。"
 
-#: js/blocks/MediaBlocks.js:762
-#: js/blocks/PitchBlocks.js:1633
-#: js/widgets/phrasemaker.js:1287
-#: js/widgets/musickeyboard.js:2219
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
+#: js/blocks/MediaBlocks.js:762 js/blocks/PitchBlocks.js:1633
+#: js/widgets/phrasemaker.js:1287 js/widgets/musickeyboard.js:2219
 msgid "hertz"
 msgstr "ヘルツ"
 
-#: js/blocks/MediaBlocks.js:775
-#: js/blocks/WidgetBlocks.js:250
-#: js/widgets/temperament.js:595
-#: js/widgets/temperament.js:646
-#: js/widgets/temperament.js:793
-#: js/widgets/temperament.js:801
-#: js/widgets/temperament.js:1699
-#: js/widgets/timbre.js:1970
+#: js/blocks/MediaBlocks.js:775 js/blocks/WidgetBlocks.js:250
+#: js/widgets/temperament.js:595 js/widgets/temperament.js:646
+#: js/widgets/temperament.js:793 js/widgets/temperament.js:801
+#: js/widgets/temperament.js:1699 js/widgets/timbre.js:1970
 msgid "frequency"
 msgstr "周波数"
 
-#: js/blocks/MediaBlocks.js:775
-#: plugins/rodi.rtp:193
+#: js/blocks/MediaBlocks.js:775 plugins/rodi.rtp:193
 msgid "duration (MS)"
 msgstr "けいぞくじかん（ミリびょう）"
 
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 #: js/blocks/MediaBlocks.js:811
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "おんぷの たかさを しゅうはすう ひょうじへ"
 
@@ -6041,27 +5576,21 @@ msgstr "おんぷの たかさを しゅうはすう ひょうじへ"
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr "「おんぷの たかさを しゅうはすう ひょうじへ」ブロックはおんめいとオクターヴをヘルツにへんかんします。"
 
-#: js/blocks/MediaBlocks.js:829
-#: js/blocks/PitchBlocks.js:695
-#: js/blocks/PitchBlocks.js:1001
-#: js/blocks/PitchBlocks.js:1960
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#: js/blocks/MediaBlocks.js:829 js/blocks/PitchBlocks.js:695
+#: js/blocks/PitchBlocks.js:1001 js/blocks/PitchBlocks.js:1960
 msgid "name2"
 msgstr "なまえ"
 
-#: js/blocks/MediaBlocks.js:829
-#: js/blocks/IntervalsBlocks.js:63
-#: js/blocks/PitchBlocks.js:696
-#: js/blocks/PitchBlocks.js:1002
-#: js/blocks/PitchBlocks.js:1041
-#: js/blocks/PitchBlocks.js:1073
-#: js/blocks/PitchBlocks.js:1242
-#: js/blocks/PitchBlocks.js:1794
-#: js/blocks/PitchBlocks.js:1840
-#: js/blocks/PitchBlocks.js:1960
-#: js/blocks/ToneBlocks.js:1058
-#: js/turtleactions/IntervalsActions.js:157
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the
+#. interval between two notes, one having twice or half the frequency in Hz of
+#. the other.)
+#: js/blocks/MediaBlocks.js:829 js/blocks/IntervalsBlocks.js:63
+#: js/blocks/PitchBlocks.js:696 js/blocks/PitchBlocks.js:1002
+#: js/blocks/PitchBlocks.js:1041 js/blocks/PitchBlocks.js:1073
+#: js/blocks/PitchBlocks.js:1242 js/blocks/PitchBlocks.js:1794
+#: js/blocks/PitchBlocks.js:1840 js/blocks/PitchBlocks.js:1960
+#: js/blocks/ToneBlocks.js:1058 js/turtleactions/IntervalsActions.js:157
 msgid "octave"
 msgstr "オクターヴの たかさ"
 
@@ -6073,9 +5602,8 @@ msgstr "「アバター」ブロックはネズミのがいけんをへんこう
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr "「アバター」ブロックはタートルのがいけんをへんこうするためにつかわれます。"
 
-#: js/blocks/MediaBlocks.js:914
-#: js/blocks/MediaBlocks.js:974
-#.TRANS: a media object
+#. TRANS: a media object
+#: js/blocks/MediaBlocks.js:914 js/blocks/MediaBlocks.js:974
 msgid "size"
 msgstr "おおきさ"
 
@@ -6085,10 +5613,12 @@ msgstr "がぞう そざい"
 
 #: js/blocks/MediaBlocks.js:963
 msgid "The Show block is used to display text or images on the canvas."
-msgstr "<h2>ひょうじブロック（スタンプ）</h2><br>スタンプは、 じっこうすると ネズミの いちに してい した もじ または がぞう を ひょうじする。 ネズミの からだの したに あらわれるので、 ちいさいもじ や がぞう だと ネズミがいどうしないと みえない ばあいがある。"
+msgstr ""
+"<h2>ひょうじブロック（スタンプ）</h2><br>スタンプは、 じっこうすると ネズミの いちに してい した もじ または がぞう を "
+"ひょうじする。 ネズミの からだの したに あらわれるので、 ちいさいもじ や がぞう だと ネズミがいどうしないと みえない ばあいがある。"
 
+#. TRANS: show1 is show as in display an image or text on the screen.
 #: js/blocks/MediaBlocks.js:971
-#.TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "スタンプ"
 
@@ -6098,7 +5628,9 @@ msgstr "そざい"
 
 #: js/blocks/MediaBlocks.js:1021
 msgid "The Media block is used to import an image."
-msgstr "<h2>がぞう ブロック</h2><br>がぞうのブロック。 ブロックの マークを おすと、 コンピューターじょうから がぞうファイルを よみこむことが できる。"
+msgstr ""
+"<h2>がぞう ブロック</h2><br>がぞうのブロック。 ブロックの マークを おすと、 コンピューターじょうから がぞうファイルを よみこむことが"
+" できる。"
 
 #: js/blocks/MediaBlocks.js:1057
 msgid "The Text block holds a text string."
@@ -6141,17 +5673,20 @@ msgid "abs"
 msgstr "ぜったいち"
 
 #: js/blocks/NumberBlocks.js:367
-msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
+msgid ""
+"The Distance block returns the distance between two points. For example, "
+"between the mouse and the center of the screen."
 msgstr "「きょり」ブロックは2てんかんのきょりをかえします。たとえば、ネズミとがめんちゅうおうのきょりです。"
 
-#: js/blocks/NumberBlocks.js:375
-#: plugins/rodi.rtp:310
+#: js/blocks/NumberBlocks.js:375 plugins/rodi.rtp:310
 msgid "distance"
 msgstr "きょり"
 
 #: js/blocks/NumberBlocks.js:427
 msgid "The Divide block is used to divide."
-msgstr "<h2>すうちブロック（けいさん）</h2><br>２つの すうちの わりざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ すうちを、 したに つないだ すうちで わる。"
+msgstr ""
+"<h2>すうちブロック（けいさん）</h2><br>２つの すうちの わりざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ "
+"すうちを、 したに つないだ すうちで わる。"
 
 #: js/blocks/NumberBlocks.js:487
 msgid "The Multiply block is used to multiply."
@@ -6159,7 +5694,9 @@ msgstr "<h2>すうちブロック（けいさん）</h2><br>２つの すうち�
 
 #: js/blocks/NumberBlocks.js:613
 msgid "The Minus block is used to subtract."
-msgstr "<h2>すうちブロック（けいさん）</h2><br>２つのすうちの ひきざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ すうちから、 したに つないだ すうちを ひく。"
+msgstr ""
+"<h2>すうちブロック（けいさん）</h2><br>２つのすうちの ひきざんした けいさんけっかを あらわす すうちブロック。 うえに つないだ "
+"すうちから、 したに つないだ すうちを ひく。"
 
 #: js/blocks/NumberBlocks.js:699
 msgid "The Plus block is used to add."
@@ -6167,10 +5704,13 @@ msgstr "<h2>すうちブロック（けいさん）</h2><br>２つの すうち�
 
 #: js/blocks/NumberBlocks.js:814
 msgid "The One-of block returns one of two choices."
-msgstr "<h2>「どちらか ランダム」ブロック</h2><br>つないだ ２つの ブロックのうち、 1つだけを ランダムに えらぶ。 「すうち」「アクションめい」など、 さまざまな ブロックを つなぐことが できる。<br><br>★ランダムとは<br>サイコロの め のように、 なにが でるか わからない すうちのこと。ランダム（random）は にほんごで 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが できる。"
+msgstr ""
+"<h2>「どちらか ランダム」ブロック</h2><br>つないだ ２つの ブロックのうち、 1つだけを ランダムに えらぶ。 "
+"「すうち」「アクションめい」など、 さまざまな ブロックを つなぐことが できる。<br><br>★ランダムとは<br>サイコロの め のように、 "
+"なにが でるか わからない すうちのこと。ランダム（random）は にほんごで 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 "
+"じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが できる。"
 
-#: js/blocks/NumberBlocks.js:821
-#: js/blocks/PitchBlocks.js:653
+#: js/blocks/NumberBlocks.js:821 js/blocks/PitchBlocks.js:653
 msgid "one of"
 msgstr "どちらか ランダム"
 
@@ -6184,7 +5724,11 @@ msgstr "それか"
 
 #: js/blocks/NumberBlocks.js:878
 msgid "The Random block returns a random number."
-msgstr "<h2>「ランダム」ブロック</h2><br>してい した さいしょうち から さいだいち までの はんいで、 ランダムな すうちに なる。<br><br>★ランダムとは<br>サイコロの め のように、 なにが でるか わからない すうちのこと。ランダム（random）は にほんごで 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが できる。"
+msgstr ""
+"<h2>「ランダム」ブロック</h2><br>してい した さいしょうち から さいだいち までの はんいで、 ランダムな すうちに "
+"なる。<br><br>★ランダムとは<br>サイコロの め のように、 なにが でるか わからない すうちのこと。ランダム（random）は にほんごで"
+" 「らんすう」「でたらめな」という いみ。 ランダムを つかうと、 じっこうの たびに えんそうじゅんじょが かわる きょくなどを つくることが "
+"できる。"
 
 #: js/blocks/NumberBlocks.js:885
 msgid "random"
@@ -6210,8 +5754,7 @@ msgstr "むらさき"
 msgid "yellow"
 msgstr "きいろ"
 
-#: js/blocks/PenBlocks.js:96
-#: plugins/nutrition.rtp:164
+#: js/blocks/PenBlocks.js:96 plugins/nutrition.rtp:164
 msgid "orange"
 msgstr "オレンジ"
 
@@ -6231,16 +5774,13 @@ msgstr "きにゅうを はじめる"
 msgid "end fill"
 msgstr "きにゅうを おわらせる"
 
-#: js/blocks/PenBlocks.js:212
-#: js/blocks/PenBlocks.js:561
-#.TRANS: set the background color
+#. TRANS: set the background color
+#: js/blocks/PenBlocks.js:212 js/blocks/PenBlocks.js:561
 msgid "background"
 msgstr "はいけい"
 
-#: js/blocks/PenBlocks.js:259
-#: js/turtleactions/DictActions.js:71
-#: js/turtleactions/DictActions.js:138
-#: js/turtleactions/DictActions.js:170
+#: js/blocks/PenBlocks.js:259 js/turtleactions/DictActions.js:71
+#: js/turtleactions/DictActions.js:138 js/turtleactions/DictActions.js:170
 msgid "grey"
 msgstr "はいいろ"
 
@@ -6248,10 +5788,8 @@ msgstr "はいいろ"
 msgid "The Grey block returns the current pen grey value."
 msgstr "「はいいろ」ブロックはげんざいのぺんのはいいろあたいをかえします。"
 
-#: js/blocks/PenBlocks.js:329
-#: js/turtleactions/DictActions.js:69
-#: js/turtleactions/DictActions.js:136
-#: js/turtleactions/DictActions.js:169
+#: js/blocks/PenBlocks.js:329 js/turtleactions/DictActions.js:69
+#: js/turtleactions/DictActions.js:136 js/turtleactions/DictActions.js:169
 msgid "shade"
 msgstr "シェード"
 
@@ -6259,10 +5797,8 @@ msgstr "シェード"
 msgid "The Shade block returns the current pen shade value."
 msgstr "「シェード」ブロックはげんざいのぺんのシェードあたいをかえします。"
 
-#: js/blocks/PenBlocks.js:398
-#: js/turtleactions/DictActions.js:67
-#: js/turtleactions/DictActions.js:134
-#: js/turtleactions/DictActions.js:168
+#: js/blocks/PenBlocks.js:398 js/turtleactions/DictActions.js:67
+#: js/turtleactions/DictActions.js:134 js/turtleactions/DictActions.js:168
 msgid "color"
 msgstr "いろ"
 
@@ -6270,10 +5806,8 @@ msgstr "いろ"
 msgid "The Color block returns the current pen color."
 msgstr "<h2>ペンブロック</h2>げんざいの ペンの いろを、 すうちで ひょうじする。"
 
-#: js/blocks/PenBlocks.js:467
-#: js/turtleactions/DictActions.js:73
-#: js/turtleactions/DictActions.js:140
-#: js/turtleactions/DictActions.js:171
+#: js/blocks/PenBlocks.js:467 js/turtleactions/DictActions.js:73
+#: js/turtleactions/DictActions.js:140 js/turtleactions/DictActions.js:171
 msgid "pen size"
 msgstr "ペンの おおきさ"
 
@@ -6287,7 +5821,7 @@ msgstr "フォントの せってい"
 
 #: js/blocks/PenBlocks.js:519
 msgid "The Set font block sets the font used by the Show block."
-msgstr "「フォントの せってい"」ブロックはしょうブロックでつかわれるフォントをせっていします。"
+msgstr "「フォントの せってい」ブロックはしょうブロックでつかわれるフォントをせっていします。"
 
 #: js/blocks/PenBlocks.js:568
 msgid "The Background block sets the window background color."
@@ -6297,8 +5831,8 @@ msgstr "はいけいブロック は、 カンバスの いろを せってい�
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr "「（ちゅうくうの）せん」ブロックはちゅうくうのせんをさくせいします。"
 
+#. TRANS: draw a line logo has a hollow space down its center
 #: js/blocks/PenBlocks.js:607
-#.TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "（ちゅうくうの）せん"
 
@@ -6306,13 +5840,13 @@ msgstr "（ちゅうくうの）せん"
 msgid "The Fill block fills in a shape with a color."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがいた ずけいの うちがわを ぬりつぶす。"
 
+#. TRANS: fill in as a solid color
 #: js/blocks/PenBlocks.js:685
-#.TRANS: fill in as a solid color
 msgid "fill"
 msgstr "ぬりつぶす"
 
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 #: js/blocks/PenBlocks.js:762
-#.TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ペンを あげる"
 
@@ -6320,8 +5854,8 @@ msgstr "ペンを あげる"
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "<h2>ペンブロック</h2><br>ネズミの うごきに あわせて せんを えがくことを やめる。"
 
+#. TRANS: put down the pen so logo it draws when it is moved
 #: js/blocks/PenBlocks.js:803
-#.TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ペンを おろす"
 
@@ -6329,8 +5863,8 @@ msgstr "ペンを おろす"
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "<h2>ペンブロック</h2><br>ネズミの うごきに あわせて せんを えがく。"
 
+#. TRANS: set the width of the line drawn by the pen
 #: js/blocks/PenBlocks.js:845
-#.TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "ふとさを せってい"
 
@@ -6338,14 +5872,16 @@ msgstr "ふとさを せってい"
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんの ふとさを かえる。 ふとさには、 0より おおきい あたいを つかう。"
 
+#. TRANS: set degree of translucence of the pen color
 #: js/blocks/PenBlocks.js:914
-#.TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "透明度をせってい"
 
 #: js/blocks/PenBlocks.js:922
 msgid "The Set translucency block changes the opacity of the pen."
-msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんが どのくらい すきとおるかを せっていする。 すうちが おおきい ほど、 せんが すきとおる。"
+msgstr ""
+"<h2>ペンブロック</h2><br>ネズミが えがく せんが どのくらい すきとおるかを せっていする。 すうちが おおきい ほど、 せんが "
+"すきとおる。"
 
 #: js/blocks/PenBlocks.js:982
 msgid "set hue"
@@ -6363,8 +5899,8 @@ msgstr "いろのこさを せってい"
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんの いろの こさを せっていする。"
 
+#. TRANS: set the level of vividness of the pen color
 #: js/blocks/PenBlocks.js:1112
-#.TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "はいいろを せってい"
 
@@ -6378,14 +5914,16 @@ msgstr "いろを せってい"
 
 #: js/blocks/PenBlocks.js:1183
 msgid "The Set-color block changes the pen color."
-msgstr "<h2>ペンブロック</h2><br>ネズミが えがく せんのいろを かえる。 いろは がめんじょうで えらぶ ほか、 それぞれ すうちで きめることも できる。 いろは、 0いじょうで、 100より ちいさい あたいになる。"
+msgstr ""
+"<h2>ペンブロック</h2><br>ネズミが えがく せんのいろを かえる。 いろは がめんじょうで えらぶ ほか、 それぞれ すうちで きめることも"
+" できる。 いろは、 0いじょうで、 100より ちいさい あたいになる。"
 
 #: js/blocks/ProgramBlocks.js:33
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "「アプリから ヒープを ロード」ブロックはウェブページからヒープをよみこみます。"
 
+#. TRANS: load the heap contents from a URL
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "アプリから ヒープを ロード"
 
@@ -6401,8 +5939,8 @@ msgstr "JSON データの こうぶん エラー です。"
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "「アプリに ヒープを ほぞん」ブロックはヒープをウェブページにほぞんします。"
 
+#. TRANS: save the heap contents to a URL
 #: js/blocks/ProgramBlocks.js:140
-#.TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "アプリに ヒープを ほぞん"
 
@@ -6414,8 +5952,8 @@ msgstr "ただしい ヒープが みつかりません。"
 msgid "The Load-heap block loads the heap from a file."
 msgstr "「ヒープを ロード する」ブロックはファイルからヒープをよみこみます。"
 
+#. TRANS: load the heap from a file
 #: js/blocks/ProgramBlocks.js:218
-#.TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ヒープを ロード する"
 
@@ -6443,13 +5981,12 @@ msgstr "「ヒープを せってい する」ブロックにはヒープがひ�
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "「じしょを ロードする」ブロックはファイルからじしょをよみこみます。"
 
+#. TRANS: load a dictionary from a file
 #: js/blocks/ProgramBlocks.js:376
-#.TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "じしょを ロードする"
 
-#: js/blocks/ProgramBlocks.js:394
-#: js/blocks/ProgramBlocks.js:664
+#: js/blocks/ProgramBlocks.js:394 js/blocks/ProgramBlocks.js:664
 #: js/blocks/ToneBlocks.js:1058
 msgid "file"
 msgstr "ファイル"
@@ -6459,11 +5996,15 @@ msgid "Tremolo makes the sound pulse louder and quieter."
 msgstr "トレモロを しようすると、おとが パルスの ように おおきく なったり、ちーさく なったり します。"
 
 #: js/blocks/ToneBlocks.js:490
-msgid "The rate (first argument) controls how fast the sound pulses (cycles per second)."
+msgid ""
+"The rate (first argument) controls how fast the sound pulses (cycles per "
+"second)."
 msgstr "レート (さいしょの ひきすう) は、おとの パルスそくど (1 びょうあたりの サイクルかず) をせいぎょ します。"
 
 #: js/blocks/ToneBlocks.js:494
-msgid "The depth (second argument) controls the strength of the pulsing effect (0-100%)."
+msgid ""
+"The depth (second argument) controls the strength of the pulsing effect "
+"(0-100%)."
 msgstr "ふかさ (2 ばんめの ひきすう)は、パルスこうかの つよさを せいぎょ します (0 ～ 100%)。"
 
 #: js/blocks/ProgramBlocks.js:448
@@ -6478,8 +6019,8 @@ msgstr "「じしょを ロードする」ブロックには「load file」ブ�
 msgid "The Set-dictionary block loads a dictionary."
 msgstr "「じしょを せってい」ブロックはじしょをよみこみます。"
 
+#. TRANS: load a dictionary from a JSON
 #: js/blocks/ProgramBlocks.js:482
-#.TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "じしょを せってい"
 
@@ -6495,8 +6036,8 @@ msgstr "「じしょを せってい」ブロックにはじしょがひつよ�
 msgid "The Save-heap block saves the heap to a file."
 msgstr "「ヒープを ほぞん する」ブロックはヒープをファイルにほぞんします。"
 
+#. TRANS: save the heap to a file
 #: js/blocks/ProgramBlocks.js:584
-#.TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ヒープを ほぞん する"
 
@@ -6504,8 +6045,8 @@ msgstr "ヒープを ほぞん する"
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "「じしょを せってい」ブロックはじしょをファイルにほぞんします。"
 
+#. TRANS: save a dictionary to a file
 #: js/blocks/ProgramBlocks.js:646
-#.TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "じしょを せってい"
 
@@ -6514,15 +6055,20 @@ msgid "The Open palette block opens a palette."
 msgstr "「パレットを ひらきます」ブロックはパレットをひらきます。"
 
 #: js/blocks/ToneBlocks.js:630
-msgid "The rate (first argument) controls the speed of the chorus modulation (cycles per second)."
+msgid ""
+"The rate (first argument) controls the speed of the chorus modulation "
+"(cycles per second)."
 msgstr "レート (さいしょの ひきすう) は、コーラスへんちょうの そくど (1 びょう あたりの サイクルかず)を せいぎょ します。"
 
 #: js/blocks/ToneBlocks.js:634
-msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
+msgid ""
+"The delay (second argument) sets the time delay between chorus voices "
+"(milliseconds)."
 msgstr "ディレイ(だい 2ひきすう) は、コーラス・ボイスまの ちえんじかん (ミリびょう)を せっていします。"
 
 #: js/blocks/ToneBlocks.js:638
-msgid "The depth (third argument) controls the amount of chorus effect (0-100%)."
+msgid ""
+"The depth (third argument) controls the amount of chorus effect (0-100%)."
 msgstr "ふかさ (3 ばんめのひきすう) は、コーラス・エフェクターのりょう (0 ～ 100%) をせいぎょします。"
 
 #: js/blocks/ProgramBlocks.js:741
@@ -6533,8 +6079,8 @@ msgstr "パレットを ひらきます"
 msgid "The Delete block block removes a block."
 msgstr "「ブロックを けす」ブロックはブロックをさくじょします。"
 
+#. TRANS: Move this block to the trash.
 #: js/blocks/ProgramBlocks.js:811
-#.TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ブロックを けす"
 
@@ -6542,26 +6088,29 @@ msgstr "ブロックを けす"
 msgid "The Move block block moves a block."
 msgstr "「ブロックを うごかす」ブロックはブロックをいどうします。"
 
+#. TRANS: Move the position of a block on the screen.
 #: js/blocks/ProgramBlocks.js:883
-#.TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ブロックを うごかす"
 
-#: js/blocks/ProgramBlocks.js:895
-#: js/blocks/ProgramBlocks.js:1058
+#: js/blocks/ProgramBlocks.js:895 js/blocks/ProgramBlocks.js:1058
 msgid "block number"
 msgstr "ブロックの ばんごう"
 
 #: js/blocks/ProgramBlocks.js:936
-msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
+msgid ""
+"The Run block block runs a block. It accepts two types of arguments: block "
+"number or block name."
 msgstr "「ブロックをさいせい」ブロックはブロックをじっこうします。ブロックばんごうまたはブロックめいの 2 しゅるいのひきすうをうけいれます。"
 
 #: js/blocks/ToneBlocks.js:703
-msgid "The rate (second argument) controls the speed of the pitch variation (cycles per second)."
+msgid ""
+"The rate (second argument) controls the speed of the pitch variation (cycles"
+" per second)."
 msgstr "レート (2 ばんめの ひきすう) は、ピッチへんかの そくど (1 びょうあたりの サイクルかず)を せいぎょします。"
 
+#. TRANS: Run program beginning at this block.
 #: js/blocks/ProgramBlocks.js:949
-#.TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ブロックを じっこう"
 
@@ -6569,8 +6118,8 @@ msgstr "ブロックを じっこう"
 msgid "The Dock block connects two blocks."
 msgstr "「Dock block」ブロックは2つのブロックをせつぞくします。"
 
+#. TRANS: We can connect a block to another block.
 #: js/blocks/ProgramBlocks.js:1046
-#.TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ブロックを つなぐ"
 
@@ -6587,26 +6136,23 @@ msgid "The Make block block creates a new block."
 msgstr "「ブロックを つくる」ブロックはあたらしいブロックをさくせいします。"
 
 #: js/blocks/ToneBlocks.js:871
-msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+msgid ""
+"The set default instrument block changes the default instrument from "
+"electronic synth to the instrument of your choice."
 msgstr "ねいろひょうじゅんをせっていすると、デフォルトのねいろがでんしシンセからせんたくしたねいろにへんこうされます。"
 
+#. TRANS: Create a new block
 #: js/blocks/ProgramBlocks.js:1158
-#.TRANS: Create a new block
 msgid "make block"
 msgstr "ブロックを つくる"
 
-#: js/blocks/ProgramBlocks.js:1192
-#: js/blocks/ProgramBlocks.js:1233
-#: js/blocks/PitchBlocks.js:1041
-#: js/blocks/PitchBlocks.js:1073
-#: js/blocks/RhythmBlocks.js:1122
-#: js/widgets/status.js:213
-#: js/widgets/temperament.js:560
-#: js/widgets/temperament.js:582
-#: js/widgets/temperament.js:586
-#: js/widgets/temperament.js:800
+#. TRANS: a musical note consisting of pitch and duration
+#: js/blocks/ProgramBlocks.js:1192 js/blocks/ProgramBlocks.js:1233
+#: js/blocks/PitchBlocks.js:1041 js/blocks/PitchBlocks.js:1073
+#: js/blocks/RhythmBlocks.js:1122 js/widgets/status.js:213
+#: js/widgets/temperament.js:560 js/widgets/temperament.js:582
+#: js/widgets/temperament.js:586 js/widgets/temperament.js:800
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "おんぷ"
 
@@ -6618,8 +6164,7 @@ msgstr "がっき"
 msgid "Cannot find block"
 msgstr "ブロックが みつかりません"
 
-#: js/blocks/ProgramBlocks.js:1361
-#: js/blocks/ProgramBlocks.js:1370
+#: js/blocks/ProgramBlocks.js:1361 js/blocks/ProgramBlocks.js:1370
 #: js/blocks/ProgramBlocks.js:1379
 msgid "Warning: block argument type mismatch"
 msgstr "ちゅうい：ブロックと タイプが あっていません。"
@@ -6637,22 +6182,28 @@ msgid "synth volume"
 msgstr "シンセの おんりょう"
 
 #: js/blocks/VolumeBlocks.js:39
-msgid "The Synth volume block returns the current volume of the current synthesizer."
+msgid ""
+"The Synth volume block returns the current volume of the current "
+"synthesizer."
 msgstr "「シンセの おんりょう」ブロックは げんざいの シンセサイザーの おんりょうを かえします。"
 
 #: js/blocks/ProgramBlocks.js:1430
 msgid "open project"
 msgstr "プロジェクトを ひらく"
 
-#: js/blocks/ProgramBlocks.js:1482
-#: js/blocks/ProgramBlocks.js:1495
+#: js/blocks/ProgramBlocks.js:1482 js/blocks/ProgramBlocks.js:1495
 #: js/blocks/ProgramBlocks.js:1507
-msgid "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
+msgid ""
+"Please enter a valid project URL (for example: /index.html?id=123&run=true)."
 msgstr "ゆうこうなプロジェクト URL (れい: /index.html?id=123&run=true) をにゅうりょくしてください。"
 
 #: js/blocks/ProgramBlocks.js:1522
-msgid "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
-msgstr "ミュージック・ブロックス プロジェクトのりんくのみがきょかされます (おなじさいと、musicblocks.sugarlabs.org、musicblocks.net)。"
+msgid ""
+"Only Music Blocks project links are allowed (same site, "
+"musicblocks.sugarlabs.org, musicblocks.net)."
+msgstr ""
+"ミュージック・ブロックス プロジェクトのりんくのみがきょかされます "
+"(おなじさいと、musicblocks.sugarlabs.org、musicblocks.net)。"
 
 #: js/blocks/ProgramBlocks.js:1532
 msgid "Please allow popups for this site"
@@ -6666,19 +6217,20 @@ msgstr "シンセの おんりょうを せってい"
 msgid "synth"
 msgstr "シンセ"
 
-#: js/blocks/WidgetBlocks.js:149
-#: js/widgets/timbre.js:905
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
+#: js/blocks/WidgetBlocks.js:149 js/widgets/timbre.js:905
 msgid "Envelope"
 msgstr "エンベロープ"
 
+#. TRANS: Attack time is the time taken for initial run-up of level from nil
+#. to peak, beginning when the key is first pressed.
 #: js/blocks/WidgetBlocks.js:157
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "アタック"
 
+#. TRANS: Decay time is the time taken for the subsequent run down from the
+#. attack level to the designated sustain level.
 #: js/blocks/WidgetBlocks.js:159
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "ディケイ"
 
@@ -6686,19 +6238,24 @@ msgstr "ディケイ"
 msgid "Synth not found"
 msgstr "シンセ(がっき)が みつかりません"
 
+#. TRANS: Sustain level is the level during the main sequence of the sound's
+#. duration, until the key is released.
 #: js/blocks/WidgetBlocks.js:161
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "サステイン"
 
+#. TRANS: Release time is the time taken for the level to decay from the
+#. sustain level to zero after the key is released.
 #: js/blocks/WidgetBlocks.js:163
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "リリース"
 
 #: js/blocks/VolumeBlocks.js:531
-msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
-msgstr "「シンセの おんりょうを せってい」ブロックは、ギター、バイオリン、スネア・ドラムなどのとくていのシンセサイザーのおんりょうをへんこうします。"
+msgid ""
+"The Set synth volume block will change the volume of a particular synth, eg "
+"guitar violin snare drum etc."
+msgstr ""
+"「シンセの おんりょうを せってい」ブロックは、ギター、バイオリン、スネア・ドラムなどのとくていのシンセサイザーのおんりょうをへんこうします。"
 
 #: js/blocks/WidgetBlocks.js:181
 msgid "Attack value should be from 0 to 100."
@@ -6724,29 +6281,26 @@ msgstr "「ステレオをせってい」ブロックはすべてのシンセの
 msgid "You are adding multiple envelope blocks."
 msgstr "封筒ブロックを複数追加しています。"
 
-#: js/blocks/WidgetBlocks.js:239
-#: js/widgets/timbre.js:961
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
+#: js/blocks/WidgetBlocks.js:239 js/widgets/timbre.js:961
 msgid "Filter"
 msgstr "フィルター"
 
-#: js/blocks/WidgetBlocks.js:247
-#: js/blocks/ToneBlocks.js:42
-#: js/widgets/timbre.js:1656
-#: js/widgets/timbre.js:1908
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of
+#. oscillators.
+#: js/blocks/WidgetBlocks.js:247 js/blocks/ToneBlocks.js:42
+#: js/widgets/timbre.js:1656 js/widgets/timbre.js:1908
 msgid "type"
 msgstr "しゅるい"
 
-#: js/blocks/WidgetBlocks.js:249
-#: js/widgets/timbre.js:1932
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
+#: js/blocks/WidgetBlocks.js:249 js/widgets/timbre.js:1932
 msgid "rolloff"
 msgstr "ロールオフ"
 
+#. TRANS: rolloff is the steepness of a change in frequency.
 #: js/blocks/WidgetBlocks.js:281
-#.TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "ロールオフ あたいは -12, -24, -48, -98 デシベル / オクターヴ である ひつようが あります。"
 
@@ -6754,20 +6308,21 @@ msgstr "ロールオフ あたいは -12, -24, -48, -98 デシベル / オクタ
 msgid "The Temperament tool is used to define custom tuning."
 msgstr "「おんりつ」つーるはカスタムカスタムをていぎするためにしようされます。"
 
-#: js/blocks/WidgetBlocks.js:411
-#: js/blocks/WidgetBlocks.js:1936
+#: js/blocks/WidgetBlocks.js:411 js/blocks/WidgetBlocks.js:1936
 #: js/widgets/sampler.js:1343
 msgid "Upload a sample and adjust its pitch center."
 msgstr "ねいろサンプルを アップロードして、 おとの たかさを あわせる"
 
+#. TRANS: the speed at music is should be played.
 #: js/blocks/WidgetBlocks.js:418
-#.TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "サンプラー"
 
 #: js/blocks/WidgetBlocks.js:611
 msgid "The Meter block opens a tool to select strong beats for the meter."
-msgstr "<h2>ひょうしブロック</h2><br>テーブルの すうじを クリックして、 つよい はくの いちを きめる。<br>★ひょうし とは<br>はくが いくつか まとまった もの。<br>★はく とは<br>くりかえされる リズムの こと。"
+msgstr ""
+"<h2>ひょうしブロック</h2><br>テーブルの すうじを クリックして、 つよい はくの いちを きめる。<br>★ひょうし とは<br>はくが "
+"いくつか まとまった もの。<br>★はく とは<br>くりかえされる リズムの こと。"
 
 #: js/blocks/WidgetBlocks.js:673
 msgid "The oscilloscope block opens a tool to visualize waveforms."
@@ -6778,24 +6333,31 @@ msgid "oscilloscope"
 msgstr "オシロスコープ"
 
 #: js/blocks/WidgetBlocks.js:753
-msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
-msgstr "<h2>モード（おんかい）ブロック</h2><br>いろいろな ちょうを さがす ツールを ひょうじする。おんかいは、 おとと おとの かんかくを きめながら さがすことが できる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+msgid ""
+"The Custom mode block opens a tool to explore musical mode (the spacing of "
+"the notes in a scale)."
+msgstr ""
+"<h2>モード（おんかい）ブロック</h2><br>いろいろな ちょうを さがす ツールを ひょうじする。おんかいは、 おとと おとの かんかくを "
+"きめながら さがすことが できる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと "
+"に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major
+#. or Minor modes
 #: js/blocks/WidgetBlocks.js:761
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "おんかい"
 
 #: js/blocks/WidgetBlocks.js:818
 msgid "The Tempo block opens a metronome to visualize the beat."
-msgstr "<h2>メトロノームブロック</h2><br>メトロノームを ひょうじする。 ボタンを おすと、 メトロノームの はやさを かえられる。 テーブルには、 １ぷんあたりの はくのかずが ひょうじされる。<br><br>★はくとは<br>くりかえされる リズムのこと。"
+msgstr ""
+"<h2>メトロノームブロック</h2><br>メトロノームを ひょうじする。 ボタンを おすと、 メトロノームの はやさを かえられる。 テーブルには、"
+" １ぷんあたりの はくのかずが ひょうじされる。<br><br>★はくとは<br>くりかえされる リズムのこと。"
 
 #: js/blocks/WidgetBlocks.js:888
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr "「アルペジオ」ウィジェットは コードしんこう をつくる ためです。"
 
-#: js/blocks/WidgetBlocks.js:894
-#: js/blocks/IntervalsBlocks.js:764
+#: js/blocks/WidgetBlocks.js:894 js/blocks/IntervalsBlocks.js:764
 msgid "arpeggio"
 msgstr "アルペジオ"
 
@@ -6803,21 +6365,28 @@ msgstr "アルペジオ"
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "Pitch drumまとりっくすはピッチをドラムおとにまっぴんぐするためにつかわれます。"
 
+#. TRANS: makes a mapping between pitches and drum sounds
 #: js/blocks/WidgetBlocks.js:977
-#.TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "音高-ドラム・マッパー"
 
 #: js/blocks/WidgetBlocks.js:1034
-msgid "You must have at least one pitch block and one drum block in the matrix."
+msgid ""
+"You must have at least one pitch block and one drum block in the matrix."
 msgstr "フレーズメーカーブロックには、 おとの たかさブロックと ドラムブロックを さいてい 1つずつ いれて ください。"
 
 #: js/blocks/WidgetBlocks.js:1066
-msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
-msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを きくことが できる。 つくった おとを データに することが できる。また、 ヘルツの しょきせっていち は じゆうに かえられる。<br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+msgid ""
+"The Pitch slider tool to is used to generate pitches at selected "
+"frequencies."
+msgstr ""
+"<h2>ヘルツスライダーブロック</h2><br>スライダーを じょうげに うごかすことで、 ちがう しゅうはすう（ヘルツのすうち） の おとを "
+"きくことが できる。 つくった おとを データに することが できる。また、 ヘルツの しょきせっていち は じゆうに "
+"かえられる。<br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい "
+"しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
 
+#. TRANS: widget to generate pitches using a slider
 #: js/blocks/WidgetBlocks.js:1071
-#.TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "ヘルツスライダー"
 
@@ -6825,29 +6394,32 @@ msgstr "ヘルツスライダー"
 msgid "chromatic keyboard"
 msgstr "クロマティック キーボード"
 
-#: js/blocks/WidgetBlocks.js:1165
-#: js/blocks/WidgetBlocks.js:1236
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
+#: js/blocks/WidgetBlocks.js:1165 js/blocks/WidgetBlocks.js:1236
 msgid "music keyboard"
 msgstr "キーボード"
 
-#: js/blocks/WidgetBlocks.js:1217
-#: js/blocks/WidgetBlocks.js:1226
-msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
+#: js/blocks/WidgetBlocks.js:1217 js/blocks/WidgetBlocks.js:1226
+msgid ""
+"The Music keyboard block opens a piano keyboard that can be used to create "
+"notes."
 msgstr "<h2>キーボードブロック</h2><br>ピアノの キーボードを ひょうじする。 つくったおとを データに することが できる。"
 
 #: js/blocks/WidgetBlocks.js:1296
-msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
+msgid ""
+"The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr "Pitch staircaseつーるはしていされたひりつからピッチをせいせいするためにしようされます。"
 
+#. TRANS: generate a progressive sequence of pitches
 #: js/blocks/WidgetBlocks.js:1303
-#.TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "音高の数列を作る"
 
 #: js/blocks/WidgetBlocks.js:1399
 msgid "The Rhythm Maker block opens a tool to create drum machines."
-msgstr "<h2>リズムメーカー ブロック</h2><br>おとの ながさで ぶんかつして、 リズムを つくる テーブルを ひょうじする。 つくった リズムを データに することが できる。"
+msgstr ""
+"<h2>リズムメーカー ブロック</h2><br>おとの ながさで ぶんかつして、 リズムを つくる テーブルを ひょうじする。 つくった リズムを "
+"データに することが できる。"
 
 #: js/blocks/WidgetBlocks.js:1476
 msgid "G major scale"
@@ -6859,10 +6431,12 @@ msgstr "Cメジャー"
 
 #: js/blocks/WidgetBlocks.js:1552
 msgid "The Phrase Maker block opens a tool to create musical phrases."
-msgstr "<h2>フレーズメーカーブロック</h2><br>フレーズを つくるための テーブルを  ひょうじする。 つくった フレーズを データに することが できる。<br><br>"
+msgstr ""
+"<h2>フレーズメーカーブロック</h2><br>フレーズを つくるための テーブルを  ひょうじする。 つくった フレーズを データに することが "
+"できる。<br><br>"
 
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 #: js/blocks/WidgetBlocks.js:1559
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "フレーズメーカー"
 
@@ -6871,21 +6445,24 @@ msgid "lyrics"
 msgstr "かし"
 
 #: js/blocks/WidgetBlocks.js:1717
-msgid "You must have at least one pitch block and one rhythm block in the matrix."
+msgid ""
+"You must have at least one pitch block and one rhythm block in the matrix."
 msgstr "フレーズメーカーには、 おとのたかさ ブロックと おんぷブロックを くみあわせて ください。"
 
 #: js/blocks/WidgetBlocks.js:1779
-msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
+msgid ""
+"The Status block opens a tool for inspecting the status of Music Blocks as "
+"it is running."
 msgstr "<h2>じっこうじょうきょうブロック</h2><br>ブロックのじっこうじょうきょうをけんさくするテーブルをひょうじする。<br>"
 
-#: js/blocks/WidgetBlocks.js:1943
-#: js/widgets/aiwidget.js:822
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
+#: js/blocks/WidgetBlocks.js:1943 js/widgets/aiwidget.js:822
 msgid "AI Music"
 msgstr "AIおんがく"
 
 #: js/blocks/WidgetBlocks.js:1996
-msgid "The Reflection block opens a space for you to think about your learning."
+msgid ""
+"The Reflection block opens a space for you to think about your learning."
 msgstr "「ふりかえり」ブロックは、がくしゅうについてかんがえるためのすぺーすをひらきます。"
 
 #: js/blocks/WidgetBlocks.js:2001
@@ -6893,11 +6470,12 @@ msgid "reflection"
 msgstr "「ふりかえり」"
 
 #: js/blocks/WidgetBlocks.js:2059
-msgid "The LEGO Bricks block opens a widget for designing virtual LEGO creations."
+msgid ""
+"The LEGO Bricks block opens a widget for designing virtual LEGO creations."
 msgstr "「LEGO ブロック」ブロックは、かそう LEGO さくひんをでざいんするためのツールをひらきます。"
 
+#. TRANS: LEGO bricks designer
 #: js/blocks/WidgetBlocks.js:2066
-#.TRANS: LEGO bricks designer
 msgid "LEGO Bricks"
 msgstr "LEGO ブロック"
 
@@ -6906,7 +6484,9 @@ msgid "You must have at least one pitch block in the LEGO bricks widget."
 msgstr "「レゴ・ブロック」ツールにはすくなくとも 1つの「おとの たかさ」ブロックがひつようです。"
 
 #: js/blocks/WidgetBlocks.js:2149
-msgid "Debug your music blocks project with new possibilities and more understanding."
+msgid ""
+"Debug your music blocks project with new possibilities and more "
+"understanding."
 msgstr "あらたなかのうせいとりかいをふかめて、ミュージック・ブロックス プロジェクトをでばっぐします。"
 
 #: js/blocks/DrumBlocks.js:32
@@ -6923,19 +6503,24 @@ msgstr "ドラムめい"
 
 #: js/blocks/DrumBlocks.js:108
 msgid "The Drum name block is used to select a drum."
-msgstr "<h2>ドラムブロック</h2><br>ドラムの しゅるいを かえるときに つかう。 クリックで、 いろいろな ドラムの おとを えらぶことが できる。"
+msgstr ""
+"<h2>ドラムブロック</h2><br>ドラムの しゅるいを かえるときに つかう。 クリックで、 いろいろな ドラムの おとを えらぶことが できる。"
 
 #: js/blocks/DrumBlocks.js:125
 msgid "effects name"
 msgstr "えふぇくとめい"
 
 #: js/blocks/MeterBlocks.js:975
-msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
+msgid ""
+"The Master beats per minute block sets the number of 1/4 notes per minute "
+"for every voice."
 msgstr "「ぜんたいの スピードを きめる」ブロックは、かくおんせいの 1 ふんあたりの 1/4 おんぷのかずをせっていします。"
 
 #: js/blocks/DrumBlocks.js:155
 msgid "The Effects name block is used to select a sound effect."
-msgstr "<h2>こうかおんブロック</h2><br>こうかおんの しゅるいを かえるときに つかう。 クリックで、 いろいろな おもしろい おとを えらぶことが できる。"
+msgstr ""
+"<h2>こうかおんブロック</h2><br>こうかおんの しゅるいを かえるときに つかう。 クリックで、 いろいろな おもしろい おとを えらぶことが"
+" できる。"
 
 #: js/blocks/DrumBlocks.js:172
 msgid "noise"
@@ -6949,22 +6534,23 @@ msgstr "「ノイズさいせい」ブロックはほわいとのいず、ぴん
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラムおとにおきかえます。"
 
+#. TRANS: map a pitch to a drum sound
 #: js/blocks/DrumBlocks.js:352
-#.TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "ドラムを おんぷに かえる"
 
-#: js/blocks/DrumBlocks.js:406
-#: js/blocks/DrumBlocks.js:415
-msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
+#: js/blocks/DrumBlocks.js:406 js/blocks/DrumBlocks.js:415
+msgid ""
+"The Set drum block will select a drum sound to replace the pitch of any "
+"contained notes."
 msgstr "「ドラムをせってい」ブロックは、ふくまれているおんぷの ピッチを おきかえるドラムの おとを せんたくします。"
 
 #: js/blocks/DrumBlocks.js:419
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
 
+#. TRANS: set the current drum sound for playback
 #: js/blocks/DrumBlocks.js:431
-#.TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムを せってい"
 
@@ -6974,14 +6560,18 @@ msgstr "こうかおん"
 
 #: js/blocks/DrumBlocks.js:514
 msgid "You can use multiple Drum blocks within a Note block."
-msgstr "<h2>ドラム ブロック</h2><br>「おんぷブロック」 の なかに いれて つかう。 いろいろな  ドラムの ねいろを えらぶことが できる。 １つの 「おんぷブロック」 の なかで、 ふくすうの ねいろの ドラムを  くみあわせて つかうことが できる。"
+msgstr ""
+"<h2>ドラム ブロック</h2><br>「おんぷブロック」 の なかに いれて つかう。 いろいろな  ドラムの ねいろを えらぶことが できる。 "
+"１つの 「おんぷブロック」 の なかで、 ふくすうの ねいろの ドラムを  くみあわせて つかうことが できる。"
 
 #: js/blocks/IntervalsBlocks.js:45
 msgid "set temperament"
 msgstr "おんりつを せってい"
 
 #: js/blocks/IntervalsBlocks.js:53
-msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
+msgid ""
+"The Set temperament block is used to choose the tuning system used by Music "
+"Blocks."
 msgstr "「おんりつをせってい」ブロックは、ミュージック・ブロックスでしようされるカスタム しすてむをせんたくするためにしようされます。"
 
 #: js/blocks/IntervalsBlocks.js:94
@@ -6990,7 +6580,10 @@ msgstr "きしつめい"
 
 #: js/blocks/IntervalsBlocks.js:102
 msgid "The Temperament name block is used to select a tuning method."
-msgstr "<hr>おんりつブロック</hr><br>ちょうりつの しかたを せっていする。<br>★おんりつとは<br>おんてい （おとどうしの へだたり） の きめかた。 おなじ おんかい でも、 おんりつに よって おとの たかさが かわる。<br>★ちょうりつとは<br>がっきの おとのたかさを、 おんりつに したがって ととのえること。"
+msgstr ""
+"<hr>おんりつブロック</hr><br>ちょうりつの しかたを せっていする。<br>★おんりつとは<br>おんてい （おとどうしの へだたり） の "
+"きめかた。 おなじ おんかい でも、 おんりつに よって おとの たかさが かわる。<br>★ちょうりつとは<br>がっきの おとのたかさを、 "
+"おんりつに したがって ととのえること。"
 
 #: js/blocks/IntervalsBlocks.js:170
 msgid "doubly"
@@ -7005,7 +6598,9 @@ msgid "interval number"
 msgstr "おんていを かずで ひょうじ"
 
 #: js/blocks/IntervalsBlocks.js:279
-msgid "The Interval number block returns the number of scalar steps in the current interval."
+msgid ""
+"The Interval number block returns the number of scalar steps in the current "
+"interval."
 msgstr "「おんていを かずで ひょうじ」ブロックは、げんざいのおんかいのすうちをかえします。"
 
 #: js/blocks/IntervalsBlocks.js:332
@@ -7013,34 +6608,41 @@ msgid "current interval"
 msgstr "げんざいの おんかい"
 
 #: js/blocks/IntervalsBlocks.js:337
-msgid "The Current interval block returns the name of scalar steps in the current interval."
+msgid ""
+"The Current interval block returns the name of scalar steps in the current "
+"interval."
 msgstr "「げんざいの おんかい」ブロックは、げんざいのおんかいのなまえをかえします。"
 
 #: js/blocks/IntervalsBlocks.js:395
-msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
+msgid ""
+"The Semi-tone interval block measures the distance between two notes in "
+"semi-tones."
 msgstr "「はんおんかいてきな おんてい」ブロックは、2つのおんぷまのきょりをはんおんたんいでそくていします。"
 
+#. TRANS: measure the distance between two pitches in semi-tones
 #: js/blocks/IntervalsBlocks.js:403
-#.TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "半おんかい的音程で計る"
 
-#: js/blocks/IntervalsBlocks.js:474
-#: js/blocks/IntervalsBlocks.js:595
+#: js/blocks/IntervalsBlocks.js:474 js/blocks/IntervalsBlocks.js:595
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr "音程を計る際は、２つの音符を使うひつようがあります。"
 
 #: js/blocks/IntervalsBlocks.js:515
-msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
+msgid ""
+"The Scalar interval block measures the distance between two notes in the "
+"current key and mode."
 msgstr "「おんかいてきな おんてい」ブロックはげんざいのちょうとモードで2つのおとのきょりをそくていします。"
 
+#. TRANS: measure the distance between two pitches in steps of musical scale
 #: js/blocks/IntervalsBlocks.js:523
-#.TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "全おんかい的音程で計る"
 
 #: js/blocks/IntervalsBlocks.js:698
-msgid "The Semi-tone interval block calculates a relative interval based on half steps."
+msgid ""
+"The Semi-tone interval block calculates a relative interval based on half "
+"steps."
 msgstr "「はんおんかいてきおんてい」ブロックは、はんおんにもとづいてそうたいかんかくをけいさんします。"
 
 #: js/blocks/IntervalsBlocks.js:702
@@ -7048,7 +6650,9 @@ msgid "In the figure, we add sol# to sol."
 msgstr "れいの がぞうには <em>ソル</em>が <em>ソル#</em>に なります。"
 
 #: js/blocks/IntervalsBlocks.js:753
-msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
+msgid ""
+"The Arpeggio block will run each note block multiple times, adding a "
+"transposition based on the specified chord."
 msgstr "「アルペジオ」ブロックはかく「おんぷ」ブロックをふくすうかいじっこうし、していされたコードにもとづいていちょうをついかします。"
 
 #: js/blocks/IntervalsBlocks.js:757
@@ -7076,19 +6680,28 @@ msgid "ratio interval"
 msgstr "ひで おんてい"
 
 #: js/blocks/IntervalsBlocks.js:1116
-msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
-msgstr "「おんかいてきなおんてい」ブロックは、げんざいのモードにもとづいてそうたいてきなおんていをけいさんし、モードそとのピッチをすべてスキップします。"
+msgid ""
+"The Scalar interval block calculates a relative interval based on the "
+"current mode, skipping all notes outside of the mode."
+msgstr ""
+"「おんかいてきなおんてい」ブロックは、げんざいのモードにもとづいてそうたいてきなおんていをけいさんし、モードそとのピッチをすべてスキップします。"
 
 #: js/blocks/IntervalsBlocks.js:1120
 msgid "In the figure, we add la to sol."
-msgstr "<br><br>うえのず では、 ソの 「おんぷブロック」 を きじゅんに して、 「おんかいの じょうげブロック」の すうちを ２に せっていしている ので、 ソと、 ソから ２おん あがった シの おとが どうじに えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+msgstr ""
+"<br><br>うえのず では、 ソの 「おんぷブロック」 を きじゅんに して、 「おんかいの じょうげブロック」の すうちを ２に せっていしている"
+" ので、 ソと、 ソから ２おん あがった シの おとが どうじに えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの"
+" まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの "
+"「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/IntervalsBlocks.js:1169
-msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
+msgid ""
+"The Define mode block allows you to define a custom mode by specifying pitch"
+" numbers."
 msgstr "「モードをていぎする」ブロックをしようすると、ピッチばんごうをしていしてカスタム モードをていぎできます。"
 
+#. TRANS: define a custom mode
 #: js/blocks/IntervalsBlocks.js:1178
-#.TRANS: define a custom mode
 msgid "define mode"
 msgstr "ちょうを ていぎ する"
 
@@ -7097,11 +6710,18 @@ msgid "movable Do"
 msgstr "いどう ド"
 
 #: js/blocks/IntervalsBlocks.js:1235
-msgid "When Movable do is false, the solfege note names are always tied to specific pitches, eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
-msgstr "「いどうど」が「にせ」のばあい、そるふぇーじゅおんめいはつねにとくていのピッチにかんれんづけられます。たとえば、「いどうど」が「まこと」のばあい、「ど」はつねに「ど・めじゃー」となり、そるふぇーじゅおんめいはすけーるどにわりあてられます。「ど」はつねにちょうおんかいの 1 どです。"
+msgid ""
+"When Movable do is false, the solfege note names are always tied to specific"
+" pitches, eg \"do\" is always \"C-natural\" when Movable do is true, the "
+"solfege note names are assigned to scale degrees \"do\" is always the first "
+"degree of the major scale."
+msgstr ""
+"「いどうど」が「にせ」のばあい、そるふぇーじゅおんめいはつねにとくていのピッチにかんれんづけられます。たとえば、「いどうど」が「まこと」のばあい、「ど」はつねに「ど・めじゃー」となり、そるふぇーじゅおんめいはすけーるどにわりあてられます。「ど」はつねにちょうおんかいの"
+" 1 どです。"
 
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major
+#. and minor scales; 12 for chromatic scales
 #: js/blocks/IntervalsBlocks.js:1278
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "おんかいの おんすう"
 
@@ -7111,40 +6731,50 @@ msgstr "<h2>おんかいの おんすうブロック</h2><br>えんそう され
 
 #: js/blocks/IntervalsBlocks.js:1289
 msgid "Most Western scales have 7 notes."
-msgstr "<br>せいようの ほとんどの おんかいは、 7つの おとを もつ。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。<br><br>たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+msgstr ""
+"<br>せいようの ほとんどの おんかいは、 7つの おとを もつ。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの "
+"まとまり。<br><br>たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの "
+"「ソラシドレミ（♯ファ）ソ」 の こと。"
 
+#. TRANS: the mode in music is 'major', 'minor', etc.
 #: js/blocks/IntervalsBlocks.js:1341
-#.TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "げんだいの おんかい"
 
+#. TRANS: the key is a group of pitches with which a music composition is
+#. created
 #: js/blocks/IntervalsBlocks.js:1397
-#.TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "げんだいの ちょう"
 
-#: js/blocks/IntervalsBlocks.js:1452
-#: js/blocks/IntervalsBlocks.js:1497
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
+#: js/blocks/IntervalsBlocks.js:1452 js/blocks/IntervalsBlocks.js:1497
 msgid "set key"
 msgstr "ちょうを せってい"
 
 #: js/blocks/IntervalsBlocks.js:1506
 msgid "The Set key block is used to set the key and mode,"
-msgstr "<h2>ちょうをせっていブロック</h2><br>ちょうの ぶぶんに おとのたかさ、おんかいの ぶぶんに おんかいのしゅるいを えらび、ちょうを せっていする。<br><br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。<br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。"
+msgstr ""
+"<h2>ちょうをせっていブロック</h2><br>ちょうの ぶぶんに おとのたかさ、おんかいの ぶぶんに おんかいのしゅるいを えらび、ちょうを "
+"せっていする。<br><br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの "
+"かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。<br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。"
 
 #: js/blocks/IntervalsBlocks.js:1512
 msgid "The Set key block is used to set the key and mode, eg C Major"
 msgstr "「ちょうを せってい」ブロックは、ちょうと おんかい(どめじゃーなど) をせっていするためにしようされます。"
 
+#. TRANS: the number of pitches in the current temperament system
 #: js/blocks/IntervalsBlocks.js:1572
-#.TRANS: the number of pitches in the current temperament system
 msgid "temperament length"
 msgstr "おんりつのながさ"
 
 #: js/blocks/IntervalsBlocks.js:1577
-msgid "The Temperament length block returns the number of pitches in the current temperament system. For example, 12 for standard equal temperament or 31 for a 31-tone temperament."
-msgstr "「おんりつのながさ」ブロックは、げんざいのおんりつしすてむにおけるピッチのかずをかえします。たとえば、ひょうじゅんへいきんりつのばあいは「12」、31おんりつのばあいは「31」です。"
+msgid ""
+"The Temperament length block returns the number of pitches in the current "
+"temperament system. For example, 12 for standard equal temperament or 31 for"
+" a 31-tone temperament."
+msgstr ""
+"「おんりつのながさ」ブロックは、げんざいのおんりつしすてむにおけるピッチのかずをかえします。たとえば、ひょうじゅんへいきんりつのばあいは「12」、31おんりつのばあいは「31」です。"
 
 #: js/blocks/OrnamentBlocks.js:32
 msgid "staccato factor"
@@ -7154,15 +6784,19 @@ msgstr "スタッカートの ながさ ファクター"
 msgid "slur factor"
 msgstr "スラーの ながさ ファクター"
 
-#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of
-#. C
+#.  TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of
+#.  C
 #: js/blocks/OrnamentBlocks.js:217 js/blocks/OrnamentBlocks.js:309
 msgid "neighbor"
 msgstr "おとを くわえる"
 
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
-msgstr "<h2>おとを くわえる ブロック</h2><br>２つの おなじたかさの おとの あいだに、 おとを １つ いれることが できる。<br>ずのれいでは、 ソとソの あいだに ラが はいり、 「ソ、ラ、ソ」 と すばやく えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、 「ソ」 を はじまりのおと に したときの 「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」 の こと。"
+msgstr ""
+"<h2>おとを くわえる ブロック</h2><br>２つの おなじたかさの おとの あいだに、 おとを １つ いれることが "
+"できる。<br>ずのれいでは、 ソとソの あいだに ラが はいり、 「ソ、ラ、ソ」 と すばやく "
+"えんそうされる。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの "
+"「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、 「ソ」 を はじまりのおと に したときの 「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」 の こと。"
 
 #: js/blocks/OrnamentBlocks.js:364
 msgid "glide"
@@ -7172,103 +6806,125 @@ msgstr "グリッサンド"
 msgid "slur"
 msgstr "スラー"
 
-#. TRANS: play each note sharply detached from the others
+#.  TRANS: play each note sharply detached from the others
 #: js/blocks/OrnamentBlocks.js:551 js/blocks/OrnamentBlocks.js:703
 msgid "staccato"
 msgstr "スタッカート"
 
 #: js/blocks/OrnamentBlocks.js:619
-msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
+msgid ""
+"The Slur block lengthens the sustain of notes while maintaining the "
+"specified rhythmic value of the notes."
 msgstr "「スラー」ブロックは、していされたおんぷのながさをぜんぶくみあわせてながくします。"
 
 #: js/blocks/OrnamentBlocks.js:685
-msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
+msgid ""
+"The Staccato block shortens the length of the actual note while maintaining "
+"the specified rhythmic value of the notes."
 msgstr "「スタッカート」ブロックは、していされたおんぷのながさをいじしながら、じっさいのおんぷのながさをたんしゅくします。"
 
+#.  TRANS: musical transposition (adjustment of pitch up or down)
 #. TRANS: musical transposition (adjustment of pitch up or down)
-#: js/blocks/PitchBlocks.js:141
-#: js/blocks/PitchBlocks.js:143
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#: js/blocks/PitchBlocks.js:141 js/blocks/PitchBlocks.js:143
 msgid "transposition"
 msgstr "いちょう"
 
+#. TRANS: step down one note in current musical scale
 #: js/blocks/PitchBlocks.js:170
-#.TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "おんかいうちで~どさがる:"
 
 #: js/blocks/PitchBlocks.js:174
-msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
+msgid ""
+"The Scalar step down block returns the number of semi-tones down to the "
+"previous note in the current key and mode."
 msgstr "「おんかいうちで~どさがる」ブロックはげんざいのちょうとモードにおけるまえのおとまでのはんおんかずをかえします。"
 
+#. TRANS: step up one note in current musical scale
 #: js/blocks/PitchBlocks.js:194
-#.TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "おんかいうちで~どあがる:"
 
 #: js/blocks/PitchBlocks.js:198
-msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
+msgid ""
+"The Scalar step up block returns the number of semi-tones up to the next "
+"note in the current key and mode."
 msgstr "「おんかいうちで~どあがる」ブロックはげんざいのちょうとモードにおけるつぎのおとまでのはんおんかずをかえします。"
 
+#. TRANS: the change measured in half-steps between the current pitch and the
+#. previous pitch
 #: js/blocks/PitchBlocks.js:218
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "おんていの ちがい"
 
 #: js/blocks/PitchBlocks.js:222
-msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
+msgid ""
+"The Change in pitch block is the difference (in half steps) between the "
+"current pitch being played and the previous pitch played."
 msgstr "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半おとの値で）の違いです。"
 
+#. TRANS: the change measured in scale-steps between the current pitch and the
+#. previous pitch
 #: js/blocks/PitchBlocks.js:251
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "おんかいに よって おんていの ちがい"
 
-#: js/blocks/PitchBlocks.js:258
-#: js/blocks/PitchBlocks.js:457
-#: js/blocks/PitchBlocks.js:1737
-#: js/turtleactions/DictActions.js:89
-#: js/widgets/temperament.js:793
-#: js/widgets/temperament.js:797
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
+#: js/blocks/PitchBlocks.js:258 js/blocks/PitchBlocks.js:457
+#: js/blocks/PitchBlocks.js:1737 js/turtleactions/DictActions.js:89
+#: js/widgets/temperament.js:793 js/widgets/temperament.js:797
 #: js/widgets/temperament.js:1073
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "おとのたかさを かずでひょうじ"
 
 #: js/blocks/PitchBlocks.js:264
-msgid "The Pitch number block is the value of the pitch of the note currently being played."
-msgstr "<h2>おとのたかさを かずでひょうじ ブロック</h2><br>おとの たかさを かずで ひょうじする。 たとえば、 「ド_４」 ならば １、 「ソ_４」 ならば ７ 、「シ_３」ならば-１、と ひょうじされる。"
+msgid ""
+"The Pitch number block is the value of the pitch of the note currently being"
+" played."
+msgstr ""
+"<h2>おとのたかさを かずでひょうじ ブロック</h2><br>おとの たかさを かずで ひょうじする。 たとえば、 「ド_４」 ならば １、 "
+"「ソ_４」 ならば ７ 、「シ_３」ならば-１、と ひょうじされる。"
 
-#: js/blocks/PitchBlocks.js:345
-#: js/blocks/PitchBlocks.js:458
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
+#: js/blocks/PitchBlocks.js:345 js/blocks/PitchBlocks.js:458
 msgid "pitch in hertz"
 msgstr "おとのたかさを ヘルツで ひょうじ"
 
 #: js/blocks/PitchBlocks.js:350
-msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
-msgstr "<h2>おとの たかさを ヘルツで ひょうじ ブロック</h2><br>おとの たかさを ヘルツで ひょうじ する。<br>たとえば、 オクターヴが４の ラのおとは、 ４４０ヘルツという すうちで あらわすことが できる。<br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+msgid ""
+"The Pitch in Hertz block is the value in Hertz of the pitch of the note "
+"currently being played."
+msgstr ""
+"<h2>おとの たかさを ヘルツで ひょうじ ブロック</h2><br>おとの たかさを ヘルツで ひょうじ する。<br>たとえば、 オクターヴが４の"
+" ラのおとは、 ４４０ヘルツという すうちで あらわすことが できる。<br><br>★ヘルツとは<br>おとの たかさを あらわす "
+"しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい "
+"（すうちが おおきい） ほど、 おとが たかくなる。"
 
-#: js/blocks/PitchBlocks.js:385
-#: js/turtleactions/DictActions.js:87
+#: js/blocks/PitchBlocks.js:385 js/turtleactions/DictActions.js:87
 msgid "current pitch"
 msgstr "げんだいの おとの たかさ"
 
 #: js/blocks/PitchBlocks.js:391
-msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
-msgstr "「げんだいの おとの たかさ」ブロックは「Pitch Converter」ブロックとともにしようされます。じょうきのれいでは、げんざいのピッチsol 4が392ヘルツとしてひょうじされます。"
+msgid ""
+"The Current Pitch block is used with the Pitch Converter block. In the "
+"example above, current pitch, sol 4, is displayed as 392 hertz."
+msgstr ""
+"「げんだいの おとの たかさ」ブロックは「Pitch Converter」ブロックとともにしようされます。じょうきのれいでは、げんざいのピッチsol "
+"4が392ヘルツとしてひょうじされます。"
 
 #: js/blocks/PitchBlocks.js:433
-msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
+msgid ""
+"This block converts the pitch value of the last note played into different "
+"formats such as hertz, letter name, pitch number, et al."
 msgstr "このブロックはさいごにえんそうされたおとのピッチあたいをヘルツ、おんめい、ピッチばんごうなどのことなるけいしきにへんかんします。"
 
 #: js/blocks/PitchBlocks.js:459
 msgid "alphabet"
 msgstr "アルファベット"
 
+#. TRANS: Translate as "alphabet class"
 #: js/blocks/PitchBlocks.js:461
-#.TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "アルファベット・クラス"
 
@@ -7304,23 +6960,24 @@ msgstr "おとのたかさをシェードに"
 msgid "pitch to color"
 msgstr "おとのたかさをいろに"
 
-#: js/blocks/PitchBlocks.js:666
-#: js/widgets/musickeyboard.js:856
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
+#: js/blocks/PitchBlocks.js:666 js/widgets/musickeyboard.js:856
 msgid "MIDI"
 msgstr "MIDI"
 
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "音高の数字を初期化"
 
 #: js/blocks/PitchBlocks.js:682
-msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
+msgid ""
+"The Set pitch number offset block is used to set the offset for mapping "
+"pitch numbers to pitch and octave."
 msgstr "ピッチばんごうをピッチとオクターヴにまっぴんぐするためのおふせっとをせっていするためにつかわれるブロックです。"
 
+#. TRANS: convert piano key number (1-88) to pitch
 #: js/blocks/PitchBlocks.js:721
-#.TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "すうじを おんめいへ"
 
@@ -7328,8 +6985,8 @@ msgstr "すうじを おんめいへ"
 msgid "The Number to pitch block will convert a pitch number to a pitch name."
 msgstr "「すうじを おんめいへ」ブロックは、すうじをピッチめいにへんかんします。"
 
+#. TRANS: convert piano key number (1-88) to octave
 #: js/blocks/PitchBlocks.js:756
-#.TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "すうちをオクターヴひょうきへ"
 
@@ -7342,7 +6999,9 @@ msgid "y to pitch"
 msgstr "おとの たかさを yに"
 
 #: js/blocks/PitchBlocks.js:770
-msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
+msgid ""
+"Y to pitch block will convert a staff y position to corresponding pitch "
+"notation."
 msgstr "ごせんふのyいちをたいおうするおんこうひょうきにへんかんするブロック"
 
 #: js/blocks/PitchBlocks.js:884
@@ -7350,8 +7009,11 @@ msgid "accidental selector"
 msgstr "りんじきごうせれくたー"
 
 #: js/blocks/PitchBlocks.js:890
-msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
-msgstr "<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）からえらぶことができます。"
+msgid ""
+"The Accidental selector block is used to choose between double-sharp, sharp,"
+" natural, flat, and double-flat."
+msgstr ""
+"<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）からえらぶことができます。"
 
 #: js/blocks/PitchBlocks.js:903
 msgid "east indian solfege"
@@ -7367,7 +7029,9 @@ msgstr "おんめい"
 
 #: js/blocks/PitchBlocks.js:924
 msgid "Pitch can be specified in terms of C D E F G A B."
-msgstr "<h2>おとのたかさブロック</h2><br>おとのたかさを、 CDEFGABの ７つの アルファベットで せっていする。 たとえば、 ドならばＣ、 レならばＤ で あらわされる。"
+msgstr ""
+"<h2>おとのたかさブロック</h2><br>おとのたかさを、 CDEFGABの ７つの アルファベットで せっていする。 たとえば、 ドならばＣ、 "
+"レならばＤ で あらわされる。"
 
 #: js/blocks/PitchBlocks.js:936
 msgid "solfege"
@@ -7375,114 +7039,132 @@ msgstr "ソルファ"
 
 #: js/blocks/PitchBlocks.js:941
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
-msgstr "<h2>おとのたかさブロック</h2><br>おとのたかさを、 ド、レ、ミ、ファ、ソ、ラ、シの ７つの ソルフェージュで せっていする。 たとえば、 ドならばＣ、 レならばＤ で あらわされる。"
+msgstr ""
+"<h2>おとのたかさブロック</h2><br>おとのたかさを、 ド、レ、ミ、ファ、ソ、ラ、シの ７つの ソルフェージュで せっていする。 たとえば、 "
+"ドならばＣ、 レならばＤ で あらわされる。"
 
 #: js/blocks/PitchBlocks.js:989
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr "「てんかいを」ブロックはふくまれるおんぷをたいしょうのおんぷのまわりではんてんさせます。"
 
-#: js/blocks/PitchBlocks.js:996
-#: js/widgets/modewidget.js:179
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
+#: js/blocks/PitchBlocks.js:996 js/widgets/modewidget.js:179
 msgid "Invert"
 msgstr "てんかいを"
 
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 #: js/blocks/PitchBlocks.js:1035
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "てんかいを (きすう)"
 
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 #: js/blocks/PitchBlocks.js:1067
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "てんかいを (ぐうすう)"
 
+#. TRANS: register is the octave of the current pitch
 #: js/blocks/PitchBlocks.js:1088
-#.TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "登録"
 
 #: js/blocks/PitchBlocks.js:1092
-msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
+msgid ""
+"The Register block provides an easy way to modify the register (octave) of "
+"the notes that follow it."
 msgstr "「Register」ブロックはのちにつづくおんぷのオクターヴ（れじすたー）をかんたんにへんこうするほうほうをていきょうします。"
 
+#. TRANS: cents are units used to specify the ratio between pitches. There are
+#. 100 cents between successive notes.
 #: js/blocks/PitchBlocks.js:1115
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50セント"
 
 #: js/blocks/PitchBlocks.js:1146
-msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
-msgstr "<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。"
+msgid ""
+"The Semi-tone transposition block will shift the pitches contained inside "
+"Note blocks up (or down) by half steps."
+msgstr ""
+"<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。"
 
 #: js/blocks/PitchBlocks.js:1150
-msgid "In the example shown above, sol is shifted up to sol#."
+msgid "In the example shown above, sol is shifted up to sol#. "
 msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
 
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 #: js/blocks/PitchBlocks.js:1156
-#.TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "はんおんで いちょう"
 
 #: js/blocks/PitchBlocks.js:1188
-msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
+msgid ""
+"The Transpose by Ratio block will shift the pitches contained inside Note "
+"blocks up (or down) by a ratio"
 msgstr "「ひで いどう」ブロックは おんぷの なかの ピッチを ひで いどうさせる。"
 
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 #: js/blocks/PitchBlocks.js:1196
-#.TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "ひで いどう"
 
+#. TRANS: down sixth means the note is five scale degrees below current note
 #: js/blocks/PitchBlocks.js:1287
-#.TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "おんかいで6ど した"
 
+#. TRANS: down third means the note is two scale degrees below current note
 #: js/blocks/PitchBlocks.js:1306
-#.TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "おんかいで3ど した"
 
+#. TRANS: seventh means the note is the six scale degrees above current note
 #: js/blocks/PitchBlocks.js:1325
-#.TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "7どの おと"
 
+#. TRANS: sixth means the note is the five scale degrees above current note
 #: js/blocks/PitchBlocks.js:1344
-#.TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "6どの おと"
 
+#. TRANS: fifth means the note is the four scale degrees above current note
 #: js/blocks/PitchBlocks.js:1363
-#.TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "5どの おと"
 
+#. TRANS: fourth means the note is three scale degrees above current note
 #: js/blocks/PitchBlocks.js:1383
-#.TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "４どの おと"
 
+#. TRANS: third means the note is two scale degrees above current note
 #: js/blocks/PitchBlocks.js:1402
-#.TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "3どの おと"
 
+#. TRANS: second means the note is one scale degree above current note
 #: js/blocks/PitchBlocks.js:1421
-#.TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "2どの おと"
 
 #: js/blocks/PitchBlocks.js:1462
-msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
-msgstr "<h2>ちょうを かえるブロック</h2><br>「おんぷブロック」 ないの おとのたかさを、 すべて （おんかいないで、 せっていした すうちぶんだけ） あげる、 または さげる。"
+msgid ""
+"The Scalar transposition block will shift the pitches contained inside Note "
+"blocks up (or down) the scale."
+msgstr ""
+"<h2>ちょうを かえるブロック</h2><br>「おんぷブロック」 ないの おとのたかさを、 すべて （おんかいないで、 せっていした "
+"すうちぶんだけ） あげる、 または さげる。"
 
 #: js/blocks/PitchBlocks.js:1466
 msgid "In the example shown above, sol is shifted up to la."
-msgstr "<br><br>ずのれいでは、 ソがラに、 ラがシに、 シがドに… と おきかえられている。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、 きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。"
+msgstr ""
+"<br><br>ずのれいでは、 ソがラに、 ラがシに、 シがドに… と おきかえられている。<br><br>★おんかいとは<br>じゅんばんに ならんだ"
+" おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの "
+"「ソラシドレミ（♯ファ）ソ」 の こと。<br>★ちょうとは<br>ちゅうしんてきな やくわりを はたすおとと、 おんかいの しゅるいによって きまる、"
+" きょくの かんじ。 ちゅうしんてきな やくわりを はたすおと だけを  さすこともある。"
 
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale
+#. (scalar) steps
 #: js/blocks/PitchBlocks.js:1473
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "ちょうを かえる"
 
@@ -7490,75 +7172,109 @@ msgstr "ちょうを かえる"
 msgid "The Accidental block is used to create sharps and flats"
 msgstr "<em>変化記号</em>ブロックは <em>シャープ(嬰)</em>と<em>フラット(変)</em>を決めるきのうです。"
 
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 #: js/blocks/PitchBlocks.js:1515
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "へんかきごう　むし"
 
 #: js/blocks/PitchBlocks.js:1638
-msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
-msgstr "<h2>ヘルツ ブロック</h2><br>おとのたかさを ヘルツ （しゅうはすうの たんい） で せっていする。 「すうちブロック」 を くみあわせて つかう。<br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
+msgid ""
+"The Hertz block (in combination with a Number block) will play a sound at "
+"the specified frequency."
+msgstr ""
+"<h2>ヘルツ ブロック</h2><br>おとのたかさを ヘルツ （しゅうはすうの たんい） で せっていする。 「すうちブロック」 を くみあわせて "
+"つかう。<br><br>★ヘルツとは<br>おとの たかさを あらわす しゅうはすう。<br>★しゅうはすうとは<br>おとが １びょうかん に "
+"なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。"
 
 #: js/blocks/PitchBlocks.js:1742
-msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
+msgid ""
+"The Pitch Number block will play a pitch associated by its number, e.g. 0 "
+"for C and 7 for G."
 msgstr "「Pitch Number」ブロックはばんごうにたいおうしたおんこうをさいせいします。れい：0はC、7はG。"
 
-#: js/blocks/PitchBlocks.js:1776
-#: js/blocks/PitchBlocks.js:1822
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical
+#. mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical
+#. mode
+#: js/blocks/PitchBlocks.js:1776 js/blocks/PitchBlocks.js:1822
 msgid "nth modal pitch"
 msgstr "ピッチど"
 
 #: js/blocks/PitchBlocks.js:1779
-msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
+msgid ""
+"nth Modal Pitch takes the pattern of pitches in semitones for a mode and "
+"makes each point a degree of the mode,"
 msgstr "「ピッチど」はモードのはんおんたんいのおんこうぱたーんをとり、かくてんをモードのどすうにします。"
 
 #: js/blocks/PitchBlocks.js:1783
-msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
+msgid ""
+"starting from 1 and regardless of tonal framework (i.e. not always 8 notes "
+"in the octave)"
 msgstr "1からはじまり、おんかいのわくぐみにかんけいなく（つまりオクターヴがつねに8おととはかぎらない）"
 
 #: js/blocks/PitchBlocks.js:1827
-msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
-msgstr "「ピッチど」はばんごうをにゅうりょくとしてうけとり、していされたモードの「なん」どすうをあらわします。0はさいしょのいち、1は2ばんめ、-1はさいしょのまえのおとなど。"
+msgid ""
+"Nth Modal Pitch takes a number as an input as the nth degree for the given "
+"mode. 0 is the first position, 1 is the second, -1 is the note before the "
+"first etc."
+msgstr ""
+"「ピッチど」はばんごうをにゅうりょくとしてうけとり、していされたモードの「なん」どすうをあらわします。0はさいしょのいち、1は2ばんめ、-1はさいしょのまえのおとなど。"
 
 #: js/blocks/PitchBlocks.js:1831
-msgid "The pitches change according to the mode specified without any need for respellings."
+msgid ""
+"The pitches change according to the mode specified without any need for "
+"respellings."
 msgstr "おんこうはしていされたモードにしたがってへんかし、かきかえはふようです。"
 
 #: js/blocks/PitchBlocks.js:1874
-msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
-msgstr "すけーるでぃぐりーはおんがくでいっぱんてきなひょうきほうです。すけーるないの7つのいち（1-7）をしめし、りんじきごうでへんこうかのうです。"
+msgid ""
+"Scale Degree is a common convention in music. Scale Degree offers seven "
+"possible positions in the scale (1-7) and can be modified via accidentals."
+msgstr ""
+"すけーるでぃぐりーはおんがくでいっぱんてきなひょうきほうです。すけーるないの7つのいち（1-7）をしめし、りんじきごうでへんこうかのうです。"
 
 #: js/blocks/PitchBlocks.js:1878
-msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
+msgid ""
+"Scale Degree 1 is always the first pitch in a given scale, regardless of "
+"octave."
 msgstr "すけーるでぃぐりー1は、オクターヴにかんけいなくつねにあたえられたすけーるのさいしょのおとです。"
 
+#. TRANS: step some number of notes in current musical scale
 #: js/blocks/PitchBlocks.js:1902
-#.TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "おんかいないを のぼる／おりる"
 
 #: js/blocks/PitchBlocks.js:1908
-msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
-msgstr "<h2>おんかいないをのぼる／おりるブロック</h2><br>おんかいない を じゅんばんに （ある いっていの かんかくで） のぼりながら、 または おりながら おとを えんそう する。 すうちを せっていする ことで、 つぎの おとは まえの おとと いくつちがうか が きまる。"
+msgid ""
+"The Scalar Step block (in combination with a Number block) will play the "
+"next pitch in a scale,"
+msgstr ""
+"<h2>おんかいないをのぼる／おりるブロック</h2><br>おんかいない を じゅんばんに （ある いっていの かんかくで） のぼりながら、 または "
+"おりながら おとを えんそう する。 すうちを せっていする ことで、 つぎの おとは まえの おとと いくつちがうか が きまる。"
 
 #: js/blocks/PitchBlocks.js:1912
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
-msgstr "<br><br>たとえば、 すうちを １に せっていした ばあい、 ソの つぎには ラ（ソの １おんうえ）、 ファの つぎには ソ（ファの １おんうえ） が えんそう される。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
+msgstr ""
+"<br><br>たとえば、 すうちを １に せっていした ばあい、 ソの つぎには ラ（ソの １おんうえ）、 ファの つぎには ソ（ファの １おんうえ）"
+" が えんそう される。<br><br>★おんかいとは<br>じゅんばんに ならんだ おとの まとまり。たとえば、「ド」 を はじまりのおと に "
+"したときの 「ドレミファソラシド」、 「ソ」 を はじまりのおと に したときの 「ソラシドレミ（♯ファ）ソ」 の こと。"
 
 #: js/blocks/PitchBlocks.js:1949
-msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
-msgstr "<h2>おとのたかさ ブロック</h2><br>おとのたかさを せってい する。 なまえと オクターヴの たかさを きめて つかう。 おとの しゅうはすうも どうじに  きまる。<br><br>★しゅうはすうとは<br>おとが １びょうかんに なんかい しんどうするかを あらわす すうち。 しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。<br>★オクターヴの たかさとは<br>おなじ なまえでも たかさがちがう おとを あらわす すうち。"
+msgid ""
+"The Pitch block specifies the pitch name and octave of a note that together "
+"determine the frequency of the note."
+msgstr ""
+"<h2>おとのたかさ ブロック</h2><br>おとのたかさを せってい する。 なまえと オクターヴの たかさを きめて つかう。 おとの "
+"しゅうはすうも どうじに  きまる。<br><br>★しゅうはすうとは<br>おとが １びょうかんに なんかい しんどうするかを あらわす すうち。 "
+"しゅうはすうが たかい （すうちが おおきい） ほど、 おとが たかくなる。<br>★オクターヴの たかさとは<br>おなじ なまえでも たかさがちがう"
+" おとを あらわす すうち。"
 
-#: js/blocks/ToneBlocks.js:34
-#: js/widgets/timbre.js:858
+#: js/blocks/ToneBlocks.js:34 js/widgets/timbre.js:858
 msgid "Oscillator"
 msgstr "オシレータ―"
 
-#: js/blocks/ToneBlocks.js:44
-#: js/widgets/timbre.js:1670
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
+#: js/blocks/ToneBlocks.js:44 js/widgets/timbre.js:1670
 msgid "partials"
 msgstr "ばいおん"
 
@@ -7566,18 +7282,17 @@ msgstr "ばいおん"
 msgid "You are adding multiple oscillator blocks."
 msgstr "ふくすうの オシレーター ブロックを ついか しています。"
 
-#: js/blocks/ToneBlocks.js:148
-#: js/widgets/timbre.js:1359
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
+#: js/blocks/ToneBlocks.js:148 js/widgets/timbre.js:1359
 msgid "duo synth"
 msgstr "シーケンサーこみ シンセ"
 
 #: js/blocks/ToneBlocks.js:153
-msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
+msgid ""
+"The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr "「シーケンサーこみ シンセ」ブロックはねいろをていぎするためのにじゅうしゅうはすうモジュレータです。"
 
-#: js/blocks/ToneBlocks.js:161
-#: js/widgets/timbre.js:1585
+#: js/blocks/ToneBlocks.js:161 js/widgets/timbre.js:1585
 msgid "vibrato rate"
 msgstr "ビブラート エフェクタの レート"
 
@@ -7585,9 +7300,8 @@ msgstr "ビブラート エフェクタの レート"
 msgid "vibrato intensity"
 msgstr "ビブラート エフェクタの きょうど"
 
-#: js/blocks/ToneBlocks.js:189
-#: js/widgets/timbre.js:1343
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
+#: js/blocks/ToneBlocks.js:189 js/widgets/timbre.js:1343
 msgid "AM synth"
 msgstr "AM シンセ"
 
@@ -7595,9 +7309,8 @@ msgstr "AM シンセ"
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr "「AM シンセ」ブロックはねいろをていぎするためのしんぷくへんちょうそうちです。"
 
-#: js/blocks/ToneBlocks.js:228
-#: js/widgets/timbre.js:1351
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
+#: js/blocks/ToneBlocks.js:228 js/widgets/timbre.js:1351
 msgid "FM synth"
 msgstr "FM シンセ"
 
@@ -7610,25 +7323,29 @@ msgid "partial"
 msgstr "ばいおん"
 
 #: js/blocks/ToneBlocks.js:269
-msgid "The Partial block is used to specify a weight for a specific partial harmonic."
+msgid ""
+"The Partial block is used to specify a weight for a specific partial "
+"harmonic."
 msgstr "「ばいおん」ブロックはとくていのぶぶんばいおんのおもみをしていするためにつかわれます。"
 
+#. TRANS: partials are weighted components in a harmonic series
 #: js/blocks/ToneBlocks.js:288
-#.TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "ばいおんの ウェートは ０と １の あいだ である ひつようが あります。"
 
+#. TRANS: partials are weighted components in a harmonic series
 #: js/blocks/ToneBlocks.js:301
-#.TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "ばいおん ブロック が「ばいおん ウェート ブロック」の なかに ある ひつようが あります。"
 
 #: js/blocks/ToneBlocks.js:321
-msgid "The Weighted partials block is used to specify the partials associated with a timbre."
+msgid ""
+"The Weighted partials block is used to specify the partials associated with "
+"a timbre."
 msgstr "「ウェートばいおん」ブロックは、ねいろーにかんれんづけられたぶぶんおんをしていするためにしようされます。"
 
+#. TRANS: partials are weighted components in a harmonic series
 #: js/blocks/ToneBlocks.js:329
-#.TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ウェートばいおん"
 
@@ -7636,8 +7353,8 @@ msgstr "ウェートばいおん"
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "「ハーモニックス」ブロックはふくまれるおんぷにばいおんをついかします。"
 
+#. TRANS: A harmonic is an overtone.
 #: js/blocks/ToneBlocks.js:393
-#.TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "ハーモニックス"
 
@@ -7645,8 +7362,8 @@ msgstr "ハーモニックス"
 msgid "The Distortion block adds distortion to the pitch."
 msgstr "「ディストーション」ブロックはおんていにひずみをくわえます。"
 
+#. TRANS: distortion is an alteration in the sound
 #: js/blocks/ToneBlocks.js:441
-#.TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "ディストーション"
 
@@ -7659,35 +7376,33 @@ msgid "Tremolo makes the sound pulse louder and quieter."
 msgstr "とれもろをしようすると、おとがぱるすのようにおおきくなったり、ちーさくなったりします。"
 
 #: js/blocks/ToneBlocks.js:494
-msgid "The rate (first argument) controls how fast the sound pulses (cycles per second)."
+msgid ""
+"The rate (first argument) controls how fast the sound pulses (cycles per "
+"second)."
 msgstr "れーと (さいしょのひきすう) は、さうんどのぱるすそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
 
 #: js/blocks/ToneBlocks.js:498
-msgid "The depth (second argument) controls the strength of the pulsing effect (0-100%)."
+msgid ""
+"The depth (second argument) controls the strength of the pulsing effect "
+"(0-100%)."
 msgstr "ふかさ (2 ばんめのひきすう) は、ぱるすこうかのつよさをせいぎょします (0 ～ 100%)。"
 
+#. TRANS: a wavering effect in a musical tone
 #: js/blocks/ToneBlocks.js:508
-#.TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "トレモロ"
 
-#: js/blocks/ToneBlocks.js:513
-#: js/blocks/ToneBlocks.js:582
-#: js/blocks/ToneBlocks.js:653
-#: js/blocks/ToneBlocks.js:720
-#: js/widgets/timbre.js:2337
-#: js/widgets/timbre.js:2410
-#: js/widgets/timbre.js:2491
-#: js/widgets/timbre.js:2583
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
+#: js/blocks/ToneBlocks.js:513 js/blocks/ToneBlocks.js:582
+#: js/blocks/ToneBlocks.js:653 js/blocks/ToneBlocks.js:720
+#: js/widgets/timbre.js:2337 js/widgets/timbre.js:2410
+#: js/widgets/timbre.js:2491 js/widgets/timbre.js:2583
 msgid "rate"
 msgstr "はやさ"
 
-#: js/blocks/ToneBlocks.js:515
-#: js/blocks/ToneBlocks.js:653
-#: js/widgets/timbre.js:2340
-#: js/widgets/timbre.js:2501
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
+#: js/blocks/ToneBlocks.js:515 js/blocks/ToneBlocks.js:653
+#: js/widgets/timbre.js:2340 js/widgets/timbre.js:2501
 msgid "depth"
 msgstr "おおきさ"
 
@@ -7695,53 +7410,61 @@ msgstr "おおきさ"
 msgid "The Phaser block adds a sweeping sound."
 msgstr "「フェーザー」ブロックはスィープおとをくわえます。"
 
+#. TRANS: alter the phase of the sound
 #: js/blocks/ToneBlocks.js:579
-#.TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "フェーザー"
 
-#: js/blocks/ToneBlocks.js:582
-#: js/turtleactions/IntervalsActions.js:157
+#: js/blocks/ToneBlocks.js:582 js/turtleactions/IntervalsActions.js:157
 #: js/widgets/timbre.js:2586
 msgid "octaves"
 msgstr "オクターヴ"
 
-#: js/blocks/ToneBlocks.js:582
-#: js/widgets/timbre.js:2589
+#: js/blocks/ToneBlocks.js:582 js/widgets/timbre.js:2589
 msgid "base frequency"
 msgstr "きほん しゅうはすう"
 
 #: js/blocks/ToneBlocks.js:632
 msgid "The Chorus block adds a chorus effect."
-msgstr "<h2>コーラス ブロック</h2><br>ひろがりの ある おとの ひびきに する。 はやさ と ずれ で、 ひびきが のこる かんじを ちょうせつ できる。"
+msgstr ""
+"<h2>コーラス ブロック</h2><br>ひろがりの ある おとの ひびきに する。 はやさ と ずれ で、 ひびきが のこる かんじを ちょうせつ "
+"できる。"
 
 #: js/blocks/ToneBlocks.js:634
-msgid "The rate (first argument) controls the speed of the chorus modulation (cycles per second)."
+msgid ""
+"The rate (first argument) controls the speed of the chorus modulation "
+"(cycles per second)."
 msgstr "れーと (さいしょのひきすう) は、こーらすへんちょうのそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
 
 #: js/blocks/ToneBlocks.js:638
-msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
+msgid ""
+"The delay (second argument) sets the time delay between chorus voices "
+"(milliseconds)."
 msgstr "でぃれい(だい 2 ひきすう) は、こーらすぼいすまのちえんじかん (みりびょう) をせっていします。"
 
 #: js/blocks/ToneBlocks.js:642
-msgid "The depth (third argument) controls the amount of chorus effect (0-100%)."
+msgid ""
+"The depth (third argument) controls the amount of chorus effect (0-100%)."
 msgstr "ふかさ (3 ばんめのひきすう) は、こーらす・えふぇくたーのりょう (0 ～ 100%) をせいぎょします。"
 
 #: js/blocks/ProgramBlocks.js:1521
-msgid "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
-msgstr "ミュージック・ブロックス プロジェクトの リンクのみが きょかされます (おなじサイト、musicblocks.sugarlabs.org、musicblocks.net)。"
+msgid ""
+"Only Music Blocks project links are allowed (same site, "
+"musicblocks.sugarlabs.org, musicblocks.net)."
+msgstr ""
+"ミュージック・ブロックス プロジェクトの リンクのみが きょかされます "
+"(おなじサイト、musicblocks.sugarlabs.org、musicblocks.net)。"
 
 #: js/blocks/ProgramBlocks.js:1531
 msgid "Please allow popups for this site"
 msgstr "このサイトの ポップアップを きょかしてください"
 
+#. TRANS: musical effect to simulate a choral sound
 #: js/blocks/ToneBlocks.js:650
-#.TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "コーラス"
 
-#: js/blocks/ToneBlocks.js:653
-#: js/widgets/timbre.js:2496
+#: js/blocks/ToneBlocks.js:653 js/widgets/timbre.js:2496
 msgid "delay (MS)"
 msgstr "ディレイ・エフェクター（ms）"
 
@@ -7750,25 +7473,28 @@ msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr "<h2>ビブラートブロック</h2><br>おとの たかさに こきざみな へんかを つける。"
 
 #: js/blocks/ToneBlocks.js:703
-msgid "The intensity (first argument) controls how much the pitch varies (semitones)."
+msgid ""
+"The intensity (first argument) controls how much the pitch varies "
+"(semitones)."
 msgstr "おおきさ (さいしょのひきすう) は、ピッチのへんかりょう (はんおん) をせいぎょします。"
 
 #: js/blocks/ToneBlocks.js:707
-msgid "The rate (second argument) controls the speed of the pitch variation (cycles per second)."
+msgid ""
+"The rate (second argument) controls the speed of the pitch variation (cycles"
+" per second)."
 msgstr "れーと (2 ばんめのひきすう) は、ピッチへんかのそくど (1 びょうあたりのさいくるかず) をせいぎょします。"
 
+#. TRANS: a rapid, slight variation in pitch
 #: js/blocks/ToneBlocks.js:717
-#.TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "ビブラート"
 
-#: js/blocks/ToneBlocks.js:720
-#: js/widgets/timbre.js:2409
+#: js/blocks/ToneBlocks.js:720 js/widgets/timbre.js:2409
 msgid "intensity"
 msgstr "おおきさ"
 
+#. TRANS: select synthesizer
 #: js/blocks/ToneBlocks.js:764
-#.TRANS: select synthesizer
 msgid "set synth"
 msgstr "シンセを せってい"
 
@@ -7781,18 +7507,20 @@ msgid "set default instrument"
 msgstr "ねいろひょうじゅんを せってい"
 
 #: js/blocks/ToneBlocks.js:875
-msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
+msgid ""
+"The set default instrument block changes the default instrument from "
+"electronic synth to the instrument of your choice."
 msgstr "ねいろひょうじゅんをせっていすると、デフォルトのねいろがでんししんせからせんたくしたねいろにへんこうされます。"
 
-#: js/blocks/ToneBlocks.js:925
-#: js/blocks/ToneBlocks.js:976
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
+#: js/blocks/ToneBlocks.js:925 js/blocks/ToneBlocks.js:976
 msgid "set instrument"
 msgstr "ねいろを せってい"
 
-#: js/blocks/ToneBlocks.js:931
-#: js/blocks/ToneBlocks.js:965
-msgid "The Set instrument block selects a voice for the synthesizer, eg guitar piano violin or cello."
+#: js/blocks/ToneBlocks.js:931 js/blocks/ToneBlocks.js:965
+msgid ""
+"The Set instrument block selects a voice for the synthesizer, eg guitar "
+"piano violin or cello."
 msgstr "「ねいろをせってい」ブロックは、シンセサイザーのおんせい (ギター、ピアノ、バイオリン、チェロなど) をせんたくします。"
 
 #: js/blocks/ToneBlocks.js:959
@@ -7808,32 +7536,41 @@ msgid "Upload a sound file to connect with the sample block."
 msgstr "ねいろサンプルを アップロードして、 おとの たかさを あわせ"
 
 #: js/blocks/RhythmBlocks.js:38
-msgid "The Note value block is the value of the duration of the note currently being played."
+msgid ""
+"The Note value block is the value of the duration of the note currently "
+"being played."
 msgstr "「おとの ながさ」ブロックは、げんざい えんそうされている おんぷの ながさの あたいです。"
 
 #: js/blocks/RhythmBlocks.js:150
-msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
-msgstr "「Milliseconds」ブロックは、おんぷのながさをしていするためにじかん (MS たんい) をしようすることをのぞいて、「おんぷ」ブロックににています。"
+msgid ""
+"The Milliseconds block is similar to a Note block except that it uses time "
+"(in MS) to specify the note duration."
+msgstr ""
+"「Milliseconds」ブロックは、おんぷのながさをしていするためにじかん (MS たんい) "
+"をしようすることをのぞいて、「おんぷ」ブロックににています。"
 
-#: js/blocks/RhythmBlocks.js:193
-#: js/blocks/RhythmBlocks.js:1085
+#: js/blocks/RhythmBlocks.js:193 js/blocks/RhythmBlocks.js:1085
 #: js/blocks/RhythmBlocks.js:1156
 msgid "Note value must be greater than 0."
 msgstr "おとの ながさは、 0より おおきい あたいを せってい して ください。"
 
-#: js/blocks/RhythmBlocks.js:218
-#: js/blocks/RhythmBlocks.js:280
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
+#: js/blocks/RhythmBlocks.js:218 js/blocks/RhythmBlocks.js:280
 #: js/blocks/RhythmBlocks.js:351
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "スイング"
 
 #: js/blocks/RhythmBlocks.js:342
-msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
-msgstr "「スイング」ブロックは、おんぷのぺあ (おんぷのあたいでしてい) にさようし、さいしょのおんぷにいっていのながさ (スイングあたいでしてい) をついかし、2 ばんめのおんぷからおなじりょうをしゅとくします。"
+msgid ""
+"The Swing block works on pairs of notes (specified by note value), adding "
+"some duration (specified by swing value) to the first note and taking the "
+"same amount from the second note."
+msgstr ""
+"「スイング」ブロックは、おんぷのぺあ (おんぷのあたいでしてい) にさようし、さいしょのおんぷにいっていのながさ (スイングあたいでしてい) "
+"をついかし、2 ばんめのおんぷからおなじりょうをしゅとくします。"
 
+#. TRANS: the amount to shift to the offbeat note
 #: js/blocks/RhythmBlocks.js:356
-#.TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "スイングの すうち"
 
@@ -7841,37 +7578,40 @@ msgstr "スイングの すうち"
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr "「Skip notes」ブロックはおんぷをスキップさせます。"
 
+#. TRANS: substitute rests on notes being skipped
 #: js/blocks/RhythmBlocks.js:428
-#.TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "おんぷの省略"
 
 #: js/blocks/RhythmBlocks.js:479
-msgid "The Multiply note value block changes the duration of notes by changing their note values."
+msgid ""
+"The Multiply note value block changes the duration of notes by changing "
+"their note values."
 msgstr "[おんかを ～ばいにする ファクター] ブロックは、おんかをへんこうすることでおんぷのながさをへんこうします。"
 
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes
+#. by using a factor of 2
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "おんかを ～ばいにする ファクター"
 
 #: js/blocks/RhythmBlocks.js:542
 msgid "The Tie block works on pairs of notes, combining them into one note."
-msgstr "<h2>タイブロック</h2><br>２つの おとを つなげて １つの おとに する。 「おとのたかさブロック」 を いれて つかう。 おなじ たかさの おとだけ、 つなぐことが できる。"
+msgstr ""
+"<h2>タイブロック</h2><br>２つの おとを つなげて １つの おとに する。 「おとのたかさブロック」 を いれて つかう。 おなじ たかさの"
+" おとだけ、 つなぐことが できる。"
 
+#. TRANS: tie notes together into one longer note
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "タイ"
 
-#: js/blocks/RhythmBlocks.js:591
-#: js/blocks/RhythmBlocks.js:670
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#: js/blocks/RhythmBlocks.js:591 js/blocks/RhythmBlocks.js:670
 msgid "dot"
 msgstr "ふてんおんぷ"
 
-#: js/blocks/RhythmBlocks.js:619
-#: js/turtleactions/RhythmActions.js:237
+#: js/blocks/RhythmBlocks.js:619 js/turtleactions/RhythmActions.js:237
 msgid "An argument of -1 results in a note value of 0."
 msgstr "ー１は ０の おんかに します"
 
@@ -7884,11 +7624,13 @@ msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "れい：ふてんよんぶんおんぷは1はくの3/8（1/4 + 1/8）えんそうされます。"
 
 #: js/blocks/RhythmBlocks.js:715
-msgid "A rest of the specified note value duration can be constructed using a Silence block."
+msgid ""
+"A rest of the specified note value duration can be constructed using a "
+"Silence block."
 msgstr "していしたおんぷのながさのきゅうふは、「きゅうふ」ブロックをしようしてこうちくできます。"
 
+#. TRANS: Japanese only: note value block for drum
 #: js/blocks/RhythmBlocks.js:764
-#.TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "おんぷ（ドラム）"
 
@@ -7898,7 +7640,8 @@ msgstr "３９２ヘルツ"
 
 #: js/blocks/RhythmBlocks.js:1113
 msgid "The Note block is a container for one or more Pitch blocks."
-msgstr "<h2>おんぷブロック</h2><br>おとの ながさと たかさを せってい する。ながさを きめ、「おとのたかさブロック」 を いれて つかう。"
+msgstr ""
+"<h2>おんぷブロック</h2><br>おとの ながさと たかさを せってい する。ながさを きめ、「おとのたかさブロック」 を いれて つかう。"
 
 #: js/blocks/RhythmBlocks.js:1115
 msgid "The Note block specifies the duration (note value) of its contents."
@@ -7912,22 +7655,21 @@ msgstr "ながさ"
 msgid "define frequency"
 msgstr "周波数を明確にする"
 
-#: js/blocks/RhythmBlocks.js:1208
-#: js/widgets/temperament.js:996
+#: js/blocks/RhythmBlocks.js:1208 js/widgets/temperament.js:996
 #: js/widgets/temperament.js:1790
 msgid "octave space"
 msgstr "オクターヴ・スペース"
 
-#: js/blocks/GraphicsBlocks.js:46
-#: js/turtleactions/DictActions.js:77
-#: js/turtleactions/DictActions.js:144
-#: js/turtleactions/DictActions.js:173
+#: js/blocks/GraphicsBlocks.js:46 js/turtleactions/DictActions.js:77
+#: js/turtleactions/DictActions.js:144 js/turtleactions/DictActions.js:173
 msgid "heading"
 msgstr "むき（ネズミ）"
 
 #: js/blocks/GraphicsBlocks.js:56
 msgid "The Heading block returns the orientation of the mouse."
-msgstr "<h2>すうち ブロック</h2><br>ネズミの むいている かくどを あらわす すうちブロック。 むきの あたいは、 ０いじょうで、 ３６０より ちいさい あたい になり、 プラスだと みぎまわり、 マイナスだと ひだりまわりに へんかする。"
+msgstr ""
+"<h2>すうち ブロック</h2><br>ネズミの むいている かくどを あらわす すうちブロック。 むきの あたいは、 ０いじょうで、 ３６０より "
+"ちいさい あたい になり、 プラスだと みぎまわり、 マイナスだと ひだりまわりに へんかする。"
 
 #: js/blocks/GraphicsBlocks.js:62
 msgid "The Heading block returns the orientation of the turtle."
@@ -7935,7 +7677,11 @@ msgstr "「むき（タートル）」ブロックはタートルのむきをか
 
 #: js/blocks/GraphicsBlocks.js:136
 msgid "The Y block returns the vertical position of the mouse."
-msgstr "<h2>すうち ブロック</h2><br>ネズミの ｙざひょう（たて ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの めもり（ｙざひょう）を つかって あらわす。"
+msgstr ""
+"<h2>すうち ブロック</h2><br>ネズミの ｙざひょう（たて ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう "
+"とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 "
+"がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの "
+"めもり（ｙざひょう）を つかって あらわす。"
 
 #: js/blocks/GraphicsBlocks.js:143
 msgid "The Y block returns the vertical position of the turtle."
@@ -7947,7 +7693,11 @@ msgstr "yざひょうち（ネズミ）"
 
 #: js/blocks/GraphicsBlocks.js:222
 msgid "The X block returns the horizontal position of the mouse."
-msgstr "<h2>すうち ブロック</h2><br>ネズミの ｘざひょう（よこ ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの めもり（ｙざひょう）を つかって あらわす。"
+msgstr ""
+"<h2>すうち ブロック</h2><br>ネズミの ｘざひょう（よこ ほうこうの いち）を あらわす すうちブロック。<br><br>★ざひょう "
+"とは<br>もの の いちを あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ１くみの すうち（ざひょう）を つかう。 "
+"がめんじょうの ネズミの いちは、 ほうがん ようし の ますめ の ように、 よこ ほうこうの めもり（xざひょう）と たて ほうこうの "
+"めもり（ｙざひょう）を つかって あらわす。"
 
 #: js/blocks/GraphicsBlocks.js:229
 msgid "The X block returns the horizontal position of the turtle."
@@ -7963,7 +7713,11 @@ msgstr "カンバスを うごかす"
 
 #: js/blocks/GraphicsBlocks.js:306
 msgid "The Scroll XY block moves the canvas."
-msgstr "<h2>いどう ブロック（カンバス）</h2><br>カンバスを じょうげ さゆうに いどう させる。 カンバスだけが いどう するので けっかてきに、 がめんじょうの すべての ネズミが どうじに いどう するように みえる。 カンバスを みぎ（プラス）に いどう すると ネズミは ひだりへ、 ひだり（マイナス）に いどう すると ネズミは みぎに うごいて みえる。 おなじく、 カンバスを うえ（プラス）に いどう すると ネズミは したへ、 した（マイナス）に いどうすると ネズミは うえに うごいて みえる。"
+msgstr ""
+"<h2>いどう ブロック（カンバス）</h2><br>カンバスを じょうげ さゆうに いどう させる。 カンバスだけが いどう するので けっかてきに、"
+" がめんじょうの すべての ネズミが どうじに いどう するように みえる。 カンバスを みぎ（プラス）に いどう すると ネズミは ひだりへ、 "
+"ひだり（マイナス）に いどう すると ネズミは みぎに うごいて みえる。 おなじく、 カンバスを うえ（プラス）に いどう すると ネズミは したへ、"
+" した（マイナス）に いどうすると ネズミは うえに うごいて みえる。"
 
 #: js/blocks/GraphicsBlocks.js:316
 msgid "x2"
@@ -7974,29 +7728,28 @@ msgid "y2"
 msgstr "たていどう"
 
 #: js/blocks/GraphicsBlocks.js:422
-msgid "The Control-point 2 block sets the second control point for the Bezier curve."
+msgid ""
+"The Control-point 2 block sets the second control point for the Bezier "
+"curve."
 msgstr "「コントロールてん２」ブロックはベジェきょくせんのだい2こんとろーるぽいんとをせっていします。"
 
 #: js/blocks/GraphicsBlocks.js:429
 msgid "control point 2"
 msgstr "コントロールてん２"
 
-#: js/blocks/GraphicsBlocks.js:432
-#: js/blocks/GraphicsBlocks.js:483
-#: js/blocks/GraphicsBlocks.js:530
-#: js/blocks/GraphicsBlocks.js:761
+#: js/blocks/GraphicsBlocks.js:432 js/blocks/GraphicsBlocks.js:483
+#: js/blocks/GraphicsBlocks.js:530 js/blocks/GraphicsBlocks.js:761
 msgid "x1"
 msgstr "xざひょう（ネズミ）"
 
-#: js/blocks/GraphicsBlocks.js:432
-#: js/blocks/GraphicsBlocks.js:483
-#: js/blocks/GraphicsBlocks.js:530
-#: js/blocks/GraphicsBlocks.js:761
+#: js/blocks/GraphicsBlocks.js:432 js/blocks/GraphicsBlocks.js:483
+#: js/blocks/GraphicsBlocks.js:530 js/blocks/GraphicsBlocks.js:761
 msgid "y1"
 msgstr "yざひょう（ネズミ）"
 
 #: js/blocks/GraphicsBlocks.js:473
-msgid "The Control-point 1 block sets the first control point for the Bezier curve."
+msgid ""
+"The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr "「コントロールてん1」ブロックはベジェきょくせんのだい1こんとろーるぽいんとをせっていします。"
 
 #: js/blocks/GraphicsBlocks.js:480
@@ -8014,6 +7767,8 @@ msgstr "ベジェきょくせん"
 #: js/blocks/GraphicsBlocks.js:589
 msgid "The Arc block moves the mouse in an arc."
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/blocks/GraphicsBlocks.js:596
 msgid "The Arc block moves the turtle in an arc."
@@ -8031,17 +7786,13 @@ msgstr "かくど"
 msgid "radius"
 msgstr "はんけい"
 
-#: js/blocks/GraphicsBlocks.js:626
-#: js/blocks/GraphicsBlocks.js:782
-#: js/blocks/GraphicsBlocks.js:1034
-#: js/blocks/GraphicsBlocks.js:1123
+#: js/blocks/GraphicsBlocks.js:626 js/blocks/GraphicsBlocks.js:782
+#: js/blocks/GraphicsBlocks.js:1034 js/blocks/GraphicsBlocks.js:1123
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr "らっぷモードがおふのとき、あたいは -5000 から 5000 のはんいでなければなりません。"
 
-#: js/blocks/GraphicsBlocks.js:631
-#: js/blocks/GraphicsBlocks.js:790
-#: js/blocks/GraphicsBlocks.js:1039
-#: js/blocks/GraphicsBlocks.js:1128
+#: js/blocks/GraphicsBlocks.js:631 js/blocks/GraphicsBlocks.js:790
+#: js/blocks/GraphicsBlocks.js:1039 js/blocks/GraphicsBlocks.js:1128
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr "らっぷモードがおんのとき、あたいは -20000 から 20000 のはんいでなければなりません。"
 
@@ -8055,11 +7806,18 @@ msgstr "<h2>「むきを かえる」ブロック</h2><br>タートルのむき�
 
 #: js/blocks/GraphicsBlocks.js:744
 msgid "The Set XY block moves the mouse to a specific position on the screen."
-msgstr "<h2>「していざひょうに いどう」ブロック</h2><br>ネズミの いちを、 してい した ざひょう に いどう させる。<br><br>★ざひょうとは<br>もの の いち を あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ １くみの すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめのように、 よこほうこうの めもり（xざひょう）と たてほうこうの めもり（ｙざひょう）を つかって あらわす。"
+msgstr ""
+"<h2>「していざひょうに いどう」ブロック</h2><br>ネズミの いちを、 してい した ざひょう に いどう "
+"させる。<br><br>★ざひょうとは<br>もの の いち を あらわす ための すうちのこと。 ミュージック・ブロックスでは、 ２つ １くみの "
+"すうち（ざひょう）を つかう。 がめんじょうの ネズミの いちは、 ほうがん ようし の ますめのように、 よこほうこうの めもり（xざひょう）と "
+"たてほうこうの めもり（ｙざひょう）を つかって あらわす。"
 
 #: js/blocks/GraphicsBlocks.js:750
-msgid "The Set XY block moves the turtle to a specific position on the screen."
-msgstr "<h2>「していざひょうに いどう」ブロック</h2><br>タートルのいちを、していしたざひょうにいどうさせる。<br><br>★ざひょうとは<br>もののいちをあらわすためのすうちのこと。ミュージック・ブロックスでは、２つ１くみのすうち（ざひょう）をつかう。がめんじょうのタートルのいちは、ほうがんようしのますめのように、よこほうこうのめもり（xざひょう）とたてほうこうのめもり（ｙざひょう）をつかってあらわす。"
+msgid ""
+"The Set XY block moves the turtle to a specific position on the screen."
+msgstr ""
+"<h2>「していざひょうに "
+"いどう」ブロック</h2><br>タートルのいちを、していしたざひょうにいどうさせる。<br><br>★ざひょうとは<br>もののいちをあらわすためのすうちのこと。ミュージック・ブロックスでは、２つ１くみのすうち（ざひょう）をつかう。がめんじょうのタートルのいちは、ほうがんようしのますめのように、よこほうこうのめもり（xざひょう）とたてほうこうのめもり（ｙざひょう）をつかってあらわす。"
 
 #: js/blocks/GraphicsBlocks.js:758
 msgid "set xy"
@@ -8077,9 +7835,7 @@ msgstr "<h2>「みぎを むく」ブロック</h2><br>タートルのむきを�
 msgid "right1"
 msgstr "みぎを むく"
 
-#: js/blocks/GraphicsBlocks.js:858
-#: plugins/rodi.rtp:77
-#: plugins/rodi.rtp:340
+#: js/blocks/GraphicsBlocks.js:858 plugins/rodi.rtp:77 plugins/rodi.rtp:340
 #: plugins/rodi.rtp:375
 msgid "right"
 msgstr "ざひょうち（みぎ）"
@@ -8096,31 +7852,26 @@ msgstr "<h2>「ひだりを むく」ブロック</h2><br>タートルのむき�
 msgid "left1"
 msgstr "ひだりを むく"
 
-#: js/blocks/GraphicsBlocks.js:938
-#: plugins/rodi.rtp:79
-#: plugins/rodi.rtp:339
+#: js/blocks/GraphicsBlocks.js:938 plugins/rodi.rtp:79 plugins/rodi.rtp:339
 #: plugins/rodi.rtp:362
 msgid "left"
 msgstr "ざひょうち（ひだり）"
 
-#: js/blocks/GraphicsBlocks.js:990
-#: js/widgets/temperament.js:170
-#: plugins/rodi.rtp:69
-#: plugins/rodi.rtp:387
+#: js/blocks/GraphicsBlocks.js:990 js/widgets/temperament.js:170
+#: plugins/rodi.rtp:69 plugins/rodi.rtp:387
 msgid "back"
 msgstr "うしろへ すすむ"
 
 #: js/blocks/GraphicsBlocks.js:999
 msgid "The Back block moves the mouse backward."
-msgstr "<h2>「うしろへ すすむ」ブロック</h2><br>してい した すうちぶん、 ネズミを うしろに もどす。 からだの むきは かえない。"
+msgstr ""
+"<h2>「うしろへ すすむ」ブロック</h2><br>してい した すうちぶん、 ネズミを うしろに もどす。 からだの むきは かえない。"
 
 #: js/blocks/GraphicsBlocks.js:1006
 msgid "The Back block moves the turtle backward."
 msgstr "<h2>「うしろへ すすむ」ブロック</h2><br>していしたすうちふん、タートルをうしろにもどす。からだのむきはかえない。"
 
-#: js/blocks/GraphicsBlocks.js:1079
-#: plugins/rodi.rtp:71
-#: plugins/rodi.rtp:400
+#: js/blocks/GraphicsBlocks.js:1079 plugins/rodi.rtp:71 plugins/rodi.rtp:400
 msgid "forward"
 msgstr "まえへ すすむ"
 
@@ -8136,17 +7887,17 @@ msgstr "<h2>「まえへ すすむ」ブロック</h2><br>していしたすう�
 msgid "reflection"
 msgstr "ふりかえり"
 
-#: js/blocks/GraphicsBlocks.js:1203
-#: js/blocks/GraphicsBlocks.js:1221
+#: js/blocks/GraphicsBlocks.js:1203 js/blocks/GraphicsBlocks.js:1221
 msgid "wrap"
 msgstr "まきつける"
 
 #: js/blocks/GraphicsBlocks.js:1211
-msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
+msgid ""
+"The Wrap block enables or disables screen wrapping for the graphics actions "
+"within it."
 msgstr "「まきつける」ブロックは、そのなかのぐらふぃっくす のがめんらっぴんぐをゆうこうまたはむこうにします。"
 
-#: js/turtleactions/DictActions.js:75
-#: js/turtleactions/DictActions.js:142
+#: js/turtleactions/DictActions.js:75 js/turtleactions/DictActions.js:142
 #: js/turtleactions/DictActions.js:172
 msgid "font"
 msgstr "フォント"
@@ -8163,18 +7914,15 @@ msgstr "このなまえのキー（ちょう）は %s にそんざいしませ�
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr "ノイズ・ブロック：おんぷ ブロックと いっしょに つかいますか？"
 
-#: js/turtleactions/MeterActions.js:116
-#: js/turtleactions/MeterActions.js:140
+#: js/turtleactions/MeterActions.js:116 js/turtleactions/MeterActions.js:140
 msgid "beats per minute must be greater than %s"
 msgstr "1 ふんあたりのはくすうは %s よりおおきくなければなりません"
 
-#: js/turtleactions/MeterActions.js:124
-#: js/turtleactions/MeterActions.js:148
+#: js/turtleactions/MeterActions.js:124 js/turtleactions/MeterActions.js:148
 msgid "maximum"
 msgstr "さいだいげん"
 
-#: js/turtleactions/MeterActions.js:124
-#: js/turtleactions/MeterActions.js:148
+#: js/turtleactions/MeterActions.js:124 js/turtleactions/MeterActions.js:148
 msgid "beats per minute is %s"
 msgstr "1 ふんあたりのはくすうは %s です"
 
@@ -8234,6 +7982,8 @@ msgstr "と"
 #: js/turtleactions/IntervalsActions.js:192
 msgid "steps"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/turtleactions/IntervalsActions.js:311
 msgid "Adding missing pitch number 0."
@@ -8244,7 +7994,9 @@ msgid "Ignoring duplicate pitch numbers."
 msgstr "ちょうふく している ピッチすうちは むし します"
 
 #: js/turtleactions/PitchActions.js:288
-msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
+msgid ""
+"Scalar transpositions are equal to Semitone transpositions for custom "
+"temperament."
 msgstr "おんかいてきないちょうは、カスタムおんりつのはんおんいちょうとおなじです。"
 
 #: js/turtleactions/OrnamentActions.js:49
@@ -8263,9 +8015,8 @@ msgstr "ビブラートの おおきさは、 1から 100までの はんいで 
 msgid "Vibrato rate must be greater than 0."
 msgstr "ビブラートの はやさは、 0より おおきい あたいを せってい して ください。"
 
-#: js/turtleactions/ToneActions.js:195
-#: js/turtleactions/ToneActions.js:268
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
+#: js/turtleactions/ToneActions.js:195 js/turtleactions/ToneActions.js:268
 msgid "Depth is out of range."
 msgstr "（エフェクタの）ふかさの すうじが へんいきがい です。"
 
@@ -8273,20 +8024,17 @@ msgstr "（エフェクタの）ふかさの すうじが へんいきがい で
 msgid "Distortion must be from 0 to 100."
 msgstr "ディストーションは、 0から 100までの はんいで せってい して ください。"
 
+#. TRANS: partials components in a harmonic series
 #: js/turtleactions/ToneActions.js:335
-#.TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "ばいおんが ０いじょう である ひつようが あります。"
 
-#: js/turtleactions/ToneActions.js:381
-#: js/turtleactions/ToneActions.js:420
-#: js/turtleactions/ToneActions.js:459
-#: js/widgets/timbre.js:851
+#: js/turtleactions/ToneActions.js:381 js/turtleactions/ToneActions.js:420
+#: js/turtleactions/ToneActions.js:459 js/widgets/timbre.js:851
 msgid "Unable to use synth due to existing oscillator."
 msgstr "きぞんのおしれーたーがあるためシンセはしようできません。"
 
-#: js/turtleactions/ToneActions.js:391
-#: js/turtleactions/ToneActions.js:430
+#: js/turtleactions/ToneActions.js:391 js/turtleactions/ToneActions.js:430
 msgid "The input cannot be negative."
 msgstr "マイナスの すうちを いれることは できません。"
 
@@ -8324,7 +8072,9 @@ msgid "New start block generated."
 msgstr "あたらしい「スタート」ブロックがせいせいされました。"
 
 #: js/widgets/aiwidget.js:647
-msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
+msgid ""
+"MIDI loading. This may take some time depending upon the number of notes in "
+"the track"
 msgstr "「MIDI]を よみこみちゅうです。おんぷの かずと トラックの かずによって じかんが かかるかもしれません。"
 
 #: js/widgets/aiwidget.js:656 js/widgets/sampler.js:300
@@ -8352,7 +8102,8 @@ msgid "Audio not supported in this browser."
 msgstr "このブラウザーでは おんせいが サポート されていません。"
 
 #: js/widgets/aiwidget.js:1103
-msgid "Please set your Groq API Key using the settings button (wrench icon) first."
+msgid ""
+"Please set your Groq API Key using the settings button (wrench icon) first."
 msgstr "まず せっていボタン (レンチ・アイコン) をしようして Groq API キーを せっていしてください。"
 
 #: js/widgets/meterwidget.js:195 js/widgets/meterwidget.js:196
@@ -8432,6 +8183,8 @@ msgstr "あたらしいおんせいをせいせいしています..."
 #: js/turtleactions/RhythmActions.js:151
 msgid "Neighbor note value is too large for the current note duration."
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/jseditor.js:393
 msgid "Reset Code"
@@ -8446,7 +8199,9 @@ msgid "Toggle Console"
 msgstr "こんそーるのきりかえ"
 
 #: js/widgets/jseditor.js:984
-msgid "JavaScript block conversion is unavailable because its configuration file failed to load."
+msgid ""
+"JavaScript block conversion is unavailable because its configuration file "
+"failed to load."
 msgstr "JavaScript ブロックへんかんは、こうせいファイルのろーどにしっぱいしたためしようできません。"
 
 #: js/widgets/jseditor.js:987
@@ -8454,7 +8209,8 @@ msgid "JavaScript block conversion is still loading. Please try again."
 msgstr "JavaScript ブロックへんかんはまだよみこみなかです。もういちどためしてください。"
 
 #: js/widgets/plugin-dialog.js:76
-msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
+msgid ""
+"Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "くみこみぷらぐいんのなまえをにゅうりょくするか、くうはくのままにしてぷらぐいん ファイルをあっぷろーどします。"
 
 #: js/widgets/widgetWindows.js:221
@@ -8505,25 +8261,34 @@ msgstr "さーばー エラー: AI ばっくえんどからのむこうなおう
 msgid "Server error: Unable to connect to AI backend."
 msgstr "さーばー エラー: AI ばっくえんどにせつぞくできません。"
 
-#: js/widgets/aidebugger.js:466
-#: js/widgets/aidebugger.js:738
-msgid "Could not reach the AI assistant. Please check your connection and try again."
+#: js/widgets/aidebugger.js:466 js/widgets/aidebugger.js:738
+msgid ""
+"Could not reach the AI assistant. Please check your connection and try "
+"again."
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/aidebugger.js:552
 msgid "Before we start"
 msgstr "はじめるまえに"
 
 #: js/widgets/aidebugger.js:556
-msgid "The AI Debugger will send your current project data to an external server for analysis. Your project blocks and structure will be shared with:"
-msgstr "AI デバッガーは、ぶんせきのためにげんざいのプロジェクト データをがいぶさーばーにそうしんします。プロジェクトのブロックとこうぞうはいかときょうゆうされます。"
+msgid ""
+"The AI Debugger will send your current project data to an external server "
+"for analysis. Your project blocks and structure will be shared with:"
+msgstr ""
+"AI デバッガーは、ぶんせきのためにげんざいのプロジェクト "
+"データをがいぶさーばーにそうしんします。プロジェクトのブロックとこうぞうはいかときょうゆうされます。"
 
 #: js/widgets/aidebugger.js:570
 msgid "Analyze my project"
 msgstr "わたしのプロジェクトをぶんせきしてください"
 
 #: js/widgets/aidebugger.js:599
-msgid "AI analysis was not started. You can type a question below, but project data will not be sent until you agree."
+msgid ""
+"AI analysis was not started. You can type a question below, but project data"
+" will not be sent until you agree."
 msgstr "AIかいせきはかいしされていません。いかにしつもんをにゅうりょくできますが、どういするまでプロジェクト データはそうしんされません。"
 
 #: js/widgets/aidebugger.js:629
@@ -8535,7 +8300,9 @@ msgid "Debugger error: Could not load project data."
 msgstr "デバッガー エラー: プロジェクト データをろーどできませんでした。"
 
 #: js/widgets/aidebugger.js:670
-msgid "AI Debugger is not available on this host. The backend URL could not be determined."
+msgid ""
+"AI Debugger is not available on this host. The backend URL could not be "
+"determined."
 msgstr "AI デバッガーはこのほすとではしようできません。ばっくえんど URL をとくていできませんでした。"
 
 #: js/widgets/aidebugger.js:723
@@ -8559,7 +8326,9 @@ msgid "Debugger error: Could not retrieve project data for export."
 msgstr "デバッガー エラー: えくすぽーとするプロジェクト データをしゅとくできませんでした。"
 
 #: js/widgets/help.js:65
-msgid "Start by dragging a block from the left panel and connect it to the Start block."
+msgid ""
+"Start by dragging a block from the left panel and connect it to the Start "
+"block."
 msgstr "はじめに ひだりがわの パネルから ブロックを ドラッグして、それを「スタート」ブロックに せつぞくします。"
 
 #: js/widgets/aidebugger.js:818
@@ -8570,22 +8339,15 @@ msgstr "ちゃっとはせいじょうにえくすぽーとされました。"
 msgid "Chat cleared."
 msgstr "ちゃっとがくりあされました。"
 
-#: js/widgets/aiwidget.js:136
-#: js/widgets/aiwidget.js:137
-#: js/widgets/rhythmruler.js:841
-#: js/widgets/rhythmruler.js:2057
-#: js/widgets/tempo.js:93
-#: js/widgets/tempo.js:113
-#: js/widgets/tempo.js:114
-#: js/widgets/sampler.js:247
-#: js/widgets/sampler.js:248
-#: js/widgets/sampler.js:252
-#: js/widgets/sampler.js:253
+#: js/widgets/aiwidget.js:136 js/widgets/aiwidget.js:137
+#: js/widgets/rhythmruler.js:841 js/widgets/rhythmruler.js:2057
+#: js/widgets/tempo.js:93 js/widgets/tempo.js:113 js/widgets/tempo.js:114
+#: js/widgets/sampler.js:247 js/widgets/sampler.js:248
+#: js/widgets/sampler.js:252 js/widgets/sampler.js:253
 msgid "Pause"
 msgstr "いちじ ていし"
 
-#: js/widgets/aiwidget.js:181
-#: js/widgets/sampler.js:298
+#: js/widgets/aiwidget.js:181 js/widgets/sampler.js:298
 msgid "Warning: Sample is bigger than 1MB."
 msgstr "ワーニング： サンプルは １MB より おおきいです。"
 
@@ -8598,11 +8360,12 @@ msgid "Load this block"
 msgstr "このブロックをロードします"
 
 #: js/widgets/aiwidget.js:651
-msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
+msgid ""
+"MIDI loading. This may take some time depending upon the number of notes in "
+"the track"
 msgstr "「MIDI]を よみこみちゅうです。おんぷの かずと トラックの かずによって じかんが かかるかもしれません。"
 
-#: js/widgets/aiwidget.js:660
-#: js/widgets/sampler.js:323
+#: js/widgets/aiwidget.js:660 js/widgets/sampler.js:323
 msgid "Upload failed: Sample is not a .wav file."
 msgstr "あっぷろーどできませんでした： さんぷるは .wavファイルでは ありません。"
 
@@ -8623,7 +8386,9 @@ msgid "Synth error: %s"
 msgstr "しんせのエラー: %s"
 
 #: js/widgets/jseditor.js:984
-msgid "JavaScript block conversion is unavailable because its configuration file failed to load."
+msgid ""
+"JavaScript block conversion is unavailable because its configuration file "
+"failed to load."
 msgstr "JavaScript ブロックへんかんは、こうせいファイルのロードにしっぱいしたためしようできません。"
 
 #: js/widgets/aiwidget.js:878
@@ -8631,11 +8396,11 @@ msgid "Audio not supported in this browser."
 msgstr "このぶらうざではおんせいがさぽーとされていません。"
 
 #: js/widgets/aiwidget.js:1108
-msgid "Please set your Groq API Key using the settings button (wrench icon) first."
+msgid ""
+"Please set your Groq API Key using the settings button (wrench icon) first."
 msgstr "まずせっていボタン (レンチ・アイコン) をしようして Groq API キーをせっていしてください。"
 
-#: js/widgets/legobricks.js:355
-#: js/widgets/phrasemaker.js:683
+#: js/widgets/legobricks.js:355 js/widgets/phrasemaker.js:683
 msgid "Export"
 msgstr "エクスポート"
 
@@ -8648,7 +8413,9 @@ msgid "Webcam"
 msgstr "ウェブカメラ"
 
 #: js/widgets/legobricks.js:409
-msgid "LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, Instrument)"
+msgid ""
+"LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, "
+"Instrument)"
 msgstr "レゴ・ブロック - %s ピッチおこなをふくむふれーず・めーかー (しゅうはすう、おんせいじゅんにならべかえ)"
 
 #: js/widgets/legobricks.js:856
@@ -8682,6 +8449,8 @@ msgstr "がぞうがせいじょうにプラグインされました"
 #: js/widgets/legobricks.js:1323
 msgid "Photo captured"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/legobricks.js:1328
 msgid "Webcam started"
@@ -8692,7 +8461,9 @@ msgid "Webcam access denied: %s"
 msgstr "ウェブカメラへ のアクセスが きょひ されました: %s"
 
 #: js/widgets/legobricks.js:1388
-msgid "Eye dropper active - hover over image to preview colors, click to select background color."
+msgid ""
+"Eye dropper active - hover over image to preview colors, click to select "
+"background color."
 msgstr "すぽいとがアクティブ - がぞうのうえにカーソルをおくといろがプレビューされ、クリックしてはいけいしょくをせんたくできます。"
 
 #: js/widgets/legobricks.js:1449
@@ -8703,8 +8474,7 @@ msgstr "せんたくされたはいけいしょく: %s"
 msgid "Could not sample color - please try clicking on the image."
 msgstr "からーのさんぷるができませんでした - がぞうをクリックしてみてください。"
 
-#: js/widgets/legobricks.js:1935
-#: js/widgets/legobricks.js:2078
+#: js/widgets/legobricks.js:1935 js/widgets/legobricks.js:2078
 #: js/widgets/legobricks.js:2106
 msgid "Instrument changed to: %s"
 msgstr "おんせいはつぎのようにへんこうされました: %s"
@@ -8713,20 +8483,15 @@ msgstr "おんせいはつぎのようにへんこうされました: %s"
 msgid "Scanning image with vertical lines..."
 msgstr "がぞうをすきゃんするとたてせんがいります..."
 
-#: js/widgets/meterwidget.js:198
-#: js/widgets/meterwidget.js:199
-#: js/widgets/modewidget.js:151
-#: js/widgets/modewidget.js:674
-#: js/widgets/modewidget.js:729
-#: js/widgets/rhythmruler.js:638
-#: js/widgets/rhythmruler.js:1995
-#: js/widgets/rhythmruler.js:2012
+#: js/widgets/meterwidget.js:198 js/widgets/meterwidget.js:199
+#: js/widgets/modewidget.js:151 js/widgets/modewidget.js:674
+#: js/widgets/modewidget.js:729 js/widgets/rhythmruler.js:638
+#: js/widgets/rhythmruler.js:1995 js/widgets/rhythmruler.js:2012
 #: js/widgets/temperament.js:2550
 msgid "Play all"
 msgstr "すべてさいせい"
 
-#: js/widgets/meterwidget.js:286
-#: js/widgets/sampler.js:1287
+#: js/widgets/meterwidget.js:286 js/widgets/sampler.js:1287
 msgid "Reset"
 msgstr "リセット"
 
@@ -8742,26 +8507,20 @@ msgstr "ひだりまわりにずれる"
 msgid "Rotate clockwise"
 msgstr "みぎまわりにずれる"
 
-#: js/widgets/modewidget.js:182
-#: js/widgets/pitchstaircase.js:795
-#: js/widgets/rhythmruler.js:737
-#: js/widgets/timbre.js:1013
+#: js/widgets/modewidget.js:182 js/widgets/pitchstaircase.js:795
+#: js/widgets/rhythmruler.js:737 js/widgets/timbre.js:1013
 msgid "Undo"
 msgstr "１つもどす"
 
+#. TRANS: A circle of notes represents the musical mode.
 #: js/widgets/modewidget.js:200
-#.TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "クリックでおとのたかさを選んでちょうをせっていできます。"
 
-#: js/widgets/modewidget.js:1015
-#: js/widgets/phrasemaker.js:5131
-#: js/widgets/pitchstaircase.js:685
-#: js/widgets/rhythmruler.js:2449
-#: js/widgets/rhythmruler.js:2667
-#: js/widgets/tempo.js:471
-#: js/widgets/musickeyboard.js:3548
-#: js/widgets/temperament.js:2163
+#: js/widgets/modewidget.js:1015 js/widgets/phrasemaker.js:5131
+#: js/widgets/pitchstaircase.js:685 js/widgets/rhythmruler.js:2449
+#: js/widgets/rhythmruler.js:2667 js/widgets/tempo.js:471
+#: js/widgets/musickeyboard.js:3548 js/widgets/temperament.js:2163
 msgid "New action block generated."
 msgstr "あたらしいアクションを つくりました。"
 
@@ -8777,8 +8536,7 @@ msgstr "ズームアウト"
 msgid "Sort"
 msgstr "せいり する"
 
-#: js/widgets/phrasemaker.js:690
-#: js/widgets/musickeyboard.js:846
+#: js/widgets/phrasemaker.js:690 js/widgets/musickeyboard.js:846
 msgid "Add note"
 msgstr "おんぷをた"
 
@@ -8786,8 +8544,7 @@ msgstr "おんぷをた"
 msgid "Click on the table to add notes."
 msgstr "ます目をクリックするとメロディやリズムを作れます。"
 
-#: js/widgets/phrasemaker.js:2954
-#: js/widgets/phrasemaker.js:3107
+#: js/widgets/phrasemaker.js:2954 js/widgets/phrasemaker.js:3107
 msgid "tuplet value"
 msgstr "何れんぷ価"
 
@@ -8807,14 +8564,12 @@ msgstr "ピッチをへんこうするには、じょうげボタンまたはや
 msgid "Click on the slider to create a note block."
 msgstr "スライダーでおとのたかさを変えます。"
 
-#: js/widgets/pitchstaircase.js:402
-#: js/widgets/pitchstaircase.js:738
+#: js/widgets/pitchstaircase.js:402 js/widgets/pitchstaircase.js:738
 #: js/widgets/pitchstaircase.js:747
 msgid "Play chord"
 msgstr "わおんを さいせい する"
 
-#: js/widgets/pitchstaircase.js:445
-#: js/widgets/pitchstaircase.js:758
+#: js/widgets/pitchstaircase.js:445 js/widgets/pitchstaircase.js:758
 #: js/widgets/pitchstaircase.js:768
 msgid "Play scale"
 msgstr "ちょうを さいせい する"
@@ -8855,8 +8610,7 @@ msgstr "りふれっしゅ"
 msgid "Reflect on your project."
 msgstr "じぶんのプロジェクトをふりかえってください。"
 
-#: js/widgets/reflection.js:378
-#: js/widgets/reflection.js:626
+#: js/widgets/reflection.js:378 js/widgets/reflection.js:626
 msgid "Failed to send message."
 msgstr "めっせーじのそうしんにしっぱいしました。"
 
@@ -8876,8 +8630,8 @@ msgstr "リズムだけをほぞん"
 msgid "Save drum machine"
 msgstr "ドラム として ほぞん"
 
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 #: js/widgets/rhythmruler.js:748
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "リズムをタップする"
 
@@ -8889,8 +8643,7 @@ msgstr "えんけいびゅー"
 msgid "Click on the ruler to divide it."
 msgstr "クリック すると リズムを わる ことが できます。"
 
-#: js/widgets/rhythmruler.js:1167
-#: js/widgets/rhythmruler.js:1367
+#: js/widgets/rhythmruler.js:1167 js/widgets/rhythmruler.js:1367
 #: js/widgets/rhythmruler.js:1979
 msgid "tap a rhythm"
 msgstr "リズムを タップ する"
@@ -8919,8 +8672,7 @@ msgstr "ボタンで テンポが せってい できます。"
 msgid "Please enter a number between 30 and 1000"
 msgstr "３０から １０００までの かんじを にゅうりょくしてください。"
 
-#: js/widgets/tempo.js:318
-#: js/widgets/tempo.js:321
+#: js/widgets/tempo.js:318 js/widgets/tempo.js:321
 msgid "The beats per minute must be between 30 and 1000."
 msgstr "1ぷん あたりの はくの かずは、 30から 1000までの はんいで せってい して ください。"
 
@@ -8937,41 +8689,31 @@ msgid "Click in the grid to add steps to the arpeggio."
 msgstr "テーブルを クリックでアルペジオのピッチを加える。"
 
 #: js/widgets/help.js:65
-msgid "Start by dragging a block from the left panel and connect it to the Start block."
+msgid ""
+"Start by dragging a block from the left panel and connect it to the Start "
+"block."
 msgstr "はじめにひだりがわのぱねるからブロックをドラッグして、それを「スタート」ブロックにせつぞくします。"
 
-#: js/widgets/help.js:104
-#: js/widgets/help.js:142
-#: js/widgets/help.js:143
-#: js/widgets/help.js:211
-#: js/widgets/help.js:212
-#: js/widgets/help.js:715
+#: js/widgets/help.js:104 js/widgets/help.js:142 js/widgets/help.js:143
+#: js/widgets/help.js:211 js/widgets/help.js:212 js/widgets/help.js:715
 msgid "Next"
 msgstr "つぎ"
 
-#: js/widgets/help.js:111
-#: js/widgets/help.js:148
-#: js/widgets/help.js:149
-#: js/widgets/help.js:217
-#: js/widgets/help.js:218
-#: js/widgets/help.js:722
+#: js/widgets/help.js:111 js/widgets/help.js:148 js/widgets/help.js:149
+#: js/widgets/help.js:217 js/widgets/help.js:218 js/widgets/help.js:722
 msgid "Previous"
 msgstr "まえの"
 
-#: js/widgets/help.js:135
-#: js/widgets/help.js:172
-#: js/widgets/help.js:202
+#: js/widgets/help.js:135 js/widgets/help.js:172 js/widgets/help.js:202
 #: js/widgets/help.js:523
 msgid "Take a tour"
 msgstr "ツアーを はじめよう"
 
-#: js/widgets/help.js:255
-#: js/widgets/help.js:801
+#: js/widgets/help.js:255 js/widgets/help.js:801
 msgid "Show Palette containing the block"
 msgstr "ブロックをふくむパレットをひょうじ"
 
-#: js/widgets/help.js:337
-#: js/widgets/help.js:873
+#: js/widgets/help.js:337 js/widgets/help.js:873
 msgid "Load this block"
 msgstr "このブロックをろーどします"
 
@@ -8999,8 +8741,7 @@ msgstr "12このピッチ、すべてがすでにキーボードにくみこま�
 msgid "New action blocks generated."
 msgstr "あたらしいアクションを つくりました。"
 
-#: js/widgets/musickeyboard.js:3681
-#: js/widgets/musickeyboard.js:3689
+#: js/widgets/musickeyboard.js:3681 js/widgets/musickeyboard.js:3689
 msgid "MIDI device present."
 msgstr "MIDIデバイスがみつかりました。"
 
@@ -9016,23 +8757,18 @@ msgstr "えんけいビュー"
 msgid "Failed to get MIDI access in browser."
 msgstr "ブラウザはMIDIのアクセスができませんでした。"
 
-#: js/widgets/pitchdrummatrix.js:377
-#: js/widgets/pitchdrummatrix.js:722
+#: js/widgets/pitchdrummatrix.js:377 js/widgets/pitchdrummatrix.js:722
 msgid "Click in the grid to map notes to drums."
 msgstr "グラフに クリックして おんぷを どちらの ドラムに かえるか きめる ことが できます。"
 
-#: js/widgets/temperament.js:170
-#: js/widgets/temperament.js:1193
+#: js/widgets/temperament.js:170 js/widgets/temperament.js:1193
 #: js/widgets/temperament.js:1357
 msgid "preview"
 msgstr "ためす"
 
-#: js/widgets/temperament.js:174
-#: js/widgets/temperament.js:680
-#: js/widgets/temperament.js:1184
-#: js/widgets/temperament.js:1343
-#: js/widgets/temperament.js:1615
-#: js/widgets/temperament.js:1712
+#: js/widgets/temperament.js:174 js/widgets/temperament.js:680
+#: js/widgets/temperament.js:1184 js/widgets/temperament.js:1343
+#: js/widgets/temperament.js:1615 js/widgets/temperament.js:1712
 #: js/widgets/temperament.js:1812
 msgid "done"
 msgstr "おわった"
@@ -9049,8 +8785,7 @@ msgstr "へんしゅうする"
 msgid "cents"
 msgstr "セント"
 
-#: js/widgets/temperament.js:793
-#: js/widgets/temperament.js:798
+#: js/widgets/temperament.js:793 js/widgets/temperament.js:798
 #: js/widgets/temperament.js:1246
 msgid "ratio"
 msgstr "ひりつ"
@@ -9086,6 +8821,8 @@ msgstr "はんぷく"
 #: js/widgets/temperament.js:1300
 msgid "Please enter a valid ratio (e.g. 3:2) within the octave space."
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/temperament.js:1832
 msgid "The octave ratio has changed. This changes temperament significantly."
@@ -9123,8 +8860,7 @@ msgstr "あたらしい 「ねいろサンプル」 ブロックが つくりま
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr "ワーニング：ねいろサンプルは > 1MB であるため よみこむことが できません。"
 
-#: js/widgets/sampler.js:578
-#: js/widgets/sampler.js:1106
+#: js/widgets/sampler.js:578 js/widgets/sampler.js:1106
 msgid "Tuner stopped."
 msgstr "ちゅーなーがていししました。"
 
@@ -9151,6 +8887,8 @@ msgstr "ぷろんぷと"
 #: js/widgets/sampler.js:732
 msgid "AI Sample Generation"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/sampler.js:798
 msgid "Generating audio... (It may take up to 1 minute)"
@@ -9176,8 +8914,7 @@ msgstr "エラーがはっせいしました。"
 msgid "Debugger error: Could not load project data."
 msgstr "デバッガー エラー: プロジェクト データをロードできませんでした。"
 
-#: js/widgets/sampler.js:920
-#: js/widgets/sampler.js:2232
+#: js/widgets/sampler.js:920 js/widgets/sampler.js:2232
 msgid "Tuner"
 msgstr "ちゅーなー"
 
@@ -9203,23 +8940,26 @@ msgstr "まいくあくせすにしっぱいしました: %s"
 
 #: js/widgets/sampler.js:2239
 msgid "Start"
-msgstr ""
+msgstr "スタート"
 
 #: js/widgets/sampler.js:2251
 msgid "Detected Pitch:"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/sampler.js:2260
 msgid "Note:"
 msgstr ""
+"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
+"try again later.That’s all we know."
 
 #: js/widgets/timbre.js:839
 msgid "Synthesizer"
 msgstr "シンセサイザー"
 
-#: js/widgets/timbre.js:947
-#: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
+#: js/widgets/timbre.js:947 planet/js/GlobalTag.js:48
 msgid "Effects"
 msgstr "こうかおん"
 
@@ -9235,8 +8975,7 @@ msgstr "ボタンをクリックするとカスタムねいろツールが開き
 msgid "harmonicity"
 msgstr "ばいおんの ねいろ"
 
-#: js/widgets/timbre.js:1474
-#: js/widgets/timbre.js:1540
+#: js/widgets/timbre.js:1474 js/widgets/timbre.js:1540
 msgid "modulation index"
 msgstr "モジュレーションインデックス"
 
@@ -9256,8 +8995,7 @@ msgstr "ディストーションの おおきさ"
 msgid "More Details"
 msgstr "さらにくわしく"
 
-#: planet/js/GlobalCard.js:53
-#: planet/js/SaveInterface.js:34
+#: planet/js/GlobalCard.js:53 planet/js/SaveInterface.js:34
 msgid "Open in Music Blocks"
 msgstr "ミュージック・ブロックスで ひらきます"
 
@@ -9313,49 +9051,48 @@ msgstr "のリミックス"
 msgid "Cannot connect to server"
 msgstr "サーバに せつぞく できません"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:26
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "すべての プロジェクト"
 
-#: planet/js/GlobalTag.js:28
-#: planet/js/StringHelper.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
+#: planet/js/GlobalTag.js:28 planet/js/StringHelper.js:36
 msgid "My Projects"
 msgstr "じぶんの プロジェクト"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:30
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "プロジェクトの みほん"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "アート"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "さんすう"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "インタラクティブ"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "デザイン"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ゲーム"
 
+#. TRANS: On the Planet, we use labels to tag projects.
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "みじかいコード"
 
@@ -9387,8 +9124,7 @@ msgstr "リンクが クリップボードに コピーされました!"
 msgid "Failed to copy link to clipboard"
 msgstr "リンクを クリップボードに コピーできませんでした"
 
-#: planet/js/LocalCard.js:44
-#: planet/js/StringHelper.js:37
+#: planet/js/LocalCard.js:44 planet/js/StringHelper.js:37
 msgid "Publish project"
 msgstr "プロジェクトを こうかい する"
 
@@ -9421,18 +9157,17 @@ msgid "Error: Report could not be submitted. Try again later."
 msgstr "エラー：つうほうが できませんでした。あとで さいど ためして ください。"
 
 #: planet/js/ProjectViewer.js:30
-msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
+msgid ""
+"Thank you for reporting this project. A moderator will review the project "
+"shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr "このプロジェクトを つうほうして くださって ありがとう ございます。モデレータが まもなく、プロジェクトを みます。"
 
-#: planet/js/ProjectViewer.js:33
-#: planet/js/StringHelper.js:64
-#: planet/js/StringHelper.js:66
-#: planet/js/StringHelper.js:75
+#: planet/js/ProjectViewer.js:33 planet/js/StringHelper.js:64
+#: planet/js/StringHelper.js:66 planet/js/StringHelper.js:75
 msgid "Report Project"
 msgstr "プロジェクトを通報する"
 
-#: planet/js/ProjectViewer.js:34
-#: planet/js/StringHelper.js:65
+#: planet/js/ProjectViewer.js:34 planet/js/StringHelper.js:65
 msgid "Project Reported"
 msgstr "プロジェクトは つうほう されました"
 
@@ -9445,11 +9180,12 @@ msgid "Report description too long"
 msgstr "レポート ひょうきが ながすぎます"
 
 #: planet/js/Publisher.js:31
-msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
+msgid ""
+"Feature unavailable - cannot connect to server. Reload Music Blocks to try "
+"again."
 msgstr "エラー：サーバに せつぞく できません。ブラウザを さいきどう して、さいど ためしてください。"
 
-#: planet/js/Publisher.js:216
-#: planet/js/Publisher.js:233
+#: planet/js/Publisher.js:216 planet/js/Publisher.js:233
 msgid "This field is required"
 msgstr "この こうもくは ひっすこうもく です"
 
@@ -9501,13 +9237,11 @@ msgstr "プロジェクト けんさく"
 msgid "Tags (max 5)"
 msgstr "タッグ（さいだい５こ）"
 
-#: planet/js/StringHelper.js:40
-#: planet/js/StringHelper.js:63
+#: planet/js/StringHelper.js:40 planet/js/StringHelper.js:63
 msgid "Description"
 msgstr "きにゅう"
 
-#: planet/js/StringHelper.js:41
-#: planet/js/StringHelper.js:74
+#: planet/js/StringHelper.js:41 planet/js/StringHelper.js:74
 msgid "Submit"
 msgstr "かくにん"
 
@@ -9523,8 +9257,7 @@ msgstr "プロジェクト「<span id=\"deleter-name\"></span>」をかんぜん
 msgid "Explore Projects"
 msgstr "プロジェクトを さがす"
 
-#: planet/js/StringHelper.js:51
-#: planet/js/helper.js:149
+#: planet/js/StringHelper.js:51 planet/js/helper.js:149
 msgid "Show more tags"
 msgstr "タッグを もっと みる"
 
@@ -9573,8 +9306,15 @@ msgid "Tags:"
 msgstr "タッグ"
 
 #: planet/js/StringHelper.js:69
-msgid "Report projects which violate the <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs Code of Conduct</a>."
-msgstr "<a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs こうどうきはん</a>にいはんするプロジェクトをほうこくします。"
+msgid ""
+"Report projects which violate the <a "
+"href=\"https://github.com/sugarlabs/sugar-"
+"docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Sugar Labs Code of Conduct</a>."
+msgstr ""
+"<a href=\"https://github.com/sugarlabs/sugar-"
+"docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Sugar Labs こうどうきはん</a>にいはんするプロジェクトをほうこくします。"
 
 #: planet/js/StringHelper.js:73
 msgid "Reason for reporting project"
@@ -9780,8 +9520,7 @@ msgstr "赤外光 （右）"
 msgid "move"
 msgstr "動き出し"
 
-#: plugins/weather.rtp:68
-#: plugins/weather.rtp:97
+#: plugins/weather.rtp:68 plugins/weather.rtp:97
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "日にちは -１から５までの数でなくてはなりません"
 
@@ -9789,15 +9528,11 @@ msgstr "日にちは -１から５までの数でなくてはなりません"
 msgid "forecast"
 msgstr "天気予報"
 
-#: plugins/weather.rtp:123
-#: plugins/weather.rtp:137
-#: plugins/weather.rtp:150
+#: plugins/weather.rtp:123 plugins/weather.rtp:137 plugins/weather.rtp:150
 msgid "city"
 msgstr "市"
 
-#: plugins/weather.rtp:124
-#: plugins/weather.rtp:138
-#: plugins/weather.rtp:151
+#: plugins/weather.rtp:124 plugins/weather.rtp:138 plugins/weather.rtp:151
 msgid "day"
 msgstr "曜日"
 
@@ -9809,138 +9544,90 @@ msgstr "高"
 msgid "low"
 msgstr "低"
 
-#: js/utils/utils-logic.js:324
+#~ msgid "Invalid input passed to rationalSum"
+#~ msgstr ""
 
-#~msgid "Invalid input passed to rationalSum"
-#~msgstr ""
+#~ msgid "Save recording"
+#~ msgstr "ろくおんをほぞんする"
 
-#: js/activity.js:2014 js/activity.js:2092
+#~ msgid "File save canceled"
+#~ msgstr "ファイルのほぞんがきゃんせるされました"
 
-#~msgid "Save recording"
-#~msgstr "ろくおんをほぞんする"
+#~ msgid "Recorded file is empty. File not saved."
+#~ msgstr "ろくおんされたファイルはそらです。ファイルがほぞんされていません。"
 
-#: js/activity.js:2021 js/activity.js:2071
+#~ msgid "Enter file name"
+#~ msgstr "ファイルめいをにゅうりょくしてください"
 
-#~msgid "File save canceled"
-#~msgstr "ファイルのほぞんがきゃんせるされました"
+#~ msgid "Saved! Check your Downloads folder."
+#~ msgstr "ほぞんしました！ダウンロードふぉるだーをかくにんしてください。"
 
-#: js/activity.js:2042 js/activity.js:2052
+#~ msgid "Recording stopped. File saved."
+#~ msgstr "ろくおんがていしされました。ファイルがほぞんされました。"
 
-#~msgid "Recorded file is empty. File not saved."
-#~msgstr "ろくおんされたファイルはそらです。ファイルがほぞんされていません。"
+#~ msgid "recording"
+#~ msgstr "ろくおんちゅう"
 
-#: js/activity.js:2069 js/activity.js:2099
+#~ msgid "Recording started. Click stop to finish."
+#~ msgstr "ろくおんがかいしされました。しゅうりょうするには「ていし」をクリックします。"
 
-#~msgid "Enter file name"
-#~msgstr "ファイルめいをにゅうりょくしてください"
+#~ msgid "Recording failed: %s"
+#~ msgstr "ろくおんにしっぱいしました: %s"
 
-#: js/activity.js:2082
+#~ msgid "show Cartesian"
+#~ msgstr "ほうがん（ざひょう）を ひょうじ"
 
-#~msgid "Saved! Check your Downloads folder."
-#~msgstr "ほぞんしました！ダウンロードふぉるだーをかくにんしてください。"
+#~ msgid "output tools"
+#~ msgstr "しゅつりょくつーる"
 
-#: js/activity.js:2089
+#~ msgid "custom note"
+#~ msgstr "カスタムピッチ"
 
-#~msgid "Recording stopped. File saved."
-#~msgstr "ろくおんがていしされました。ファイルがほぞんされました。"
+#~ msgid "accidental name"
+#~ msgstr "ぐうぜんのなまえ"
 
-#: js/activity.js:2094
+#~ msgid "chord name"
+#~ msgstr "chord name"
 
-#~msgid "recording"
-#~msgstr "ろくおんちゅう"
+#~ msgid "filter type"
+#~ msgstr "ふぃるたーのしゅるい"
 
-#: js/activity.js:2131
+#~ msgid "oscillator type"
+#~ msgstr "はっしんきのしゅるい"
 
-#~msgid "Recording started. Click stop to finish."
-#~msgstr "ろくおんがかいしされました。しゅうりょうするには「ていし」をクリックします。"
+#~ msgid "wrap mode"
+#~ msgstr "らっぷモード"
 
-#: js/activity.js:2211
+#~ msgid "load file"
+#~ msgstr "ろーど ファイル "
 
-#~msgid "Recording failed: %s"
-#~msgstr "ろくおんにしっぱいしました: %s"
+#~ msgid "This block is deprecated."
+#~ msgstr "この ブロックは もう ありません。"
 
-#: js/activity.js:2671
+#~ msgid "Block cannot be found."
+#~ msgstr "ブロックが みつかりません。"
 
-#~msgid "show Cartesian"
-#~msgstr "ほうがん（ざひょう）を ひょうじ"
+#~ msgid ""
+#~ "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores "
+#~ "are allowed."
+#~ msgstr "ぷらぐいんめいがむこうです。えいすうじ、はいふん、あんだーすこあのみがしようできます。"
 
-#: js/activity.js:3340
+#~ msgid "You can type d to create a do block and r to create a re block etc."
+#~ msgstr ""
+#~ "キーボードの ショートカット<br><br>キーボードを つかうと、 パレットボタンから ブロックを ドラッグして はいち するだけでなく、 ボタンを "
+#~ "おすだけで ちょくせつ ブロックを おくことが できる。<br><br>★ショートカットキー<br> d …… "
+#~ "「ド」（４ぶおんぷ、４オクターヴ）<br> r …… 「レ」（４ぶおんぷ、４オクターヴ）<br> m …… 「ミ」（４ぶおんぷ、４オクターヴ）<br> "
+#~ "f …… 「ファ」（４ぶおんぷ、４オクターヴ）<br> s …… 「ソ」（４ぶおんぷ、４オクターヴ）<br> l …… "
+#~ "「ラ」（４ぶおんぷ、４オクターヴ）<br> t …… 「シ」（４ぶおんぷ、４オクターヴ）"
 
-#~msgid "output tools"
-#~msgstr "しゅつりょくつーる"
+#~ msgid "Select is enabled."
+#~ msgstr "せんたくモードがゆうこうです。"
 
-#: js/activity.js:3343
+#~ msgid "Select is disabled."
+#~ msgstr "せんたくモードがむこうです。"
 
-#~msgid "custom note"
-#~msgstr "カスタムピッチ"
+#~ msgid "Error regenerating palettes. Please refresh the page."
+#~ msgstr "パレットのさいせいせいにしっぱいしました。ページをこうしんしてください。"
 
-#: js/activity.js:3346
-
-#~msgid "accidental name"
-#~msgstr "ぐうぜんのなまえ"
-
-#: js/activity.js:3361
-
-#~msgid "chord name"
-#~msgstr "chord name"
-
-#: js/activity.js:3367
-
-#~msgid "filter type"
-#~msgstr "ふぃるたーのしゅるい"
-
-#: js/activity.js:3370
-
-#~msgid "oscillator type"
-#~msgstr "はっしんきのしゅるい"
-
-#: js/activity.js:3385
-
-#~msgid "wrap mode"
-#~msgstr "らっぷモード"
-
-#: js/activity.js:3388
-
-#~msgid "load file"
-#~msgstr "ろーど ファイル "
-
-#: js/activity.js:3717 js/activity.js:7467
-
-#~msgid "This block is deprecated."
-#~msgstr "この ブロックは もう ありません。"
-
-#: js/activity.js:3719 js/activity.js:7469
-
-#~msgid "Block cannot be found."
-#~msgstr "ブロックが みつかりません。"
-
-#: js/activity.js:7080
-
-#~msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
-#~msgstr "ぷらぐいんめいがむこうです。えいすうじ、はいふん、あんだーすこあのみがしようできます。"
-
-#: js/activity.js:7586
-
-#~msgid "You can type d to create a do block and r to create a re block etc."
-#~msgstr "キーボードの ショートカット<br><br>キーボードを つかうと、 パレットボタンから ブロックを ドラッグして はいち するだけでなく、 ボタンを おすだけで ちょくせつ ブロックを おくことが できる。<br><br>★ショートカットキー<br> d …… 「ド」（４ぶおんぷ、４オクターヴ）<br> r …… 「レ」（４ぶおんぷ、４オクターヴ）<br> m …… 「ミ」（４ぶおんぷ、４オクターヴ）<br> f …… 「ファ」（４ぶおんぷ、４オクターヴ）<br> s …… 「ソ」（４ぶおんぷ、４オクターヴ）<br> l …… 「ラ」（４ぶおんぷ、４オクターヴ）<br> t …… 「シ」（４ぶおんぷ、４オクターヴ）"
-
-#: js/activity.js:8099
-
-#~msgid "Select is enabled."
-#~msgstr "せんたくモードがゆうこうです。"
-
-#: js/activity.js:8100
-
-#~msgid "Select is disabled."
-#~msgstr "せんたくモードがむこうです。"
-
-#: js/activity.js:9291
-
-#~msgid "Error regenerating palettes. Please refresh the page."
-#~msgstr "パレットのさいせいせいにしっぱいしました。ページをこうしんしてください。"
-
-#: js/widgets/sampler.js:615
-
-#~msgid "Trim"
-#~msgstr "とりむ"
-
+#~ msgid "Trim"
+#~ msgstr "とりむ"

--- a/po/ja-kana.po
+++ b/po/ja-kana.po
@@ -1725,9 +1725,7 @@ msgstr "えらばれた おんめいが てきせつでは ありません。"
 
 #: js/logoconstants.js:44
 msgid "Pitch index exceeds EDO range"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "ぴっちいんでっくすが へいきんりつ はんいをこえています。"
 
 #: js/project-manager.js:60
 msgid "Catching mice"
@@ -1795,9 +1793,7 @@ msgstr "プロジェクトを よみこめません。 ファイルの しゅる
 
 #: js/project-manager.js:787 js/project-manager.js:902
 msgid "Cannot find project data in this HTML file."
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "このHTMLふぁいるないにぷろじぇくとでーたがみつかりません。"
 
 #: js/project-manager.js:1076
 msgid "Something went wrong reading JSON-encoded project data."
@@ -2386,9 +2382,7 @@ msgstr "ぶろっくがごみはこにおくられる"
 
 #: js/svgAssetSelector.js:63
 msgid "Choose an image"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "がぞうをせんたくしてください"
 
 #: js/svgAssetSelector.js:83
 msgid "Built-in images"
@@ -2408,9 +2402,7 @@ msgstr "PNG、JPG、SVG、GIF、そのほかのがぞうけいしきをさぽー
 
 #: js/svgAssetSelector.js:176
 msgid "Apply"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "てきようする"
 
 #: js/utils/utils-logic.js:324
 msgid "Invalid input passed to rational sum"
@@ -3275,9 +3267,7 @@ msgstr "7へいきんりつ"
 
 #: js/utils/musicutils.js:1948 js/utils/musicutils.js:1965
 msgid "Equal (17EDO)"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "17へいきんりつ"
 
 #: js/utils/musicutils.js:1949 js/utils/musicutils.js:1966
 msgid "Equal (19EDO)"
@@ -7766,9 +7756,7 @@ msgstr "ベジェきょくせん"
 
 #: js/blocks/GraphicsBlocks.js:589
 msgid "The Arc block moves the mouse in an arc."
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "あーぶろっくは、まうすをえんこじょうにうごかします。"
 
 #: js/blocks/GraphicsBlocks.js:596
 msgid "The Arc block moves the turtle in an arc."
@@ -7981,9 +7969,7 @@ msgstr "と"
 
 #: js/turtleactions/IntervalsActions.js:192
 msgid "steps"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "てじゅん"
 
 #: js/turtleactions/IntervalsActions.js:311
 msgid "Adding missing pitch number 0."
@@ -8182,9 +8168,7 @@ msgstr "あたらしいおんせいをせいせいしています..."
 
 #: js/turtleactions/RhythmActions.js:151
 msgid "Neighbor note value is too large for the current note duration."
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "ねいばーのーとのあたいが、げんざいのおんぷのながさにくらべておおきすぎます。"
 
 #: js/widgets/jseditor.js:393
 msgid "Reset Code"
@@ -8265,9 +8249,7 @@ msgstr "さーばー エラー: AI ばっくえんどにせつぞくできませ
 msgid ""
 "Could not reach the AI assistant. Please check your connection and try "
 "again."
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "AIあしすたんとにせつぞくできませんでした。せつぞくじょうきょうをかくにんし、もういちどおためしください。"
 
 #: js/widgets/aidebugger.js:552
 msgid "Before we start"
@@ -8448,9 +8430,7 @@ msgstr "がぞうがせいじょうにプラグインされました"
 
 #: js/widgets/legobricks.js:1323
 msgid "Photo captured"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "しゃしんをさつえいしました"
 
 #: js/widgets/legobricks.js:1328
 msgid "Webcam started"
@@ -8820,9 +8800,7 @@ msgstr "はんぷく"
 
 #: js/widgets/temperament.js:1300
 msgid "Please enter a valid ratio (e.g. 3:2) within the octave space."
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "おくたーぶのはんいないで、ゆうこうなひりつ（れい：3:2）をにゅうりょくしてください。"
 
 #: js/widgets/temperament.js:1832
 msgid "The octave ratio has changed. This changes temperament significantly."
@@ -8886,9 +8864,7 @@ msgstr "ぷろんぷと"
 
 #: js/widgets/sampler.js:732
 msgid "AI Sample Generation"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "AIによるさんぷるせいせい"
 
 #: js/widgets/sampler.js:798
 msgid "Generating audio... (It may take up to 1 minute)"
@@ -8944,15 +8920,11 @@ msgstr "スタート"
 
 #: js/widgets/sampler.js:2251
 msgid "Detected Pitch:"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "けんしゅつされたぴっち:"
 
 #: js/widgets/sampler.js:2260
 msgid "Note:"
-msgstr ""
-"Error 500 (Server Error)!!1500.That’s an error.There was an error. Please "
-"try again later.That’s all we know."
+msgstr "おんぷ:"
 
 #: js/widgets/timbre.js:839
 msgid "Synthesizer"

--- a/po/ja.po
+++ b/po/ja.po
@@ -46,158 +46,8 @@ msgstr ""
 #: planet/js/GlobalPlanet.js:467
 #: planet/js/GlobalPlanet.js:495
 #: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/SaveInterface.js:25
-#: js/activity.js:5337
-#: js/activity.js:5341
-#: js/activity.js:6060
-#: planet/js/ProjectStorage.js:26
-#: planet/js/GlobalPlanet.js:465
-#: planet/js/GlobalPlanet.js:467
-#: planet/js/GlobalPlanet.js:495
-#: js/macros.js:170
-#: js/macros.js:266
-#: js/macros.js:267
-#: js/macros.js:276
-#: js/macros.js:828
-#: js/palette.js:1202
-#: js/palette.js:1211
-#: js/palette.js:1220
-#: js/palette.js:1229
-#: js/palette.js:1857
-#: js/palette.js:1868
-#: js/palette.js:1879
-#: js/palette.js:1890
-#: js/palette.js:1909
-#: js/turtledefs.js:131
-#: js/turtledefs.js:229
-#: js/rubrics.js:540
-#: js/block.js:1667
-#: js/block.js:4869
-#: js/blocks.js:1286
-#: js/blocks.js:2984
-#: js/blocks.js:2985
-#: js/blocks.js:3158
-#: js/blocks.js:3574
-#: js/blocks.js:3759
-#: js/blocks.js:4988
-#: js/blocks.js:6243
-#: js/blocks/MeterBlocks.js:750
-#: js/blocks/MeterBlocks.js:803
-#: js/blocks/MeterBlocks.js:866
-#: js/blocks/MeterBlocks.js:927
-#: js/blocks/ActionBlocks.js:251
-#: js/blocks/ActionBlocks.js:328
-#: js/blocks/ActionBlocks.js:639
-#: js/blocks/ActionBlocks.js:739
-#: js/blocks/ActionBlocks.js:984
-#: js/blocks/ActionBlocks.js:1071
-#: js/blocks/ActionBlocks.js:1351
-#: js/blocks/ActionBlocks.js:1354
-#: js/blocks/ActionBlocks.js:1366
-#: js/blocks/ActionBlocks.js:1432
-#: js/widgets/phrasemaker.js:4684
-#: js/widgets/rhythmruler.js:2514
-#: js/widgets/rhythmruler.js:2521
-#: js/widgets/rhythmruler.js:2706
-#: js/widgets/rhythmruler.js:2713
-#: js/widgets/musickeyboard.js:3344
-#: js/macros.js:170
-#: js/macros.js:266
-#: js/macros.js:267
-#: js/macros.js:276
-#: js/macros.js:828
-#: js/palette.js:1202
-#: js/palette.js:1211
-#: js/palette.js:1220
-#: js/palette.js:1229
-#: js/palette.js:1857
-#: js/palette.js:1868
-#: js/palette.js:1879
-#: js/palette.js:1890
-#: js/palette.js:1909
-#: js/turtledefs.js:131
-#: js/turtledefs.js:229
-#: js/rubrics.js:540
-#: js/block.js:1667
-#: js/block.js:4869
-#: js/blocks.js:1286
-#: js/blocks.js:2984
-#: js/blocks.js:2985
-#: js/blocks.js:3158
-#: js/blocks.js:3574
-#: js/blocks.js:3759
-#: js/blocks.js:4988
-#: js/blocks.js:6243
-#: js/blocks/MeterBlocks.js:750
-#: js/blocks/MeterBlocks.js:803
-#: js/blocks/MeterBlocks.js:866
-#: js/blocks/MeterBlocks.js:927
-#: js/blocks/ActionBlocks.js:251
-#: js/blocks/ActionBlocks.js:328
-#: js/blocks/ActionBlocks.js:639
-#: js/blocks/ActionBlocks.js:739
-#: js/blocks/ActionBlocks.js:984
-#: js/blocks/ActionBlocks.js:1071
-#: js/blocks/ActionBlocks.js:1351
-#: js/blocks/ActionBlocks.js:1354
-#: js/blocks/ActionBlocks.js:1366
-#: js/blocks/ActionBlocks.js:1432
-#: js/widgets/phrasemaker.js:4684
-#: js/widgets/rhythmruler.js:2514
-#: js/widgets/rhythmruler.js:2521
-#: js/widgets/rhythmruler.js:2706
-#: js/widgets/rhythmruler.js:2713
-#: js/widgets/musickeyboard.js:3344
 msgid "action"
 msgstr "アクション"
-
 
 #: js/macros.js:711
 #: js/utils/musicutils.js:1443
@@ -205,7 +55,6 @@ msgstr "アクション"
 #. TRANS: animal sound effect
 msgid "duck"
 msgstr "あひる"
-
 
 #: js/turtle-painter.js:1361
 #: js/turtle-painter.js:1362
@@ -220,11 +69,9 @@ msgstr "あひる"
 msgid "start"
 msgstr "スタート"
 
-
 #: js/keyboard-controller.js:165
 msgid "Saving block artwork"
 msgstr "ブロックのアートを保存中"
-
 
 #: js/keyboard-controller.js:169
 #: js/turtledefs.js:644
@@ -232,11 +79,9 @@ msgstr "ブロックのアートを保存中"
 msgid "Copy"
 msgstr "コピー"
 
-
 #: js/keyboard-controller.js:173
 msgid "Erase"
 msgstr "消す"
-
 
 #: js/keyboard-controller.js:178
 #: js/turtledefs.js:430
@@ -300,7 +145,6 @@ msgstr "消す"
 msgid "Play"
 msgstr "実行"
 
-
 #: js/keyboard-controller.js:209
 #: js/turtledefs.js:435
 #: js/turtledefs.js:471
@@ -334,93 +178,75 @@ msgstr "実行"
 msgid "Stop"
 msgstr "停止"
 
-
 #: js/keyboard-controller.js:213
 #: js/keyboard-controller.js:243
 msgid "Paste"
 msgstr "貼り付け"
 
-
 #: js/keyboard-controller.js:217
 msgid "Save block help"
 msgstr "ブロックの ヘルプを 保存"
-
 
 #: js/keyboard-controller.js:285
 msgid "Jumping to the bottom of the page."
 msgstr "画面の下にジャンプしています"
 
-
 #: js/keyboard-controller.js:291
 msgid "Scrolling up."
 msgstr "上にスクロールしています"
-
 
 #: js/keyboard-controller.js:296
 msgid "Scrolling down."
 msgstr "下にスクロールしています"
 
-
 #: js/keyboard-controller.js:301
 msgid "Extracting block"
 msgstr "ブロックを取り出しています"
-
 
 #: js/keyboard-controller.js:309
 msgid "Moving block up."
 msgstr "ブロックを上に動かしています"
 
-
 #: js/keyboard-controller.js:330
 msgid "Moving block down."
 msgstr "ブロックを下に動かしています"
-
 
 #: js/keyboard-controller.js:352
 msgid "Moving block left."
 msgstr "ブロックを左に動かしています"
 
-
 #: js/keyboard-controller.js:369
 msgid "Moving block right."
 msgstr "ブロックを右に動かしています"
 
-
 #: js/keyboard-controller.js:384
 msgid "Jump to home position."
 msgstr "まんなかにジャンプする"
-
 
 #: js/keyboard-controller.js:404
 #: js/blocks/ExtrasBlocks.js:276
 msgid "Hide blocks"
 msgstr "ブロックを非表示"
 
-
 #: js/languagebox.js:293
 msgid "Refresh your browser to change your language preference."
 msgstr "言語を変えるには、ブラウザをこうしんしてください。"
-
 
 #: js/languagebox.js:329
 msgid "Music Blocks is already set to this language."
 msgstr " Music Blocksは既にこの言語に設定されています。"
 
-
 #: js/palette.js:624
 msgid "Block Palettes"
 msgstr "ブロックパレット"
-
 
 #: js/palette.js:635
 msgid "Palette Categories"
 msgstr "パレットのカテゴリ"
 
-
 #: js/palette.js:656
 msgid "Toggle Palette"
 msgstr "パレットの切り替え"
-
 
 #: js/palette.js:1184
 #: js/palette.js:1313
@@ -439,13 +265,11 @@ msgstr "パレットの切り替え"
 msgid "box"
 msgstr "箱"
 
-
 #: js/palette.js:1246
 #: js/turtledefs.js:674
 #: js/turtles.js:992
 msgid "Grid"
 msgstr "グリッド"
-
 
 #: js/palette.js:1249
 #: js/blocks.js:2739
@@ -453,7 +277,6 @@ msgstr "グリッド"
 #: js/blocks/MediaBlocks.js:1046
 msgid "text"
 msgstr "文字そざい"
-
 
 #: js/palette.js:1252
 #: js/turtledefs.js:129
@@ -470,16 +293,13 @@ msgstr "文字そざい"
 msgid "drum"
 msgstr "ドラム"
 
-
 #: js/palette.js:1255
 msgid "effect"
 msgstr "こうかおん"
 
-
 #: js/palette.js:1261
 msgid "sargam"
 msgstr "Sargam (インドの ソルファ)"
-
 
 #: js/palette.js:1264
 #: js/blocks/PitchBlocks.js:467
@@ -489,27 +309,22 @@ msgstr "Sargam (インドの ソルファ)"
 msgid "scale degree"
 msgstr "音度"
 
-
 #: js/palette.js:1267
 msgid "mode name"
 msgstr "モード名"
-
 
 #: js/palette.js:1270
 msgid "invert mode"
 msgstr "モードを反転させる"
 
-
 #: js/palette.js:1273
 msgid "voice name"
 msgstr "音名"
-
 
 #: js/palette.js:1276
 #: js/blocks/PitchBlocks.js:1257
 msgid "custom pitch"
 msgstr "カスタムピッチ"
-
 
 #: js/palette.js:1280
 #: js/block.js:1674
@@ -519,16 +334,13 @@ msgstr "カスタムピッチ"
 msgid "temperament"
 msgstr "音律"
 
-
 #: js/palette.js:1284
 msgid "accidental"
 msgstr "変化記号"
 
-
 #: js/palette.js:1290
 msgid "interval name"
 msgstr "音程名"
-
 
 #: js/palette.js:1293
 #: js/block.js:4223
@@ -549,12 +361,10 @@ msgstr "音程名"
 msgid "true"
 msgstr "真"
 
-
 #: js/palette.js:1308
 #: js/blocks/PitchBlocks.js:425
 msgid "pitch converter"
 msgstr "音の高さを調節"
-
 
 #: js/palette.js:1314
 #: js/palette.js:1319
@@ -564,7 +374,6 @@ msgstr "音の高さを調節"
 msgid "store in"
 msgstr "入れる"
 
-
 #: js/palette.js:1316
 #: js/palette.js:1317
 #: js/blocks.js:2937
@@ -572,13 +381,11 @@ msgstr "入れる"
 msgid "store in box"
 msgstr "箱にほぞん"
 
-
 #: js/palette.js:1328
 #: js/blocks.js:1929
 #: js/blocks/MediaBlocks.js:686
 msgid "open file"
 msgstr "ファイルを開く"
-
 
 #: js/palette.js:1555
 #: js/piemenu-block-context.js:103
@@ -592,33 +399,27 @@ msgstr "ファイルを開く"
 msgid "Close"
 msgstr "閉じる"
 
-
 #: js/themebox.js:391
 msgid "Theme switched to %s mode."
 msgstr "テーマが %s モードに切り替わりました。"
 
-
 #: js/themebox.js:584
 msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocksはすでにこのテーマに設定されています。"
-
 
 #: js/turtledefs.js:43
 #. TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
 msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
 
-
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"
 msgstr "タートル・ブロックス"
-
 
 #: js/turtledefs.js:121
 #: js/turtledefs.js:219
 msgid "search"
 msgstr "検索"
-
 
 #: js/turtledefs.js:122
 #: js/turtledefs.js:220
@@ -635,7 +436,6 @@ msgstr "検索"
 msgid "rhythm"
 msgstr "音符"
 
-
 #: js/turtledefs.js:123
 #: js/turtledefs.js:221
 #: js/blocks/MeterBlocks.js:1391
@@ -643,7 +443,6 @@ msgstr "音符"
 #. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "拍子"
-
 
 #: js/turtledefs.js:124
 #: js/turtledefs.js:222
@@ -660,12 +459,10 @@ msgstr "拍子"
 msgid "pitch"
 msgstr "音の高さ"
 
-
 #: js/turtledefs.js:125
 #: js/turtledefs.js:223
 msgid "intervals"
 msgstr "音程"
-
 
 #: js/turtledefs.js:126
 #: js/turtledefs.js:224
@@ -673,12 +470,10 @@ msgstr "音程"
 msgid "tone"
 msgstr "音色"
 
-
 #: js/turtledefs.js:127
 #: js/turtledefs.js:225
 msgid "ornament"
 msgstr "そうしょく"
-
 
 #: js/turtledefs.js:128
 #: js/turtledefs.js:226
@@ -689,25 +484,21 @@ msgstr "そうしょく"
 msgid "volume"
 msgstr "音量"
 
-
 #: js/turtledefs.js:130
 #: js/turtledefs.js:228
 #: js/rubrics.js:539
 msgid "flow"
 msgstr "実行手順"
 
-
 #: js/turtledefs.js:132
 #: js/turtledefs.js:230
 msgid "boxes"
 msgstr "数の箱"
 
-
 #: js/turtledefs.js:133
 #: js/turtledefs.js:231
 msgid "widgets"
 msgstr "ツール"
-
 
 #: js/turtledefs.js:134
 #: js/turtledefs.js:232
@@ -715,14 +506,12 @@ msgstr "ツール"
 msgid "graphics"
 msgstr "ネズミの動き"
 
-
 #: js/turtledefs.js:135
 #: js/turtledefs.js:233
 #: js/rubrics.js:537
 #: js/widgets/phrasemaker.js:1290
 msgid "pen"
 msgstr "ペン"
-
 
 #: js/turtledefs.js:136
 #: js/turtledefs.js:234
@@ -733,12 +522,10 @@ msgstr "ペン"
 msgid "number"
 msgstr "すうち"
 
-
 #: js/turtledefs.js:137
 #: js/turtledefs.js:235
 msgid "boolean"
 msgstr "比べる"
-
 
 #: js/turtledefs.js:138
 #: js/turtledefs.js:236
@@ -749,7 +536,6 @@ msgstr "比べる"
 msgid "media"
 msgstr "メディア"
 
-
 #: js/turtledefs.js:139
 #: js/turtledefs.js:237
 #: js/rubrics.js:541
@@ -758,14 +544,12 @@ msgstr "メディア"
 msgid "sensors"
 msgstr "センサー"
 
-
 #: js/turtledefs.js:140
 #: js/turtledefs.js:238
 #: js/blocks/HeapBlocks.js:59
 #: js/widgets/status.js:150
 msgid "heap"
 msgstr "ヒープ"
-
 
 #: js/turtledefs.js:141
 #: js/turtledefs.js:239
@@ -774,18 +558,15 @@ msgstr "ヒープ"
 msgid "dictionary"
 msgstr "辞書"
 
-
 #: js/turtledefs.js:142
 #: js/turtledefs.js:240
 msgid "ensemble"
 msgstr "合奏"
 
-
 #: js/turtledefs.js:143
 #: js/turtledefs.js:241
 msgid "extras"
 msgstr "その他"
-
 
 #: js/turtledefs.js:145
 #: js/turtledefs.js:242
@@ -793,24 +574,20 @@ msgstr "その他"
 msgid "program"
 msgstr "プログラム"
 
-
 #: js/turtledefs.js:146
 #: js/turtledefs.js:243
 msgid "my blocks"
 msgstr "自分のブロック"
-
 
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
 msgid "artwork"
 msgstr "アート"
 
-
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
 msgid "logic"
 msgstr "論理"
-
 
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
@@ -819,21 +596,17 @@ msgstr "論理"
 msgid "Music"
 msgstr "音楽"
 
-
 #: js/turtledefs.js:187
 msgid "Music Blocks"
 msgstr "ミュージック・ブロックス"
-
 
 #: js/turtledefs.js:423
 msgid "Welcome to Turtle Blocks"
 msgstr "タートル・ブロックへようこそ"
 
-
 #: js/turtledefs.js:424
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr "タートル・ブロックスはアートと数学を求めるビジュアル・プログラミング言語だ。"
-
 
 #: js/turtledefs.js:426
 #: js/turtledefs.js:446
@@ -841,7 +614,6 @@ msgstr "タートル・ブロックスはアートと数学を求めるビジュ
 #: js/turtledefs.js:780
 msgid "The current version is"
 msgstr "ミュージック・ブロックスの最新バージョンは"
-
 
 #: js/turtledefs.js:430
 #: js/turtledefs.js:466
@@ -912,12 +684,10 @@ msgstr "ミュージック・ブロックスの最新バージョンは"
 msgid "Play"
 msgstr "実行"
 
-
 #: js/turtledefs.js:431
 #: js/turtledefs.js:467
 msgid "Click the run button to run the project in fast mode."
 msgstr "クリックをすると、ふつうのスピードでプログラムを実行することができる。"
-
 
 #: js/turtledefs.js:435
 #: js/turtledefs.js:471
@@ -952,49 +722,40 @@ msgstr "クリックをすると、ふつうのスピードでプログラムを
 msgid "Stop"
 msgstr "停止"
 
-
 #: js/turtledefs.js:436
 msgid "Stop the turtle."
 msgstr "タータルを止める"
-
 
 #: js/turtledefs.js:436
 #: js/turtledefs.js:472
 msgid "You can also type Alt-S to stop."
 msgstr "プログラムは、このボタンをおすかわりに、キーボードで「Altキーと Sキーの同時おし」でも止めることができる。"
 
-
 #: js/turtledefs.js:443
 #: js/widgets/help.js:547
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへようこそ"
 
-
 #: js/turtledefs.js:444
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr "音楽と算数とプログラミングをむすびつけ、深く楽しむことができるツール。それが、ミュージック・ブロックスだ。"
-
 
 #: js/turtledefs.js:450
 #: js/widgets/help.js:548
 msgid "Meet Mr. Mouse!"
 msgstr "ミスター・マウスに会おう！"
 
-
 #: js/turtledefs.js:451
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr "ミスター・マウスは、ミュージック・ブロックスの指揮者。"
-
 
 #: js/turtledefs.js:453
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr "ミスター・マウスと一緒に、ミュージック・ブロックスの世界をたんきゅうしよう。"
 
-
 #: js/turtledefs.js:455
 msgid "Let us start our tour!"
 msgstr "では、ツアーを始めよう。"
-
 
 #: js/turtledefs.js:459
 #: js/turtledefs.js:737
@@ -1002,16 +763,13 @@ msgstr "では、ツアーを始めよう。"
 msgid "Guide"
 msgstr "もっとくわしく知るには"
 
-
 #: js/turtledefs.js:460
 msgid "A detailed guide to Music Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
-
 #: js/turtledefs.js:472
 msgid "Stop the music (and the mice)."
 msgstr "実行しているプログラムを止める。"
-
 
 #: js/turtledefs.js:479
 #: js/toolbar.js:122
@@ -1021,11 +779,9 @@ msgstr "実行しているプログラムを止める。"
 msgid "Record"
 msgstr "録音"
 
-
 #: js/turtledefs.js:480
 msgid "Record your project as video."
 msgstr "再生されているビデオを録音する"
-
 
 #: js/turtledefs.js:485
 #: js/toolbar.js:125
@@ -1035,11 +791,9 @@ msgstr "再生されているビデオを録音する"
 msgid "Toggle Fullscreen"
 msgstr "フルスクリーンの切り替え"
 
-
 #: js/turtledefs.js:486
 msgid "Toggle Fullscreen mode."
 msgstr "フルスクリーンの切り替え"
-
 
 #: js/turtledefs.js:490
 #: js/toolbar.js:126
@@ -1051,11 +805,9 @@ msgstr "フルスクリーンの切り替え"
 msgid "New project"
 msgstr "新しいプロジェクト"
 
-
 #: js/turtledefs.js:491
 msgid "Initialize a new project."
 msgstr "新しいプロジェクトを作る。"
-
 
 #: js/turtledefs.js:495
 #: js/toolbar.js:127
@@ -1065,11 +817,9 @@ msgstr "新しいプロジェクトを作る。"
 msgid "Load project from file"
 msgstr "プロジェクトを読みこむ"
 
-
 #: js/turtledefs.js:496
 msgid "You can also load projects from the file system."
 msgstr "コンピューターに保存してあるファイルから、ミュージック・ブロックスのプロジェクトを読み込んで開く。"
-
 
 #: js/turtledefs.js:501
 #: js/turtledefs.js:509
@@ -1081,7 +831,6 @@ msgstr "コンピューターに保存してあるファイルから、ミュー
 #: js/toolbar.js:323
 msgid "Save project"
 msgstr "プロジェクトをほぞん"
-
 
 #: js/turtledefs.js:502
 #: js/turtledefs.js:529
@@ -1100,7 +849,6 @@ msgstr "プロジェクトをほぞん"
 msgid "Save project as HTML"
 msgstr "HTMLをほぞん"
 
-
 #: js/turtledefs.js:502
 #: js/toolbar.js:155
 #: js/toolbar.js:159
@@ -1108,11 +856,9 @@ msgstr "HTMLをほぞん"
 msgid "Save mouse artwork as PNG"
 msgstr "PNGでほぞん"
 
-
 #: js/turtledefs.js:511
 msgid "Save your project to a file."
 msgstr "げんざい開いているプロジェクトをほぞんする。"
-
 
 #: js/turtledefs.js:513
 #: js/toolbar.js:240
@@ -1121,11 +867,9 @@ msgstr "げんざい開いているプロジェクトをほぞんする。"
 msgid "Save turtle artwork as SVG"
 msgstr "アートをSVGで保存"
 
-
 #: js/turtledefs.js:515
 msgid "Save graphics from your project to as SVG."
 msgstr "プロジェクトのグラフィックをSVGで保存"
-
 
 #: js/turtledefs.js:517
 #: js/toolbar.js:238
@@ -1137,11 +881,9 @@ msgstr "プロジェクトのグラフィックをSVGで保存"
 msgid "Save turtle artwork as PNG"
 msgstr "アートをPNGで保存"
 
-
 #: js/turtledefs.js:519
 msgid "Save graphics from your project as PNG."
 msgstr "プロジェクトのグラフィックをPNGで保存"
-
 
 #: js/turtledefs.js:521
 #: js/toolbar.js:164
@@ -1152,11 +894,9 @@ msgstr "プロジェクトのグラフィックをPNGで保存"
 msgid "Save block artwork as SVG"
 msgstr "ブロックのアートをほぞん"
 
-
 #: js/turtledefs.js:523
 msgid "Save block artwork as an SVG file."
 msgstr "ブロックのグラフィックをSVGで保存"
-
 
 #: js/turtledefs.js:531
 #: js/toolbar.js:157
@@ -1164,48 +904,39 @@ msgstr "ブロックのグラフィックをSVGで保存"
 msgid "Save project as MIDI"
 msgstr "プロジェクトをMIDIとして保存"
 
-
 #: js/turtledefs.js:533
 #: js/toolbar.js:160
 #: js/toolbar.js:230
 msgid "Save music as WAV"
 msgstr "WAVでほぞん"
 
-
 #: js/turtledefs.js:535
 msgid "Save sheet music as ABC, Lilypond or MusicXML"
 msgstr "楽譜をABC、Lilypond、またはMusicXMLとして保存する。"
-
 
 #: js/turtledefs.js:537
 msgid "Save block artwork as SVG or PNG"
 msgstr "ブロックのアートワークをSVGまたはPNGとして保存する。"
 
-
 #: js/turtledefs.js:543
 msgid "Load samples from server"
 msgstr "みんなの作品"
-
 
 #: js/turtledefs.js:544
 msgid "This button opens a viewer for loading example projects."
 msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
 
-
 #: js/turtledefs.js:548
 msgid "Expand/collapse option toolbar"
 msgstr "オプションツールバーを表示"
-
 
 #: js/turtledefs.js:549
 msgid "Click this button to expand or collapse the auxiliary toolbar."
 msgstr "このボタンをクリックすると「サブメニュー」を開いたり、折りたたんだりすることができる。"
 
-
 #: js/turtledefs.js:554
 msgid "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
 msgstr "メインおよび補助ツールバー、ブロックとキャンバスの右クリックコンテキストメニュー、パレットのヘルプメッセージを表示します。"
-
 
 #: js/turtledefs.js:560
 #: js/toolbar.js:136
@@ -1215,11 +946,9 @@ msgstr "メインおよび補助ツールバー、ブロックとキャンバス
 msgid "Run slowly"
 msgstr "ゆっくり実行する"
 
-
 #: js/turtledefs.js:561
 msgid "Click to run the project in slow mode."
 msgstr "クリックをすると、ゆっくりとしたスピードでプログラムを実行することができる。"
-
 
 #: js/turtledefs.js:565
 #: js/toolbar.js:137
@@ -1229,11 +958,9 @@ msgstr "クリックをすると、ゆっくりとしたスピードでプログ
 msgid "Run step by step"
 msgstr "ブロックを１つずつ実行する"
 
-
 #: js/turtledefs.js:566
 msgid "Click to run the project step by step."
 msgstr "クリックをすると、とてもゆっくり、ブロックを１つずつ実行する。プログラムがうまくはたらかず、どのブロックが原因なのかを調べたいときなどに便利だ。"
-
 
 #: js/turtledefs.js:571
 #: js/toolbar.js:138
@@ -1243,11 +970,9 @@ msgstr "クリックをすると、とてもゆっくり、ブロックを１つ
 msgid "Display statistics"
 msgstr "とうけいを表示する"
 
-
 #: js/turtledefs.js:572
 msgid "Display statistics about your Music project."
 msgstr "プロジェクトに含まれているブロックの種類、わりあいなど、とうけいてきなじょうほうを表示する。"
-
 
 #: js/turtledefs.js:576
 #: js/toolbar.js:139
@@ -1257,11 +982,9 @@ msgstr "プロジェクトに含まれているブロックの種類、わりあ
 msgid "Load plugin"
 msgstr "プラグインを読みこむ"
 
-
 #: js/turtledefs.js:577
 msgid "Load a selected plugin."
 msgstr "選択したプラグインを読み込みます。"
-
 
 #: js/turtledefs.js:581
 #: js/toolbar.js:140
@@ -1271,21 +994,17 @@ msgstr "選択したプラグインを読み込みます。"
 msgid "Delete plugin"
 msgstr "プラグインを消す"
 
-
 #: js/turtledefs.js:582
 msgid "Delete a selected plugin."
 msgstr "せんたくしたプラグインを消す。"
-
 
 #: js/turtledefs.js:586
 msgid "Enable scrolling"
 msgstr "自由な方向に／たて方向にスクロール"
 
-
 #: js/turtledefs.js:587
 msgid "You can scroll the blocks on the canvas."
 msgstr "カンバス上をドラッグそうさしたときに、画面をスクロールさせることができる方向を上下だけと上下左右に変える。"
-
 
 #: js/turtledefs.js:592
 #: js/toolbar.js:143
@@ -1296,11 +1015,9 @@ msgstr "カンバス上をドラッグそうさしたときに、画面をスク
 msgid "Change theme"
 msgstr "テーマを変更"
 
-
 #: js/turtledefs.js:593
 msgid "Switch between dark and light mode."
 msgstr "ダークモードとライトモードを切り替えます。"
-
 
 #: js/turtledefs.js:597
 #: js/toolbar.js:147
@@ -1313,21 +1030,17 @@ msgstr "ダークモードとライトモードを切り替えます。"
 msgid "Merge with current project"
 msgstr "プロジェクトを組みあわせる"
 
-
 #: js/turtledefs.js:598
 msgid "Click to add another project into the current one."
 msgstr "クリックして別のプロジェクトを現在のプロジェクトに追加します。"
-
 
 #: js/turtledefs.js:602
 msgid "Wrap Turtle"
 msgstr "アートを包む"
 
-
 #: js/turtledefs.js:603
 msgid "Turn Turtle wrapping On or Off."
 msgstr "アートを包むか・包まない"
-
 
 #: js/turtledefs.js:607
 #: js/toolbar.js:148
@@ -1335,11 +1048,9 @@ msgstr "アートを包むか・包まない"
 msgid "Set Pitch Preview"
 msgstr "変化記号を設定"
 
-
 #: js/turtledefs.js:608
 msgid "Click to set the current pitch."
 msgstr "クリックして現在の音高を設定します。"
-
 
 #: js/turtledefs.js:613
 #: js/toolbar.js:149
@@ -1349,11 +1060,9 @@ msgstr "クリックして現在の音高を設定します。"
 msgid "JavaScript Editor"
 msgstr "JavaScript エディタ"
 
-
 #: js/turtledefs.js:614
 msgid "Converts Music Block programs to JavaScript."
 msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
-
 
 #: js/turtledefs.js:619
 #: js/toolbar.js:150
@@ -1363,21 +1072,17 @@ msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
 msgid "Restore"
 msgstr "すてたブロックをもどす"
 
-
 #: js/turtledefs.js:620
 msgid "Restore blocks from the trash."
 msgstr "ゴミ箱にすててしまったブロックを取り出してもどす。ふくすうのブロックをすててあるときは新しい順に、ゴミ箱が空になるまでブロックを拾いもどすことができる。"
-
 
 #: js/turtledefs.js:624
 msgid "Switch mode"
 msgstr "はってんモード／かんたんモードにする"
 
-
 #: js/turtledefs.js:625
 msgid "Switch between beginner and advance modes."
 msgstr "ミュージック・ブロックスをかんたんモード／はってんモードに切りかえる。モードによって使えるきのうやブロックの種類が変わる。"
-
 
 #: js/turtledefs.js:629
 #: js/toolbar.js:153
@@ -1388,33 +1093,27 @@ msgstr "ミュージック・ブロックスをかんたんモード／はって
 msgid "Select language"
 msgstr "言語をえらぶ"
 
-
 #: js/turtledefs.js:630
 msgid "Select your language preference."
 msgstr "ブロックの名前などに表示される言語をえらぶ。"
-
 
 #: js/turtledefs.js:634
 #: js/widgets/help.js:564
 msgid "Contextual Menu for Blocks"
 msgstr "ブロックのコンテキストメニュー"
 
-
 #: js/turtledefs.js:635
 msgid "Right-click on a block to access common actions."
 msgstr "ブロックを右クリックして共通操作にアクセスします。"
-
 
 #: js/turtledefs.js:639
 #: planet/js/StringHelper.js:48
 msgid "Delete"
 msgstr "消す"
 
-
 #: js/turtledefs.js:640
 msgid "To delete a block, right-click on it. Then you will see the delete option."
 msgstr "ブロックを削除するには、ブロックを右クリックします。次に、削除オプションが表示されます。"
-
 
 #: js/turtledefs.js:644
 #: js/activity.js:3871
@@ -1422,38 +1121,31 @@ msgstr "ブロックを削除するには、ブロックを右クリックしま
 msgid "Copy"
 msgstr "コピー"
 
-
 #: js/turtledefs.js:645
 msgid "To copy a block, right-click on it. Then you will see the copy option."
 msgstr "ブロックをコピーするには、ブロックを右クリックします。次に、コピーオプションが表示されます。"
 
-
 #: js/turtledefs.js:650
 msgid "To extract a block, right-click on it. Then you will see the extract option."
 msgstr "ブロックを抽出するには、ブロックを右クリックします。次に、抽出オプションが表示されます。"
-
 
 #: js/turtledefs.js:659
 #: js/widgets/help.js:563
 msgid "Tab Navigation"
 msgstr "タブのナビゲーション"
 
-
 #: js/turtledefs.js:660
 msgid "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
 msgstr "キーボードの Tab キーを押すと、ワークスペース、ツールバー、パレットからを魔法のようにジャンプできます。"
-
 
 #: js/turtledefs.js:668
 #: js/widgets/help.js:565
 msgid "Contextual Menu for Canvas"
 msgstr "キャンバスのコンテキストメニュー"
 
-
 #: js/turtledefs.js:669
 msgid "Right-click on the canvas to perform additional canvas-related tasks."
 msgstr "キャンバスを右クリックして追加のキャンバス関連タスクを実行します。"
-
 
 #: js/turtledefs.js:674
 #: js/turtles.js:982
@@ -1461,16 +1153,13 @@ msgstr "キャンバスを右クリックして追加のキャンバス関連タ
 msgid "Grid"
 msgstr "グリッド"
 
-
 #: js/turtledefs.js:675
 msgid "Turn on/off lines for cartesian or polar grids."
 msgstr "デカルト座標または極座標グリッドの線をオン/オフにします。"
 
-
 #: js/turtledefs.js:677
 msgid "Turn on/off music staffs."
 msgstr "五線譜の表示/非表示を切り替えます。"
-
 
 #: js/turtledefs.js:681
 #: js/turtles.js:999
@@ -1489,112 +1178,91 @@ msgstr "五線譜の表示/非表示を切り替えます。"
 msgid "Clear"
 msgstr "もとにもどす"
 
-
 #: js/turtledefs.js:682
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr "ネズミを元の位置にもどし、ペンでえがいた線をすべて消す。"
-
 
 #: js/turtledefs.js:686
 #: js/turtles.js:1020
 msgid "Collapse"
 msgstr "カンバスをしゅくしょう"
 
-
 #: js/turtledefs.js:687
 msgid "Collapse the graphics window."
 msgstr "ネズミがいどうしたり、ペンで線をえがいたりできる「カンバス」の表示サイズを しゅくしょうしたり、かくだいしたりする。カンバスをしゅくしょうした場合は、プログラムをふつうのそくどで実行しても、ブロックがかくれない。ふつうの実行そくどでプログラムの動作かくにんをしたいときなどに便利だ。"
-
 
 #: js/turtledefs.js:691
 #: js/activity.js:7131
 msgid "Home"
 msgstr "ホーム"
 
-
 #: js/turtledefs.js:692
 msgid "Return all blocks to the center of the screen."
 msgstr "すべてのブロックを、カンバスのまんなかに配置する。"
-
 
 #: js/turtledefs.js:696
 #: js/activity.js:7148
 msgid "Show/hide blocks"
 msgstr "ブロックを表示する／かくす"
 
-
 #: js/turtledefs.js:697
 msgid "Hide or show the blocks and the palettes."
 msgstr "クリックすると、パレットボタンとプログラムのブロックを画面上に表示させたり、かくしたりすることができる。"
-
 
 #: js/turtledefs.js:701
 #: js/activity.js:7164
 msgid "Expand/collapse blocks"
 msgstr "ブロックを広げる/折りたたむ"
 
-
 #: js/turtledefs.js:702
 msgid "Expand or collapse start and action stacks."
 msgstr "クリックすると、「スタート」と「アクション」に使われているブロックを、広げて表示したり、折りたたんでかくしたりすることができる。"
-
 
 #: js/turtledefs.js:706
 #: js/activity.js:7180
 msgid "Decrease block size"
 msgstr "ブロックの表示を小さくする"
 
-
 #: js/turtledefs.js:707
 msgid "Decrease the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを小さくする。"
-
 
 #: js/turtledefs.js:711
 #: js/activity.js:7196
 msgid "Increase block size"
 msgstr "ブロックの表示を大きくする"
 
-
 #: js/turtledefs.js:712
 msgid "Increase the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを大きくする。"
-
 
 #: js/turtledefs.js:717
 msgid "Select"
 msgstr "選択"
 
-
 #: js/turtledefs.js:718
 msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr "ワークスペースを左クリックしてドラッグすると複数のブロックを選択できます。"
-
 
 #: js/turtledefs.js:724
 msgid "Palette buttons"
 msgstr "パレットボタン"
 
-
 #: js/turtledefs.js:725
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr "ミュージック・ブロックスの左側には、プログラミングに使うさまざまなブロックをグループ分けした「パレットボタン」がある。"
-
 
 #: js/turtledefs.js:729
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr "それぞれのパレットボタンをクリックし、「音符（おんぷ）」「アクション」「ペン」などから好きなブロックを選んで、カンバス上にドラッグして置いてみよう。"
 
-
 #: js/turtledefs.js:738
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
-
 #: js/turtledefs.js:741
 msgid "Turtle Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
-
 
 #: js/turtledefs.js:744
 #: js/turtledefs.js:769
@@ -1602,26 +1270,21 @@ msgstr "ミュージック・ブロックスガイド"
 msgid "About"
 msgstr "ミュージック・ブロックスについて"
 
-
 #: js/turtledefs.js:745
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
-
 
 #: js/turtledefs.js:749
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
 
-
 #: js/turtledefs.js:753
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
-
 #: js/turtledefs.js:760
 msgid "Turtle Blocks GitHub repository"
 msgstr "タータル・ブロックスのリポジトリ"
-
 
 #: js/turtledefs.js:763
 #: js/widgets/help.js:494
@@ -1629,58 +1292,47 @@ msgstr "タータル・ブロックスのリポジトリ"
 msgid "Congratulations."
 msgstr "おめでとうございます！"
 
-
 #: js/turtledefs.js:764
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr "ツアーはここで終わり。タータル・ブロックスを自由に楽しもう。"
-
 
 #: js/turtledefs.js:770
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
 
-
 #: js/turtledefs.js:774
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
-
 
 #: js/turtledefs.js:778
 msgid "Music Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
-
 #: js/turtledefs.js:783
 msgid "Music Blocks GitHub repository"
 msgstr "ミュージック・ブロックスのリポジトリ"
-
 
 #: js/turtledefs.js:786
 #: js/widgets/help.js:552
 msgid "Congratulations!"
 msgstr "おめでとうございます！"
 
-
 #: js/turtledefs.js:787
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr "ミスター・マウスのツアーはここで終わり。ミュージック・ブロックスを自由に楽しもう。"
-
 
 #: js/turtles.js:1088
 msgid "Expand"
 msgstr "カンバスをかくだい"
 
-
 #: js/rubrics.js:543
 msgid "mice"
 msgstr "ネズミ達の関係"
-
 
 #: js/toolbar.js:119
 #: js/toolbar.js:191
 msgid "About Music Blocks"
 msgstr "ミュージック・ブロックスについて"
-
 
 #: js/toolbar.js:123
 #: js/toolbar.js:124
@@ -1693,14 +1345,12 @@ msgstr "ミュージック・ブロックスについて"
 msgid "Enter Fullscreen"
 msgstr "全画面表示に入る"
 
-
 #: js/toolbar.js:130
 #: js/toolbar.js:202
 #: js/toolbar.js:259
 #: js/toolbar.js:325
 msgid "Find and share projects"
 msgstr "みんなの作品"
-
 
 #: js/toolbar.js:131
 #: js/toolbar.js:203
@@ -1709,7 +1359,6 @@ msgstr "みんなの作品"
 msgid "Offline. Sharing is unavailable"
 msgstr "オフライン。シェア機能が使えません"
 
-
 #: js/toolbar.js:132
 #: js/toolbar.js:204
 #: js/toolbar.js:261
@@ -1717,14 +1366,12 @@ msgstr "オフライン。シェア機能が使えません"
 msgid "Auxiliary menu"
 msgstr "サブメニュー"
 
-
 #: js/toolbar.js:133
 #: js/toolbar.js:205
 #: js/toolbar.js:262
 #: js/toolbar.js:328
 msgid "Help and shortcuts"
 msgstr "ヘルプとショートカット"
-
 
 #: js/toolbar.js:135
 #: js/toolbar.js:207
@@ -1735,14 +1382,12 @@ msgstr "ヘルプとショートカット"
 msgid "Keyboard shortcuts"
 msgstr "キーボードのショートカット"
 
-
 #: js/toolbar.js:141
 #: js/toolbar.js:213
 #: js/toolbar.js:270
 #: js/toolbar.js:336
 msgid "Enable horizontal scrolling"
 msgstr "自由な方向にスクロール"
-
 
 #: js/toolbar.js:142
 #: js/toolbar.js:214
@@ -1751,14 +1396,12 @@ msgstr "自由な方向にスクロール"
 msgid "Disable horizontal scrolling"
 msgstr "たて方向にスクロール"
 
-
 #: js/toolbar.js:144
 #: js/toolbar.js:216
 #: js/toolbar.js:273
 #: js/toolbar.js:339
 msgid "Light Mode"
 msgstr "ライトモード"
-
 
 #: js/toolbar.js:145
 #: js/toolbar.js:217
@@ -1767,14 +1410,12 @@ msgstr "ライトモード"
 msgid "Dark Mode"
 msgstr "ダークモード"
 
-
 #: js/toolbar.js:146
 #: js/toolbar.js:218
 #: js/toolbar.js:275
 #: js/toolbar.js:341
 msgid "High-contrast Mode"
 msgstr "ハイコントラストモード"
-
 
 #: js/toolbar.js:151
 #: js/toolbar.js:223
@@ -1783,7 +1424,6 @@ msgstr "ハイコントラストモード"
 msgid "Switch to beginner mode"
 msgstr "かんたんモードにする"
 
-
 #: js/toolbar.js:152
 #: js/toolbar.js:224
 #: js/toolbar.js:280
@@ -1791,29 +1431,24 @@ msgstr "かんたんモードにする"
 msgid "Switch to advanced mode"
 msgstr "はってんモードにする"
 
-
 #: js/toolbar.js:158
 #: js/toolbar.js:228
 msgid "Save mouse artwork as SVG"
 msgstr "SVGでほぞん"
-
 
 #: js/toolbar.js:161
 #: js/toolbar.js:231
 msgid "Save sheet music as ABC"
 msgstr "ABCのフォーマットでほぞん"
 
-
 #: js/toolbar.js:162
 #: js/toolbar.js:232
 msgid "Save sheet music as Lilypond"
 msgstr "がくふ(Lilypondのフォーマット)でほぞん"
 
-
 #: js/toolbar.js:163
 msgid "Save sheet music as MusicXML"
 msgstr "プロジェクトをMusicXML楽譜でほぞん"
-
 
 #: js/toolbar.js:165
 #: js/toolbar.js:234
@@ -1822,7 +1457,6 @@ msgstr "プロジェクトをMusicXML楽譜でほぞん"
 #: js/toolbar.js:354
 msgid "Save block artwork as PNG"
 msgstr "ブロックのアートワークをPNGで保存"
-
 
 #: js/toolbar.js:166
 #: js/toolbar.js:235
@@ -1836,29 +1470,24 @@ msgstr "ブロックのアートワークをPNGで保存"
 msgid "Confirm"
 msgstr "作成する"
 
-
 #: js/toolbar.js:248
 #: js/toolbar.js:314
 msgid "About Turtle Blocks"
 msgstr "タートル・ブロックスについて"
-
 
 #: js/toolbar.js:470
 #: js/activity.js:7546
 msgid "Play project"
 msgstr "プロジェクトを再生"
 
-
 #: js/toolbar.js:532
 #: js/activity.js:7550
 msgid "Stop project"
 msgstr "プロジェクトを停止する"
 
-
 #: js/toolbar.js:574
 msgid "Are you sure you want to create a new project?"
 msgstr "新しいプロジェクトを作成してもよろしいですか？"
-
 
 #: js/toolbar.js:766
 #: js/toolbar.js:777
@@ -1868,7 +1497,6 @@ msgstr "新しいプロジェクトを作成してもよろしいですか？"
 msgid "Turtle Wrap Off"
 msgstr "画面の境界を無視しない"
 
-
 #: js/toolbar.js:778
 #: js/toolbar.js:787
 #: js/toolbar.js:820
@@ -1876,146 +1504,118 @@ msgstr "画面の境界を無視しない"
 msgid "Turtle Wrap On"
 msgstr "画面の境界を無視する"
 
-
 #: js/activity.js:509
 #: js/activity.js:514
 msgid "Search for blocks"
 msgstr "ブロックを検索"
 
-
 #: js/activity.js:1580
 msgid "Import MIDI"
 msgstr "MIDIをインポートする"
-
 
 #: js/activity.js:1588
 msgid "Set the max blocks to generate:"
 msgstr "生成する最大ブロックを設定します。"
 
-
 #: js/activity.js:1647
 msgid "Clear workspace"
 msgstr "すっきりとしたワークスペース"
 
-
 #: js/activity.js:1653
 msgid "Are you sure you want to clear the workspace?"
 msgstr "ワークスペースを本当にクリアしますか？"
-
 
 #: js/activity.js:2014
 #: js/activity.js:2092
 msgid "Save recording"
 msgstr "録音を保存する"
 
-
 #: js/activity.js:2021
 #: js/activity.js:2071
 msgid "File save canceled"
 msgstr "ファイルの保存がキャンセルされました"
-
 
 #: js/activity.js:2042
 #: js/activity.js:2052
 msgid "Recorded file is empty. File not saved."
 msgstr "録音されたファイルは空です。ファイルが保存されていません。"
 
-
 #: js/activity.js:2069
 #: js/activity.js:2099
 msgid "Enter file name"
 msgstr "ファイル名を入力してください"
 
-
 #: js/activity.js:2082
 msgid "Saved! Check your Downloads folder."
 msgstr "保存しました！ダウンロードフォルダーを確認してください。"
-
 
 #: js/activity.js:2089
 msgid "Recording stopped. File saved."
 msgstr "録音が停止されました。ファイルが保存されました。"
 
-
 #: js/activity.js:2094
 msgid "recording"
 msgstr "録音中"
-
 
 #: js/activity.js:2131
 msgid "Recording started. Click stop to finish."
 msgstr "録音が開始されました。終了するには「停止」をクリックします。"
 
-
 #: js/activity.js:2211
 msgid "Recording failed: %s"
 msgstr "録音に失敗しました: %s"
-
 
 #: js/activity.js:2412
 msgid "Horizontal scrolling enabled."
 msgstr "水平スクロールが有効になりました。"
 
-
 #: js/activity.js:2421
 msgid "Horizontal scrolling disabled."
 msgstr "水平スクロールが無効になっています。"
-
 
 #: js/activity.js:2432
 msgid "Catching mice"
 msgstr "ネズミをつかまえているよ"
 
-
 #: js/activity.js:2433
 msgid "Cleaning the instruments"
 msgstr "楽器のおていれをしているよ"
-
 
 #: js/activity.js:2434
 msgid "Testing key pieces"
 msgstr "キーボードの音をたしかめているよ"
 
-
 #: js/activity.js:2435
 msgid "Sight-reading"
 msgstr "がくふをよみこんでいるよ"
-
 
 #: js/activity.js:2436
 msgid "Combining math and music"
 msgstr "音楽と算数をくっつけているよ"
 
-
 #: js/activity.js:2437
 msgid "Generating more blocks"
 msgstr "ブロックをたくさんつくっているよ"
-
 
 #: js/activity.js:2438
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr "ド　レ　ミ　ファ　ソ　ラ　シ　ド"
 
-
 #: js/activity.js:2439
 msgid "Tuning string instruments"
 msgstr "弦楽器のチューニングをしているよ"
-
 
 #: js/activity.js:2440
 msgid "Pressing random keys"
 msgstr "キーボードでおんがくをつくっているよ"
 
-
 #: js/activity.js:2662
 msgid "plugins will be removed upon restart."
 msgstr "プラグインは再起動時に削除されます。"
 
-
 #: js/activity.js:2671
 msgid "show Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
-
 
 #: js/activity.js:3331
 #: js/palette.js:1258
@@ -2026,78 +1626,64 @@ msgstr "ほうがん（ざひょう）を表示"
 msgid "scale degree"
 msgstr "音度"
 
-
 #: js/activity.js:3334
 #: js/palette.js:1267
 msgid "voice name"
 msgstr "音名"
-
 
 #: js/activity.js:3337
 #: js/palette.js:1264
 msgid "invert mode"
 msgstr "モードを反転させる"
 
-
 #: js/activity.js:3340
 msgid "output tools"
 msgstr "出力ツール"
-
 
 #: js/activity.js:3343
 msgid "custom note"
 msgstr "カスタムノート"
 
-
 #: js/activity.js:3346
 msgid "accidental name"
 msgstr "偶然の名前"
-
 
 #: js/activity.js:3349
 #: js/blocks/PitchBlocks.js:895
 msgid "east indian solfege"
 msgstr "東インドのソルフェージュ"
 
-
 #: js/activity.js:3352
 #: js/blocks/PitchBlocks.js:909
 msgid "note name"
 msgstr "音名"
-
 
 #: js/activity.js:3355
 #: js/blocks/IntervalsBlocks.js:94
 msgid "temperament name"
 msgstr "気質名"
 
-
 #: js/activity.js:3358
 #: js/palette.js:1261
 msgid "mode name"
 msgstr "モード名"
 
-
 #: js/activity.js:3361
 msgid "chord name"
 msgstr "chord name"
-
 
 #: js/activity.js:3364
 #: js/palette.js:1284
 msgid "interval name"
 msgstr "音程名"
 
-
 #: js/activity.js:3367
 msgid "filter type"
 msgstr "フィルターの種類"
 
-
 #: js/activity.js:3370
 msgid "oscillator type"
 msgstr "発振器の種類"
-
 
 #: js/activity.js:3373
 #: js/blocks.js:2685
@@ -2105,301 +1691,243 @@ msgstr "発振器の種類"
 msgid "audio file"
 msgstr "オーディオファイル"
 
-
 #: js/activity.js:3376
 #: js/blocks/DrumBlocks.js:32
 msgid "noise name"
 msgstr "ノイズ名"
-
 
 #: js/activity.js:3379
 #: js/blocks/DrumBlocks.js:75
 msgid "drum name"
 msgstr "ドラム名"
 
-
 #: js/activity.js:3382
 #: js/blocks/DrumBlocks.js:119
 msgid "effects name"
 msgstr "エフェクト名"
 
-
 #: js/activity.js:3385
 msgid "wrap mode"
 msgstr "ラップモード"
 
-
 #: js/activity.js:3388
 msgid "load file"
 msgstr "ロード ファイル "
-
 
 #: js/activity.js:3717
 #: js/activity.js:7467
 msgid "This block is deprecated."
 msgstr "このブロックはもうありません。"
 
-
 #: js/activity.js:3719
 #: js/activity.js:7469
 msgid "Block cannot be found."
 msgstr "ブロックが見つかりません。"
 
-
 #: js/activity.js:3867
 msgid "Saving block artwork"
 msgstr "ブロックのアートを保存中"
 
-
 #: js/activity.js:3875
 msgid "Erase"
 msgstr "消す"
-
 
 #: js/activity.js:3919
 #: js/activity.js:3949
 msgid "Paste"
 msgstr "貼り付け"
 
-
 #: js/activity.js:3923
 msgid "Save block help"
 msgstr "ブロックの ヘルプを 保存"
-
 
 #: js/activity.js:3995
 msgid "Jumping to the bottom of the page."
 msgstr "画面の下にジャンプしています"
 
-
 #: js/activity.js:4001
 msgid "Scrolling up."
 msgstr "上にスクロールしています"
-
 
 #: js/activity.js:4006
 msgid "Scrolling down."
 msgstr "下にスクロールしています"
 
-
 #: js/activity.js:4011
 msgid "Extracting block"
 msgstr "ブロックを取り出しています"
-
 
 #: js/activity.js:4019
 msgid "Moving block up."
 msgstr "ブロックを上に動かしています"
 
-
 #: js/activity.js:4040
 msgid "Moving block down."
 msgstr "ブロックを下に動かしています"
-
 
 #: js/activity.js:4062
 msgid "Moving block left."
 msgstr "ブロックを左に動かしています"
 
-
 #: js/activity.js:4079
 msgid "Moving block right."
 msgstr "ブロックを右に動かしています"
 
-
 #: js/activity.js:4094
 msgid "Jump to home position."
 msgstr "まんなかにジャンプする"
-
 
 #: js/activity.js:4114
 #: js/blocks/ExtrasBlocks.js:275
 msgid "Hide blocks"
 msgstr "ブロックを非表示"
 
-
 #: js/activity.js:4498
 #: js/activity.js:4516
 msgid "Trash can is empty."
 msgstr "ゴミ箱は空です。"
-
 
 #: js/activity.js:4520
 #: js/activity.js:4652
 msgid "Item restored from the trash."
 msgstr "ゴミ箱からアイテムを復元しました。"
 
-
 #: js/activity.js:4724
 msgid "Restore last item"
 msgstr "先のアイテムを復元"
-
 
 #: js/activity.js:4725
 msgid "Restore all items"
 msgstr "すべてのアイテムを復元"
 
-
 #: js/activity.js:5393
 msgid "Click the run button to run the project."
 msgstr "プロジェクトを再生するため、再生のボタンをクリックしてください。"
-
 
 #: js/activity.js:6009
 msgid "Loading Complete!"
 msgstr "読み込み完了！"
 
-
 #: js/activity.js:7068
 msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "組み込みプラグインの名前を入力するか、空白のままにしてプラグイン ファイルをアップロードします。"
-
 
 #: js/activity.js:7080
 msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
 msgstr "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。"
 
-
 #: js/activity.js:7538
 msgid "Windows/Linux"
 msgstr "Windows/Linux"
-
 
 #: js/activity.js:7538
 msgid "Mac"
 msgstr "マック"
 
-
 #: js/activity.js:7542
 msgid "Workspace"
 msgstr "ワークスペース"
-
 
 #: js/activity.js:7554
 msgid "Play or stop depending on the current state"
 msgstr "現在の状態に応じて再生または停止します"
 
-
 #: js/activity.js:7558
 msgid "Play or stop when no text input or widget is active"
 msgstr "アクティブなテキスト入力またはウィジェットがない場合は再生または停止します"
-
 
 #: js/activity.js:7562
 msgid "Toggle stage scale"
 msgstr "ステージスケールの切り替え"
 
-
 #: js/activity.js:7566
 msgid "Jump to home position"
 msgstr "ホームポジションに戻る"
-
 
 #: js/activity.js:7570
 msgid "Jump to the bottom of the workspace"
 msgstr "ワークスペースの一番下にジャンプします"
 
-
 #: js/activity.js:7574
 msgid "Scroll workspace up"
 msgstr "ワークスペースを上にスクロールする"
-
 
 #: js/activity.js:7578
 msgid "Scroll workspace down"
 msgstr "ワークスペースを下にスクロールします"
 
-
 #: js/activity.js:7582
 msgid "Hide block search when it is open"
 msgstr "ブロック検索が開いているときに非表示にする"
-
 
 #: js/activity.js:7586
 msgid "You can type d to create a do block and r to create a re block etc."
 msgstr "キーボードを使うと、パレットボタンからブロックをドラッグして配置するだけでなく、ボタンをおすだけでちょくせつブロックを置くことができる。★ショートカットキー d …… 「ド」（４分音符、４オクターヴ） r …… 「レ」（４分音符、４オクターヴ） m …… 「ミ」（４分音符、４オクターヴ） f</em> …… 「ファ」（４分音符、４オクターヴ s …… 「ソ」（４分音符、４オクターヴ） l …… 「ラ」（４分音符、４オクターヴ） t …… 「シ」（４分音符、４オクターヴ）"
 
-
 #: js/activity.js:7593
 msgid "Editing"
 msgstr "編集"
-
 
 #: js/activity.js:7597
 msgid "Copy selected stack."
 msgstr "選択したスタックをコピーします。"
 
-
 #: js/activity.js:7601
 msgid "Paste previous stack."
 msgstr "この前のスタックを貼り付けます。"
-
 
 #: js/activity.js:7605
 msgid "Open the JSON paste box."
 msgstr "JSON 貼り付けボックスを開きます。"
 
-
 #: js/activity.js:7609
 msgid "Paste JSON when the paste box is focused."
 msgstr "貼り付けボックスにフォーカスがあるときに JSON を貼り付けます。"
-
 
 #: js/activity.js:7613
 msgid "Extract the active block."
 msgstr "アクティブなブロックを抽出します。"
 
-
 #: js/activity.js:7617
 msgid "Clear workspace."
 msgstr "すっきりとしたワークスペース。"
-
 
 #: js/activity.js:7621
 msgid "Save block artwork."
 msgstr "ブロックアートワークを保存します。"
 
-
 #: js/activity.js:7625
 msgid "Save block help."
 msgstr "ブロックのヘルプを保存します。"
-
 
 #: js/activity.js:7630
 msgid "Navigation"
 msgstr "ナビゲーション"
 
-
 #: js/activity.js:7634
 msgid "Move focus between the toolbar, palettes, and workspace."
 msgstr "ツールバー、パレット、ワークスペースの中からフォーカスを移動します。"
-
 
 #: js/activity.js:7637
 #: js/activity.js:7703
 msgid "Arrow keys"
 msgstr "矢印キー"
 
-
 #: js/activity.js:7638
 msgid "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
 msgstr "コンテキストに応じて、アクティブなブロックの移動、パレットのスクロール、テンポ ウィジェットの調整、またはワークスペースのパンを行います。"
-
 
 #: js/activity.js:7644
 msgid "Pan workspace right when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを右に移動します。"
 
-
 #: js/activity.js:7648
 msgid "Pan workspace left when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを左に移動します。"
 
-
 #: js/activity.js:7653
 msgid "Toolbar"
 msgstr "ツールバー"
-
 
 #: js/activity.js:7657
 #: js/activity.js:7658
@@ -2408,82 +1936,66 @@ msgstr "ツールバー"
 msgid "Arrow Left / Arrow Right"
 msgstr "左矢印 / 右矢印"
 
-
 #: js/activity.js:7660
 msgid "Move focus within the current toolbar."
 msgstr "現在のツールバー内でフォーカスを移動します。"
-
 
 #: js/activity.js:7664
 #: js/activity.js:7665
 msgid "Arrow Up / Arrow Down"
 msgstr "上矢印 / 下矢印"
 
-
 #: js/activity.js:7667
 msgid "Move focus between main and auxiliary toolbars."
 msgstr "メイン ツールバーと補助ツールバーの間でフォーカスを移動します。"
-
 
 #: js/activity.js:7671
 msgid "Activate the focused toolbar button."
 msgstr "フォーカスされたツールバーからのボタンをアクティブにします。"
 
-
 #: js/activity.js:7675
 msgid "Exit toolbar keyboard navigation."
 msgstr "ツールバーのキーボードナビゲーションを終了します。"
-
 
 #: js/activity.js:7680
 msgid "Widget Windows"
 msgstr "ウィジェット・ウィンドウ"
 
-
 #: js/activity.js:7684
 msgid "Close the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを閉じます。"
-
 
 #: js/activity.js:7688
 msgid "Maximize or restore the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを最大化または復元します。"
 
-
 #: js/activity.js:7693
 msgid "Help and Pitch Slider"
 msgstr "ヘルプとピッチ・スライダー"
-
 
 #: js/activity.js:7700
 msgid "Move between help pages when Help is open."
 msgstr "ヘルプが開いているときにヘルプ・ページの中から移動します。"
 
-
 #: js/activity.js:7704
 msgid "Adjust pitch by semitone when Pitch Slider is open."
 msgstr "ピッチ・スライダーが開いているときに半音単位でピッチを調整します。"
-
 
 #: js/activity.js:7739
 msgid "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
 msgstr "ショートカットは状況に依存します。一部の機能は、関連するパネル、ウィジェット、またはモードがアクティブな場合にのみ機能します。 Windows/Linux および Mac の同等のものを一緒に示します。"
 
-
 #: js/activity.js:7873
 msgid "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
 msgstr "クリップボードデータが無効です。ブロックを貼り付けるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストを貼り付けるには、入力フィールド内をクリックします。"
-
 
 #: js/activity.js:8099
 msgid "Select is enabled."
 msgstr "選択モードが有効です。"
 
-
 #: js/activity.js:8100
 msgid "Select is disabled."
 msgstr "選択モードが無効です。"
-
 
 #: js/activity.js:8561
 #: js/activity.js:8626
@@ -2494,21 +2006,17 @@ msgstr "選択モードが無効です。"
 msgid "Cannot load project from the file. Please check the file type."
 msgstr "プロジェクトを読みこめません。ファイルの種類をかくにんしてください。"
 
-
 #: js/activity.js:8987
 msgid "Something went wrong reading JSON-encoded project data."
 msgstr "JSON エンコードされたプロジェクト データの読み取り中に問題が発生しました。"
-
 
 #: js/activity.js:8998
 msgid "Invalid parameters"
 msgstr "無効なパラメータ"
 
-
 #: js/activity.js:9291
 msgid "Error regenerating palettes. Please refresh the page."
 msgstr "パレットの再生成に失敗しました。ページを更新してください。"
-
 
 #: js/block.js:1738
 #: js/block.js:1857
@@ -2518,11 +2026,9 @@ msgstr "パレットの再生成に失敗しました。ページを更新して
 msgid "temperament"
 msgstr "音律"
 
-
 #: js/block.js:1752
 msgid "matrix"
 msgstr "フレーズメーカー"
-
 
 #: js/block.js:1759
 #: js/blocks/WidgetBlocks.js:1743
@@ -2530,16 +2036,13 @@ msgstr "フレーズメーカー"
 msgid "status"
 msgstr "実行じょうきょう"
 
-
 #: js/block.js:1766
 msgid "drum mapper"
 msgstr "ドラム・ピッチ行列"
 
-
 #: js/block.js:1773
 msgid "ruler"
 msgstr "リズムメーカー"
-
 
 #: js/block.js:1780
 #: js/blocks/WidgetBlocks.js:457
@@ -2547,11 +2050,9 @@ msgstr "リズムメーカー"
 msgid "timbre"
 msgstr "音色"
 
-
 #: js/block.js:1787
 msgid "stair"
 msgstr "階段"
-
 
 #: js/block.js:1794
 #: js/blocks/ProgramBlocks.js:1278
@@ -2560,7 +2061,6 @@ msgstr "階段"
 msgid "tempo"
 msgstr "メトロノーム"
 
-
 #: js/block.js:1801
 #: js/block.js:1864
 #: js/blocks/IntervalsBlocks.js:1506
@@ -2568,17 +2068,14 @@ msgstr "メトロノーム"
 msgid "mode"
 msgstr "モード（音階）"
 
-
 #: js/block.js:1808
 msgid "slider"
 msgstr "スライダー"
-
 
 #: js/block.js:1815
 #: js/blocks/SensorsBlocks.js:943
 msgid "keyboard"
 msgstr "キーボード"
-
 
 #: js/block.js:1829
 #: js/blocks/WidgetBlocks.js:1319
@@ -2586,7 +2083,6 @@ msgstr "キーボード"
 #.  TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
-
 
 #: js/block.js:1836
 #: js/block.js:2650
@@ -2613,7 +2109,6 @@ msgstr "リズムメーカー"
 msgid "note value"
 msgstr "音の長さ"
 
-
 #: js/block.js:1843
 #: js/blocks/IntervalsBlocks.js:1108
 #: js/blocks/OrnamentBlocks.js:312
@@ -2621,18 +2116,15 @@ msgstr "音の長さ"
 msgid "scalar interval"
 msgstr "音階の上下"
 
-
 #: js/block.js:1850
 #: js/blocks/RhythmBlocks.js:154
 msgid "milliseconds"
 msgstr "ミリ秒"
 
-
 #: js/block.js:2575
 #: js/block.js:2598
 msgid "scalar interval %s"
 msgstr "音階の上下 %s"
-
 
 #: js/block.js:2648
 #: js/block.js:2652
@@ -2645,7 +2137,6 @@ msgstr "音階の上下 %s"
 msgid "silence"
 msgstr "休符"
 
-
 #: js/block.js:2744
 #: js/block.js:3844
 #: js/block.js:3861
@@ -2656,23 +2147,19 @@ msgstr "休符"
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
-
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627
 #.  TRANS: scalar step
 msgid "down"
 msgstr "下"
 
-
 #: js/block.js:2833
 msgid "up"
 msgstr "上"
 
-
 #: js/block.js:3300
 msgid "Silence block cannot be removed."
 msgstr "「休符」は取り出すことができません。"
-
 
 #: js/block.js:4191
 #: js/blocks.js:2813
@@ -2693,7 +2180,6 @@ msgstr "「休符」は取り出すことができません。"
 msgid "true"
 msgstr "真"
 
-
 #: js/block.js:4191
 #: js/blocks.js:2815
 #: js/blocks.js:3434
@@ -2711,13 +2197,11 @@ msgstr "真"
 msgid "false"
 msgstr "偽"
 
-
 #: js/block.js:4201
 #: js/block.js:4205
 #: js/blocks/ExtrasBlocks.js:618
 msgid "Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
-
 
 #: js/block.js:4201
 #: js/block.js:4206
@@ -2725,13 +2209,11 @@ msgstr "ほうがん（ざひょう）を表示"
 msgid "polar"
 msgstr "極座標を表示"
 
-
 #: js/block.js:4201
 #: js/block.js:4207
 #: js/blocks/ExtrasBlocks.js:626
 msgid "Cartesian/Polar"
 msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
-
 
 #: js/block.js:4201
 #: js/block.js:4214
@@ -2739,36 +2221,30 @@ msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
 msgid "none"
 msgstr "なし"
 
-
 #: js/block.js:4208
 #: js/blocks/ExtrasBlocks.js:631
 msgid "treble"
 msgstr "トレブル記号"
-
 
 #: js/block.js:4209
 #: js/blocks/ExtrasBlocks.js:635
 msgid "grand staff"
 msgstr "トレブルとバス記号"
 
-
 #: js/block.js:4210
 #: js/blocks/ExtrasBlocks.js:639
 msgid "mezzo-soprano"
 msgstr "メゾソプラノ記号"
-
 
 #: js/block.js:4211
 #: js/blocks/ExtrasBlocks.js:643
 msgid "alto"
 msgstr "アルト記号"
 
-
 #: js/block.js:4212
 #: js/blocks/ExtrasBlocks.js:647
 msgid "tenor"
 msgstr "テノール記号"
-
 
 #: js/block.js:4213
 #: js/utils/musicutils.js:1168
@@ -2779,13 +2255,11 @@ msgstr "テノール記号"
 msgid "bass"
 msgstr "コントラバス"
 
-
 #: js/block.js:4258
 #: js/blocks.js:2806
 #: js/blocks.js:3425
 msgid "on2"
 msgstr "オン"
-
 
 #: js/block.js:4260
 #: js/blocks.js:2808
@@ -2793,21 +2267,17 @@ msgstr "オン"
 msgid "off"
 msgstr "オフ"
 
-
 #: js/block.js:4731
 msgid "Not a number"
 msgstr "数字ではありません"
-
 
 #: js/block.js:4742
 msgid "Octave value must be between 1 and 8."
 msgstr "オクターヴの値が「１」から「8」までの範囲でなければなりません。"
 
-
 #: js/block.js:4750
 msgid "Numbers can have at most 10 digits."
 msgstr "数字は最大１０桁までです。"
-
 
 #: js/blocks.js:1423
 #: js/blocks.js:3657
@@ -2826,18 +2296,15 @@ msgstr "数字は最大１０桁までです。"
 msgid "box"
 msgstr "箱"
 
-
 #: js/blocks.js:1949
 msgid "Consider breaking this stack into parts."
 msgstr "アクションブロックを使ってプログラムをまとめませんか"
-
 
 #: js/blocks.js:2678
 #: js/palette.js:1322
 #: js/blocks/MediaBlocks.js:686
 msgid "open file"
 msgstr "ファイルを開く"
-
 
 #: js/blocks.js:3461
 #: js/palette.js:1243
@@ -2846,14 +2313,12 @@ msgstr "ファイルを開く"
 msgid "text"
 msgstr "文字そざい"
 
-
 #: js/blocks.js:3656
 #: js/palette.js:1310
 #: js/palette.js:1311
 #: js/blocks/BoxesBlocks.js:517
 msgid "store in box"
 msgstr "箱にほぞん"
-
 
 #: js/blocks.js:3661
 #: js/blocks.js:4144
@@ -2865,7 +2330,6 @@ msgstr "箱にほぞん"
 msgid "box1"
 msgstr "箱１"
 
-
 #: js/blocks.js:3663
 #: js/blocks.js:4146
 #: js/blocks.js:4192
@@ -2876,7 +2340,6 @@ msgstr "箱１"
 msgid "box2"
 msgstr "箱２"
 
-
 #: js/blocks.js:4411
 #: js/palette.js:1308
 #: js/palette.js:1313
@@ -2884,7 +2347,6 @@ msgstr "箱２"
 #: js/blocks/BoxesBlocks.js:594
 msgid "store in"
 msgstr "入れる"
-
 
 #: js/blocks.js:4411
 #: js/blocks/BoxesBlocks.js:598
@@ -2903,7 +2365,6 @@ msgstr "入れる"
 msgid "name"
 msgstr "名前"
 
-
 #: js/blocks.js:4411
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:598
@@ -2914,23 +2375,19 @@ msgstr "名前"
 msgid "value"
 msgstr "値"
 
-
 #: js/blocks.js:4749
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr "「ずっとくり返す」状態が「音符」の中にある。"
 
-
 #: js/blocks.js:5296
 msgid "There is no block selected."
 msgstr "ブロックが選ばれていません"
-
 
 #: js/blocks.js:5408
 #: js/blocks/MediaBlocks.js:886
 #.  TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
-
 
 #: js/blocks.js:5411
 #: js/utils/synthutils.js:3615
@@ -2940,31 +2397,25 @@ msgstr "ネズミへんこう"
 msgid "sample"
 msgstr "音色サンプル"
 
-
 #: js/languagebox.js:256
 msgid "Refresh your browser to change your language preference."
 msgstr "言語を変えるには、ブラウザをこうしんしてください。"
-
 
 #: js/languagebox.js:288
 msgid "Music Blocks is already set to this language."
 msgstr " Music Blocksは既にこの言語に設定されています。"
 
-
 #: js/loader.js:431
 msgid "Failed to load EaselJS. Please refresh the page."
 msgstr "EaselJS のロードに失敗しました。ページを更新してください。"
-
 
 #: js/loader.js:453
 msgid "Failed to load Music Blocks. Please refresh the page."
 msgstr "ミュージック・ブロックスの読み込みに失敗しました。ページを更新してください。"
 
-
 #: js/loader.js:460
 msgid "Failed to initialize Music Blocks core. Please refresh the page.\n\nError: %s"
 msgstr "ミュージック・ブロックス コアの初期化に失敗しました。ページを更新してください。\n\nエラー: %s"
-
 
 #: js/logo.js:663
 #: js/blocks/ProgramBlocks.js:259
@@ -2972,23 +2423,19 @@ msgstr "ミュージック・ブロックス コアの初期化に失敗しま�
 msgid "You must select a file."
 msgstr "ファイルをえらんでください。"
 
-
 #: js/logo.js:1655
 msgid "Infinite loop detected. Execution stopped to prevent browser freeze."
 msgstr "無限ループが検出されました。ブラウザのフリーズを防ぐために実行が停止されました。"
-
 
 #: js/logo.js:1852
 #: js/blocks/MediaBlocks.js:338
 msgid "width"
 msgstr "カンバスのよこはば"
 
-
 #: js/logo.js:1853
 #: js/blocks/MediaBlocks.js:395
 msgid "height"
 msgstr "カンバスのたてはば"
-
 
 #: js/logo.js:1854
 #: js/blocks/MediaBlocks.js:35
@@ -2996,108 +2443,88 @@ msgstr "カンバスのたてはば"
 msgid "right (screen)"
 msgstr "ざひょうち（右）"
 
-
 #: js/logo.js:1855
 #: js/blocks/MediaBlocks.js:111
 #.  TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち（左）"
 
-
 #: js/logo.js:1856
 #: js/blocks/MediaBlocks.js:186
 msgid "top (screen)"
 msgstr "ざひょうち（上）"
-
 
 #: js/logo.js:1857
 #: js/blocks/MediaBlocks.js:261
 msgid "bottom (screen)"
 msgstr "ざひょうち（下）"
 
-
 #: js/logo.js:2159
 msgid "Playback is ready."
 msgstr "コンパイル完了"
-
 
 #: js/palette.js:618
 msgid "Block Palettes"
 msgstr "ブロックパレット"
 
-
 #: js/palette.js:629
 msgid "Palette Categories"
 msgstr "パレットのカテゴリ"
-
 
 #: js/palette.js:650
 msgid "Toggle Palette"
 msgstr "パレットの切り替え"
 
-
 #: js/palette.js:1249
 msgid "effect"
 msgstr "こうかおん"
 
-
 #: js/palette.js:1255
 msgid "sargam"
 msgstr "Sargam (インドの ソルファ)"
-
 
 #: js/palette.js:1270
 #: js/blocks/PitchBlocks.js:1230
 msgid "custom pitch"
 msgstr "カスタムピッチ"
 
-
 #: js/palette.js:1278
 msgid "accidental"
 msgstr "変化記号"
-
 
 #: js/palette.js:1302
 #: js/blocks/PitchBlocks.js:423
 msgid "pitch converter"
 msgstr "音の高さを調節"
 
-
 #: js/planetInterface.js:151
 msgid "project undefined"
 msgstr "プロジェクト未定義"
-
 
 #: js/planetInterface.js:282
 msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
 msgstr "エラー: ローカル ストレージが不足しているため、保存できません。保存されているプロジェクトをいくつか削除してみてください。"
 
-
 #: js/themebox.js:375
 msgid "Theme switched to %s mode."
 msgstr "テーマが %s モードに切り替わりました。"
 
-
 #: js/themebox.js:568
 msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocksはすでにこのテーマに設定されています。"
-
 
 #: js/turtle-singer.js:1509
 #.  TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。"
 
-
 #: js/turtle-singer.js:1726
 msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
 msgstr "同じピッチの音符のみを結ぶことができます。スラーを使うつもりでしたか？"
 
-
 #: js/turtle-singer.js:2298
 msgid "synth cannot play chords."
 msgstr "このシンセでは和音ができません"
-
 
 #: js/utils/musicutils.js:536
 #: js/utils/musicutils.js:676
@@ -3106,232 +2533,186 @@ msgstr "このシンセでは和音ができません"
 msgid "rest"
 msgstr "休符"
 
-
 #: js/utils/musicutils.js:719
 msgid "Perfect unison"
 msgstr "完全1度"
-
 
 #: js/utils/musicutils.js:719
 msgid "Diminished second"
 msgstr "減2度"
 
-
 #: js/utils/musicutils.js:720
 msgid "Minor second"
 msgstr "短2度"
-
 
 #: js/utils/musicutils.js:720
 msgid "Augmented unison"
 msgstr "増1度"
 
-
 #: js/utils/musicutils.js:721
 msgid "Major second"
 msgstr "長2度"
-
 
 #: js/utils/musicutils.js:721
 msgid "Diminished third"
 msgstr "減3度"
 
-
 #: js/utils/musicutils.js:722
 msgid "Minor third"
 msgstr "短3度"
-
 
 #: js/utils/musicutils.js:722
 msgid "Augmented second"
 msgstr "増2度"
 
-
 #: js/utils/musicutils.js:723
 msgid "Major third"
 msgstr "長3度"
-
 
 #: js/utils/musicutils.js:723
 msgid "Diminished fourth"
 msgstr "減4度"
 
-
 #: js/utils/musicutils.js:724
 msgid "Perfect fourth"
 msgstr "完全4度"
-
 
 #: js/utils/musicutils.js:724
 msgid "Augmented third"
 msgstr "増3度"
 
-
 #: js/utils/musicutils.js:725
 msgid "Diminished fifth"
 msgstr "減5度"
-
 
 #: js/utils/musicutils.js:725
 msgid "Augmented fourth"
 msgstr "増4度"
 
-
 #: js/utils/musicutils.js:726
 msgid "Perfect fifth"
 msgstr "完全5度"
-
 
 #: js/utils/musicutils.js:726
 msgid "Diminished sixth"
 msgstr "減6度"
 
-
 #: js/utils/musicutils.js:727
 msgid "Minor sixth"
 msgstr "短6度"
-
 
 #: js/utils/musicutils.js:727
 msgid "Augmented fifth"
 msgstr "増5度"
 
-
 #: js/utils/musicutils.js:728
 msgid "Major sixth"
 msgstr "長6度"
-
 
 #: js/utils/musicutils.js:728
 msgid "Diminished seventh"
 msgstr "減7度"
 
-
 #: js/utils/musicutils.js:729
 msgid "Minor seventh"
 msgstr "短7度"
-
 
 #: js/utils/musicutils.js:729
 msgid "Augmented sixth"
 msgstr "増6度"
 
-
 #: js/utils/musicutils.js:730
 msgid "Major seventh"
 msgstr "長7度"
-
 
 #: js/utils/musicutils.js:730
 msgid "Diminished octave"
 msgstr "減8度"
 
-
 #: js/utils/musicutils.js:731
 msgid "Perfect octave"
 msgstr "完全8度"
-
 
 #: js/utils/musicutils.js:731
 msgid "Augmented seventh"
 msgstr "増7度"
 
-
 #: js/utils/musicutils.js:732
 msgid "Minor ninth"
 msgstr "短9度"
-
 
 #: js/utils/musicutils.js:732
 msgid "Augmented octave"
 msgstr "増8度"
 
-
 #: js/utils/musicutils.js:733
 msgid "Major ninth"
 msgstr "長9度"
-
 
 #: js/utils/musicutils.js:733
 msgid "Diminished tenth"
 msgstr "減10度"
 
-
 #: js/utils/musicutils.js:734
 msgid "Minor tenth"
 msgstr "短10度"
-
 
 #: js/utils/musicutils.js:734
 msgid "Augmented ninth"
 msgstr "増9度"
 
-
 #: js/utils/musicutils.js:735
 msgid "Major tenth"
 msgstr "長10度"
-
 
 #: js/utils/musicutils.js:735
 msgid "Diminished eleventh"
 msgstr "減11度"
 
-
 #: js/utils/musicutils.js:736
 msgid "Perfect eleventh"
 msgstr "完全11度"
-
 
 #: js/utils/musicutils.js:736
 msgid "Augmented tenth"
 msgstr "増10度"
 
-
 #: js/utils/musicutils.js:737
 msgid "Diminished twelfth"
 msgstr "減12度"
-
 
 #: js/utils/musicutils.js:737
 msgid "Augmented eleventh"
 msgstr "増11度"
 
-
 #: js/utils/musicutils.js:738
 msgid "Perfect twelfth"
 msgstr "完全12度"
-
 
 #: js/utils/musicutils.js:738
 msgid "Diminished thirteenth"
 msgstr "減13度"
 
-
 #: js/utils/musicutils.js:739
 msgid "Minor thirteenth"
 msgstr "短13度"
-
 
 #: js/utils/musicutils.js:739
 msgid "Augmented fifth, plus an octave"
 msgstr "増12度"
 
-
 #: js/utils/musicutils.js:740
 msgid "Major thirteenth"
 msgstr "長13度"
-
 
 #: js/utils/musicutils.js:740
 msgid "Diminished seventh, plus an octave"
 msgstr "減14度"
 
-
 #: js/utils/musicutils.js:868
 #.  TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
-
 
 #: js/utils/musicutils.js:1061
 #: js/utils/musicutils.js:1247
@@ -3340,14 +2721,12 @@ msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
 msgid "augmented"
 msgstr "オーギュメント（増）"
 
-
 #: js/utils/musicutils.js:1063
 #: js/utils/musicutils.js:1248
 #: js/utils/musicutils.js:1474
 #.  TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（減）"
-
 
 #: js/utils/musicutils.js:1069
 #: js/utils/musicutils.js:1472
@@ -3358,216 +2737,178 @@ msgstr "ディミニッシュ（減）"
 msgid "perfect"
 msgstr "パーフェクト（完全）"
 
-
 #: js/utils/musicutils.js:1071
 #.  TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック音階"
 
-
 #: js/utils/musicutils.js:1072
 msgid "algerian"
 msgstr "アルジェリア音階"
 
-
 #: js/utils/musicutils.js:1073
 msgid "spanish"
 msgstr "スペイン音階"
-
 
 #: js/utils/musicutils.js:1075
 #.  TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
-
 #: js/utils/musicutils.js:1077
 #.  TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長音階）"
-
 
 #: js/utils/musicutils.js:1079
 #.  TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "自然短音階"
 
-
 #: js/utils/musicutils.js:1081
 #.  TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "和声短音階"
-
 
 #: js/utils/musicutils.js:1083
 #.  TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "旋律短音階"
 
-
 #: js/utils/musicutils.js:1087
 #.  TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン音階"
-
 
 #: js/utils/musicutils.js:1089
 #.  TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン音階"
 
-
 #: js/utils/musicutils.js:1091
 #.  TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン音階"
-
 
 #: js/utils/musicutils.js:1093
 #.  TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン音階"
 
-
 #: js/utils/musicutils.js:1097
 #.  TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン音階"
-
 
 #: js/utils/musicutils.js:1099
 #.  TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード音階"
 
-
 #: js/utils/musicutils.js:1101
 #.  TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ音階"
 
-
 #: js/utils/musicutils.js:1102
 msgid "arabic"
 msgstr "アラビア音階"
 
-
 #: js/utils/musicutils.js:1103
 msgid "byzantine"
 msgstr "ビザンティン"
-
 
 #: js/utils/musicutils.js:1105
 #.  TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディの音階"
 
-
 #: js/utils/musicutils.js:1106
 msgid "ethiopian"
 msgstr "エチオピア音階"
-
 
 #: js/utils/musicutils.js:1108
 #.  TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ音階"
 
-
 #: js/utils/musicutils.js:1109
 msgid "hindu"
 msgstr "ヒンドゥー音階"
 
-
 #: js/utils/musicutils.js:1110
 msgid "hungarian"
 msgstr "ハンガリー音階"
-
 
 #: js/utils/musicutils.js:1112
 #.  TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー音階"
 
-
 #: js/utils/musicutils.js:1113
 msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー音階"
-
 
 #: js/utils/musicutils.js:1115
 #.  TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム音階"
 
-
 #: js/utils/musicutils.js:1117
 #.  TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース音階"
-
 
 #: js/utils/musicutils.js:1119
 #.  TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース音階"
 
-
 #: js/utils/musicutils.js:1120
 msgid "whole tone"
 msgstr "ホールトーン音階"
-
 
 #: js/utils/musicutils.js:1122
 #.  TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック音階"
 
-
 #: js/utils/musicutils.js:1124
 #.  TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニック音階"
 
-
 #: js/utils/musicutils.js:1125
 msgid "chinese"
 msgstr "中国音階"
 
-
 #: js/utils/musicutils.js:1126
 msgid "egyptian"
 msgstr "エジプト音階"
-
 
 #: js/utils/musicutils.js:1128
 #.  TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "平調子"
 
-
 #: js/utils/musicutils.js:1129
 msgid "Japan"
 msgstr "日本"
-
 
 #: js/utils/musicutils.js:1131
 #.  TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "陰音階"
 
-
 #: js/utils/musicutils.js:1133
 #.  TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "民謡音階"
 
-
 #: js/utils/musicutils.js:1135
 #.  TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ音階"
-
 
 #: js/utils/musicutils.js:1136
 #: js/utils/musicutils.js:1190
@@ -3586,7 +2927,6 @@ msgstr "フィボナッチ音階"
 msgid "custom"
 msgstr "オリジナル"
 
-
 #: js/utils/musicutils.js:1138
 #: js/utils/musicutils.js:1694
 #: js/blocks/WidgetBlocks.js:222
@@ -3594,13 +2934,11 @@ msgstr "オリジナル"
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
-
 #: js/utils/musicutils.js:1140
 #: js/utils/musicutils.js:1695
 #.  TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
-
 
 #: js/utils/musicutils.js:1142
 #: js/utils/musicutils.js:1696
@@ -3608,13 +2946,11 @@ msgstr "ローパス・フィルター"
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
-
 #: js/utils/musicutils.js:1144
 #: js/utils/musicutils.js:1697
 #.  TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
-
 
 #: js/utils/musicutils.js:1146
 #: js/utils/musicutils.js:1698
@@ -3622,13 +2958,11 @@ msgstr "ハイシェルフ・フィルター"
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
-
 #: js/utils/musicutils.js:1148
 #: js/utils/musicutils.js:1699
 #.  TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
-
 
 #: js/utils/musicutils.js:1150
 #: js/utils/musicutils.js:1700
@@ -3636,13 +2970,11 @@ msgstr "ノッチ・フィルター"
 msgid "allpass"
 msgstr "オールパスフィルター"
 
-
 #: js/utils/musicutils.js:1152
 #: js/utils/musicutils.js:1701
 #.  TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
-
 
 #: js/utils/musicutils.js:1153
 #: js/utils/musicutils.js:1709
@@ -3653,7 +2985,6 @@ msgstr "ピーク・フィルタ"
 msgid "sine"
 msgstr "サイン波"
 
-
 #: js/utils/musicutils.js:1154
 #: js/utils/musicutils.js:1710
 #: js/utils/synthutils.js:142
@@ -3662,7 +2993,6 @@ msgstr "サイン波"
 #.  TRANS: square wave
 msgid "square"
 msgstr "四角の波"
-
 
 #: js/utils/musicutils.js:1155
 #: js/utils/musicutils.js:1711
@@ -3674,7 +3004,6 @@ msgstr "四角の波"
 msgid "triangle"
 msgstr "三角の波"
 
-
 #: js/utils/musicutils.js:1156
 #: js/utils/musicutils.js:1712
 #: js/utils/synthutils.js:144
@@ -3683,7 +3012,6 @@ msgstr "三角の波"
 #.  TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの波"
-
 
 #: js/utils/musicutils.js:1158
 #: js/utils/musicutils.js:1462
@@ -3695,7 +3023,6 @@ msgstr "ぎざぎざの波"
 msgid "even"
 msgstr "偶数"
 
-
 #: js/utils/musicutils.js:1160
 #: js/utils/musicutils.js:1463
 #: js/blocks/PitchBlocks.js:977
@@ -3704,14 +3031,12 @@ msgstr "偶数"
 msgid "odd"
 msgstr "奇数"
 
-
 #: js/utils/musicutils.js:1161
 #: js/utils/musicutils.js:1464
 #: js/blocks/PitchBlocks.js:977
 #: js/turtleactions/PitchActions.js:572
 msgid "scalar"
 msgstr "音階的"
-
 
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:80
@@ -3721,14 +3046,12 @@ msgstr "音階的"
 msgid "piano"
 msgstr "ピアノ"
 
-
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:82
 #: js/widgets/legobricks.js:1929
 #.  TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
-
 
 #: js/utils/musicutils.js:1164
 #: js/utils/synthutils.js:84
@@ -3737,20 +3060,17 @@ msgstr "バイオリン"
 msgid "viola"
 msgstr "ビオラ"
 
-
 #: js/utils/musicutils.js:1165
 #: js/utils/synthutils.js:128
 #.  TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "木琴"
 
-
 #: js/utils/musicutils.js:1166
 #: js/utils/synthutils.js:150
 #.  TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "鉄琴"
-
 
 #: js/utils/musicutils.js:1167
 #: js/utils/synthutils.js:86
@@ -3759,13 +3079,11 @@ msgstr "鉄琴"
 msgid "cello"
 msgstr "チェロ"
 
-
 #: js/utils/musicutils.js:1169
 #: js/utils/synthutils.js:90
 #.  TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
-
 
 #: js/utils/musicutils.js:1170
 #: js/utils/synthutils.js:98
@@ -3775,13 +3093,11 @@ msgstr "ダブルベース"
 msgid "guitar"
 msgstr "ギター"
 
-
 #: js/utils/musicutils.js:1171
 #: js/utils/synthutils.js:92
 #.  TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "シタール"
-
 
 #: js/utils/musicutils.js:1172
 #: js/utils/synthutils.js:94
@@ -3789,13 +3105,11 @@ msgstr "シタール"
 msgid "harmonium"
 msgstr "ハルモニウム"
 
-
 #: js/utils/musicutils.js:1173
 #: js/utils/synthutils.js:96
 #.  TRANS: mandolin musical instrument
 msgid "mandolin"
 msgstr "マンドリン"
-
 
 #: js/utils/musicutils.js:1174
 #: js/utils/synthutils.js:100
@@ -3804,14 +3118,12 @@ msgstr "マンドリン"
 msgid "acoustic guitar"
 msgstr "アコースティック"
 
-
 #: js/utils/musicutils.js:1175
 #: js/utils/synthutils.js:102
 #: js/widgets/legobricks.js:1933
 #.  TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
-
 
 #: js/utils/musicutils.js:1176
 #: js/utils/synthutils.js:104
@@ -3820,14 +3132,12 @@ msgstr "フルート"
 msgid "clarinet"
 msgstr "クラリネット"
 
-
 #: js/utils/musicutils.js:1177
 #: js/utils/synthutils.js:106
 #: js/widgets/legobricks.js:1935
 #.  TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
-
 
 #: js/utils/musicutils.js:1178
 #: js/utils/synthutils.js:108
@@ -3836,14 +3146,12 @@ msgstr "サクソフォン"
 msgid "tuba"
 msgstr "チューバ"
 
-
 #: js/utils/musicutils.js:1179
 #: js/utils/synthutils.js:110
 #: js/widgets/legobricks.js:1936
 #.  TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
-
 
 #: js/utils/musicutils.js:1180
 #: js/utils/synthutils.js:112
@@ -3852,14 +3160,12 @@ msgstr "トランペット"
 msgid "oboe"
 msgstr "オーボエ"
 
-
 #: js/utils/musicutils.js:1181
 #: js/utils/synthutils.js:114
 #: js/widgets/legobricks.js:1937
 #.  TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
-
 
 #: js/utils/musicutils.js:1182
 #: js/utils/synthutils.js:130
@@ -3868,28 +3174,23 @@ msgstr "トロンボーン"
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
-
 #: js/utils/musicutils.js:1183
 #: js/utils/synthutils.js:132
 #.  TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
 
-
 #: js/utils/musicutils.js:1184
 msgid "simple 2"
 msgstr "シンプル２"
-
 
 #: js/utils/musicutils.js:1185
 msgid "simple 3"
 msgstr "シンプル３"
 
-
 #: js/utils/musicutils.js:1186
 msgid "simple 4"
 msgstr "シンプル４"
-
 
 #: js/utils/musicutils.js:1187
 #: js/utils/synthutils.js:66
@@ -3898,20 +3199,17 @@ msgstr "シンプル４"
 msgid "white noise"
 msgstr "ホワイトノイズ"
 
-
 #: js/utils/musicutils.js:1188
 #: js/utils/synthutils.js:68
 #.  TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
-
 #: js/utils/musicutils.js:1189
 #: js/utils/synthutils.js:70
 #.  TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
-
 
 #: js/utils/musicutils.js:1191
 #: js/utils/synthutils.js:162
@@ -3921,13 +3219,11 @@ msgstr "ピンクノイズ"
 msgid "snare drum"
 msgstr "スネアドラム"
 
-
 #: js/utils/musicutils.js:1192
 #: js/utils/synthutils.js:164
 #.  TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
-
 
 #: js/utils/musicutils.js:1193
 #: js/utils/synthutils.js:166
@@ -3935,13 +3231,11 @@ msgstr "キックドラム"
 msgid "tom tom"
 msgstr "タムタム"
 
-
 #: js/utils/musicutils.js:1194
 #: js/utils/synthutils.js:168
 #.  TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
-
 
 #: js/utils/musicutils.js:1195
 #: js/utils/synthutils.js:170
@@ -3949,13 +3243,11 @@ msgstr "フロアタム"
 msgid "bass drum"
 msgstr "バスドラム"
 
-
 #: js/utils/musicutils.js:1196
 #: js/utils/synthutils.js:172
 #.  TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
-
 
 #: js/utils/musicutils.js:1197
 #: js/utils/synthutils.js:174
@@ -3963,13 +3255,11 @@ msgstr "カップドラム"
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
-
 #: js/utils/musicutils.js:1198
 #: js/utils/synthutils.js:178
 #.  TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
-
 
 #: js/utils/musicutils.js:1199
 #: js/utils/synthutils.js:180
@@ -3977,18 +3267,15 @@ msgstr "ハイハット"
 msgid "ride bell"
 msgstr "ライドベル"
 
-
 #: js/utils/musicutils.js:1200
 #: js/utils/synthutils.js:182
 #.  TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
 
-
 #: js/utils/musicutils.js:1201
 msgid "japanese drum"
 msgstr "太鼓"
-
 
 #: js/utils/musicutils.js:1202
 #: js/utils/synthutils.js:188
@@ -3996,13 +3283,11 @@ msgstr "太鼓"
 msgid "japanese bell"
 msgstr "鉦"
 
-
 #: js/utils/musicutils.js:1203
 #: js/utils/synthutils.js:184
 #.  TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
-
 
 #: js/utils/musicutils.js:1204
 #: js/utils/synthutils.js:186
@@ -4010,13 +3295,11 @@ msgstr "トライアングル"
 msgid "finger cymbals"
 msgstr "フィンガーシンバル"
 
-
 #: js/utils/musicutils.js:1205
 #: js/utils/synthutils.js:190
 #.  TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
-
 
 #: js/utils/musicutils.js:1206
 #: js/utils/synthutils.js:192
@@ -4024,13 +3307,11 @@ msgstr "チャイム"
 msgid "gong"
 msgstr "ドラ"
 
-
 #: js/utils/musicutils.js:1207
 #: js/utils/synthutils.js:194
 #.  TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
-
 
 #: js/utils/musicutils.js:1208
 #: js/utils/synthutils.js:196
@@ -4038,13 +3319,11 @@ msgstr "カチャカチャ"
 msgid "crash"
 msgstr "クラッシュ"
 
-
 #: js/utils/musicutils.js:1209
 #: js/utils/synthutils.js:198
 #.  TRANS: sound effect
 msgid "bottle"
 msgstr "空きびん"
-
 
 #: js/utils/musicutils.js:1210
 #: js/utils/synthutils.js:200
@@ -4052,13 +3331,11 @@ msgstr "空きびん"
 msgid "clap"
 msgstr "てびょうし"
 
-
 #: js/utils/musicutils.js:1211
 #: js/utils/synthutils.js:202
 #.  TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
-
 
 #: js/utils/musicutils.js:1212
 #: js/utils/synthutils.js:204
@@ -4066,13 +3343,11 @@ msgstr "ピシャリ"
 msgid "splash"
 msgstr "しぶき"
 
-
 #: js/utils/musicutils.js:1213
 #: js/utils/synthutils.js:206
 #.  TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
-
 
 #: js/utils/musicutils.js:1214
 #: js/utils/synthutils.js:208
@@ -4080,13 +3355,11 @@ msgstr "あわ"
 msgid "raindrop"
 msgstr "雨のしずく"
 
-
 #: js/utils/musicutils.js:1215
 #: js/utils/synthutils.js:210
 #.  TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
-
 
 #: js/utils/musicutils.js:1216
 #: js/utils/synthutils.js:212
@@ -4094,13 +3367,11 @@ msgstr "ねこ"
 msgid "cricket"
 msgstr "こおろぎ"
 
-
 #: js/utils/musicutils.js:1217
 #: js/utils/synthutils.js:214
 #.  TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
-
 
 #: js/utils/musicutils.js:1219
 #: js/utils/synthutils.js:116
@@ -4109,20 +3380,17 @@ msgstr "いぬ"
 msgid "banjo"
 msgstr "バンジョー"
 
-
 #: js/utils/musicutils.js:1220
 #: js/utils/synthutils.js:118
 #.  TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
-
 #: js/utils/musicutils.js:1221
 #: js/utils/synthutils.js:120
 #.  TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
-
 
 #: js/utils/musicutils.js:1222
 #: js/utils/synthutils.js:122
@@ -4131,13 +3399,11 @@ msgstr "ダルシマー"
 msgid "electric guitar"
 msgstr "エレキギター"
 
-
 #: js/utils/musicutils.js:1223
 #: js/utils/synthutils.js:124
 #.  TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
-
 
 #: js/utils/musicutils.js:1224
 #: js/utils/synthutils.js:126
@@ -4145,25 +3411,21 @@ msgstr "バスーン"
 msgid "celeste"
 msgstr "セレスタ"
 
-
 #: js/utils/musicutils.js:1226
 #: js/widgets/temperament.js:923
 #.  TRANS: musical temperament
 msgid "equal"
 msgstr "平均律"
 
-
 #: js/utils/musicutils.js:1228
 #.  TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス音律 "
 
-
 #: js/utils/musicutils.js:1230
 #.  TRANS: musical temperament
 msgid "just intonation"
 msgstr "純正律"
-
 
 #: js/utils/musicutils.js:1232
 #: js/utils/musicutils.js:1727
@@ -4174,136 +3436,112 @@ msgstr "純正律"
 msgid "Meantone"
 msgstr "中全音律"
 
-
 #: js/utils/musicutils.js:1249
 msgid "major 7th"
 msgstr "長七の和音（メイジャー・セブンス)"
-
 
 #: js/utils/musicutils.js:1250
 msgid "minor 7th"
 msgstr "短七の和音（マイナー・セブンス）"
 
-
 #: js/utils/musicutils.js:1251
 msgid "dominant 7th"
 msgstr "属七の和音（ドミナント・セブンス）"
-
 
 #: js/utils/musicutils.js:1252
 msgid "minor-major 7th"
 msgstr "短三長七の和音（マイナー・メイジャー・セブンス）"
 
-
 #: js/utils/musicutils.js:1253
 msgid "fully-diminished 7th"
 msgstr "減七の和音（ディミニッシュト・セブンス）"
 
-
 #: js/utils/musicutils.js:1254
 msgid "half-diminished 7th"
 msgstr "減五短七の和音（ハーフ・ディミニッシュト）"
-
 
 #: js/utils/musicutils.js:1720
 #: js/utils/musicutils.js:1736
 msgid "Equal (12EDO)"
 msgstr "12平均律"
 
-
 #: js/utils/musicutils.js:1721
 #: js/utils/musicutils.js:1737
 msgid "Equal (5EDO)"
 msgstr "5平均律"
-
 
 #: js/utils/musicutils.js:1722
 #: js/utils/musicutils.js:1738
 msgid "Equal (7EDO)"
 msgstr "7平均律"
 
-
 #: js/utils/musicutils.js:1723
 #: js/utils/musicutils.js:1739
 msgid "Equal (19EDO)"
 msgstr "19平均律"
-
 
 #: js/utils/musicutils.js:1724
 #: js/utils/musicutils.js:1740
 msgid "Equal (31EDO)"
 msgstr "31平均律"
 
-
 #: js/utils/musicutils.js:1725
 #: js/utils/musicutils.js:1741
 msgid "5-limit Just Intonation"
 msgstr "5限界純正律"
-
 
 #: js/utils/musicutils.js:1726
 #: js/utils/musicutils.js:1742
 msgid "Pythagorean (3-limit JI)"
 msgstr "ピタゴラス音律"
 
-
 #: js/utils/musicutils.js:4051
 #: js/widgets/temperament.js:2602
 msgid "Invalid temperament. Falling back to equal temperament."
 msgstr "無効な気質。平均律に戻ります。"
-
 
 #: js/utils/musicutils.js:6174
 #: js/utils/musicutils.js:6217
 msgid "current"
 msgstr "現在の"
 
-
 #: js/utils/musicutils.js:6177
 #: js/utils/musicutils.js:6208
 msgid "next"
 msgstr "この次の"
-
 
 #: js/utils/musicutils.js:6180
 #: js/utils/musicutils.js:6213
 msgid "previous"
 msgstr "この前の"
 
-
 #: js/utils/synthutils.js:134
 #.  TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
-
 
 #: js/utils/synthutils.js:136
 #.  TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
-
 #: js/utils/synthutils.js:138
 #.  TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
-
 
 #: js/utils/synthutils.js:176
 #.  TRANS: musical instrument
 msgid "taiko"
 msgstr "太鼓"
 
-
 #: js/utils/synthutils.js:2091
 msgid "⚠️ Sound is disabled!\n\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
 msgstr "⚠⚠ 音声は ブロックされています。。。ブラウザー の設定 (サイトの せってい > 音声) を確認して、ミュージック・ブロックスの 音声を 許可して ください。"
 
-
 #: js/utils/synthutils.js:3548
 msgid "Cents Adjustment"
 msgstr "セント調整"
-
 
 #: js/utils/synthutils.js:3577
 #: js/widgets/sampler.js:1992
@@ -4311,26 +3549,21 @@ msgstr "セント調整"
 msgid "reference tone"
 msgstr "参照ピッチ"
 
-
 #: js/utils/utils.js:619
 msgid "Security Warning"
 msgstr "セキュリティ警告"
-
 
 #: js/utils/utils.js:621
 msgid "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
 msgstr "このプラグインには、ブラウザで実行されるコードが含まれています。組み込みのプラグイン ディレクトリからロードされていないため、安全でないコードが含まれている可能性があります。"
 
-
 #: js/utils/utils.js:625
 msgid "Do you want to allow this plugin to run?"
 msgstr "このプラグインの実行を許可しますか?"
 
-
 #: js/utils/utils.js:627
 msgid "Source: %s"
 msgstr "ソース: %s"
-
 
 #: js/utils/utils.js:627
 #: js/blocks/ExtrasBlocks.js:692
@@ -4344,33 +3577,27 @@ msgstr "ソース: %s"
 msgid "unknown"
 msgstr "不明"
 
-
 #: js/blocks/ActionBlocks.js:58
 msgid "The Return block will return a value from an action."
 msgstr "Returnブロックはアクションから値を返します。"
-
 
 #: js/blocks/ActionBlocks.js:75
 msgid "return"
 msgstr "リターン"
 
-
 #: js/blocks/ActionBlocks.js:136
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Return to URLブロックは値をウェブページに返します。"
 
-
 #: js/blocks/ActionBlocks.js:153
 msgid "return to URL"
 msgstr "URLに戻ります"
-
 
 #: js/blocks/ActionBlocks.js:186
 #: js/blocks/ProgramBlocks.js:86
 #: js/blocks/ProgramBlocks.js:181
 msgid "Invalid URL"
 msgstr "無効な URL"
-
 
 #: js/blocks/ActionBlocks.js:238
 #: js/blocks/ActionBlocks.js:295
@@ -4379,13 +3606,11 @@ msgstr "無効な URL"
 msgid "The Calculate block returns a value calculated by an action."
 msgstr "Calculateブロックはアクションで計算された値を返します。"
 
-
 #: js/blocks/ActionBlocks.js:256
 #: js/blocks/ActionBlocks.js:521
 #: js/blocks/ActionBlocks.js:711
 msgid "calculate"
 msgstr "計算する"
-
 
 #: js/blocks/ActionBlocks.js:381
 #: js/blocks/ActionBlocks.js:597
@@ -4395,7 +3620,6 @@ msgstr "計算する"
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（指定）</h2><br>指定したアクションブロックを実行する。"
 
-
 #: js/blocks/ActionBlocks.js:395
 #: js/blocks/ActionBlocks.js:614
 #: js/blocks/ActionBlocks.js:963
@@ -4403,7 +3627,6 @@ msgstr "<h2>アクションブロック（指定）</h2><br>指定したアク�
 #: js/blocks/MeterBlocks.js:804
 msgid "do1"
 msgstr "アクション実行"
-
 
 #: js/blocks/ActionBlocks.js:395
 #: js/blocks/ActionBlocks.js:614
@@ -4415,18 +3638,15 @@ msgstr "アクション実行"
 msgid "do"
 msgstr "アクション"
 
-
 #: js/blocks/ActionBlocks.js:795
 #: js/blocks/ActionBlocks.js:869
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr "Argブロックはアクションに渡された引数の値を含みます。"
 
-
 #: js/blocks/ActionBlocks.js:810
 #: js/blocks/ActionBlocks.js:882
 msgid "arg"
 msgstr "引数"
-
 
 #: js/blocks/ActionBlocks.js:840
 #: js/blocks/ActionBlocks.js:904
@@ -4434,27 +3654,22 @@ msgstr "引数"
 msgid "Invalid argument"
 msgstr "無効な議論"
 
-
 #: js/blocks/ActionBlocks.js:948
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr "<br><br>図の例は、決まったアクションではなく、２つのうちどちらか１つのアクションをランダムに実行させる。"
-
 
 #: js/blocks/ActionBlocks.js:1022
 #: js/blocks/ActionBlocks.js:1029
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr "<h2>イベントブロック（受け取り）</h2><br>特定のイベントに対して、その発生を受け取るたびに実行するアクションを１つ決めておくことができる。"
 
-
 #: js/blocks/ActionBlocks.js:1031
 msgid "When the event happens, an action is taken."
 msgstr "<br><br>イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
 
-
 #: js/blocks/ActionBlocks.js:1048
 msgid "on"
 msgstr "のとき"
-
 
 #: js/blocks/ActionBlocks.js:1051
 #: js/blocks/ActionBlocks.js:1052
@@ -4462,138 +3677,111 @@ msgstr "のとき"
 msgid "event"
 msgstr "イベント"
 
-
 #: js/blocks/ActionBlocks.js:1141
 msgid "The Broadcast block is used to trigger an event."
 msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
-
 
 #: js/blocks/ActionBlocks.js:1159
 msgid "broadcast"
 msgstr "イベント発生"
 
-
 #: js/blocks/ActionBlocks.js:1216
 msgid "Each Start block is a separate voice."
 msgstr "<h2>スタートブロック</h2><br>実行ボタンがおされると、スタートブロックが実行される。"
-
 
 #: js/blocks/ActionBlocks.js:1218
 msgid "All of the Start blocks run at the same time when the Play button is pressed."
 msgstr "[再生] ボタンを押すと、すべての Start ブロックが同時に実行されます。"
 
-
 #: js/blocks/ActionBlocks.js:1308
 msgid "The Action block is used to group together blocks so that they can be used more than once."
 msgstr "アクション ブロックは、複数のブロックをグループ化して複数回使用できるようにするために使用されます。"
-
 
 #: js/blocks/ActionBlocks.js:1312
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr "<br><br>何度も実行する音楽のフレーズなどにアクションを作っておくと便利。"
 
-
 #: js/blocks/ActionBlocks.js:1501
 msgid "define temperament"
 msgstr "音律を明確にする"
-
 
 #: js/blocks/BooleanBlocks.js:44
 msgid "The Not block is the logical not operator."
 msgstr "「ではない」ブロックは論理的なNOT演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:62
 msgid "not"
 msgstr "ではない"
-
 
 #: js/blocks/BooleanBlocks.js:133
 msgid "The And block is the logical and operator."
 msgstr "「かつ」ブロックは論理積（AND）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:151
 msgid "and"
 msgstr "かつ"
-
 
 #: js/blocks/BooleanBlocks.js:217
 msgid "The Or block is the logical or operator."
 msgstr "「または」ブロックは論理和（OR）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:235
 msgid "or"
 msgstr "または"
-
 
 #: js/blocks/BooleanBlocks.js:301
 msgid "The XOR block is the logical XOR operator."
 msgstr "XORブロックは排他的論理和（XOR）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:319
 msgid "xor"
 msgstr "XOR（エクスクルーシブ・オア）"
-
 
 #: js/blocks/BooleanBlocks.js:391
 msgid "The Greater-than block returns True if the top number is greater than the bottom number."
 msgstr "「＞」ブロックは、上の数値が下の数値より大きい場合に「実」を返します。"
 
-
 #: js/blocks/BooleanBlocks.js:496
 msgid "The Less-than block returns True if the top number is less than the bottom number."
 msgstr "「＜」ブロックは、上の数値が下の数値より小さい場合に「実」を返します。"
-
 
 #: js/blocks/BooleanBlocks.js:596
 msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
 msgstr "「≦」ブロックは、上の数値が下の数値以下の場合に「実」を返します。"
 
-
 #: js/blocks/BooleanBlocks.js:696
 msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
 msgstr "「≥」ブロックは、上の数値が下の数値以上である場合に「実」を返します。"
-
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "<h2>しんぎブロック（等しい）</h2><br>２つのすうちをくらべて、同じすうちであるかどうかはんていする。「＝」は、２つのすうちが同じであれば「真（しん）」、同じでなければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
-
 #: js/blocks/BooleanBlocks.js:901
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr "「≠」ブロックは2つの数字が等しくない場合に「実」を返します。"
 
-
 #: js/blocks/BooleanBlocks.js:1001
 msgid "The Boolean block is used to specify true or false."
 msgstr "「比べる」ブロックは「実」または「偽」を指定するために使われます。"
-
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、好きなすうちを足す。マイナスのすうちを使うと引き算になる。"
 
-
 #: js/blocks/BoxesBlocks.js:61
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr "<br><br>マイナスの数値を使うと引き算になる。"
-
 
 #: js/blocks/BoxesBlocks.js:73
 msgid "add"
 msgstr "足す"
 
-
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:1001
 msgid "to"
 msgstr "箱へ"
-
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:598
@@ -4601,43 +3789,35 @@ msgstr "箱へ"
 msgid "value1"
 msgstr "すうち"
 
-
 #: js/blocks/BoxesBlocks.js:118
 msgid "Block does not support incrementing."
 msgstr "ブロックは、増殖をサポートできません"
-
 
 #: js/blocks/BoxesBlocks.js:152
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、１を足す。"
 
-
 #: js/blocks/BoxesBlocks.js:163
 msgid "add 1 to"
 msgstr "箱に１を足す"
-
 
 #: js/blocks/BoxesBlocks.js:211
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "Subtract-1-fromブロックはボックスに保存された値から1を引きます。"
 
-
 #: js/blocks/BoxesBlocks.js:222
 msgid "subtract 1 from"
 msgstr "〜から１引く"
-
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
 msgid "The Box block returns the value stored in a box."
 msgstr "<h2>すうちブロック</h2><br>すうちブロックとして、箱のすうちを使う。"
 
-
 #: js/blocks/BoxesBlocks.js:503
 #: js/blocks/BoxesBlocks.js:579
 msgid "The Store in block will store a value in a box."
 msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、指定したすうちを入れる。"
-
 
 #: js/blocks/BoxesBlocks.js:598
 #: js/blocks/EnsembleBlocks.js:408
@@ -4645,46 +3825,37 @@ msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、�
 msgid "name1"
 msgstr "箱へ"
 
-
 #: js/blocks/BoxesBlocks.js:655
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "Box2ブロックはBox2に保存された値を返します。"
-
 
 #: js/blocks/BoxesBlocks.js:706
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr "Store in Box2ブロックは値をBox2に保存するために使われます。"
 
-
 #: js/blocks/BoxesBlocks.js:718
 msgid "store in box2"
 msgstr "箱２にすうちを入れる"
-
 
 #: js/blocks/BoxesBlocks.js:764
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "Box1ブロックはBox1に保存された値を返します。"
 
-
 #: js/blocks/BoxesBlocks.js:815
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr "Store in Box1ブロックは値をBox1に保存するために使われます。"
-
 
 #: js/blocks/BoxesBlocks.js:829
 msgid "store in box1"
 msgstr "箱１にすうちを入れる"
 
-
 #: js/blocks/DictBlocks.js:62
 msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
 msgstr "「辞書を表す」ブロックは、画面の上部に辞書の内容を表示します。"
 
-
 #: js/blocks/DictBlocks.js:77
 msgid "show dictionary"
 msgstr "辞書を表す"
-
 
 #: js/blocks/DictBlocks.js:80
 #: js/blocks/DictBlocks.js:145
@@ -4696,24 +3867,20 @@ msgstr "辞書を表す"
 msgid "My Dictionary"
 msgstr "私の辞書"
 
-
 #: js/blocks/DictBlocks.js:129
 msgid "The Dictionary block returns a dictionary."
 msgstr "Dictionaryブロックは辞書を返します。"
-
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックは指定されたキーの辞書の値を返します。"
 
-
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
 #.  TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "数価を表す"
-
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -4724,7 +3891,6 @@ msgstr "数価を表す"
 #: js/blocks/DictBlocks.js:431
 msgid "key2"
 msgstr "キーワード"
-
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -4738,12 +3904,10 @@ msgstr "キーワード"
 msgid "key"
 msgstr "調"
 
-
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックは指定されたキーに辞書の値を設定します。"
-
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
@@ -4751,89 +3915,72 @@ msgstr "Set-dictブロックは指定されたキーに辞書の値を設定し�
 msgid "set value"
 msgstr "値を設定"
 
-
 #: js/blocks/DrumBlocks.js:59
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr "Noise nameブロックはノイズシンセサイザーを選択するために使われます。"
-
 
 #: js/blocks/DrumBlocks.js:102
 msgid "The Drum name block is used to select a drum."
 msgstr "<h2>ドラムブロック</h2><br>ドラムの種類を変えるときに使う。クリックで、いろいろなドラムの音を選ぶことができる。"
 
-
 #: js/blocks/DrumBlocks.js:146
 msgid "The Effects name block is used to select a sound effect."
 msgstr "<h2>こうかおんブロック</h2><br>こうかおんの種類を変えるときに使う。クリックで、いろいろなおもしろい音を選ぶことができる。"
-
 
 #: js/blocks/DrumBlocks.js:163
 msgid "noise"
 msgstr "ノイズ"
 
-
 #: js/blocks/DrumBlocks.js:177
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr "Play noiseブロックはホワイトノイズ、ピンクノイズ、またはブラウンノイズを生成します。"
 
-
 #: js/blocks/DrumBlocks.js:332
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラム音に置き換えます。"
-
 
 #: js/blocks/DrumBlocks.js:343
 #.  TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "音符をドラムに変える"
 
-
 #: js/blocks/DrumBlocks.js:397
 #: js/blocks/DrumBlocks.js:406
 msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
 msgstr "「ドラムをせってい」ブロックは、含まれているノートのピッチを置き換えるドラム サウンドを選択します。"
 
-
 #: js/blocks/DrumBlocks.js:410
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
-
 
 #: js/blocks/DrumBlocks.js:422
 #.  TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムをせってい"
 
-
 #: js/blocks/DrumBlocks.js:466
 msgid "sound effect"
 msgstr "こうかおん"
-
 
 #: js/blocks/DrumBlocks.js:504
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。"
 
-
 #: js/blocks/EnsembleBlocks.js:90
 msgid "mouse index heap"
 msgstr "ネズミヒープに番号をふる"
-
 
 #: js/blocks/EnsembleBlocks.js:90
 msgid "turtle index heap"
 msgstr "タートル ヒープに番号をふる"
 
-
 #: js/blocks/EnsembleBlocks.js:97
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr "指定されたマウスの指定された位置のヒープ内の値を返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:104
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr "指定されたタートルの指定された位置のヒープ内の値を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:114
 #: js/blocks/EnsembleBlocks.js:189
@@ -4855,25 +4002,21 @@ msgstr "指定されたタートルの指定された位置のヒープ内の値
 msgid "Yertle"
 msgstr "ヤートル"
 
-
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/EnsembleBlocks.js:1106
 msgid "mouse name"
 msgstr "ネズミの名前"
-
 
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/EnsembleBlocks.js:1115
 msgid "turtle name"
 msgstr "ネズミの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/HeapBlocks.js:544
 #.  TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
-
 
 #: js/blocks/EnsembleBlocks.js:144
 #: js/blocks/EnsembleBlocks.js:1223
@@ -4882,33 +4025,27 @@ msgstr "インデックス"
 msgid "Index must be > 0."
 msgstr "インデクス番号は 0 より大きい必要があります。"
 
-
 #: js/blocks/EnsembleBlocks.js:149
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 msgid "Maximum heap size is 1000."
 msgstr "ヒープの大きさは、最大1000です。"
 
-
 #: js/blocks/EnsembleBlocks.js:167
 msgid "stop mouse"
 msgstr "ネズミを止める"
-
 
 #: js/blocks/EnsembleBlocks.js:169
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "指定されたマウスを停止します。"
 
-
 #: js/blocks/EnsembleBlocks.js:180
 msgid "stop turtle"
 msgstr "ネズミを止める"
 
-
 #: js/blocks/EnsembleBlocks.js:182
 msgid "The Stop turtle block stops the specified turtle."
 msgstr "指定されたタートルを停止します。"
-
 
 #: js/blocks/EnsembleBlocks.js:206
 #: js/blocks/EnsembleBlocks.js:266
@@ -4922,7 +4059,6 @@ msgstr "指定されたタートルを停止します。"
 msgid "Cannot find mouse"
 msgstr "ネズミが見つかりません。"
 
-
 #: js/blocks/EnsembleBlocks.js:208
 #: js/blocks/EnsembleBlocks.js:268
 #: js/blocks/EnsembleBlocks.js:432
@@ -4935,92 +4071,75 @@ msgstr "ネズミが見つかりません。"
 msgid "Cannot find turtle"
 msgstr "タートルが見つかりません。"
 
-
 #: js/blocks/EnsembleBlocks.js:227
 msgid "start mouse"
 msgstr "ネズミをスタート"
-
 
 #: js/blocks/EnsembleBlocks.js:230
 msgid "The Start mouse block starts the specified mouse."
 msgstr "指定されたマウスを開始します。"
 
-
 #: js/blocks/EnsembleBlocks.js:241
 msgid "start turtle"
 msgstr "ネズミをスタートする"
-
 
 #: js/blocks/EnsembleBlocks.js:244
 msgid "The Start turtle block starts the specified turtle."
 msgstr "指定されたタートルを開始します。"
 
-
 #: js/blocks/EnsembleBlocks.js:275
 msgid "Mouse is already running."
 msgstr "ネズミはすでに動いています。"
-
 
 #: js/blocks/EnsembleBlocks.js:277
 msgid "Turtle is already running."
 msgstr "タートルはすでに動いています。"
 
-
 #: js/blocks/EnsembleBlocks.js:299
 msgid "Cannot find start block"
 msgstr "「スタート」ブロックが見つかりません。"
-
 
 #: js/blocks/EnsembleBlocks.js:309
 #.  TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの色"
 
-
 #: js/blocks/EnsembleBlocks.js:311
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "指定されたマウスのペンの色を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:323
 #.  TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルの色"
 
-
 #: js/blocks/EnsembleBlocks.js:325
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "指定されたタートルのペンの色を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:355
 #.  TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの進む角度"
 
-
 #: js/blocks/EnsembleBlocks.js:357
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "指定されたマウスの向きを返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:369
 #.  TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルの進む角度"
 
-
 #: js/blocks/EnsembleBlocks.js:371
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr "指定されたタートルの向きを返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:401
 #: js/blocks/EnsembleBlocks.js:458
 #.  TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "ネズミを設定"
-
 
 #: js/blocks/EnsembleBlocks.js:408
 #: js/blocks/EnsembleBlocks.js:419
@@ -5034,7 +4153,6 @@ msgstr "ネズミを設定"
 msgid "x"
 msgstr "xざひょう（よこ）"
 
-
 #: js/blocks/EnsembleBlocks.js:408
 #: js/blocks/EnsembleBlocks.js:419
 #: js/blocks/GraphicsBlocks.js:152
@@ -5047,111 +4165,91 @@ msgstr "xざひょう（よこ）"
 msgid "y"
 msgstr "yざひょう（たて）"
 
-
 #: js/blocks/EnsembleBlocks.js:412
 #: js/blocks/EnsembleBlocks.js:473
 #.  TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "タートルを設定"
 
-
 #: js/blocks/EnsembleBlocks.js:450
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr "指定されたマウスに実行するブロックのスタックを送ります。"
 
-
 #: js/blocks/EnsembleBlocks.js:465
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr "指定されたタートルに実行するブロックのスタックを送ります。"
-
 
 #: js/blocks/EnsembleBlocks.js:501
 #.  TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミのy座標"
 
-
 #: js/blocks/EnsembleBlocks.js:503
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "指定されたマウスのY座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:515
 #.  TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "タートルのy座標"
 
-
 #: js/blocks/EnsembleBlocks.js:517
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "指定されたタートルのY座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:546
 #.  TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミのx座標"
 
-
 #: js/blocks/EnsembleBlocks.js:548
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "指定されたマウスのX座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:560
 #.  TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "タートルのx座標"
 
-
 #: js/blocks/EnsembleBlocks.js:562
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "指定されたタートルのX座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:592
 #.  TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの演奏した音符の数"
 
-
 #: js/blocks/EnsembleBlocks.js:594
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr "指定されたマウスが演奏したノート数を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:608
 #.  TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルの演奏した音符の数"
 
-
 #: js/blocks/EnsembleBlocks.js:610
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr "指定されたタートルが演奏したノート数を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:646
 #.  TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
 
-
 #: js/blocks/EnsembleBlocks.js:648
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr "指定されたマウスが現在演奏しているピッチ番号を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:662
 #.  TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルの音高数字"
 
-
 #: js/blocks/EnsembleBlocks.js:664
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr "指定されたタートルが現在演奏しているピッチ番号を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:768
 #: js/blocks/EnsembleBlocks.js:840
@@ -5159,192 +4257,155 @@ msgstr "指定されたタートルが現在演奏しているピッチ番号を
 msgid "mouse note value"
 msgstr "ネズミの音価"
 
-
 #: js/blocks/EnsembleBlocks.js:778
 #.  TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルの音価"
-
 
 #: js/blocks/EnsembleBlocks.js:851
 #.  TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを同期させる"
 
-
 #: js/blocks/EnsembleBlocks.js:853
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "マウス間のビート数を同期させるブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:865
 #.  TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルを同期させる"
 
-
 #: js/blocks/EnsembleBlocks.js:867
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr "タートル間のビート数を同期させるブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:907
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr "指定されたマウスが見つかった場合に「実」を返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:915
 msgid "found mouse"
 msgstr "ネズミを見つけた"
-
 
 #: js/blocks/EnsembleBlocks.js:925
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr "指定されたタートルが見つかった場合に「実」を返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:933
 msgid "found turtle"
 msgstr "タートル見つかった"
-
 
 #: js/blocks/EnsembleBlocks.js:956
 msgid "new mouse"
 msgstr "新しいネズミ"
 
-
 #: js/blocks/EnsembleBlocks.js:958
 msgid "The New mouse block will create a new mouse."
 msgstr "新しいマウスを作成するブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:969
 msgid "new turtle"
 msgstr "新しいタートル"
 
-
 #: js/blocks/EnsembleBlocks.js:971
 msgid "The New turtle block will create a new turtle."
 msgstr "新しいタートルを作成するブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:1034
 msgid "set mouse color"
 msgstr "ネズミ色を設定"
 
-
 #: js/blocks/EnsembleBlocks.js:1037
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr "「ネズミ色を設定」ブロックは ネズミの色を選ぶことに使います。"
-
 
 #: js/blocks/EnsembleBlocks.js:1043
 msgid "set turtle color"
 msgstr "タートル色を設定"
 
-
 #: js/blocks/EnsembleBlocks.js:1046
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr "タートルの色を設定するためのブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:1109
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "<h2>文字ブロック</h2><br>このプログラムを実行しているネズミの名前（文字列）を表す。"
 
-
 #: js/blocks/EnsembleBlocks.js:1118
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr "タートルの名前を返すブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:1141
 msgid "mouse count"
 msgstr "何匹のネズミ"
 
-
 #: js/blocks/EnsembleBlocks.js:1144
 msgid "The Mouse-count block returns the number of mice."
 msgstr "「何匹のネズミ」のブロックはネズミを数えって数字を表す。"
-
 
 #: js/blocks/EnsembleBlocks.js:1150
 msgid "turtle count"
 msgstr "何匹のタートル"
 
-
 #: js/blocks/EnsembleBlocks.js:1153
 msgid "The Turtle-count block returns the number of turtles."
 msgstr "タートルカウントブロックはタートルの数を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:1175
 msgid "nth mouse name"
 msgstr "何匹目のネズミの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:1178
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr "エヌス・マウス・ネームブロックはエヌ番目のマウスの名前を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:1184
 msgid "nth turtle name"
 msgstr "何匹目のタートルの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:1187
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr "エヌス・タートル・ネームブロックはエヌ番目のタートルの名前を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:1231
 #: js/blocks/EnsembleBlocks.js:1291
 msgid "set name"
 msgstr "ネズミに名前をつける"
 
-
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "source"
 msgstr "ソース"
-
 
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "target"
 msgstr "ターゲット"
 
-
 #: js/blocks/EnsembleBlocks.js:1297
 msgid "The Set-name block is used to name a mouse."
 msgstr "<h2>文字ブロック</h2><br>ネズミに指定した名前をつけることができる。"
-
 
 #: js/blocks/EnsembleBlocks.js:1310
 msgid "The Set-name block is used to name a turtle."
 msgstr "<h2>文字ブロック</h2><br>タートルに指定した名前をつけることができる。"
 
-
 #: js/blocks/ExtrasBlocks.js:33
 msgid "fraction"
 msgstr "分数"
-
 
 #: js/blocks/ExtrasBlocks.js:36
 msgid "Convert a float to a fraction"
 msgstr "小数から分数"
 
-
 #: js/blocks/ExtrasBlocks.js:93
 msgid "save as ABC"
 msgstr "ABCでほぞん"
 
-
 #: js/turtledefs.js:424
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr "タートル・ブロックスはアートと数学を求めるビジュアル・プログラミング言語だ。"
-
 
 #: js/turtledefs.js:426
 #: js/turtledefs.js:446
@@ -5353,55 +4414,45 @@ msgstr "タートル・ブロックスはアートと数学を求めるビジュ
 msgid "The current version is"
 msgstr "ミュージック・ブロックスの最新バージョンは"
 
-
 #: js/turtledefs.js:431
 #: js/turtledefs.js:467
 msgid "Click the run button to run the project in fast mode."
 msgstr "クリックをすると、ふつうのスピードでプログラムを実行することができる。"
 
-
 #: js/turtledefs.js:436
 msgid "Stop the turtle."
 msgstr "タータルを止める"
-
 
 #: js/turtledefs.js:436
 #: js/turtledefs.js:472
 msgid "You can also type Alt-S to stop."
 msgstr "プログラムは、このボタンをおすかわりに、キーボードで「Altキーと Sキーの同時おし」でも止めることができる。"
 
-
 #: js/turtledefs.js:443
 #: js/widgets/help.js:548
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへようこそ"
 
-
 #: js/turtledefs.js:444
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr "音楽と算数とプログラミングをむすびつけ、深く楽しむことができるツール。それが、ミュージック・ブロックスだ。"
-
 
 #: js/turtledefs.js:450
 #: js/widgets/help.js:549
 msgid "Meet Mr. Mouse!"
 msgstr "ミスター・マウスに会おう！"
 
-
 #: js/turtledefs.js:451
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr "ミスター・マウスは、ミュージック・ブロックスの指揮者。"
-
 
 #: js/turtledefs.js:453
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr "ミスター・マウスと一緒に、ミュージック・ブロックスの世界をたんきゅうしよう。"
 
-
 #: js/turtledefs.js:455
 msgid "Let us start our tour!"
 msgstr "では、ツアーを始めよう。"
-
 
 #: js/turtledefs.js:459
 #: js/turtledefs.js:737
@@ -5409,22 +4460,18 @@ msgstr "では、ツアーを始めよう。"
 msgid "Guide"
 msgstr "もっとくわしく知るには"
 
-
 #: js/turtledefs.js:460
 msgid "A detailed guide to Music Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
-
 
 #: js/turtledefs.js:463
 #: js/SaveInterface.js:93
 msgid "Music Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
 
-
 #: js/turtledefs.js:472
 msgid "Stop the music (and the mice)."
 msgstr "実行しているプログラムを止める。"
-
 
 #: js/turtledefs.js:479
 #: js/toolbar-ui.js:131
@@ -5434,11 +4481,9 @@ msgstr "実行しているプログラムを止める。"
 msgid "Record"
 msgstr "録音"
 
-
 #: js/turtledefs.js:480
 msgid "Record your project as video."
 msgstr "再生されているビデオを録音する"
-
 
 #: js/turtledefs.js:485
 #: js/toolbar-ui.js:134
@@ -5448,11 +4493,9 @@ msgstr "再生されているビデオを録音する"
 msgid "Toggle Fullscreen"
 msgstr "フルスクリーンの切り替え"
 
-
 #: js/turtledefs.js:486
 msgid "Toggle Fullscreen mode."
 msgstr "フルスクリーンの切り替え"
-
 
 #: js/turtledefs.js:490
 #: js/toolbar-ui.js:135
@@ -5464,11 +4507,9 @@ msgstr "フルスクリーンの切り替え"
 msgid "New project"
 msgstr "新しいプロジェクト"
 
-
 #: js/turtledefs.js:491
 msgid "Initialize a new project."
 msgstr "新しいプロジェクトを作る。"
-
 
 #: js/turtledefs.js:495
 #: js/toolbar-ui.js:136
@@ -5478,11 +4519,9 @@ msgstr "新しいプロジェクトを作る。"
 msgid "Load project from file"
 msgstr "プロジェクトを読みこむ"
 
-
 #: js/turtledefs.js:496
 msgid "You can also load projects from the file system."
 msgstr "コンピューターに保存してあるファイルから、ミュージック・ブロックスのプロジェクトを読み込んで開く。"
-
 
 #: js/turtledefs.js:501
 #: js/turtledefs.js:509
@@ -5494,7 +4533,6 @@ msgstr "コンピューターに保存してあるファイルから、ミュー
 #: js/toolbar-ui.js:340
 msgid "Save project"
 msgstr "プロジェクトをほぞん"
-
 
 #: js/turtledefs.js:502
 #: js/turtledefs.js:529
@@ -5513,14 +4551,12 @@ msgstr "プロジェクトをほぞん"
 msgid "Save project as HTML"
 msgstr "HTMLをほぞん"
 
-
 #: js/turtledefs.js:502
 #: js/toolbar-ui.js:164
 #: js/toolbar-ui.js:168
 #: js/toolbar-ui.js:242
 msgid "Save mouse artwork as PNG"
 msgstr "PNGでほぞん"
-
 
 #: js/turtledefs.js:508
 #: js/SaveInterface.js:256
@@ -5539,11 +4575,9 @@ msgstr "PNGでほぞん"
 msgid "Save"
 msgstr "保存する"
 
-
 #: js/turtledefs.js:511
 msgid "Save your project to a file."
 msgstr "げんざい開いているプロジェクトをほぞんする。"
-
 
 #: js/turtledefs.js:513
 #: js/toolbar-ui.js:253
@@ -5552,11 +4586,9 @@ msgstr "げんざい開いているプロジェクトをほぞんする。"
 msgid "Save turtle artwork as SVG"
 msgstr "アートをSVGで保存"
 
-
 #: js/turtledefs.js:515
 msgid "Save graphics from your project to as SVG."
 msgstr "プロジェクトのグラフィックをSVGで保存"
-
 
 #: js/turtledefs.js:517
 #: js/toolbar-ui.js:251
@@ -5568,11 +4600,9 @@ msgstr "プロジェクトのグラフィックをSVGで保存"
 msgid "Save turtle artwork as PNG"
 msgstr "アートをPNGで保存"
 
-
 #: js/turtledefs.js:519
 msgid "Save graphics from your project as PNG."
 msgstr "プロジェクトのグラフィックをPNGで保存"
-
 
 #: js/turtledefs.js:521
 #: js/toolbar-ui.js:173
@@ -5583,11 +4613,9 @@ msgstr "プロジェクトのグラフィックをPNGで保存"
 msgid "Save block artwork as SVG"
 msgstr "ブロックのアートをほぞん"
 
-
 #: js/turtledefs.js:523
 msgid "Save block artwork as an SVG file."
 msgstr "ブロックのグラフィックをSVGで保存"
-
 
 #: js/turtledefs.js:531
 #: js/toolbar-ui.js:166
@@ -5595,43 +4623,35 @@ msgstr "ブロックのグラフィックをSVGで保存"
 msgid "Save project as MIDI"
 msgstr "プロジェクトをMIDIとして保存"
 
-
 #: js/turtledefs.js:533
 #: js/toolbar-ui.js:169
 #: js/toolbar-ui.js:243
 msgid "Save music as WAV"
 msgstr "WAVでほぞん"
 
-
 #: js/turtledefs.js:535
 msgid "Save sheet music as ABC, Lilypond or MusicXML"
 msgstr "楽譜をABC、Lilypond、またはMusicXMLとして保存する。"
-
 
 #: js/turtledefs.js:537
 msgid "Save block artwork as SVG or PNG"
 msgstr "ブロックのアートワークをSVGまたはPNGとして保存する。"
 
-
 #: js/turtledefs.js:543
 msgid "Load samples from server"
 msgstr "みんなの作品"
-
 
 #: js/turtledefs.js:544
 msgid "This button opens a viewer for loading example projects."
 msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
 
-
 #: js/turtledefs.js:548
 msgid "Expand/collapse option toolbar"
 msgstr "オプションツールバーを表示"
 
-
 #: js/turtledefs.js:549
 msgid "Click this button to expand or collapse the auxiliary toolbar."
 msgstr "このボタンをクリックすると「サブメニュー」を開いたり、折りたたんだりすることができる。"
-
 
 #: js/turtledefs.js:553
 #: js/toolbar-ui.js:143
@@ -5643,11 +4663,9 @@ msgstr "このボタンをクリックすると「サブメニュー」を開い
 msgid "Help"
 msgstr "説明"
 
-
 #: js/turtledefs.js:554
 msgid "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
 msgstr "メインおよび補助ツールバー、ブロックとキャンバスの右クリックコンテキストメニュー、パレットのヘルプメッセージを表示します。"
-
 
 #: js/turtledefs.js:560
 #: js/toolbar-ui.js:145
@@ -5657,11 +4675,9 @@ msgstr "メインおよび補助ツールバー、ブロックとキャンバス
 msgid "Run slowly"
 msgstr "ゆっくり実行する"
 
-
 #: js/turtledefs.js:561
 msgid "Click to run the project in slow mode."
 msgstr "クリックをすると、ゆっくりとしたスピードでプログラムを実行することができる。"
-
 
 #: js/turtledefs.js:565
 #: js/toolbar-ui.js:146
@@ -5671,11 +4687,9 @@ msgstr "クリックをすると、ゆっくりとしたスピードでプログ
 msgid "Run step by step"
 msgstr "ブロックを１つずつ実行する"
 
-
 #: js/turtledefs.js:566
 msgid "Click to run the project step by step."
 msgstr "クリックをすると、とてもゆっくり、ブロックを１つずつ実行する。プログラムがうまくはたらかず、どのブロックが原因なのかを調べたいときなどに便利だ。"
-
 
 #: js/turtledefs.js:571
 #: js/toolbar-ui.js:147
@@ -5685,11 +4699,9 @@ msgstr "クリックをすると、とてもゆっくり、ブロックを１つ
 msgid "Display statistics"
 msgstr "とうけいを表示する"
 
-
 #: js/turtledefs.js:572
 msgid "Display statistics about your Music project."
 msgstr "プロジェクトに含まれているブロックの種類、わりあいなど、とうけいてきなじょうほうを表示する。"
-
 
 #: js/turtledefs.js:576
 #: js/toolbar-ui.js:148
@@ -5699,11 +4711,9 @@ msgstr "プロジェクトに含まれているブロックの種類、わりあ
 msgid "Load plugin"
 msgstr "プラグインを読みこむ"
 
-
 #: js/turtledefs.js:577
 msgid "Load a selected plugin."
 msgstr "選択したプラグインを読み込みます。"
-
 
 #: js/turtledefs.js:581
 #: js/toolbar-ui.js:149
@@ -5713,21 +4723,17 @@ msgstr "選択したプラグインを読み込みます。"
 msgid "Delete plugin"
 msgstr "プラグインを消す"
 
-
 #: js/turtledefs.js:582
 msgid "Delete a selected plugin."
 msgstr "せんたくしたプラグインを消す。"
-
 
 #: js/turtledefs.js:586
 msgid "Enable scrolling"
 msgstr "自由な方向に／たて方向にスクロール"
 
-
 #: js/turtledefs.js:587
 msgid "You can scroll the blocks on the canvas."
 msgstr "カンバス上をドラッグそうさしたときに、画面をスクロールさせることができる方向を上下だけと上下左右に変える。"
-
 
 #: js/turtledefs.js:592
 #: js/toolbar-ui.js:152
@@ -5738,11 +4744,9 @@ msgstr "カンバス上をドラッグそうさしたときに、画面をスク
 msgid "Change theme"
 msgstr "テーマを変更"
 
-
 #: js/turtledefs.js:593
 msgid "Switch between dark and light mode."
 msgstr "ダークモードとライトモードを切り替えます。"
-
 
 #: js/turtledefs.js:597
 #: js/toolbar-ui.js:156
@@ -5755,21 +4759,17 @@ msgstr "ダークモードとライトモードを切り替えます。"
 msgid "Merge with current project"
 msgstr "プロジェクトを組みあわせる"
 
-
 #: js/turtledefs.js:598
 msgid "Click to add another project into the current one."
 msgstr "クリックして別のプロジェクトを現在のプロジェクトに追加します。"
-
 
 #: js/turtledefs.js:602
 msgid "Wrap Turtle"
 msgstr "アートを包む"
 
-
 #: js/turtledefs.js:603
 msgid "Turn Turtle wrapping On or Off."
 msgstr "アートを包むか・包まない"
-
 
 #: js/turtledefs.js:607
 #: js/toolbar-ui.js:157
@@ -5777,11 +4777,9 @@ msgstr "アートを包むか・包まない"
 msgid "Set Pitch Preview"
 msgstr "変化記号を設定"
 
-
 #: js/turtledefs.js:608
 msgid "Click to set the current pitch."
 msgstr "クリックして現在の音高を設定します。"
-
 
 #: js/turtledefs.js:613
 #: js/toolbar-ui.js:158
@@ -5791,11 +4789,9 @@ msgstr "クリックして現在の音高を設定します。"
 msgid "JavaScript Editor"
 msgstr "JavaScript エディタ"
 
-
 #: js/turtledefs.js:614
 msgid "Converts Music Block programs to JavaScript."
 msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
-
 
 #: js/turtledefs.js:619
 #: js/toolbar-ui.js:159
@@ -5805,21 +4801,17 @@ msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
 msgid "Restore"
 msgstr "すてたブロックをもどす"
 
-
 #: js/turtledefs.js:620
 msgid "Restore blocks from the trash."
 msgstr "ゴミ箱にすててしまったブロックを取り出してもどす。ふくすうのブロックをすててあるときは新しい順に、ゴミ箱が空になるまでブロックを拾いもどすことができる。"
-
 
 #: js/turtledefs.js:624
 msgid "Switch mode"
 msgstr "はってんモード／かんたんモードにする"
 
-
 #: js/turtledefs.js:625
 msgid "Switch between beginner and advance modes."
 msgstr "ミュージック・ブロックスをかんたんモード／はってんモードに切りかえる。モードによって使えるきのうやブロックの種類が変わる。"
-
 
 #: js/turtledefs.js:629
 #: js/toolbar-ui.js:162
@@ -5830,81 +4822,66 @@ msgstr "ミュージック・ブロックスをかんたんモード／はって
 msgid "Select language"
 msgstr "言語をえらぶ"
 
-
 #: js/turtledefs.js:630
 msgid "Select your language preference."
 msgstr "ブロックの名前などに表示される言語をえらぶ。"
-
 
 #: js/turtledefs.js:634
 #: js/widgets/help.js:565
 msgid "Contextual Menu for Blocks"
 msgstr "ブロックのコンテキストメニュー"
 
-
 #: js/turtledefs.js:635
 msgid "Right-click on a block to access common actions."
 msgstr "ブロックを右クリックして共通操作にアクセスします。"
-
 
 #: js/turtledefs.js:639
 #: planet/js/StringHelper.js:48
 msgid "Delete"
 msgstr "消す"
 
-
 #: js/turtledefs.js:640
 msgid "To delete a block, right-click on it. Then you will see the delete option."
 msgstr "ブロックを削除するには、ブロックを右クリックします。次に、削除オプションが表示されます。"
 
-
 #: js/turtledefs.js:645
 msgid "To copy a block, right-click on it. Then you will see the copy option."
 msgstr "ブロックをコピーするには、ブロックを右クリックします。次に、コピーオプションが表示されます。"
-
 
 #: js/turtledefs.js:649
 #: js/piemenu-block-context.js:101
 msgid "Extract"
 msgstr "取り出す"
 
-
 #: js/turtledefs.js:650
 msgid "To extract a block, right-click on it. Then you will see the extract option."
 msgstr "ブロックを抽出するには、ブロックを右クリックします。次に、抽出オプションが表示されます。"
-
 
 #: js/turtledefs.js:659
 #: js/widgets/help.js:564
 msgid "Tab Navigation"
 msgstr "タブのナビゲーション"
 
-
 #: js/turtledefs.js:660
 msgid "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
 msgstr "キーボードの Tab キーを押すと、ワークスペース、ツールバー、パレットからを魔法のようにジャンプできます。"
-
 
 #: js/turtledefs.js:668
 #: js/widgets/help.js:566
 msgid "Contextual Menu for Canvas"
 msgstr "キャンバスのコンテキストメニュー"
 
-
 #: js/turtledefs.js:669
 msgid "Right-click on the canvas to perform additional canvas-related tasks."
 msgstr "キャンバスを右クリックして追加のキャンバス関連タスクを実行します。"
-
 
 #: js/turtledefs.js:675
 msgid "Turn on/off lines for cartesian or polar grids."
 msgstr "デカルト座標または極座標グリッドの線をオン/オフにします。"
 
-
 #: js/turtledefs.js:677
 msgid "Turn on/off music staffs."
 msgstr "五線譜の表示/非表示を切り替えます。"
-
 
 #: js/turtledefs.js:681
 #: js/turtles.js:1009
@@ -5923,112 +4900,91 @@ msgstr "五線譜の表示/非表示を切り替えます。"
 msgid "Clear"
 msgstr "もとにもどす"
 
-
 #: js/turtledefs.js:682
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr "ネズミを元の位置にもどし、ペンでえがいた線をすべて消す。"
-
 
 #: js/turtledefs.js:686
 #: js/turtles.js:1030
 msgid "Collapse"
 msgstr "カンバスをしゅくしょう"
 
-
 #: js/turtledefs.js:687
 msgid "Collapse the graphics window."
 msgstr "ネズミがいどうしたり、ペンで線をえがいたりできる「カンバス」の表示サイズを しゅくしょうしたり、かくだいしたりする。カンバスをしゅくしょうした場合は、プログラムをふつうのそくどで実行しても、ブロックがかくれない。ふつうの実行そくどでプログラムの動作かくにんをしたいときなどに便利だ。"
-
 
 #: js/turtledefs.js:691
 #: js/context-menu-controller.js:191
 msgid "Home"
 msgstr "ホーム"
 
-
 #: js/turtledefs.js:692
 msgid "Return all blocks to the center of the screen."
 msgstr "すべてのブロックを、カンバスのまんなかに配置する。"
-
 
 #: js/turtledefs.js:696
 #: js/context-menu-controller.js:208
 msgid "Show/hide blocks"
 msgstr "ブロックを表示する／かくす"
 
-
 #: js/turtledefs.js:697
 msgid "Hide or show the blocks and the palettes."
 msgstr "クリックすると、パレットボタンとプログラムのブロックを画面上に表示させたり、かくしたりすることができる。"
-
 
 #: js/turtledefs.js:701
 #: js/context-menu-controller.js:224
 msgid "Expand/collapse blocks"
 msgstr "ブロックを広げる/折りたたむ"
 
-
 #: js/turtledefs.js:702
 msgid "Expand or collapse start and action stacks."
 msgstr "クリックすると、「スタート」と「アクション」に使われているブロックを、広げて表示したり、折りたたんでかくしたりすることができる。"
-
 
 #: js/turtledefs.js:706
 #: js/context-menu-controller.js:240
 msgid "Decrease block size"
 msgstr "ブロックの表示を小さくする"
 
-
 #: js/turtledefs.js:707
 msgid "Decrease the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを小さくする。"
-
 
 #: js/turtledefs.js:711
 #: js/context-menu-controller.js:255
 msgid "Increase block size"
 msgstr "ブロックの表示を大きくする"
 
-
 #: js/turtledefs.js:712
 msgid "Increase the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを大きくする。"
-
 
 #: js/turtledefs.js:717
 msgid "Select"
 msgstr "選択"
 
-
 #: js/turtledefs.js:718
 msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr "ワークスペースを左クリックしてドラッグすると複数のブロックを選択できます。"
-
 
 #: js/turtledefs.js:724
 msgid "Palette buttons"
 msgstr "パレットボタン"
 
-
 #: js/turtledefs.js:725
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr "ミュージック・ブロックスの左側には、プログラミングに使うさまざまなブロックをグループ分けした「パレットボタン」がある。"
-
 
 #: js/turtledefs.js:729
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr "それぞれのパレットボタンをクリックし、「音符（おんぷ）」「アクション」「ペン」などから好きなブロックを選んで、カンバス上にドラッグして置いてみよう。"
 
-
 #: js/turtledefs.js:738
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
-
 #: js/turtledefs.js:741
 msgid "Turtle Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
-
 
 #: js/turtledefs.js:744
 #: js/turtledefs.js:769
@@ -6036,26 +4992,21 @@ msgstr "ミュージック・ブロックスガイド"
 msgid "About"
 msgstr "ミュージック・ブロックスについて"
 
-
 #: js/turtledefs.js:745
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
-
 
 #: js/turtledefs.js:749
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
 
-
 #: js/turtledefs.js:753
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
-
 #: js/turtledefs.js:760
 msgid "Turtle Blocks GitHub repository"
 msgstr "タータル・ブロックスのリポジトリ"
-
 
 #: js/turtledefs.js:763
 #: js/widgets/help.js:495
@@ -6063,47 +5014,38 @@ msgstr "タータル・ブロックスのリポジトリ"
 msgid "Congratulations."
 msgstr "おめでとうございます！"
 
-
 #: js/turtledefs.js:764
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr "ツアーはここで終わり。タータル・ブロックスを自由に楽しもう。"
-
 
 #: js/turtledefs.js:770
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
 
-
 #: js/turtledefs.js:774
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
-
 
 #: js/turtledefs.js:778
 msgid "Music Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
-
 #: js/turtledefs.js:783
 msgid "Music Blocks GitHub repository"
 msgstr "ミュージック・ブロックスのリポジトリ"
-
 
 #: js/turtledefs.js:786
 #: js/widgets/help.js:553
 msgid "Congratulations!"
 msgstr "おめでとうございます！"
 
-
 #: js/turtledefs.js:787
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr "ミスター・マウスのツアーはここで終わり。ミュージック・ブロックスを自由に楽しもう。"
 
-
 #: js/turtles.js:1098
 msgid "Expand"
 msgstr "カンバスをかくだい"
-
 
 #: js/SaveInterface.js:25
 #: js/project-manager.js:262
@@ -6116,104 +5058,84 @@ msgstr "カンバスをかくだい"
 msgid "My Project"
 msgstr "自分のプロジェクト"
 
-
 #: js/SaveInterface.js:26
 #: js/blocks.js:4607
 #: js/blocks/MediaBlocks.js:971
 msgid "Show"
 msgstr "プロジェクトのコードを表示する"
 
-
 #: js/SaveInterface.js:27
 msgid "Hide"
 msgstr "プロジェクトのコードを非表示にする"
-
 
 #: js/SaveInterface.js:80
 msgid "This project was created in Music Blocks"
 msgstr "このプロジェクトは、ミュージック・ブロックスで作成されました。"
 
-
 #: js/SaveInterface.js:84
 msgid "Music Blocks is a Free/Libre Software application."
 msgstr "ミュージック・ブロックスは、音楽のちしきを楽しみながら身につけることのできる、オープンソースのソフトです。"
-
 
 #: js/SaveInterface.js:86
 msgid "The source code can be accessed at"
 msgstr "ミュージック・ブロックスのソースコードは、こちらのURLから見ることができます。"
 
-
 #: js/SaveInterface.js:89
 msgid "For more information, please consult the"
 msgstr "もっと詳しく知りたい場合は、ミュージック・ブロックスのガイドを参照してください。"
-
 
 #: js/SaveInterface.js:96
 msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
 msgstr "このプロジェクトを実行するには、ブラウザでミュージック・ブロックスを開き、このファイルをブラウザ・ウィンドウにドラッグ・アンド・ドロップします。"
 
-
 #: js/SaveInterface.js:100
 msgid "Alternatively, open the file in Music Blocks using the Load project button."
 msgstr "「ファイルからプロジェクトを読みこむ」ボタンをおして、ファイルをひらいてください。"
-
 
 #: js/SaveInterface.js:102
 msgid "Project Code"
 msgstr "プロジェクトのコード"
 
-
 #: js/SaveInterface.js:104
 msgid "This code stores data about the blocks in a project."
 msgstr "このコードは、がいとうする場合、へんしゅうされたバージョンのプロジェクトといっしょに、プロジェクトの中のブロックに関するデータをほぞんします。"
-
 
 #: js/SaveInterface.js:109
 msgid "Copy to Clipboard"
 msgstr "クリップボードにコピー"
 
-
 #: js/SaveInterface.js:138
 msgid "Project code copied to clipboard!"
 msgstr "プロジェクトのコードがクリップボードにコピーされました。"
-
 
 #: js/SaveInterface.js:142
 msgid "Failed to copy."
 msgstr "コピーのエラーが発生しました。"
 
-
 #: js/SaveInterface.js:212
 msgid "Enter a filename to save your project:"
 msgstr "ファイル名を入力してプロジェクトを保存します。"
-
 
 #: js/SaveInterface.js:227
 msgid "Recording saved! Check Downloads."
 msgstr "録音が保存されました!ダウンロードを確認します。"
 
-
 #: js/SaveInterface.js:229
 msgid "Project saved! Check Downloads."
 msgstr "プロジェクトが保存されました!ダウンロードを確認します。"
-
 
 #: js/SaveInterface.js:231
 msgid "File saved! Check Downloads."
 msgstr "ファイルが保存されました!ダウンロードを確認します。"
 
-
 #: js/SaveInterface.js:253
 msgid "Save file"
 msgstr "ファイルを保存"
-
 
 #: js/SaveInterface.js:254
 #: js/SaveInterface.js:261
 msgid "Filename:"
 msgstr "ファイル名："
-
 
 #: js/SaveInterface.js:257
 #: js/project-manager.js:706
@@ -6227,17 +5149,14 @@ msgstr "ファイル名："
 msgid "Cancel"
 msgstr "キャンセル"
 
-
 #: js/SaveInterface.js:325
 #: planet/js/SaveInterface.js:90
 msgid "No description provided"
 msgstr "記入がありません"
 
-
 #: js/SaveInterface.js:585
 msgid "Your recording is in progress."
 msgstr "録音中"
-
 
 #: js/SaveInterface.js:639
 #: js/SaveInterface.js:679
@@ -6245,12 +5164,10 @@ msgstr "録音中"
 msgid "Error generating ABC output."
 msgstr "ABC 出力の生成中にエラーが発生しました。"
 
-
 #: js/SaveInterface.js:742
 #. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ファイル名"
-
 
 #: js/SaveInterface.js:744
 #: planet/js/StringHelper.js:38
@@ -6258,30 +5175,25 @@ msgstr "ファイル名"
 msgid "Project title"
 msgstr "曲名"
 
-
 #: js/SaveInterface.js:746
 #. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "作曲家"
-
 
 #: js/SaveInterface.js:748
 #. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDIのアウトプットがくふにもまとめましょうか？"
 
-
 #: js/SaveInterface.js:750
 #. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "ギターのTABもがくふにまとめましょうか？"
 
-
 #: js/SaveInterface.js:752
 #. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondがくふのフォーマットでほぞん"
-
 
 #: js/SaveInterface.js:764
 #: js/SaveInterface.js:767
@@ -6307,28 +5219,23 @@ msgstr "Lilypondがくふのフォーマットでほぞん"
 msgid "Mr. Mouse"
 msgstr "ミスター・マウス"
 
-
 #: js/SaveInterface.js:871
 #: js/SaveInterface.js:930
 #: js/logo.js:2319
 msgid "Error generating Lilypond output."
 msgstr "Lilypond 出力の生成中にエラーが発生しました。"
 
-
 #: js/SaveInterface.js:955
 msgid "The Lilypond code is copied to clipboard. You can paste it here:"
 msgstr "Lilypond コードがクリップボードにコピーされます。ここに貼り付けることができます:"
-
 
 #: js/SaveInterface.js:1017
 msgid "Failed to convert Lilypond to PDF. Please try saving as .ly file instead."
 msgstr "Lilypond を PDF に変換できませんでした。代わりに .ly ファイルとして保存してみてください。"
 
-
 #: js/block-drag-controller.js:534
 msgid "Consider breaking this stack into parts."
 msgstr "アクションブロックを使ってプログラムをまとめませんか"
-
 
 #: js/context-menu-controller.js:438
 #: js/trash-controller.js:57
@@ -6336,161 +5243,130 @@ msgstr "アクションブロックを使ってプログラムをまとめませ
 msgid "Trash can is empty."
 msgstr "ゴミ箱は空です。"
 
-
 #: js/context-menu-controller.js:444
 #: js/trash-controller.js:79
 #: js/trash-controller.js:215
 msgid "Item restored from the trash."
 msgstr "ゴミ箱からアイテムを復元しました。"
 
-
 #: js/help-controller.js:92
 msgid "Windows/Linux"
 msgstr "Windows/Linux"
-
 
 #: js/help-controller.js:92
 msgid "Mac"
 msgstr "マック"
 
-
 #: js/help-controller.js:96
 msgid "Workspace"
 msgstr "ワークスペース"
-
 
 #: js/help-controller.js:100
 #: js/toolbar-ui.js:493
 msgid "Play project"
 msgstr "プロジェクトを再生"
 
-
 #: js/help-controller.js:104
 #: js/toolbar-ui.js:555
 msgid "Stop project"
 msgstr "プロジェクトを停止する"
 
-
 #: js/help-controller.js:108
 msgid "Play or stop depending on the current state"
 msgstr "現在の状態に応じて再生または停止します"
-
 
 #: js/help-controller.js:112
 msgid "Play or stop when no text input or widget is active"
 msgstr "アクティブなテキスト入力またはウィジェットがない場合は再生または停止します"
 
-
 #: js/help-controller.js:116
 msgid "Toggle stage scale"
 msgstr "ステージスケールの切り替え"
-
 
 #: js/help-controller.js:120
 msgid "Jump to home position"
 msgstr "ホームポジションに戻る"
 
-
 #: js/help-controller.js:124
 msgid "Jump to the bottom of the workspace"
 msgstr "ワークスペースの一番下にジャンプします"
-
 
 #: js/help-controller.js:128
 msgid "Scroll workspace up"
 msgstr "ワークスペースを上にスクロールする"
 
-
 #: js/help-controller.js:132
 msgid "Scroll workspace down"
 msgstr "ワークスペースを下にスクロールします"
-
 
 #: js/help-controller.js:136
 msgid "Hide block search when it is open"
 msgstr "ブロック検索が開いているときに非表示にする"
 
-
 #: js/help-controller.js:141
 msgid "Editing"
 msgstr "編集"
-
 
 #: js/help-controller.js:145
 msgid "Copy selected stack."
 msgstr "選択したスタックをコピーします。"
 
-
 #: js/help-controller.js:149
 msgid "Paste previous stack."
 msgstr "この前のスタックを貼り付けます。"
-
 
 #: js/help-controller.js:153
 msgid "Open the JSON paste box."
 msgstr "JSON 貼り付けボックスを開きます。"
 
-
 #: js/help-controller.js:157
 msgid "Paste JSON when the paste box is focused."
 msgstr "貼り付けボックスにフォーカスがあるときに JSON を貼り付けます。"
-
 
 #: js/help-controller.js:161
 msgid "Extract the active block."
 msgstr "アクティブなブロックを抽出します。"
 
-
 #: js/help-controller.js:165
 msgid "Clear workspace."
 msgstr "すっきりとしたワークスペース。"
-
 
 #: js/help-controller.js:169
 msgid "Save block artwork."
 msgstr "ブロックアートワークを保存します。"
 
-
 #: js/help-controller.js:173
 msgid "Save block help."
 msgstr "ブロックのヘルプを保存します。"
-
 
 #: js/help-controller.js:178
 msgid "Navigation"
 msgstr "ナビゲーション"
 
-
 #: js/help-controller.js:182
 msgid "Move focus between the toolbar, palettes, and workspace."
 msgstr "ツールバー、パレット、ワークスペースの中からフォーカスを移動します。"
-
 
 #: js/help-controller.js:185
 #: js/help-controller.js:248
 msgid "Arrow keys"
 msgstr "矢印キー"
 
-
 #: js/help-controller.js:186
 msgid "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
 msgstr "コンテキストに応じて、アクティブなブロックの移動、パレットのスクロール、テンポ ウィジェットの調整、またはワークスペースのパンを行います。"
-
 
 #: js/help-controller.js:192
 msgid "Pan workspace right when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを右に移動します。"
 
-
 #: js/help-controller.js:196
 msgid "Pan workspace left when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを左に移動します。"
 
-
 #: js/help-controller.js:201
 msgid "Toolbar"
 msgstr "ツールバー"
-
 
 #: js/help-controller.js:205
 #: js/help-controller.js:206
@@ -6499,61 +5375,49 @@ msgstr "ツールバー"
 msgid "Arrow Left / Arrow Right"
 msgstr "左矢印 / 右矢印"
 
-
 #: js/help-controller.js:208
 msgid "Move focus within the current toolbar."
 msgstr "現在のツールバー内でフォーカスを移動します。"
-
 
 #: js/help-controller.js:211
 msgid "Arrow Up / Arrow Down"
 msgstr "上矢印 / 下矢印"
 
-
 #: js/help-controller.js:212
 msgid "Move focus between main and auxiliary toolbars."
 msgstr "メイン ツールバーと補助ツールバーの間でフォーカスを移動します。"
-
 
 #: js/help-controller.js:216
 msgid "Activate the focused toolbar button."
 msgstr "フォーカスされたツールバーからのボタンをアクティブにします。"
 
-
 #: js/help-controller.js:220
 msgid "Exit toolbar keyboard navigation."
 msgstr "ツールバーのキーボードナビゲーションを終了します。"
-
 
 #: js/help-controller.js:225
 msgid "Widget Windows"
 msgstr "ウィジェット・ウィンドウ"
 
-
 #: js/help-controller.js:229
 msgid "Close the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを閉じます。"
-
 
 #: js/help-controller.js:233
 msgid "Maximize or restore the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを最大化または復元します。"
 
-
 #: js/help-controller.js:238
 msgid "Help and Pitch Slider"
 msgstr "ヘルプとピッチ・スライダー"
-
 
 #: js/help-controller.js:245
 msgid "Move between help pages when Help is open."
 msgstr "ヘルプが開いているときにヘルプ・ページの中から移動します。"
 
-
 #: js/help-controller.js:249
 msgid "Adjust pitch by semitone when Pitch Slider is open."
 msgstr "ピッチ・スライダーが開いているときに半音単位でピッチを調整します。"
-
 
 #: js/help-controller.js:257
 #: js/help-controller.js:280
@@ -6564,11 +5428,9 @@ msgstr "ピッチ・スライダーが開いているときに半音単位でピ
 msgid "Keyboard shortcuts"
 msgstr "キーボードのショートカット"
 
-
 #: js/help-controller.js:284
 msgid "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
 msgstr "ショートカットは状況に依存します。一部の機能は、関連するパネル、ウィジェット、またはモードがアクティブな場合にのみ機能します。 Windows/Linux および Mac の同等のものを一緒に示します。"
-
 
 #: js/lilypond.js:619
 #: js/lilypond.js:909
@@ -6578,61 +5440,49 @@ msgstr "ショートカットは状況に依存します。一部の機能は、
 msgid "mouse"
 msgstr "ネズミ"
 
-
 #: js/lilypond.js:620
 msgid "brown rat"
 msgstr "茶色のドブネズミ"
-
 
 #: js/lilypond.js:621
 msgid "mole"
 msgstr "土竜"
 
-
 #: js/lilypond.js:622
 msgid "chipmunk"
 msgstr "リス"
-
 
 #: js/lilypond.js:623
 msgid "red squirrel"
 msgstr "赤いリス"
 
-
 #: js/lilypond.js:624
 msgid "guinea pig"
 msgstr "ギニーピッグ"
-
 
 #: js/lilypond.js:625
 msgid "capybara"
 msgstr "カピバラ"
 
-
 #: js/lilypond.js:626
 msgid "coypu"
 msgstr "ヌートリア"
-
 
 #: js/lilypond.js:627
 msgid "black rat"
 msgstr "黒い鼠"
 
-
 #: js/lilypond.js:628
 msgid "grey squirrel"
 msgstr "灰色のリス"
-
 
 #: js/lilypond.js:629
 msgid "flying squirrel"
 msgstr "モモンガ"
 
-
 #: js/lilypond.js:630
 msgid "bat"
 msgstr "蝙蝠"
-
 
 #: js/lilypond.js:758
 #: js/lilypond.js:915
@@ -6642,87 +5492,70 @@ msgstr "蝙蝠"
 msgid "start drum"
 msgstr "ドラム・スタート"
 
-
 #: js/logoconstants.js:42
 msgid "Not a valid pitch name"
 msgstr "選ばれた音名が適切ではありません。"
-
 
 #: js/blocks/HeapBlocks.js:254
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "Heap-empty?ブロックはヒープが空の場合に「実」を返します。"
 
-
 #: js/logoconstants.js:44
 #.  AUTOTRANSLATED: Google Translate
 msgid "Pitch index exceeds EDO range"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "ピッチインデックスが 平均律 範囲を超えています。"
 
 #: js/project-manager.js:60
 msgid "Catching mice"
 msgstr "ネズミをつかまえているよ"
 
-
 #: js/project-manager.js:61
 msgid "Cleaning the instruments"
 msgstr "楽器のおていれをしているよ"
-
 
 #: js/project-manager.js:62
 msgid "Testing key pieces"
 msgstr "キーボードの音をたしかめているよ"
 
-
 #: js/project-manager.js:63
 msgid "Sight-reading"
 msgstr "がくふをよみこんでいるよ"
-
 
 #: js/project-manager.js:64
 msgid "Combining math and music"
 msgstr "音楽と算数をくっつけているよ"
 
-
 #: js/project-manager.js:65
 msgid "Generating more blocks"
 msgstr "ブロックをたくさんつくっているよ"
-
 
 #: js/project-manager.js:66
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr "ド　レ　ミ　ファ　ソ　ラ　シ　ド"
 
-
 #: js/project-manager.js:67
 msgid "Tuning string instruments"
 msgstr "楽器のチューニングをしているよ"
-
 
 #: js/project-manager.js:68
 msgid "Pressing random keys"
 msgstr "キーボードでおんがくをつくっているよ"
 
-
 #: js/project-manager.js:102
 msgid "Loading Complete!"
 msgstr "読み込み完了！"
-
 
 #: js/project-manager.js:320
 msgid "Click the run button to run the project."
 msgstr "プロジェクトを再生するため、再生のボタンをクリックしてください。"
 
-
 #: js/project-manager.js:659
 msgid "Import MIDI"
 msgstr "MIDIをインポートする"
 
-
 #: js/project-manager.js:667
 msgid "Set the max blocks to generate:"
 msgstr "生成する最大ブロックを設定します。"
-
 
 #: js/project-manager.js:686
 #: js/toolbar-ui.js:175
@@ -6736,7 +5569,6 @@ msgstr "生成する最大ブロックを設定します。"
 msgid "Confirm"
 msgstr "作成する"
 
-
 #: js/project-manager.js:775
 #: js/project-manager.js:832
 #: js/project-manager.js:854
@@ -6746,40 +5578,33 @@ msgstr "作成する"
 msgid "Cannot load project from the file. Please check the file type."
 msgstr "プロジェクトを読みこめません。ファイルの種類をかくにんしてください。"
 
-
 #: js/project-manager.js:787
 #: js/project-manager.js:902
 #.  AUTOTRANSLATED: Google Translate
 msgid "Cannot find project data in this HTML file."
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "このHTMLファイル内にプロジェクトデータが見つかりません。"
 
 #: js/project-manager.js:1076
 msgid "Something went wrong reading JSON-encoded project data."
 msgstr "JSON エンコードされたプロジェクト データの読み取り中に問題が発生しました。"
 
-
 #: js/project-manager.js:1087
 msgid "Invalid parameters"
 msgstr "無効なパラメータ"
 
-
 #: js/rubrics.js:543
 msgid "mice"
 msgstr "ネズミ達の関係"
-
 
 #: js/search-ui.js:127
 #: js/activity.js:581
 msgid "Search for blocks"
 msgstr "ブロックを検索"
 
-
 #: js/toolbar-ui.js:128
 #: js/toolbar-ui.js:204
 msgid "About Music Blocks"
 msgstr "ミュージック・ブロックスについて"
-
 
 #: js/toolbar-ui.js:132
 #: js/toolbar-ui.js:133
@@ -6792,14 +5617,12 @@ msgstr "ミュージック・ブロックスについて"
 msgid "Enter Fullscreen"
 msgstr "全画面表示に入る"
 
-
 #: js/toolbar-ui.js:139
 #: js/toolbar-ui.js:215
 #: js/toolbar-ui.js:272
 #: js/toolbar-ui.js:342
 msgid "Find and share projects"
 msgstr "みんなの作品"
-
 
 #: js/toolbar-ui.js:140
 #: js/toolbar-ui.js:216
@@ -6808,14 +5631,12 @@ msgstr "みんなの作品"
 msgid "Offline. Sharing is unavailable"
 msgstr "オフライン。シェア機能が使えません"
 
-
 #: js/toolbar-ui.js:141
 #: js/toolbar-ui.js:217
 #: js/toolbar-ui.js:274
 #: js/toolbar-ui.js:344
 msgid "Auxiliary menu"
 msgstr "サブメニュー"
-
 
 #: js/toolbar-ui.js:142
 #: js/toolbar-ui.js:218
@@ -6824,14 +5645,12 @@ msgstr "サブメニュー"
 msgid "Help and shortcuts"
 msgstr "ヘルプとショートカット"
 
-
 #: js/toolbar-ui.js:150
 #: js/toolbar-ui.js:226
 #: js/toolbar-ui.js:283
 #: js/toolbar-ui.js:353
 msgid "Enable horizontal scrolling"
 msgstr "自由な方向にスクロール"
-
 
 #: js/toolbar-ui.js:151
 #: js/toolbar-ui.js:227
@@ -6840,14 +5659,12 @@ msgstr "自由な方向にスクロール"
 msgid "Disable horizontal scrolling"
 msgstr "たて方向にスクロール"
 
-
 #: js/toolbar-ui.js:153
 #: js/toolbar-ui.js:229
 #: js/toolbar-ui.js:286
 #: js/toolbar-ui.js:356
 msgid "Light Mode"
 msgstr "ライトモード"
-
 
 #: js/toolbar-ui.js:154
 #: js/toolbar-ui.js:230
@@ -6856,14 +5673,12 @@ msgstr "ライトモード"
 msgid "Dark Mode"
 msgstr "ダークモード"
 
-
 #: js/toolbar-ui.js:155
 #: js/toolbar-ui.js:231
 #: js/toolbar-ui.js:288
 #: js/toolbar-ui.js:358
 msgid "High-contrast Mode"
 msgstr "ハイコントラストモード"
-
 
 #: js/toolbar-ui.js:160
 #: js/toolbar-ui.js:236
@@ -6872,7 +5687,6 @@ msgstr "ハイコントラストモード"
 msgid "Switch to beginner mode"
 msgstr "かんたんモードにする"
 
-
 #: js/toolbar-ui.js:161
 #: js/toolbar-ui.js:237
 #: js/toolbar-ui.js:293
@@ -6880,29 +5694,24 @@ msgstr "かんたんモードにする"
 msgid "Switch to advanced mode"
 msgstr "はってんモードにする"
 
-
 #: js/toolbar-ui.js:167
 #: js/toolbar-ui.js:241
 msgid "Save mouse artwork as SVG"
 msgstr "SVGでほぞん"
-
 
 #: js/toolbar-ui.js:170
 #: js/toolbar-ui.js:244
 msgid "Save sheet music as ABC"
 msgstr "ABCのフォーマットでほぞん"
 
-
 #: js/toolbar-ui.js:171
 #: js/toolbar-ui.js:245
 msgid "Save sheet music as Lilypond"
 msgstr "がくふ(Lilypondのフォーマット)でほぞん"
 
-
 #: js/toolbar-ui.js:172
 msgid "Save sheet music as MusicXML"
 msgstr "プロジェクトをMusicXML楽譜でほぞん"
-
 
 #: js/toolbar-ui.js:174
 #: js/toolbar-ui.js:247
@@ -6912,17 +5721,14 @@ msgstr "プロジェクトをMusicXML楽譜でほぞん"
 msgid "Save block artwork as PNG"
 msgstr "ブロックのアートワークをPNGで保存"
 
-
 #: js/toolbar-ui.js:261
 #: js/toolbar-ui.js:331
 msgid "About Turtle Blocks"
 msgstr "タートル・ブロックスについて"
 
-
 #: js/toolbar-ui.js:597
 msgid "Are you sure you want to create a new project?"
 msgstr "新しいプロジェクトを作成してもよろしいですか？"
-
 
 #: js/toolbar-ui.js:792
 #: js/toolbar-ui.js:803
@@ -6932,7 +5738,6 @@ msgstr "新しいプロジェクトを作成してもよろしいですか？"
 msgid "Turtle Wrap Off"
 msgstr "画面の境界を無視しない"
 
-
 #: js/toolbar-ui.js:804
 #: js/toolbar-ui.js:813
 #: js/toolbar-ui.js:846
@@ -6940,68 +5745,55 @@ msgstr "画面の境界を無視しない"
 msgid "Turtle Wrap On"
 msgstr "画面の境界を無視する"
 
-
 #: js/trash-controller.js:286
 msgid "Restore last item"
 msgstr "先のアイテムを復元"
 
-
 #: js/trash-controller.js:287
 msgid "Restore all items"
 msgstr "すべてのアイテムを復元"
-
 
 #: js/turtle-singer.js:1576
 #. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。"
 
-
 #: js/turtle-singer.js:1793
 msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
 msgstr "同じピッチの音符のみを結ぶことができます。スラーを使うつもりでしたか？"
-
 
 #: js/turtle-singer.js:2391
 msgid "synth cannot play chords."
 msgstr "このシンセでは和音ができません"
 
-
 #: js/activity.js:751
 msgid "Clear workspace"
 msgstr "すっきりとしたワークスペース"
-
 
 #: js/activity.js:757
 msgid "Are you sure you want to clear the workspace?"
 msgstr "ワークスペースを本当にクリアしますか？"
 
-
 #: js/activity.js:1077
 msgid "Horizontal scrolling enabled."
 msgstr "水平スクロールが有効になりました。"
-
 
 #: js/activity.js:1086
 msgid "Horizontal scrolling disabled."
 msgstr "水平スクロールが無効になっています。"
 
-
 #: js/activity.js:1110
 msgid "plugins will be removed upon restart."
 msgstr "プラグインは再起動時に削除されます。"
-
 
 #: js/activity.js:1753
 #.  AUTOTRANSLATED: Google Translate
 msgid "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%."
 msgstr "キャンバスが異常に大きいため、Firefox のパフォーマンスが影響を受ける可能性があります。最高のエクスペリエンスを得るには、ブラウザーのズームを 100% にリセットすることを検討してください。"
 
-
 #: js/activity.js:2554
 msgid "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
 msgstr "クリップボードデータが無効です。ブロックを貼り付けるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストを貼り付けるには、入力フィールド内をクリックします。"
-
 
 #: js/block.js:1475
 #: js/piemenus.js:3357
@@ -7012,11 +5804,9 @@ msgstr "クリップボードデータが無効です。ブロックを貼り付
 msgid "unison"
 msgstr "ユニゾン（同度）"
 
-
 #: js/block.js:1688
 msgid "matrix"
 msgstr "フレーズメーカー"
-
 
 #: js/block.js:1695
 #: js/blocks/WidgetBlocks.js:1787
@@ -7024,16 +5814,13 @@ msgstr "フレーズメーカー"
 msgid "status"
 msgstr "実行じょうきょう"
 
-
 #: js/block.js:1702
 msgid "drum mapper"
 msgstr "ドラム・ピッチ行列"
 
-
 #: js/block.js:1709
 msgid "ruler"
 msgstr "リズムメーカー"
-
 
 #: js/block.js:1716
 #: js/blocks/WidgetBlocks.js:483
@@ -7041,11 +5828,9 @@ msgstr "リズムメーカー"
 msgid "timbre"
 msgstr "音色"
 
-
 #: js/block.js:1723
 msgid "stair"
 msgstr "階段"
-
 
 #: js/block.js:1730
 #: js/blocks/ProgramBlocks.js:1279
@@ -7054,7 +5839,6 @@ msgstr "階段"
 msgid "tempo"
 msgstr "メトロノーム"
 
-
 #: js/block.js:1737
 #: js/block.js:1800
 #: js/blocks/IntervalsBlocks.js:1527
@@ -7062,17 +5846,14 @@ msgstr "メトロノーム"
 msgid "mode"
 msgstr "モード（音階）"
 
-
 #: js/block.js:1744
 msgid "slider"
 msgstr "スライダー"
-
 
 #: js/block.js:1751
 #: js/blocks/SensorsBlocks.js:963
 msgid "keyboard"
 msgstr "キーボード"
-
 
 #: js/block.js:1765
 #: js/blocks/WidgetBlocks.js:1366
@@ -7080,7 +5861,6 @@ msgstr "キーボード"
 #. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
-
 
 #: js/block.js:1772
 #: js/block.js:2640
@@ -7107,7 +5887,6 @@ msgstr "リズムメーカー"
 msgid "note value"
 msgstr "音の長さ"
 
-
 #: js/block.js:1779
 #: js/blocks/OrnamentBlocks.js:312
 #: js/blocks/IntervalsBlocks.js:1127
@@ -7115,18 +5894,15 @@ msgstr "音の長さ"
 msgid "scalar interval"
 msgstr "音階の上下"
 
-
 #: js/block.js:1786
 #: js/blocks/RhythmBlocks.js:159
 msgid "milliseconds"
 msgstr "ミリ秒"
 
-
 #: js/block.js:2565
 #: js/block.js:2588
 msgid "scalar interval %s"
 msgstr "音階の上下 %s"
-
 
 #: js/block.js:2638
 #: js/block.js:2642
@@ -7139,7 +5915,6 @@ msgstr "音階の上下 %s"
 msgid "silence"
 msgstr "休符"
 
-
 #: js/block.js:2734
 #: js/block.js:3876
 #: js/block.js:3893
@@ -7149,35 +5924,29 @@ msgstr "休符"
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
-
 #: js/block.js:2822
 #: js/blocks/IntervalsBlocks.js:639
 #. TRANS: scalar step
 msgid "down"
 msgstr "下"
 
-
 #: js/block.js:2823
 msgid "up"
 msgstr "上"
 
-
 #: js/block.js:3295
 msgid "Silence block cannot be removed."
 msgstr "「休符」は取り出すことができません。"
-
 
 #: js/block.js:3314
 #.  AUTOTRANSLATED: Google Translate
 msgid "picked up"
 msgstr "拾った"
 
-
 #: js/block.js:3563
 #: js/piemenu-block-context.js:160
 msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
 msgstr "削除されたブロックは「ゴミ箱から復元」ボタンで復元できます。"
-
 
 #: js/block.js:4223
 #: js/blocks.js:2066
@@ -7196,13 +5965,11 @@ msgstr "削除されたブロックは「ゴミ箱から復元」ボタンで復
 msgid "false"
 msgstr "偽"
 
-
 #: js/block.js:4233
 #: js/block.js:4237
 #: js/blocks/ExtrasBlocks.js:620
 msgid "Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
-
 
 #: js/block.js:4233
 #: js/block.js:4238
@@ -7210,13 +5977,11 @@ msgstr "ほうがん（ざひょう）を表示"
 msgid "polar"
 msgstr "極座標を表示"
 
-
 #: js/block.js:4233
 #: js/block.js:4239
 #: js/blocks/ExtrasBlocks.js:628
 msgid "Cartesian/Polar"
 msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
-
 
 #: js/block.js:4233
 #: js/block.js:4246
@@ -7224,41 +5989,34 @@ msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
 msgid "none"
 msgstr "なし"
 
-
 #: js/blocks/MediaBlocks.js:819
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr "トゥーフリクエンシーブロックは音名とオクターヴをヘルツに変換します。"
-
 
 #: js/block.js:4240
 #: js/blocks/ExtrasBlocks.js:633
 msgid "treble"
 msgstr "トレブル記号"
 
-
 #: js/block.js:4241
 #: js/blocks/ExtrasBlocks.js:637
 msgid "grand staff"
 msgstr "トレブルとバス記号"
-
 
 #: js/block.js:4242
 #: js/blocks/ExtrasBlocks.js:641
 msgid "mezzo-soprano"
 msgstr "メゾソプラノ記号"
 
-
 #: js/block.js:4243
 #: js/blocks/ExtrasBlocks.js:645
 msgid "alto"
 msgstr "アルト記号"
 
-
 #: js/block.js:4244
 #: js/blocks/ExtrasBlocks.js:649
 msgid "tenor"
 msgstr "テノール記号"
-
 
 #: js/block.js:4245
 #: js/utils/musicutils.js:1393
@@ -7269,13 +6027,11 @@ msgstr "テノール記号"
 msgid "bass"
 msgstr "コントラバス"
 
-
 #: js/block.js:4290
 #: js/blocks.js:2057
 #: js/blocks.js:2702
 msgid "on2"
 msgstr "オン"
-
 
 #: js/block.js:4292
 #: js/blocks.js:2059
@@ -7283,36 +6039,29 @@ msgstr "オン"
 msgid "off"
 msgstr "オフ"
 
-
 #: js/block.js:4777
 msgid "Not a number"
 msgstr "数字ではありません"
-
 
 #: js/block.js:4788
 msgid "Octave value must be between 1 and 8."
 msgstr "オクターヴの値が「１」から「8」までの範囲でなければなりません。"
 
-
 #: js/block.js:4796
 msgid "Numbers can have at most 10 digits."
 msgstr "数字は最大１０桁までです。"
-
 
 #: js/loader.js:536
 msgid "Failed to load EaselJS. Please refresh the page."
 msgstr "EaselJS のロードに失敗しました。ページを更新してください。"
 
-
 #: js/loader.js:558
 msgid "Failed to load Music Blocks. Please refresh the page."
 msgstr "ミュージック・ブロックスの読み込みに失敗しました。ページを更新してください。"
 
-
 #: js/loader.js:565
 msgid "Failed to initialize Music Blocks core. Please refresh the page.\n\nError: %s"
 msgstr "ミュージック・ブロックス コアの初期化に失敗しました。ページを更新してください。\n\nエラー: %s"
-
 
 #: js/logo.js:694
 #: js/blocks/ProgramBlocks.js:259
@@ -7320,23 +6069,19 @@ msgstr "ミュージック・ブロックス コアの初期化に失敗しま�
 msgid "You must select a file."
 msgstr "ファイルをえらんでください。"
 
-
 #: js/logo.js:1854
 msgid "Infinite loop detected. Execution stopped to prevent browser freeze."
 msgstr "無限ループが検出されました。ブラウザのフリーズを防ぐために実行が停止されました。"
-
 
 #: js/logo.js:2037
 #: js/blocks/MediaBlocks.js:338
 msgid "width"
 msgstr "カンバスのよこはば"
 
-
 #: js/logo.js:2038
 #: js/blocks/MediaBlocks.js:395
 msgid "height"
 msgstr "カンバスのたてはば"
-
 
 #: js/logo.js:2039
 #: js/blocks/MediaBlocks.js:35
@@ -7344,51 +6089,42 @@ msgstr "カンバスのたてはば"
 msgid "right (screen)"
 msgstr "ざひょうち（右）"
 
-
 #: js/logo.js:2040
 #: js/blocks/MediaBlocks.js:111
 #. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち（左）"
 
-
 #: js/logo.js:2041
 #: js/blocks/MediaBlocks.js:186
 msgid "top (screen)"
 msgstr "ざひょうち（上）"
-
 
 #: js/logo.js:2042
 #: js/blocks/MediaBlocks.js:261
 msgid "bottom (screen)"
 msgstr "ざひょうち（下）"
 
-
 #: js/logo.js:2349
 msgid "Playback is ready."
 msgstr "コンパイル完了"
-
 
 #: js/piemenu-block-context.js:100
 #: js/blocks/FlowBlocks.js:136
 msgid "Duplicate"
 msgstr "複製する"
 
-
 #: js/piemenu-block-context.js:102
 msgid "Move to trash"
 msgstr "すてる"
-
 
 #: js/piemenu-block-context.js:109
 msgid "Save stack"
 msgstr "スタックをほぞん"
 
-
 #: js/piemenu-block-context.js:138
 msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
 msgstr "サンプルをコピーするため、ツールを再度試して、またサンプルをロード読み込で、保存することが必要です。"
-
 
 #: js/piemenus.js:447
 #: js/utils/musicutils.js:1468
@@ -7399,7 +6135,6 @@ msgstr "サンプルをコピーするため、ツールを再度試して、ま
 #. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ダブルシャープ"
-
 
 #: js/piemenus.js:448
 #: js/utils/musicutils.js:1466
@@ -7414,7 +6149,6 @@ msgstr "ダブルシャープ"
 msgid "sharp"
 msgstr "シャープ"
 
-
 #: js/piemenus.js:449
 #: js/utils/musicutils.js:1464
 #: js/utils/musicutils.js:1490
@@ -7424,7 +6158,6 @@ msgstr "シャープ"
 #. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "ナチュラル"
-
 
 #: js/piemenus.js:450
 #: js/utils/musicutils.js:1462
@@ -7439,7 +6172,6 @@ msgstr "ナチュラル"
 msgid "flat"
 msgstr "フラット"
 
-
 #: js/piemenus.js:451
 #: js/utils/musicutils.js:1460
 #: js/utils/musicutils.js:1492
@@ -7450,7 +6182,6 @@ msgstr "フラット"
 msgid "double flat"
 msgstr "ダブルフラット"
 
-
 #: js/piemenus.js:3517
 #: js/piemenus.js:3591
 #: js/utils/musicutils.js:1292
@@ -7460,14 +6191,12 @@ msgstr "ダブルフラット"
 msgid "major"
 msgstr "メジャー"
 
-
 #: js/piemenus.js:3517
 #: js/piemenus.js:3591
 #: js/utils/musicutils.js:1310
 #. TRANS: modal scale for music
 msgid "ionian"
 msgstr "アイオニアン音階"
-
 
 #: js/piemenus.js:3519
 #: js/piemenus.js:3595
@@ -7478,7 +6207,6 @@ msgstr "アイオニアン音階"
 msgid "minor"
 msgstr "マイナー（短）"
 
-
 #: js/piemenus.js:3519
 #: js/piemenus.js:3595
 #: js/utils/musicutils.js:1320
@@ -7486,27 +6214,22 @@ msgstr "マイナー（短）"
 msgid "aeolian"
 msgstr "エオリアン音階"
 
-
 #: js/piemenus.js:4154
 msgid "You have chosen key for your pitch preview."
 msgstr "ピッチプレビューのキーを選択しました。"
-
 
 #: js/planetInterface.js:152
 msgid "project undefined"
 msgstr "プロジェクト未定義"
 
-
 #: js/planetInterface.js:279
 msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
 msgstr "エラー: ローカル ストレージが不足しているため、保存できません。保存されているプロジェクトをいくつか削除してみてください。"
-
 
 #: js/blocks.js:1936
 #: js/blocks.js:1944
 msgid "audio file"
 msgstr "オーディオファイル"
-
 
 #: js/blocks.js:2942
 #: js/blocks.js:3347
@@ -7518,7 +6241,6 @@ msgstr "オーディオファイル"
 msgid "box1"
 msgstr "箱１"
 
-
 #: js/blocks.js:2944
 #: js/blocks.js:3349
 #: js/blocks.js:3395
@@ -7528,7 +6250,6 @@ msgstr "箱１"
 #: js/blocks/BoxesBlocks.js:667
 msgid "box2"
 msgstr "箱２"
-
 
 #: js/blocks.js:3616
 #: js/blocks/DictBlocks.js:215
@@ -7547,7 +6268,6 @@ msgstr "箱２"
 msgid "name"
 msgstr "名前"
 
-
 #: js/blocks.js:3616
 #: js/blocks/DictBlocks.js:289
 #: js/blocks/DictBlocks.js:430
@@ -7558,23 +6278,19 @@ msgstr "名前"
 msgid "value"
 msgstr "値"
 
-
 #: js/blocks.js:3954
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr "「ずっとくり返す」状態が「音符」の中にある。"
 
-
 #: js/blocks.js:4501
 msgid "There is no block selected."
 msgstr "ブロックが選ばれていません"
-
 
 #: js/blocks.js:4613
 #: js/blocks/MediaBlocks.js:886
 #. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
-
 
 #: js/blocks.js:4616
 #: js/utils/synthutils.js:3854
@@ -7584,60 +6300,50 @@ msgstr "ネズミへんこう"
 msgid "sample"
 msgstr "音色サンプル"
 
-
 #: js/blocks.js:6720
 #.  AUTOTRANSLATED: Google Translate
 msgid "block sent to trash"
 msgstr "ブロックがゴミ箱に送られる"
 
-
 #: js/svgAssetSelector.js:63
 #.  AUTOTRANSLATED: Google Translate
 msgid "Choose an image"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "画像を選択してください"
 
 #: js/svgAssetSelector.js:83
 #.  AUTOTRANSLATED: Google Translate
 msgid "Built-in images"
 msgstr "内蔵イメージ"
 
-
 #: js/svgAssetSelector.js:92
 #.  AUTOTRANSLATED: Google Translate
 msgid "Upload from device"
 msgstr "デバイスからアップロード"
-
 
 #: js/svgAssetSelector.js:156
 #.  AUTOTRANSLATED: Google Translate
 msgid "Choose file"
 msgstr "ファイルを選択してください"
 
-
 #: js/svgAssetSelector.js:160
 #.  AUTOTRANSLATED: Google Translate
 msgid "Supports PNG, JPG, SVG, GIF, and other image formats"
 msgstr "PNG、JPG、SVG、GIF、その他の画像形式をサポート"
 
-
 #: js/svgAssetSelector.js:176
 #.  AUTOTRANSLATED: Google Translate
 msgid "Apply"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "適用する"
 
 #: js/utils/utils-logic.js:324
 #.  AUTOTRANSLATED: Google Translate
 msgid "Invalid input passed to rational sum"
 msgstr "無効な入力が有理合計に渡されました"
 
-
 #: js/utils/utils-logic.js:331
 #.  AUTOTRANSLATED: Google Translate
 msgid "Note calculation failed: zero denominator"
 msgstr "ノートの計算が失敗しました: 分母がゼロです"
-
 
 #: js/utils/musicutils.js:595
 #: js/utils/musicutils.js:735
@@ -7646,232 +6352,186 @@ msgstr "ノートの計算が失敗しました: 分母がゼロです"
 msgid "rest"
 msgstr "休符"
 
-
 #: js/utils/musicutils.js:778
 msgid "Perfect unison"
 msgstr "完全1度"
-
 
 #: js/utils/musicutils.js:778
 msgid "Diminished second"
 msgstr "減2度"
 
-
 #: js/utils/musicutils.js:779
 msgid "Minor second"
 msgstr "短2度"
-
 
 #: js/utils/musicutils.js:779
 msgid "Augmented unison"
 msgstr "増1度"
 
-
 #: js/utils/musicutils.js:780
 msgid "Major second"
 msgstr "長2度"
-
 
 #: js/utils/musicutils.js:780
 msgid "Diminished third"
 msgstr "減3度"
 
-
 #: js/utils/musicutils.js:781
 msgid "Minor third"
 msgstr "短3度"
-
 
 #: js/utils/musicutils.js:781
 msgid "Augmented second"
 msgstr "増2度"
 
-
 #: js/utils/musicutils.js:782
 msgid "Major third"
 msgstr "長3度"
-
 
 #: js/utils/musicutils.js:782
 msgid "Diminished fourth"
 msgstr "減4度"
 
-
 #: js/utils/musicutils.js:783
 msgid "Perfect fourth"
 msgstr "完全4度"
-
 
 #: js/utils/musicutils.js:783
 msgid "Augmented third"
 msgstr "増3度"
 
-
 #: js/utils/musicutils.js:784
 msgid "Diminished fifth"
 msgstr "減5度"
-
 
 #: js/utils/musicutils.js:784
 msgid "Augmented fourth"
 msgstr "増4度"
 
-
 #: js/utils/musicutils.js:785
 msgid "Perfect fifth"
 msgstr "完全5度"
-
 
 #: js/utils/musicutils.js:785
 msgid "Diminished sixth"
 msgstr "減6度"
 
-
 #: js/utils/musicutils.js:786
 msgid "Minor sixth"
 msgstr "短6度"
-
 
 #: js/utils/musicutils.js:786
 msgid "Augmented fifth"
 msgstr "増5度"
 
-
 #: js/utils/musicutils.js:787
 msgid "Major sixth"
 msgstr "長6度"
-
 
 #: js/utils/musicutils.js:787
 msgid "Diminished seventh"
 msgstr "減7度"
 
-
 #: js/utils/musicutils.js:788
 msgid "Minor seventh"
 msgstr "短7度"
-
 
 #: js/utils/musicutils.js:788
 msgid "Augmented sixth"
 msgstr "増6度"
 
-
 #: js/utils/musicutils.js:789
 msgid "Major seventh"
 msgstr "長7度"
-
 
 #: js/utils/musicutils.js:789
 msgid "Diminished octave"
 msgstr "減8度"
 
-
 #: js/utils/musicutils.js:790
 msgid "Perfect octave"
 msgstr "完全8度"
-
 
 #: js/utils/musicutils.js:790
 msgid "Augmented seventh"
 msgstr "増7度"
 
-
 #: js/utils/musicutils.js:791
 msgid "Minor ninth"
 msgstr "短9度"
-
 
 #: js/utils/musicutils.js:791
 msgid "Augmented octave"
 msgstr "増8度"
 
-
 #: js/utils/musicutils.js:792
 msgid "Major ninth"
 msgstr "長9度"
-
 
 #: js/utils/musicutils.js:792
 msgid "Diminished tenth"
 msgstr "減10度"
 
-
 #: js/utils/musicutils.js:793
 msgid "Minor tenth"
 msgstr "短10度"
-
 
 #: js/utils/musicutils.js:793
 msgid "Augmented ninth"
 msgstr "増9度"
 
-
 #: js/utils/musicutils.js:794
 msgid "Major tenth"
 msgstr "長10度"
-
 
 #: js/utils/musicutils.js:794
 msgid "Diminished eleventh"
 msgstr "減11度"
 
-
 #: js/utils/musicutils.js:795
 msgid "Perfect eleventh"
 msgstr "完全11度"
-
 
 #: js/utils/musicutils.js:795
 msgid "Augmented tenth"
 msgstr "増10度"
 
-
 #: js/utils/musicutils.js:796
 msgid "Diminished twelfth"
 msgstr "減12度"
-
 
 #: js/utils/musicutils.js:796
 msgid "Augmented eleventh"
 msgstr "増11度"
 
-
 #: js/utils/musicutils.js:797
 msgid "Perfect twelfth"
 msgstr "完全12度"
-
 
 #: js/utils/musicutils.js:797
 msgid "Diminished thirteenth"
 msgstr "減13度"
 
-
 #: js/utils/musicutils.js:798
 msgid "Minor thirteenth"
 msgstr "短13度"
-
 
 #: js/utils/musicutils.js:798
 msgid "Augmented fifth, plus an octave"
 msgstr "増12度"
 
-
 #: js/utils/musicutils.js:799
 msgid "Major thirteenth"
 msgstr "長13度"
-
 
 #: js/utils/musicutils.js:799
 msgid "Diminished seventh, plus an octave"
 msgstr "減14度"
 
-
 #: js/utils/musicutils.js:927
 #. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
-
 
 #: js/utils/musicutils.js:1286
 #: js/utils/musicutils.js:1472
@@ -7880,14 +6540,12 @@ msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
 msgid "augmented"
 msgstr "オーギュメント（増）"
 
-
 #: js/utils/musicutils.js:1288
 #: js/utils/musicutils.js:1473
 #: js/utils/musicutils.js:1699
 #. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（減）"
-
 
 #: js/utils/musicutils.js:1294
 #: js/utils/musicutils.js:1697
@@ -7898,216 +6556,178 @@ msgstr "ディミニッシュ（減）"
 msgid "perfect"
 msgstr "パーフェクト（完全）"
 
-
 #: js/utils/musicutils.js:1296
 #. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック音階"
 
-
 #: js/utils/musicutils.js:1297
 msgid "algerian"
 msgstr "アルジェリア音階"
 
-
 #: js/utils/musicutils.js:1298
 msgid "spanish"
 msgstr "スペイン音階"
-
 
 #: js/utils/musicutils.js:1300
 #. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
-
 #: js/utils/musicutils.js:1302
 #. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長音階）"
-
 
 #: js/utils/musicutils.js:1304
 #. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "自然短音階"
 
-
 #: js/utils/musicutils.js:1306
 #. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "和声短音階"
-
 
 #: js/utils/musicutils.js:1308
 #. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "旋律短音階"
 
-
 #: js/utils/musicutils.js:1312
 #. TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン音階"
-
 
 #: js/utils/musicutils.js:1314
 #. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン音階"
 
-
 #: js/utils/musicutils.js:1316
 #. TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン音階"
-
 
 #: js/utils/musicutils.js:1318
 #. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン音階"
 
-
 #: js/utils/musicutils.js:1322
 #. TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン音階"
-
 
 #: js/utils/musicutils.js:1324
 #. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード音階"
 
-
 #: js/utils/musicutils.js:1326
 #. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ音階"
 
-
 #: js/utils/musicutils.js:1327
 msgid "arabic"
 msgstr "アラビア音階"
 
-
 #: js/utils/musicutils.js:1328
 msgid "byzantine"
 msgstr "ビザンティン"
-
 
 #: js/utils/musicutils.js:1330
 #. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディの音階"
 
-
 #: js/utils/musicutils.js:1331
 msgid "ethiopian"
 msgstr "エチオピア音階"
-
 
 #: js/utils/musicutils.js:1333
 #. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ音階"
 
-
 #: js/utils/musicutils.js:1334
 msgid "hindu"
 msgstr "ヒンドゥー音階"
 
-
 #: js/utils/musicutils.js:1335
 msgid "hungarian"
 msgstr "ハンガリー音階"
-
 
 #: js/utils/musicutils.js:1337
 #. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー音階"
 
-
 #: js/utils/musicutils.js:1338
 msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー音階"
-
 
 #: js/utils/musicutils.js:1340
 #. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム音階"
 
-
 #: js/utils/musicutils.js:1342
 #. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース音階"
-
 
 #: js/utils/musicutils.js:1344
 #. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース音階"
 
-
 #: js/utils/musicutils.js:1345
 msgid "whole tone"
 msgstr "ホールトーン音階"
-
 
 #: js/utils/musicutils.js:1347
 #. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック音階"
 
-
 #: js/utils/musicutils.js:1349
 #. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニック音階"
 
-
 #: js/utils/musicutils.js:1350
 msgid "chinese"
 msgstr "中国音階"
 
-
 #: js/utils/musicutils.js:1351
 msgid "egyptian"
 msgstr "エジプト音階"
-
 
 #: js/utils/musicutils.js:1353
 #. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "平調子"
 
-
 #: js/utils/musicutils.js:1354
 msgid "Japan"
 msgstr "日本"
-
 
 #: js/utils/musicutils.js:1356
 #. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "陰音階"
 
-
 #: js/utils/musicutils.js:1358
 #. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "民謡音階"
 
-
 #: js/utils/musicutils.js:1360
 #. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ音階"
-
 
 #: js/utils/musicutils.js:1361
 #: js/utils/musicutils.js:1415
@@ -8126,7 +6746,6 @@ msgstr "フィボナッチ音階"
 msgid "custom"
 msgstr "オリジナル"
 
-
 #: js/utils/musicutils.js:1363
 #: js/utils/musicutils.js:1919
 #: js/blocks/WidgetBlocks.js:244
@@ -8134,13 +6753,11 @@ msgstr "オリジナル"
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
-
 #: js/utils/musicutils.js:1365
 #: js/utils/musicutils.js:1920
 #. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
-
 
 #: js/utils/musicutils.js:1367
 #: js/utils/musicutils.js:1921
@@ -8148,13 +6765,11 @@ msgstr "ローパス・フィルター"
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
-
 #: js/utils/musicutils.js:1369
 #: js/utils/musicutils.js:1922
 #. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
-
 
 #: js/utils/musicutils.js:1371
 #: js/utils/musicutils.js:1923
@@ -8162,13 +6777,11 @@ msgstr "ハイシェルフ・フィルター"
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
-
 #: js/utils/musicutils.js:1373
 #: js/utils/musicutils.js:1924
 #. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
-
 
 #: js/utils/musicutils.js:1375
 #: js/utils/musicutils.js:1925
@@ -8176,13 +6789,11 @@ msgstr "ノッチ・フィルター"
 msgid "allpass"
 msgstr "オールパスフィルター"
 
-
 #: js/utils/musicutils.js:1377
 #: js/utils/musicutils.js:1926
 #. TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
-
 
 #: js/utils/musicutils.js:1378
 #: js/utils/musicutils.js:1934
@@ -8193,7 +6804,6 @@ msgstr "ピーク・フィルタ"
 msgid "sine"
 msgstr "サイン波"
 
-
 #: js/utils/musicutils.js:1379
 #: js/utils/musicutils.js:1935
 #: js/utils/synthutils.js:142
@@ -8202,7 +6812,6 @@ msgstr "サイン波"
 #. TRANS: square wave
 msgid "square"
 msgstr "四角の波"
-
 
 #: js/utils/musicutils.js:1380
 #: js/utils/musicutils.js:1936
@@ -8214,7 +6823,6 @@ msgstr "四角の波"
 msgid "triangle"
 msgstr "三角の波"
 
-
 #: js/utils/musicutils.js:1381
 #: js/utils/musicutils.js:1937
 #: js/utils/synthutils.js:144
@@ -8223,7 +6831,6 @@ msgstr "三角の波"
 #. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの波"
-
 
 #: js/utils/musicutils.js:1383
 #: js/utils/musicutils.js:1687
@@ -8235,7 +6842,6 @@ msgstr "ぎざぎざの波"
 msgid "even"
 msgstr "偶数"
 
-
 #: js/utils/musicutils.js:1385
 #: js/utils/musicutils.js:1688
 #: js/blocks/PitchBlocks.js:1004
@@ -8244,14 +6850,12 @@ msgstr "偶数"
 msgid "odd"
 msgstr "奇数"
 
-
 #: js/utils/musicutils.js:1386
 #: js/utils/musicutils.js:1689
 #: js/blocks/PitchBlocks.js:1004
 #: js/turtleactions/PitchActions.js:591
 msgid "scalar"
 msgstr "音階的"
-
 
 #: js/utils/musicutils.js:1387
 #: js/utils/synthutils.js:80
@@ -8261,14 +6865,12 @@ msgstr "音階的"
 msgid "piano"
 msgstr "ピアノ"
 
-
 #: js/utils/musicutils.js:1388
 #: js/utils/synthutils.js:82
 #: js/widgets/legobricks.js:1952
 #. TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
-
 
 #: js/utils/musicutils.js:1389
 #: js/utils/synthutils.js:84
@@ -8277,20 +6879,17 @@ msgstr "バイオリン"
 msgid "viola"
 msgstr "ビオラ"
 
-
 #: js/utils/musicutils.js:1390
 #: js/utils/synthutils.js:128
 #. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "木琴"
 
-
 #: js/utils/musicutils.js:1391
 #: js/utils/synthutils.js:150
 #. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "鉄琴"
-
 
 #: js/utils/musicutils.js:1392
 #: js/utils/synthutils.js:86
@@ -8299,13 +6898,11 @@ msgstr "鉄琴"
 msgid "cello"
 msgstr "チェロ"
 
-
 #: js/utils/musicutils.js:1394
 #: js/utils/synthutils.js:90
 #. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
-
 
 #: js/utils/musicutils.js:1395
 #: js/utils/synthutils.js:98
@@ -8315,13 +6912,11 @@ msgstr "ダブルベース"
 msgid "guitar"
 msgstr "ギター"
 
-
 #: js/utils/musicutils.js:1396
 #: js/utils/synthutils.js:92
 #. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "シタール"
-
 
 #: js/utils/musicutils.js:1397
 #: js/utils/synthutils.js:94
@@ -8329,13 +6924,11 @@ msgstr "シタール"
 msgid "harmonium"
 msgstr "ハルモニウム"
 
-
 #: js/utils/musicutils.js:1398
 #: js/utils/synthutils.js:96
 #. TRANS: mandolin musical instrument
 msgid "mandolin"
 msgstr "マンドリン"
-
 
 #: js/utils/musicutils.js:1399
 #: js/utils/synthutils.js:100
@@ -8344,14 +6937,12 @@ msgstr "マンドリン"
 msgid "acoustic guitar"
 msgstr "アコースティック"
 
-
 #: js/utils/musicutils.js:1400
 #: js/utils/synthutils.js:102
 #: js/widgets/legobricks.js:1956
 #. TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
-
 
 #: js/utils/musicutils.js:1401
 #: js/utils/synthutils.js:104
@@ -8360,14 +6951,12 @@ msgstr "フルート"
 msgid "clarinet"
 msgstr "クラリネット"
 
-
 #: js/utils/musicutils.js:1402
 #: js/utils/synthutils.js:106
 #: js/widgets/legobricks.js:1958
 #. TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
-
 
 #: js/utils/musicutils.js:1403
 #: js/utils/synthutils.js:108
@@ -8376,14 +6965,12 @@ msgstr "サクソフォン"
 msgid "tuba"
 msgstr "チューバ"
 
-
 #: js/utils/musicutils.js:1404
 #: js/utils/synthutils.js:110
 #: js/widgets/legobricks.js:1959
 #. TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
-
 
 #: js/utils/musicutils.js:1405
 #: js/utils/synthutils.js:112
@@ -8392,14 +6979,12 @@ msgstr "トランペット"
 msgid "oboe"
 msgstr "オーボエ"
 
-
 #: js/utils/musicutils.js:1406
 #: js/utils/synthutils.js:114
 #: js/widgets/legobricks.js:1960
 #. TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
-
 
 #: js/utils/musicutils.js:1407
 #: js/utils/synthutils.js:130
@@ -8408,28 +6993,23 @@ msgstr "トロンボーン"
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
-
 #: js/utils/musicutils.js:1408
 #: js/utils/synthutils.js:132
 #. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
 
-
 #: js/utils/musicutils.js:1409
 msgid "simple 2"
 msgstr "シンプル２"
-
 
 #: js/utils/musicutils.js:1410
 msgid "simple 3"
 msgstr "シンプル３"
 
-
 #: js/utils/musicutils.js:1411
 msgid "simple 4"
 msgstr "シンプル４"
-
 
 #: js/utils/musicutils.js:1412
 #: js/utils/synthutils.js:66
@@ -8438,20 +7018,17 @@ msgstr "シンプル４"
 msgid "white noise"
 msgstr "ホワイトノイズ"
 
-
 #: js/utils/musicutils.js:1413
 #: js/utils/synthutils.js:68
 #. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
-
 #: js/utils/musicutils.js:1414
 #: js/utils/synthutils.js:70
 #. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
-
 
 #: js/utils/musicutils.js:1416
 #: js/utils/synthutils.js:162
@@ -8461,13 +7038,11 @@ msgstr "ピンクノイズ"
 msgid "snare drum"
 msgstr "スネアドラム"
 
-
 #: js/utils/musicutils.js:1417
 #: js/utils/synthutils.js:164
 #. TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
-
 
 #: js/utils/musicutils.js:1418
 #: js/utils/synthutils.js:166
@@ -8475,13 +7050,11 @@ msgstr "キックドラム"
 msgid "tom tom"
 msgstr "タムタム"
 
-
 #: js/utils/musicutils.js:1419
 #: js/utils/synthutils.js:168
 #. TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
-
 
 #: js/utils/musicutils.js:1420
 #: js/utils/synthutils.js:170
@@ -8489,13 +7062,11 @@ msgstr "フロアタム"
 msgid "bass drum"
 msgstr "バスドラム"
 
-
 #: js/utils/musicutils.js:1421
 #: js/utils/synthutils.js:172
 #. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
-
 
 #: js/utils/musicutils.js:1422
 #: js/utils/synthutils.js:174
@@ -8503,13 +7074,11 @@ msgstr "カップドラム"
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
-
 #: js/utils/musicutils.js:1423
 #: js/utils/synthutils.js:178
 #. TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
-
 
 #: js/utils/musicutils.js:1424
 #: js/utils/synthutils.js:180
@@ -8517,18 +7086,15 @@ msgstr "ハイハット"
 msgid "ride bell"
 msgstr "ライドベル"
 
-
 #: js/utils/musicutils.js:1425
 #: js/utils/synthutils.js:182
 #. TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
 
-
 #: js/utils/musicutils.js:1426
 msgid "japanese drum"
 msgstr "太鼓"
-
 
 #: js/utils/musicutils.js:1427
 #: js/utils/synthutils.js:188
@@ -8536,13 +7102,11 @@ msgstr "太鼓"
 msgid "japanese bell"
 msgstr "鉦"
 
-
 #: js/utils/musicutils.js:1428
 #: js/utils/synthutils.js:184
 #. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
-
 
 #: js/utils/musicutils.js:1429
 #: js/utils/synthutils.js:186
@@ -8550,13 +7114,11 @@ msgstr "トライアングル"
 msgid "finger cymbals"
 msgstr "フィンガーシンバル"
 
-
 #: js/utils/musicutils.js:1430
 #: js/utils/synthutils.js:190
 #. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
-
 
 #: js/utils/musicutils.js:1431
 #: js/utils/synthutils.js:192
@@ -8564,13 +7126,11 @@ msgstr "チャイム"
 msgid "gong"
 msgstr "ドラ"
 
-
 #: js/utils/musicutils.js:1432
 #: js/utils/synthutils.js:194
 #. TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
-
 
 #: js/utils/musicutils.js:1433
 #: js/utils/synthutils.js:196
@@ -8578,13 +7138,11 @@ msgstr "カチャカチャ"
 msgid "crash"
 msgstr "クラッシュ"
 
-
 #: js/utils/musicutils.js:1434
 #: js/utils/synthutils.js:198
 #. TRANS: sound effect
 msgid "bottle"
 msgstr "空きびん"
-
 
 #: js/utils/musicutils.js:1435
 #: js/utils/synthutils.js:200
@@ -8592,13 +7150,11 @@ msgstr "空きびん"
 msgid "clap"
 msgstr "てびょうし"
 
-
 #: js/utils/musicutils.js:1436
 #: js/utils/synthutils.js:202
 #. TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
-
 
 #: js/utils/musicutils.js:1437
 #: js/utils/synthutils.js:204
@@ -8606,13 +7162,11 @@ msgstr "ピシャリ"
 msgid "splash"
 msgstr "しぶき"
 
-
 #: js/utils/musicutils.js:1438
 #: js/utils/synthutils.js:206
 #. TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
-
 
 #: js/utils/musicutils.js:1439
 #: js/utils/synthutils.js:208
@@ -8620,13 +7174,11 @@ msgstr "あわ"
 msgid "raindrop"
 msgstr "雨のしずく"
 
-
 #: js/utils/musicutils.js:1440
 #: js/utils/synthutils.js:210
 #. TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
-
 
 #: js/utils/musicutils.js:1441
 #: js/utils/synthutils.js:212
@@ -8634,13 +7186,11 @@ msgstr "ねこ"
 msgid "cricket"
 msgstr "こおろぎ"
 
-
 #: js/utils/musicutils.js:1442
 #: js/utils/synthutils.js:214
 #. TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
-
 
 #: js/utils/musicutils.js:1444
 #: js/utils/synthutils.js:116
@@ -8649,20 +7199,17 @@ msgstr "いぬ"
 msgid "banjo"
 msgstr "バンジョー"
 
-
 #: js/utils/musicutils.js:1445
 #: js/utils/synthutils.js:118
 #. TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
-
 #: js/utils/musicutils.js:1446
 #: js/utils/synthutils.js:120
 #. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
-
 
 #: js/utils/musicutils.js:1447
 #: js/utils/synthutils.js:122
@@ -8671,13 +7218,11 @@ msgstr "ダルシマー"
 msgid "electric guitar"
 msgstr "エレキギター"
 
-
 #: js/utils/musicutils.js:1448
 #: js/utils/synthutils.js:124
 #. TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
-
 
 #: js/utils/musicutils.js:1449
 #: js/utils/synthutils.js:126
@@ -8685,25 +7230,21 @@ msgstr "バスーン"
 msgid "celeste"
 msgstr "セレスタ"
 
-
 #: js/utils/musicutils.js:1451
 #: js/widgets/temperament.js:996
 #. TRANS: musical temperament
 msgid "equal"
 msgstr "平均律"
 
-
 #: js/utils/musicutils.js:1453
 #. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス音律 "
 
-
 #: js/utils/musicutils.js:1455
 #. TRANS: musical temperament
 msgid "just intonation"
 msgstr "純正律"
-
 
 #: js/utils/musicutils.js:1457
 #: js/utils/musicutils.js:1953
@@ -8714,143 +7255,118 @@ msgstr "純正律"
 msgid "Meantone"
 msgstr "中全音律"
 
-
 #: js/utils/musicutils.js:1474
 msgid "major 7th"
 msgstr "長七の和音（メイジャー・セブンス)"
-
 
 #: js/utils/musicutils.js:1475
 msgid "minor 7th"
 msgstr "短七の和音（マイナー・セブンス）"
 
-
 #: js/utils/musicutils.js:1476
 msgid "dominant 7th"
 msgstr "属七の和音（ドミナント・セブンス）"
-
 
 #: js/utils/musicutils.js:1477
 msgid "minor-major 7th"
 msgstr "短三長七の和音（マイナー・メイジャー・セブンス）"
 
-
 #: js/utils/musicutils.js:1478
 msgid "fully-diminished 7th"
 msgstr "減七の和音（ディミニッシュト・セブンス）"
 
-
 #: js/utils/musicutils.js:1479
 msgid "half-diminished 7th"
 msgstr "減五短七の和音（ハーフ・ディミニッシュト）"
-
 
 #: js/utils/musicutils.js:1945
 #: js/utils/musicutils.js:1962
 msgid "Equal (12EDO)"
 msgstr "12平均律"
 
-
 #: js/utils/musicutils.js:1946
 #: js/utils/musicutils.js:1963
 msgid "Equal (5EDO)"
 msgstr "5平均律"
-
 
 #: js/utils/musicutils.js:1947
 #: js/utils/musicutils.js:1964
 msgid "Equal (7EDO)"
 msgstr "7平均律"
 
-
 #: js/utils/musicutils.js:1948
 #: js/utils/musicutils.js:1965
 #.  AUTOTRANSLATED: Google Translate
 msgid "Equal (17EDO)"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "17平均律"
 
 #: js/utils/musicutils.js:1949
 #: js/utils/musicutils.js:1966
 msgid "Equal (19EDO)"
 msgstr "19平均律"
 
-
 #: js/utils/musicutils.js:1950
 #: js/utils/musicutils.js:1967
 msgid "Equal (31EDO)"
 msgstr "31平均律"
-
 
 #: js/utils/musicutils.js:1951
 #: js/utils/musicutils.js:1968
 msgid "5-limit Just Intonation"
 msgstr "5限界純正律"
 
-
 #: js/utils/musicutils.js:1952
 #: js/utils/musicutils.js:1969
 msgid "Pythagorean (3-limit JI)"
 msgstr "ピタゴラス音律"
-
 
 #: js/utils/musicutils.js:4915
 #: js/widgets/temperament.js:2569
 msgid "Invalid temperament. Falling back to equal temperament."
 msgstr "無効な気質。平均律に戻ります。"
 
-
 #: js/utils/musicutils.js:7511
 #: js/utils/musicutils.js:7554
 msgid "current"
 msgstr "現在の"
-
 
 #: js/utils/musicutils.js:7514
 #: js/utils/musicutils.js:7545
 msgid "next"
 msgstr "この次の"
 
-
 #: js/utils/musicutils.js:7517
 #: js/utils/musicutils.js:7550
 msgid "previous"
 msgstr "この前の"
-
 
 #: js/utils/synthutils.js:134
 #. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
-
 #: js/utils/synthutils.js:136
 #. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
-
 
 #: js/utils/synthutils.js:138
 #. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
-
 #: js/utils/synthutils.js:176
 #. TRANS: musical instrument
 msgid "taiko"
 msgstr "太鼓"
 
-
 #: js/utils/synthutils.js:2260
 msgid "⚠️ Sound is disabled!\n\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
 msgstr "⚠️ サウンドは無効になっています。\n\nブラウザの設定 (サイト設定 > サウンド) を確認して、ミュージック・ブロックスの音声を許可してください。"
 
-
 #: js/utils/synthutils.js:3787
 msgid "Cents Adjustment"
 msgstr "セント調整"
-
 
 #: js/utils/synthutils.js:3816
 #: js/widgets/sampler.js:1925
@@ -8858,26 +7374,21 @@ msgstr "セント調整"
 msgid "reference tone"
 msgstr "参照ピッチ"
 
-
 #: js/utils/utils.js:474
 msgid "Security Warning"
 msgstr "セキュリティ警告"
-
 
 #: js/utils/utils.js:476
 msgid "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
 msgstr "このプラグインには、ブラウザで実行されるコードが含まれています。組み込みのプラグイン ディレクトリからロードされていないため、安全でないコードが含まれている可能性があります。"
 
-
 #: js/utils/utils.js:480
 msgid "Do you want to allow this plugin to run?"
 msgstr "このプラグインの実行を許可しますか?"
 
-
 #: js/utils/utils.js:482
 msgid "Source: %s"
 msgstr "ソース: %s"
-
 
 #: js/utils/utils.js:482
 #: js/blocks/ExtrasBlocks.js:696
@@ -8891,16 +7402,13 @@ msgstr "ソース: %s"
 msgid "unknown"
 msgstr "不明"
 
-
 #: js/blocks/DictBlocks.js:62
 msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
 msgstr "「辞書を表す」ブロックは、画面の上部に辞書の内容を表示します。"
 
-
 #: js/blocks/DictBlocks.js:77
 msgid "show dictionary"
 msgstr "辞書を表す"
-
 
 #: js/blocks/DictBlocks.js:80
 #: js/blocks/DictBlocks.js:145
@@ -8912,24 +7420,20 @@ msgstr "辞書を表す"
 msgid "My Dictionary"
 msgstr "私の辞書"
 
-
 #: js/blocks/DictBlocks.js:129
 msgid "The Dictionary block returns a dictionary."
 msgstr "Dictionaryブロックは辞書を返します。"
-
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックは指定されたキーの辞書の値を返します。"
 
-
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
 #. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "数価を表す"
-
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -8940,7 +7444,6 @@ msgstr "数価を表す"
 #: js/blocks/DictBlocks.js:431
 msgid "key2"
 msgstr "キーワード"
-
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -8954,12 +7457,10 @@ msgstr "キーワード"
 msgid "key"
 msgstr "調"
 
-
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックは指定されたキーに辞書の値を設定します。"
-
 
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
@@ -8967,47 +7468,38 @@ msgstr "Set-dictブロックは指定されたキーに辞書の値を設定し�
 msgid "set value"
 msgstr "値を設定"
 
-
 #: js/blocks/HeapBlocks.js:49
 msgid "The Heap block returns the heap."
 msgstr "Heapブロックはヒープを返します。"
-
 
 #: js/blocks/HeapBlocks.js:118
 msgid "The Show-heap block displays the contents of the heap at the top of the screen."
 msgstr "「ヒープを表示する」ブロックは、ヒープの内容を画面の上部に表示します。"
 
-
 #: js/blocks/HeapBlocks.js:133
 msgid "show heap"
 msgstr "ヒープを表示する"
-
 
 #: js/blocks/HeapBlocks.js:181
 msgid "The Heap-length block returns the length of the heap."
 msgstr "Heap-lengthブロックはヒープの長さを返します。"
 
-
 #: js/blocks/HeapBlocks.js:195
 msgid "heap length"
 msgstr "ヒープの長さ"
 
-
 #: js/blocks/HeapBlocks.js:254
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "Heap-empty?ブロックはヒープが空の場合にtrueを返します。"
-
 
 #: js/blocks/HeapBlocks.js:268
 #. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ヒープは空ですか？"
 
-
 #: js/blocks/HeapBlocks.js:317
 msgid "The Empty-heap block empties the heap."
 msgstr "Empty-heapブロックはヒープを空にします。"
-
 
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
@@ -9015,28 +7507,23 @@ msgstr "Empty-heapブロックはヒープを空にします。"
 msgid "empty heap"
 msgstr "空のヒープ"
 
-
 #: js/blocks/HeapBlocks.js:371
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "Reverse-heapブロックはヒープの順序を逆にします。"
-
 
 #: js/blocks/HeapBlocks.js:384
 #. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ヒープを逆にする"
 
-
 #: js/blocks/HeapBlocks.js:428
 msgid "The Index-heap block returns a value in the heap at a specified location."
 msgstr "Index-heapブロックは指定された位置のヒープの値を返します。"
-
 
 #: js/blocks/HeapBlocks.js:443
 #. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ヒープに番号をふる"
-
 
 #: js/blocks/HeapBlocks.js:474
 #: js/blocks/HeapBlocks.js:572
@@ -9045,18 +7532,15 @@ msgstr "ヒープに番号をふる"
 msgid "Index must be > 0."
 msgstr "インデクス番号は 0 より大きい必要があります。"
 
-
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:150
 msgid "Maximum heap size is 1000."
 msgstr "ヒープの大きさは、最大1000です。"
 
-
 #: js/blocks/HeapBlocks.js:523
 msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "Set-heapエントリーブロックは指定された位置のヒープに値を設定します。"
-
 
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:301
@@ -9064,13 +7548,11 @@ msgstr "Set-heapエントリーブロックは指定された位置のヒープ�
 msgid "set heap"
 msgstr "ヒープを設定する"
 
-
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:117
 #. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
-
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/BoxesBlocks.js:75
@@ -9078,48 +7560,39 @@ msgstr "インデックス"
 msgid "value1"
 msgstr "すうち"
 
-
 #: js/blocks/HeapBlocks.js:619
 msgid "The Pop block removes the value at the top of the heap."
 msgstr "Popブロックはヒープの先頭の値を削除します。"
-
 
 #: js/blocks/HeapBlocks.js:633
 #. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ポップ"
 
-
 #: js/blocks/HeapBlocks.js:680
 msgid "The Push block adds a value to the top of the heap."
 msgstr "Pushブロックは値をヒープの先頭に追加します。"
-
 
 #: js/blocks/HeapBlocks.js:696
 #. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "プッシュ"
 
-
 #: js/blocks/EnsembleBlocks.js:91
 msgid "mouse index heap"
 msgstr "ネズミヒープに番号をふる"
-
 
 #: js/blocks/EnsembleBlocks.js:91
 msgid "turtle index heap"
 msgstr "タートル ヒープに番号をふる"
 
-
 #: js/blocks/EnsembleBlocks.js:98
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr "指定されたマウスの指定された位置のヒープ内の値を返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:105
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr "指定されたタートルの指定された位置のヒープ内の値を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:115
 #: js/blocks/EnsembleBlocks.js:190
@@ -9141,38 +7614,31 @@ msgstr "指定されたタートルの指定された位置のヒープ内の値
 msgid "Yertle"
 msgstr "ヤートル"
 
-
 #: js/blocks/EnsembleBlocks.js:117
 #: js/blocks/EnsembleBlocks.js:1106
 msgid "mouse name"
 msgstr "ネズミの名前"
-
 
 #: js/blocks/EnsembleBlocks.js:117
 #: js/blocks/EnsembleBlocks.js:1115
 msgid "turtle name"
 msgstr "ネズミの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:168
 msgid "stop mouse"
 msgstr "ネズミを止める"
-
 
 #: js/blocks/EnsembleBlocks.js:170
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "指定されたマウスを停止します。"
 
-
 #: js/blocks/EnsembleBlocks.js:181
 msgid "stop turtle"
 msgstr "ネズミを止める"
 
-
 #: js/blocks/EnsembleBlocks.js:183
 msgid "The Stop turtle block stops the specified turtle."
 msgstr "指定されたタートルを停止します。"
-
 
 #: js/blocks/EnsembleBlocks.js:207
 #: js/blocks/EnsembleBlocks.js:267
@@ -9186,7 +7652,6 @@ msgstr "指定されたタートルを停止します。"
 msgid "Cannot find mouse"
 msgstr "ネズミが見つかりません。"
 
-
 #: js/blocks/EnsembleBlocks.js:209
 #: js/blocks/EnsembleBlocks.js:269
 #: js/blocks/EnsembleBlocks.js:433
@@ -9199,85 +7664,69 @@ msgstr "ネズミが見つかりません。"
 msgid "Cannot find turtle"
 msgstr "タートルが見つかりません。"
 
-
 #: js/blocks/EnsembleBlocks.js:228
 msgid "start mouse"
 msgstr "ネズミをスタート"
-
 
 #: js/blocks/EnsembleBlocks.js:231
 msgid "The Start mouse block starts the specified mouse."
 msgstr "指定されたマウスを開始します。"
 
-
 #: js/blocks/EnsembleBlocks.js:242
 msgid "start turtle"
 msgstr "ネズミをスタートする"
-
 
 #: js/blocks/EnsembleBlocks.js:245
 msgid "The Start turtle block starts the specified turtle."
 msgstr "指定されたタートルを開始します。"
 
-
 #: js/blocks/EnsembleBlocks.js:276
 msgid "Mouse is already running."
 msgstr "ネズミはすでに動いています。"
-
 
 #: js/blocks/EnsembleBlocks.js:278
 msgid "Turtle is already running."
 msgstr "タートルはすでに動いています。"
 
-
 #: js/blocks/EnsembleBlocks.js:300
 msgid "Cannot find start block"
 msgstr "「スタート」ブロックが見つかりません。"
-
 
 #: js/blocks/EnsembleBlocks.js:310
 #. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの色"
 
-
 #: js/blocks/EnsembleBlocks.js:312
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "指定されたマウスのペンの色を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:324
 #. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルの色"
 
-
 #: js/blocks/EnsembleBlocks.js:326
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "指定されたタートルのペンの色を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:356
 #. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの進む角度"
 
-
 #: js/blocks/EnsembleBlocks.js:358
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "指定されたマウスの向きを返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:370
 #. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルの進む角度"
 
-
 #: js/blocks/EnsembleBlocks.js:372
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr "指定されたタートルの向きを返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:402
 #: js/blocks/EnsembleBlocks.js:459
@@ -9285,18 +7734,15 @@ msgstr "指定されたタートルの向きを返します。"
 msgid "set mouse"
 msgstr "ネズミを設定"
 
-
 #: js/blocks/ToneBlocks.js:634
 msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
 msgstr "ディレイ(第 2 引数) は、コーラス・ボイス間の遅延時間 (ミリ秒) を設定します。"
-
 
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
 #: js/blocks/BoxesBlocks.js:599
 msgid "name1"
 msgstr "箱へ"
-
 
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
@@ -9310,7 +7756,6 @@ msgstr "箱へ"
 msgid "x"
 msgstr "xざひょう（よこ）"
 
-
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
 #: js/blocks/ProgramBlocks.js:895
@@ -9323,111 +7768,91 @@ msgstr "xざひょう（よこ）"
 msgid "y"
 msgstr "yざひょう（たて）"
 
-
 #: js/blocks/EnsembleBlocks.js:413
 #: js/blocks/EnsembleBlocks.js:474
 #. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "タートルを設定"
 
-
 #: js/blocks/EnsembleBlocks.js:451
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr "指定されたマウスに実行するブロックのスタックを送ります。"
 
-
 #: js/blocks/EnsembleBlocks.js:466
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr "指定されたタートルに実行するブロックのスタックを送ります。"
-
 
 #: js/blocks/EnsembleBlocks.js:502
 #. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミのy座標"
 
-
 #: js/blocks/EnsembleBlocks.js:504
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "指定されたマウスのY座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:516
 #. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "タートルのy座標"
 
-
 #: js/blocks/EnsembleBlocks.js:518
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "指定されたタートルのY座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:547
 #. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミのx座標"
 
-
 #: js/blocks/EnsembleBlocks.js:549
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "指定されたマウスのX座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:561
 #. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "タートルのx座標"
 
-
 #: js/blocks/EnsembleBlocks.js:563
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "指定されたタートルのX座標を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:593
 #. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの演奏した音符の数"
 
-
 #: js/blocks/EnsembleBlocks.js:595
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr "指定されたマウスが演奏したノート数を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:609
 #. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルの演奏した音符の数"
 
-
 #: js/blocks/EnsembleBlocks.js:611
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr "指定されたタートルが演奏したノート数を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:647
 #. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
 
-
 #: js/blocks/EnsembleBlocks.js:649
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr "指定されたマウスが現在演奏しているピッチ番号を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:663
 #. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルの音高数字"
 
-
 #: js/blocks/EnsembleBlocks.js:665
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr "指定されたタートルが現在演奏しているピッチ番号を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:772
 #: js/blocks/EnsembleBlocks.js:844
@@ -9435,296 +7860,239 @@ msgstr "指定されたタートルが現在演奏しているピッチ番号を
 msgid "mouse note value"
 msgstr "ネズミの音価"
 
-
 #: js/blocks/EnsembleBlocks.js:782
 #. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルの音価"
-
 
 #: js/blocks/EnsembleBlocks.js:855
 #. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを同期させる"
 
-
 #: js/blocks/EnsembleBlocks.js:857
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "マウス間のビート数を同期させるブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:869
 #. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルを同期させる"
 
-
 #: js/blocks/EnsembleBlocks.js:871
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr "タートル間のビート数を同期させるブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:911
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr "指定されたマウスが見つかった場合にtrueを返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:919
 msgid "found mouse"
 msgstr "ネズミを見つけた"
-
 
 #: js/blocks/EnsembleBlocks.js:929
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr "指定されたタートルが見つかった場合にtrueを返します。"
 
-
 #: js/blocks/EnsembleBlocks.js:937
 msgid "found turtle"
 msgstr "タートル見つかった"
-
 
 #: js/blocks/EnsembleBlocks.js:960
 msgid "new mouse"
 msgstr "新しいネズミ"
 
-
 #: js/blocks/EnsembleBlocks.js:962
 msgid "The New mouse block will create a new mouse."
 msgstr "新しいマウスを作成するブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:973
 msgid "new turtle"
 msgstr "新しいタートル"
 
-
 #: js/blocks/EnsembleBlocks.js:975
 msgid "The New turtle block will create a new turtle."
 msgstr "新しいタートルを作成するブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:1034
 msgid "set mouse color"
 msgstr "ネズミ色を設定"
 
-
 #: js/blocks/EnsembleBlocks.js:1037
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr "「ネズミ色を設定」ブロックは ネズミの色を選ぶことに使います。"
-
 
 #: js/blocks/VolumeBlocks.js:35
 msgid "synth volume"
 msgstr "シンセの音量"
 
-
 #: js/blocks/EnsembleBlocks.js:1043
 msgid "set turtle color"
 msgstr "タートル色を設定"
-
 
 #: js/blocks/EnsembleBlocks.js:1046
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr "タートルの色を設定するためのブロックです。"
 
-
 #: js/blocks/VolumeBlocks.js:39
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr "「シンセの音量」ブロックは現在のシンセサイザーの音量を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:1109
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "<h2>文字ブロック</h2><br>このプログラムを実行しているネズミの名前（文字列）を表す。"
 
-
 #: js/blocks/EnsembleBlocks.js:1118
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr "タートルの名前を返すブロックです。"
-
 
 #: js/blocks/EnsembleBlocks.js:1141
 msgid "mouse count"
 msgstr "何匹のネズミ"
 
-
 #: js/blocks/EnsembleBlocks.js:1144
 msgid "The Mouse-count block returns the number of mice."
 msgstr "「何匹のネズミ」のブロックはネズミを数えって数字を表す。"
-
 
 #: js/blocks/EnsembleBlocks.js:1150
 msgid "turtle count"
 msgstr "何匹のタートル"
 
-
 #: js/blocks/EnsembleBlocks.js:1153
 msgid "The Turtle-count block returns the number of turtles."
 msgstr "タートルカウントブロックはタートルの数を返します。"
-
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:525
 msgid "set synth volume"
 msgstr "シンセの音量をせってい"
 
-
 #: js/blocks/EnsembleBlocks.js:1175
 msgid "nth mouse name"
 msgstr "何匹目のネズミの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:1178
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr "エヌス・マウス・ネームブロックはエヌ番目のマウスの名前を返します。"
-
 
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:546
 msgid "synth"
 msgstr "シンセ"
 
-
 #: js/blocks/EnsembleBlocks.js:1184
 msgid "nth turtle name"
 msgstr "何匹目のタートルの名前"
 
-
 #: js/blocks/EnsembleBlocks.js:1187
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr "エヌス・タートル・ネームブロックはエヌ番目のタートルの名前を返します。"
-
 
 #: js/blocks/EnsembleBlocks.js:1231
 #: js/blocks/EnsembleBlocks.js:1291
 msgid "set name"
 msgstr "ネズミに名前をつける"
 
-
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "source"
 msgstr "ソース"
 
-
 #: js/blocks/VolumeBlocks.js:440
 msgid "Synth not found"
 msgstr "シンセ（楽器）が見つかりません"
-
 
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "target"
 msgstr "ターゲット"
 
-
 #: js/blocks/EnsembleBlocks.js:1297
 msgid "The Set-name block is used to name a mouse."
 msgstr "<h2>文字ブロック</h2><br>ネズミに指定した名前をつけることができる。"
-
 
 #: js/blocks/EnsembleBlocks.js:1310
 msgid "The Set-name block is used to name a turtle."
 msgstr "<h2>文字ブロック</h2><br>タートルに指定した名前をつけることができる。"
 
-
 #: js/blocks/FlowBlocks.js:41
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
 msgstr "<h2>実行ブロック（ぎゃく実行）</h2><br>はさまれているブロックを、つうじょうとはぎゃくの順じょで、下から上に向かって実行する。"
-
 
 #: js/blocks/VolumeBlocks.js:531
 msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
 msgstr "「シンセの音量をせってい」ブロックは、ギター、バイオリン、スネアドラムなどの特定のシンセサイザーの音量を変更します。"
 
-
 #: js/blocks/FlowBlocks.js:48
 msgid "backward"
 msgstr "ぎゃく向きに実行"
-
 
 #: js/blocks/FlowBlocks.js:124
 msgid "The Duplicate block will run each block multiple times."
 msgstr "Duplicateブロックは各ブロックを複数回実行します。"
 
-
 #: js/blocks/FlowBlocks.js:126
 msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 msgstr "この例の出力は、ソ、ソ、ソ、ソ、レ、レ、レ、レ、ソ、ソ、ソ、ソ です。"
-
 
 #: js/blocks/FlowBlocks.js:372
 msgid "The Default block is used inside of a Switch to define the default action."
 msgstr "DefaultブロックはSwitch内でデフォルトの動作を定義するために使われます。"
 
-
 #: js/blocks/FlowBlocks.js:380
 msgid "default"
 msgstr "ひょうじゅん"
-
 
 #: js/blocks/FlowBlocks.js:399
 #: js/blocks/FlowBlocks.js:456
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr "ケースブロックはスイッチブロックの中にある必要があります。"
 
-
 #: js/blocks/FlowBlocks.js:427
 msgid "The Case block is used inside of a Switch to define matches."
 msgstr "CaseブロックはSwitch内で一致条件を定義するために使われます。"
-
 
 #: js/blocks/FlowBlocks.js:435
 msgid "case"
 msgstr "ケース"
 
-
 #: js/blocks/FlowBlocks.js:484
 msgid "The Switch block will run the code in the matching Case."
 msgstr "Switchブロックは一致するCase内のコードを実行します。"
-
 
 #: js/blocks/FlowBlocks.js:492
 msgid "switch"
 msgstr "スイッチ"
 
-
 #: js/blocks/FlowBlocks.js:638
 msgid "The Stop block will stop a loop"
 msgstr "Stopブロックはループを停止します。"
-
 
 #: js/blocks/FlowBlocks.js:640
 msgid "Forever, Repeat, While, or Until."
 msgstr "Forever、Repeat、While、またはUntil。"
 
-
 #: js/blocks/FlowBlocks.js:697
 msgid "The Waitfor block will wait until the condition is true."
 msgstr "Waitforブロックは条件が真になるまで待ちます。"
-
 
 #: js/blocks/FlowBlocks.js:705
 msgid "wait for"
 msgstr "を待つ"
 
-
 #: js/blocks/FlowBlocks.js:780
 msgid "The Until block will repeat until the condition is true."
 msgstr "Untilブロックは条件が真になるまで繰り返します。"
-
 
 #: js/blocks/FlowBlocks.js:788
 msgid "until"
 msgstr "までに"
 
-
 #: js/blocks/FlowBlocks.js:790
 #: js/blocks/FlowBlocks.js:873
 msgid "do2"
 msgstr "～する"
-
 
 #: js/blocks/FlowBlocks.js:790
 #: js/blocks/FlowBlocks.js:873
@@ -9736,16 +8104,13 @@ msgstr "～する"
 msgid "do"
 msgstr "アクション"
 
-
 #: js/blocks/FlowBlocks.js:863
 msgid "The While block will repeat while the condition is true."
 msgstr "Whileブロックは条件が真である間繰り返します。"
 
-
 #: js/blocks/FlowBlocks.js:871
 msgid "while"
 msgstr "の間に"
-
 
 #: js/blocks/FlowBlocks.js:953
 #: js/blocks/FlowBlocks.js:964
@@ -9754,92 +8119,75 @@ msgstr "の間に"
 msgid "Conditionals lets your program take different actions depending on the condition."
 msgstr "条件付きを使用すると、プログラムは条件に応じてさまざまなアクションを実行できます。"
 
-
 #: js/blocks/FlowBlocks.js:957
 #: js/blocks/FlowBlocks.js:1022
 #: js/blocks/FlowBlocks.js:1033
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr "<br><br>図の例では、もし、パソコンのマウスを長おししていれば「キックドラム」ブロックをえんそうする。"
 
-
 #: js/blocks/FlowBlocks.js:968
 msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
 msgstr "この例では、マウス ボタンが押されるとスネア ドラムが再生され、そうではない場合はキック ドラムが再生されます。"
-
 
 #: js/blocks/FlowBlocks.js:979
 #: js/blocks/FlowBlocks.js:1042
 msgid "if"
 msgstr "もし"
 
-
 #: js/blocks/FlowBlocks.js:981
 #: js/blocks/FlowBlocks.js:1044
 msgid "then"
 msgstr "ならば"
 
-
 #: js/blocks/FlowBlocks.js:981
 msgid "else"
 msgstr "でなければ"
-
 
 #: js/blocks/FlowBlocks.js:1079
 msgid "The Forever block will repeat the contained blocks forever."
 msgstr "<h2>実行ブロック（くり返し）</h2><br>「ずっとくり返す」のブロックは、実行を停止しないかぎり、はさまれているブロックをくり返し実行する。"
 
-
 #: js/blocks/FlowBlocks.js:1081
 msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
 msgstr "この単純なドラムマシンの例では、キックドラムは 四分音符を永遠に演奏します。"
-
 
 #: js/blocks/FlowBlocks.js:1091
 msgid "forever"
 msgstr "ずっとくり返す"
 
-
 #: js/blocks/FlowBlocks.js:1127
 msgid "The Repeat block will repeat the contained blocks."
 msgstr "<h2>実行ブロック（くり返し）</h2><br>はさまれているブロックのプログラムを、入力した回数だけくり返す。"
-
 
 #: js/blocks/FlowBlocks.js:1129
 msgid "In this example the note will be played 4 times."
 msgstr "<br><br>図の例では、「ソ」の音が４回えんそうされる。"
 
-
 #: js/blocks/FlowBlocks.js:1137
 msgid "repeat"
 msgstr "～回くり返す"
 
-
 #: js/blocks/FlowBlocks.js:1177
 msgid "duplicate factor"
 msgstr "複製ファクター"
-
 
 #: js/blocks/MeterBlocks.js:34
 #. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "現代の拍子"
 
-
 #: js/blocks/MeterBlocks.js:88
 #. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "拍を～倍にするファクター"
 
-
 #: js/blocks/MeterBlocks.js:96
 msgid "The Beat factor block returns the ratio of the note value to the meter note value."
 msgstr "「拍を～倍にするファクター」ブロックは、拍子音符値に対する音符値の比率を返します。"
 
-
 #: js/blocks/MeterBlocks.js:167
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr "「スピードを決める」ブロックは現在の1分あたりのビート数を返します。"
-
 
 #: js/blocks/MeterBlocks.js:176
 #: js/widgets/status.js:155
@@ -9847,7 +8195,6 @@ msgstr "「スピードを決める」ブロックは現在の1分あたりの�
 #. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "１分当たりの拍の数"
-
 
 #: js/blocks/MeterBlocks.js:176
 #: js/blocks/MeterBlocks.js:1101
@@ -9857,38 +8204,31 @@ msgstr "１分当たりの拍の数"
 msgid "beats per minute"
 msgstr "スピードを決める"
 
-
 #: js/blocks/MeterBlocks.js:204
 msgid "BPM must be a number, defaulting to 60."
 msgstr "BPM は数値である必要があり、デフォルトは 60 です。"
-
 
 #: js/blocks/MeterBlocks.js:207
 msgid "BPM must be at least 30, clamping to 30."
 msgstr "BPM は少なくとも 30 である必要があり、30 に固定されます。"
 
-
 #: js/blocks/MeterBlocks.js:210
 msgid "BPM must be at most 1000, clamping to 1000."
 msgstr "BPM は最大 1000 にする必要があり、1000 に固定されます。"
-
 
 #: js/blocks/MeterBlocks.js:256
 #. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "小節の数"
 
-
 #: js/blocks/MeterBlocks.js:264
 msgid "The Measure count block returns the current measure."
 msgstr "Measure countブロックは現在の小節数を返します。"
-
 
 #: js/blocks/MeterBlocks.js:316
 #. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "拍の位置"
-
 
 #: js/blocks/MeterBlocks.js:326
 #: js/blocks/MeterBlocks.js:337
@@ -9897,7 +8237,6 @@ msgstr "拍の位置"
 msgid "The Beat count block is the number of the current beat,"
 msgstr "<h2>拍（はく）の位置ブロック</h2><br>小節の中で何拍（はく）目かをあらわす数。たとえば、各小節の３拍（はく）めに何かアクション・イベントを起こしたいときなどに使う。"
 
-
 #: js/blocks/MeterBlocks.js:328
 #: js/blocks/MeterBlocks.js:341
 #: js/blocks/MeterBlocks.js:599
@@ -9905,41 +8244,34 @@ msgstr "<h2>拍（はく）の位置ブロック</h2><br>小節の中で何拍�
 msgid "In the figure, it is used to take an action on the first beat of each measure."
 msgstr "図では、各小節の最初の拍でアクションを実行するために使用されます。"
 
-
 #: js/blocks/MeterBlocks.js:339
 #: js/blocks/MeterBlocks.js:610
 msgid "eg 1, 2, 3, or 4."
 msgstr "<br>図の例では、それぞれの小節の１拍（ぱく）目に、特定のアクション・イベントを起こしている。"
-
 
 #: js/blocks/MeterBlocks.js:397
 #. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "音の長さを足す"
 
-
 #: js/blocks/MeterBlocks.js:405
 #: js/blocks/MeterBlocks.js:469
 msgid "The Note counter block can be used to count the number of contained notes."
 msgstr "Note counterブロックは含まれる音符の数を数えるために使用できます。"
-
 
 #: js/blocks/MeterBlocks.js:461
 #. TRANS: count the number of notes
 msgid "note counter"
 msgstr "音符の合計数"
 
-
 #: js/blocks/MeterBlocks.js:525
 #. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "さいせいされた全音符の数"
 
-
 #: js/blocks/MeterBlocks.js:534
 msgid "The Whole notes played block returns the total number of whole notes played."
 msgstr "Whole notes playedブロックは演奏された全音符の総数を返します。"
-
 
 #: js/blocks/MeterBlocks.js:587
 #: js/turtleactions/DictActions.js:83
@@ -9947,42 +8279,34 @@ msgstr "Whole notes playedブロックは演奏された全音符の総数を返
 msgid "notes played"
 msgstr "全体の拍の数"
 
-
 #: js/blocks/MeterBlocks.js:688
 msgid "The No clock block decouples the notes from the master clock."
 msgstr "<em>クロックなし</em>ブロックはそれぞれの動作の順番をリズムより優先します。"
-
 
 #: js/blocks/MeterBlocks.js:696
 #. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "クロックなし"
 
-
 #: js/blocks/MeterBlocks.js:735
 msgid "on weak beat do"
 msgstr "弱拍に～する"
-
 
 #: js/blocks/MeterBlocks.js:740
 msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr "On-weak-beatブロックは弱拍（裏拍）で実行するアクションを指定できます。"
 
-
 #: js/blocks/MeterBlocks.js:785
 msgid "on strong beat"
 msgstr "強拍に"
-
 
 #: js/blocks/MeterBlocks.js:793
 msgid "The On-strong-beat block lets you specify actions to take on specified beats."
 msgstr "On-strong-beatブロックは指定された強拍で実行するアクションを指定できます。"
 
-
 #: js/blocks/MeterBlocks.js:804
 msgid "beat"
 msgstr "拍子"
-
 
 #: js/blocks/MeterBlocks.js:804
 #: js/blocks/ActionBlocks.js:411
@@ -9992,26 +8316,21 @@ msgstr "拍子"
 msgid "do1"
 msgstr "アクション実行"
 
-
 #: js/blocks/MeterBlocks.js:848
 msgid "on every beat do"
 msgstr "全ての拍子にアクション実行"
-
 
 #: js/blocks/MeterBlocks.js:856
 msgid "The On-every-beat block lets you specify actions to take on every beat."
 msgstr "On-every-beatブロックはすべての拍で実行するアクションを指定できます。"
 
-
 #: js/blocks/MeterBlocks.js:909
 msgid "on every note do"
 msgstr "全ての音符にアクション実行"
 
-
 #: js/blocks/MeterBlocks.js:917
 msgid "The On-every-note block lets you specify actions to take on every note."
 msgstr "On-every-noteブロックはすべての音符で実行するアクションを指定できます。"
-
 
 #: js/blocks/MeterBlocks.js:963
 #: js/blocks/MeterBlocks.js:1039
@@ -10019,11 +8338,9 @@ msgstr "On-every-noteブロックはすべての音符で実行するアクシ�
 msgid "master beats per minute"
 msgstr "全体のスピードを決める"
 
-
 #: js/blocks/MeterBlocks.js:975
 msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
 msgstr "「全体のスピードを決める」ブロックは、各ボイスの 1 分あたりの 1/4 音符の数を設定します。"
-
 
 #: js/blocks/MeterBlocks.js:987
 #: js/blocks/MeterBlocks.js:1123
@@ -10031,13 +8348,11 @@ msgstr "「全体のスピードを決める」ブロックは、各ボイスの
 msgid "bpm"
 msgstr "１分あたりの拍の数"
 
-
 #: js/blocks/MeterBlocks.js:987
 #: js/blocks/MeterBlocks.js:1123
 #: js/blocks/MeterBlocks.js:1185
 msgid "beat value"
 msgstr "１拍"
-
 
 #: js/blocks/MeterBlocks.js:1070
 #: js/blocks/MeterBlocks.js:1217
@@ -10045,49 +8360,40 @@ msgstr "１拍"
 msgid "Beats per minute must be > 30."
 msgstr "１分あたりの拍の数には、３０より大きいあたいをせっていしてください。"
 
-
 #: js/blocks/MeterBlocks.js:1073
 #: js/blocks/MeterBlocks.js:1220
 #: js/blocks/MeterBlocks.js:1293
 msgid "Maximum beats per minute is 1000."
 msgstr "1分あたりの拍の数は、最大1000です。"
 
-
 #: js/blocks/MeterBlocks.js:1113
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "<h2>スピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
-
 
 #: js/blocks/MeterBlocks.js:1327
 #. TRANS: anacrusis
 msgid "pickup"
 msgstr "ピックアップ"
 
-
 #: js/blocks/MeterBlocks.js:1334
 msgid "The Pickup block is used to accommodate any notes that come in before the beat."
 msgstr "「ピックアップ」ブロックは、ビートの前に入力されるノートを収容するために使用されます。"
-
 
 #: js/blocks/MeterBlocks.js:1400
 msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
 msgstr "音楽のビートは「拍子」ブロックによって決定されます (デフォルトでは、1 小節あたり ４つの1/4音符)。"
 
-
 #: js/blocks/MeterBlocks.js:1415
 msgid "number of beats"
 msgstr "拍の数"
-
 
 #: js/blocks/OrnamentBlocks.js:32
 msgid "staccato factor"
 msgstr "スタッカートの長さファクター"
 
-
 #: js/blocks/OrnamentBlocks.js:108
 msgid "slur factor"
 msgstr "スラーの長さファクター"
-
 
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
@@ -10095,29 +8401,24 @@ msgstr "スラーの長さファクター"
 msgid "neighbor"
 msgstr "音を加える"
 
-
 #: js/blocks/OrnamentBlocks.js:220
 #: js/blocks/IntervalsBlocks.js:708
 #. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "半音階的音程"
 
-
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr "<h2>音を加えるブロック</h2><br>２つの同じ高さの音のあいだに、音を１つ入れることができる。<br>図の例では、ソとソのあいだにラが入り、「ソラソ」とすばやくえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
-
 
 #: js/blocks/OrnamentBlocks.js:364
 msgid "glide"
 msgstr "グリッサンド"
 
-
 #: js/blocks/OrnamentBlocks.js:472
 #: js/blocks/OrnamentBlocks.js:636
 msgid "slur"
 msgstr "スラー"
-
 
 #: js/blocks/OrnamentBlocks.js:551
 #: js/blocks/OrnamentBlocks.js:703
@@ -10125,16 +8426,13 @@ msgstr "スラー"
 msgid "staccato"
 msgstr "スタッカート"
 
-
 #: js/blocks/OrnamentBlocks.js:619
 msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
 msgstr "「スラー」ブロックは、指定された音符の長さを全部組み合わせて長くします。"
 
-
 #: js/blocks/OrnamentBlocks.js:685
 msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
 msgstr "「スタッカート」ブロックは、指定された音符の長さを維持しながら、実際の音符の長さを短縮します。"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:69
 #: js/blocks/RhythmBlockPaletteBlocks.js:248
@@ -10142,7 +8440,6 @@ msgstr "「スタッカート」ブロックは、指定された音符の長さ
 #. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "連符（かけ算）"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:89
 #: js/blocks/RhythmBlockPaletteBlocks.js:267
@@ -10152,16 +8449,13 @@ msgstr "連符（かけ算）"
 msgid "number of notes"
 msgstr "音符の数"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:150
 msgid "polyphonic rhythm"
 msgstr "ポリリズム"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:234
 msgid "The Rhythm block is used to generate rhythm patterns."
 msgstr "<h2>連符（れんぷ）ブロック（かけ算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つなどくり返して使う。３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:296
 #: js/blocks/RhythmBlockPaletteBlocks.js:301
@@ -10169,13 +8463,11 @@ msgstr "<h2>連符（れんぷ）ブロック（かけ算）</h2><br>まとま�
 msgid "1/64 note"
 msgstr "６４分音符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:327
 #: js/blocks/RhythmBlockPaletteBlocks.js:332
 #. TRANS: Do not modify the following line
 msgid "1/32 note"
 msgstr "３２分音符"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:361
 #: js/blocks/RhythmBlockPaletteBlocks.js:366
@@ -10183,18 +8475,15 @@ msgstr "３２分音符"
 msgid "1/16 note"
 msgstr "１６分音符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:395
 #. TRANS: Do not modify the following line
 msgid "eighth note"
 msgstr "８分音符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:423
 #. TRANS: Do not modify the following line
 msgid "quarter note"
 msgstr "４分音符"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:451
 #: js/blocks/RhythmBlockPaletteBlocks.js:456
@@ -10202,13 +8491,11 @@ msgstr "４分音符"
 msgid "half note"
 msgstr "２分音符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:485
 #: js/blocks/RhythmBlockPaletteBlocks.js:490
 #. TRANS: Do not modify the following line
 msgid "whole note"
 msgstr "全音符"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:529
 #: js/blocks/RhythmBlockPaletteBlocks.js:597
@@ -10219,159 +8506,129 @@ msgstr "全音符"
 msgid "tuplet"
 msgstr "～連符（タプル）"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:637
 #. TRANS: Do not modify the following line
 msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
 msgstr "「～連符」連符ブロックは、凝縮された時間で演奏される音符のグループを生成するために使用されます。"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:795
 #. TRANS: Do not modify the following line
 msgid "septuplet"
 msgstr "７連符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:823
 #. TRANS: Do not modify the following line
 msgid "quintuplet"
 msgstr "５連符"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:851
 #. TRANS: A tuplet divided into 3 time values.
 msgid "triplet"
 msgstr "３連符"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:878
 msgid "simple tuplet"
 msgstr "連符（わり算）"
-
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:888
 msgid "Tuplets are a collection of notes that get scaled to a specific duration."
 msgstr "<h2>連符（れんぷ）ブロック（わり算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つに等分して使う。"
 
-
 #: js/blocks/RhythmBlockPaletteBlocks.js:890
 msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
 msgstr "連符を使用すると、2 の累乗に基づいていない音符のグループを簡単に作成できます。"
-
 
 #: js/blocks/SensorsBlocks.js:36
 msgid "The Input block prompts for keyboard input."
 msgstr "インプットブロックはキーボード入力を促します。"
 
-
 #: js/blocks/SensorsBlocks.js:46
 msgid "input"
 msgstr "インプット"
-
 
 #: js/blocks/SensorsBlocks.js:64
 msgid "Input a value"
 msgstr "価値をインプット"
 
-
 #: js/blocks/SensorsBlocks.js:134
 msgid "input value"
 msgstr "インプットの価値"
-
 
 #: js/blocks/SensorsBlocks.js:139
 msgid "The Input-value block stores the input."
 msgstr "インプット値ブロックは入力を保存します。"
 
-
 #: js/blocks/SensorsBlocks.js:246
 msgid "loudness"
 msgstr "音量"
-
 
 #: js/blocks/SensorsBlocks.js:253
 msgid "The Loudness block returns the volume detected by the microphone."
 msgstr "ラウドネスブロックはマイクで検出された音量を返します。"
 
-
 #: js/blocks/SensorsBlocks.js:308
 msgid "click"
 msgstr "クリック"
-
 
 #: js/blocks/SensorsBlocks.js:314
 msgid "The Click block triggers an event if a mouse has been clicked."
 msgstr "クリックブロックはマウスがクリックされた場合にイベントをトリガーします。"
 
-
 #: js/blocks/SensorsBlocks.js:321
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr "クリックブロックはカメがクリックされた場合にイベントをトリガーします。"
-
 
 #: js/blocks/SensorsBlocks.js:350
 #. TRANS: The mouse cursor is over the mouse icon
 msgid "cursor over"
 msgstr "カーソル（上）"
 
-
 #: js/blocks/SensorsBlocks.js:355
 msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
 msgstr "「カーソル（上）」ブロックは、カーソルがマウス上に移動するとイベントをトリガーします。"
 
-
 #: js/blocks/SensorsBlocks.js:364
 msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
 msgstr "「カーソル（上）」ブロックは、カーソルがタートル上に移動するとイベントをトリガーします。"
-
 
 #: js/blocks/SensorsBlocks.js:395
 #. TRANS: The cursor is "out" -- it is no longer over the mouse.
 msgid "cursor out"
 msgstr "カーソル（外）"
 
-
 #: js/blocks/SensorsBlocks.js:401
 #. TRANS: hover
 msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
 msgstr "「カーソル（外）」ブロックは、カーソルがマウスから離れるとイベントをトリガーします。"
-
 
 #: js/blocks/SensorsBlocks.js:411
 #. TRANS: hover
 msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
 msgstr "「カーソル（外）」ブロックは、カーソルがタートルから離れるとイベントをトリガーします。"
 
-
 #: js/blocks/SensorsBlocks.js:441
 msgid "cursor button down"
 msgstr "カーソルクリック（下）"
-
 
 #: js/blocks/SensorsBlocks.js:446
 msgid "The Cursor button down block triggers an event when the cursor button is pressed on a mouse."
 msgstr "「カーソルクリック（下）」ブロックは、マウスのカーソル ボタンが押されたときにイベントをトリガーします。"
 
-
 #: js/blocks/SensorsBlocks.js:455
 msgid "The Cursor button down block triggers an event when the cursor button is pressed on a turtle."
 msgstr "「カーソルクリック（下）」ブロックは、タートル上でカーソル ボタンが押されたときにイベントをトリガーします。"
-
 
 #: js/blocks/SensorsBlocks.js:485
 msgid "cursor button up"
 msgstr "カーソルクリック（上）"
 
-
 #: js/blocks/SensorsBlocks.js:490
 msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
 msgstr "「カーソルクリック（上）」ブロックは、マウスの上でカーソル ボタンが放されるとイベントをトリガーします。"
 
-
 #: js/blocks/SensorsBlocks.js:499
 msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
 msgstr "「カーソルクリック（上）」ブロックは、タートルの上でカーソル ボタンが放されるとイベントをトリガーします。"
-
 
 #: js/blocks/SensorsBlocks.js:529
 #: js/blocks/SensorsBlocks.js:1004
@@ -10380,87 +8637,70 @@ msgstr "「カーソルクリック（上）」ブロックは、タートルの
 msgid "red"
 msgstr "赤"
 
-
 #: js/blocks/SensorsBlocks.js:574
 #: plugins/rodi.rtp:216
 msgid "pixel color"
 msgstr "ピクセルの色"
 
-
 #: js/blocks/SensorsBlocks.js:579
 msgid "The Get pixel block returns the color of the pixel under the mouse."
 msgstr "Get pixelブロックはマウス下のピクセルの色を返します。"
-
 
 #: js/blocks/SensorsBlocks.js:585
 msgid "The Get pixel block returns the color of the pixel under the turtle."
 msgstr "Get pixelブロックはカメの下のピクセルの色を返します。"
 
-
 #: js/blocks/SensorsBlocks.js:720
 msgid "time"
 msgstr "時間"
-
 
 #: js/blocks/SensorsBlocks.js:727
 msgid "The Time block returns the number of seconds that the program has been running."
 msgstr "「時間」ブロックは、プログラムが実行されている秒数を返します。"
 
-
 #: js/blocks/SensorsBlocks.js:766
 msgid "cursor y"
 msgstr "yざひょうち（カーソル）"
-
 
 #: js/blocks/SensorsBlocks.js:771
 msgid "The Cursor Y block returns the vertical position of the mouse."
 msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルのたて位置を表すｙざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。"
 
-
 #: js/blocks/SensorsBlocks.js:807
 msgid "cursor x"
 msgstr "xざひょうち（カーソル）"
-
 
 #: js/blocks/SensorsBlocks.js:812
 msgid "The Cursor X block returns the horizontal position of the mouse."
 msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの横位置を表すｘざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。"
 
-
 #: js/blocks/SensorsBlocks.js:848
 msgid "mouse button"
 msgstr "マウスボタン"
-
 
 #: js/blocks/SensorsBlocks.js:850
 msgid "The Mouse-button block returns True if the mouse button is pressed."
 msgstr "<h2>真偽ブロック（マウスボタン）</h2><br>マウスのボタンがおされているかどうかはんていする。マウスボタンがおされていれば「真（しん）」、おされていなければ「偽（ぎ）」という値になる。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
-
 #: js/blocks/SensorsBlocks.js:896
 msgid "to ASCII"
 msgstr "ASCIIに"
-
 
 #: js/blocks/SensorsBlocks.js:900
 msgid "The To ASCII block converts numbers to letters."
 msgstr "「ASCIIに」ブロックは数字を文字に変換します。"
 
-
 #: js/blocks/SensorsBlocks.js:967
 msgid "The Keyboard block returns computer keyboard input."
 msgstr "「キーボード」ブロックはコンピュータのキーボード入力を返します。"
-
 
 #: js/blocks/SensorsBlocks.js:1006
 msgid "The Get red block returns the red component of the pixel under the mouse."
 msgstr "Get redブロックはマウス下のピクセルの赤成分を返します。"
 
-
 #: js/blocks/SensorsBlocks.js:1009
 msgid "The Get red block returns the red component of the pixel under the turtle."
 msgstr "Get redブロックはカメの下のピクセルの赤成分を返します。"
-
 
 #: js/blocks/SensorsBlocks.js:1015
 #: js/blocks/PenBlocks.js:64
@@ -10468,16 +8708,13 @@ msgstr "Get redブロックはカメの下のピクセルの赤成分を返し�
 msgid "green"
 msgstr "緑"
 
-
 #: js/blocks/SensorsBlocks.js:1017
 msgid "The Get green block returns the green component of the pixel under the mouse."
 msgstr "Get green ブロックは、マウスの下にあるピクセルの緑色コンポーネントを返します。"
 
-
 #: js/blocks/SensorsBlocks.js:1020
 msgid "The Get green block returns the green component of the pixel under the turtle."
 msgstr "Get green ブロックは、タートルの下のピクセルの緑色コンポーネントを返します。"
-
 
 #: js/blocks/SensorsBlocks.js:1026
 #: js/blocks/PenBlocks.js:48
@@ -10485,48 +8722,39 @@ msgstr "Get green ブロックは、タートルの下のピクセルの緑色�
 msgid "blue"
 msgstr "青"
 
-
 #: js/blocks/SensorsBlocks.js:1028
 msgid "The Get blue block returns the blue component of the pixel under the mouse."
 msgstr "Get blue ブロックは、マウスの下にあるピクセルの青色のコンポーネントを返します。"
-
 
 #: js/blocks/SensorsBlocks.js:1031
 msgid "The Get blue block returns the blue component of the pixel under the turtle."
 msgstr "Get blue ブロックは、タートルの下のピクセルの青コンポーネントを返します。"
 
-
 #: js/blocks/VolumeBlocks.js:35
 msgid "synth volume"
 msgstr "シンセノ音量"
-
 
 #: js/blocks/VolumeBlocks.js:39
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr "Synth volumeブロックは現在のシンセサイザーの音量を返します。"
 
-
 #: js/blocks/VolumeBlocks.js:105
 msgid "master volume"
 msgstr "マスター音量"
 
-
 #: js/blocks/VolumeBlocks.js:109
 msgid "The Master volume block returns the master volume."
 msgstr "Master volumeブロックはマスターボリュームを返します。"
-
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:525
 msgid "set synth volume"
 msgstr "楽器の音量をせってい"
 
-
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:546
 msgid "synth"
 msgstr "楽器"
-
 
 #: js/blocks/VolumeBlocks.js:403
 #: js/blocks/VolumeBlocks.js:578
@@ -10535,124 +8763,100 @@ msgstr "楽器"
 msgid "Setting volume to 0."
 msgstr "音量を「0」にせっていします。"
 
-
 #: js/blocks/VolumeBlocks.js:440
 msgid "Synth not found"
 msgstr "シンセが見つかりません"
-
 
 #: js/blocks/VolumeBlocks.js:495
 msgid "set drum volume"
 msgstr "ドラムの音量をせってい"
 
-
 #: js/blocks/VolumeBlocks.js:531
 msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
 msgstr "「楽器の音量をせってい」ブロックは、ギター、バイオリン、スネアドラムなどの特定のシンセサイザーの音量を変更します。"
-
 
 #: js/blocks/VolumeBlocks.js:535
 msgid "The default volume is 50."
 msgstr "デフォルトは音量５０。"
 
-
 #: js/blocks/VolumeBlocks.js:537
 msgid "The range is 0 for silence to 100 for full volume."
 msgstr "０から１００までのすうちをせっていできる。<br><br> "
-
 
 #: js/blocks/VolumeBlocks.js:598
 msgid "set panning"
 msgstr "ステレオを設定"
 
-
 #: js/blocks/VolumeBlocks.js:604
 msgid "The Set Panning block sets the panning for all synthesizers."
 msgstr "Set Panningブロックはすべてのシンセのパンを設定します。"
 
-
 #: js/blocks/VolumeBlocks.js:626
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr "ワーニング：音は右か左だけのスピーカーから出ている"
-
 
 #: js/blocks/VolumeBlocks.js:648
 #: js/blocks/VolumeBlocks.js:696
 msgid "set master volume"
 msgstr "全体の音量をせってい"
 
-
 #: js/blocks/VolumeBlocks.js:654
 msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr "<h2>全体の音量をせっていブロック</h2><br>全体の音量をせっていする。"
-
 
 #: js/blocks/VolumeBlocks.js:784
 msgid "The Set relative volume block changes the volume of the contained notes."
 msgstr "Set relative volumeブロックは含まれる音符の音量を変更します。"
 
-
 #: js/blocks/VolumeBlocks.js:791
 msgid "set relative volume"
 msgstr "相対音量を設定"
-
 
 #: js/blocks/VolumeBlocks.js:843
 msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
 msgstr "「デクレッシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ減少させます。"
 
-
 #: js/blocks/VolumeBlocks.js:847
 msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
 msgstr "たとえば、値が「5」の「デクレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 低くなります。"
-
 
 #: js/blocks/VolumeBlocks.js:857
 msgid "decrescendo"
 msgstr "デクレシェンド"
 
-
 #: js/blocks/VolumeBlocks.js:907
 msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
 msgstr "「クレシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ増加させます。"
-
 
 #: js/blocks/VolumeBlocks.js:911
 msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
 msgstr "たとえば、値が「5」の「クレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 大きくなります。"
 
-
 #: js/blocks/VolumeBlocks.js:921
 msgid "crescendo"
 msgstr "クレシェンド"
-
 
 #: js/blocks/ActionBlocks.js:58
 msgid "The Return block will return a value from an action."
 msgstr "Returnブロックはアクションから値を返します。"
 
-
 #: js/blocks/ActionBlocks.js:75
 msgid "return"
 msgstr "リターン"
-
 
 #: js/blocks/ActionBlocks.js:128
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Return to URLブロックは値をウェブページに返します。"
 
-
 #: js/blocks/ActionBlocks.js:145
 msgid "return to URL"
 msgstr "URLに戻ります"
-
 
 #: js/blocks/ActionBlocks.js:178
 #: js/blocks/ProgramBlocks.js:86
 #: js/blocks/ProgramBlocks.js:181
 msgid "Invalid URL"
 msgstr "無効な URL"
-
 
 #: js/blocks/ActionBlocks.js:230
 #: js/blocks/ActionBlocks.js:311
@@ -10661,13 +8865,11 @@ msgstr "無効な URL"
 msgid "The Calculate block returns a value calculated by an action."
 msgstr "Calculateブロックはアクションで計算された値を返します。"
 
-
 #: js/blocks/ActionBlocks.js:248
 #: js/blocks/ActionBlocks.js:538
 #: js/blocks/ActionBlocks.js:730
 msgid "calculate"
 msgstr "計算する"
-
 
 #: js/blocks/ActionBlocks.js:397
 #: js/blocks/ActionBlocks.js:615
@@ -10677,18 +8879,15 @@ msgstr "計算する"
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（指定）</h2><br>指定したアクションブロックを実行する。"
 
-
 #: js/blocks/ActionBlocks.js:814
 #: js/blocks/ActionBlocks.js:888
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr "Argブロックはアクションに渡された引数の値を含みます。"
 
-
 #: js/blocks/ActionBlocks.js:829
 #: js/blocks/ActionBlocks.js:901
 msgid "arg"
 msgstr "引数"
-
 
 #: js/blocks/ActionBlocks.js:859
 #: js/blocks/ActionBlocks.js:923
@@ -10696,32 +8895,26 @@ msgstr "引数"
 msgid "Invalid argument"
 msgstr "無効な議論"
 
-
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr "<h2>音を加えるブロック</h2><br>２つの同じ高さの音のあいだに、音を１つ入れることができる。<br>図の例では、ソとソのあいだにラが入り、「ソ、ラ、ソ」とすばやくえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、「ソ」を始まりの音にしたときの「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」のこと。"
 
-
 #: js/blocks/ActionBlocks.js:967
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr "<br><br>図の例は、決まったアクションではなく、２つのうちどちらか１つのアクションをランダムに実行させる。"
-
 
 #: js/blocks/ActionBlocks.js:1041
 #: js/blocks/ActionBlocks.js:1048
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr "<h2>イベントブロック（受け取り）</h2><br>特定のイベントに対して、その発生を受け取るたびに実行するアクションを１つ決めておくことができる。"
 
-
 #: js/blocks/ActionBlocks.js:1050
 msgid "When the event happens, an action is taken."
 msgstr "<br><br>イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
 
-
 #: js/blocks/ActionBlocks.js:1067
 msgid "on"
 msgstr "のとき"
-
 
 #: js/blocks/ActionBlocks.js:1070
 #: js/blocks/ActionBlocks.js:1071
@@ -10729,220 +8922,177 @@ msgstr "のとき"
 msgid "event"
 msgstr "イベント"
 
-
 #: js/blocks/ActionBlocks.js:1160
 msgid "The Broadcast block is used to trigger an event."
 msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
-
 
 #: js/blocks/ActionBlocks.js:1178
 msgid "broadcast"
 msgstr "イベント発生"
 
-
 #: js/blocks/ActionBlocks.js:1236
 msgid "Each Start block is a separate voice."
 msgstr "<h2>スタートブロック</h2><br>実行ボタンがおされると、スタートブロックが実行される。"
-
 
 #: js/blocks/ActionBlocks.js:1238
 msgid "All of the Start blocks run at the same time when the Play button is pressed."
 msgstr "[再生] ボタンを押すと、すべての Start ブロックが同時に実行されます。"
 
-
 #: js/blocks/ActionBlocks.js:1329
 msgid "The Action block is used to group together blocks so that they can be used more than once."
 msgstr "アクション ブロックは、複数のブロックをグループ化して複数回使用できるようにするために使用されます。"
-
 
 #: js/blocks/ActionBlocks.js:1333
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr "<br><br>何度も実行する音楽のフレーズなどにアクションを作っておくと便利。"
 
-
 #: js/blocks/ActionBlocks.js:1523
 msgid "define temperament"
 msgstr "音律を明確にする"
-
 
 #: js/blocks/BooleanBlocks.js:44
 msgid "The Not block is the logical not operator."
 msgstr "Notブロックは論理的なNOT演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:62
 msgid "not"
 msgstr "ではない"
-
 
 #: js/blocks/BooleanBlocks.js:133
 msgid "The And block is the logical and operator."
 msgstr "Andブロックは論理積（AND）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:151
 msgid "and"
 msgstr "かつ"
-
 
 #: js/blocks/BooleanBlocks.js:217
 msgid "The Or block is the logical or operator."
 msgstr "Orブロックは論理和（OR）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:235
 msgid "or"
 msgstr "または"
-
 
 #: js/blocks/BooleanBlocks.js:301
 msgid "The XOR block is the logical XOR operator."
 msgstr "XORブロックは排他的論理和（XOR）演算子です。"
 
-
 #: js/blocks/BooleanBlocks.js:319
 msgid "xor"
 msgstr "XOR（エクスクルーシブ・オア）"
-
 
 #: js/blocks/BooleanBlocks.js:391
 msgid "The Greater-than block returns True if the top number is greater than the bottom number."
 msgstr "「＞」ブロックは、上の数値が下の数値より大きい場合に True を返します。"
 
-
 #: js/blocks/BooleanBlocks.js:496
 msgid "The Less-than block returns True if the top number is less than the bottom number."
 msgstr "「＜」ブロックは、上の数値が下の数値より小さい場合に True を返します。"
-
 
 #: js/blocks/BooleanBlocks.js:596
 msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
 msgstr "「≦」ブロックは、上の数値が下の数値以下の場合に True を返します。"
 
-
 #: js/blocks/BooleanBlocks.js:696
 msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
 msgstr "「≥」ブロックは、上の数値が下の数値以上である場合に True を返します。"
-
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "<h2>しんぎブロック（等しい）</h2><br>２つのすうちをくらべて、同じすうちであるかどうかはんていする。「＝」は、２つのすうちが同じであれば「真（しん）」、同じでなければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
-
 #: js/blocks/BooleanBlocks.js:901
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr "「≠」ブロックは2つの数字が等しくない場合にTrueを返します。"
 
-
 #: js/blocks/BooleanBlocks.js:1003
 msgid "The Boolean block is used to specify true or false."
 msgstr "Booleanブロックはtrueまたはfalseを指定するために使われます。"
-
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、好きなすうちを足す。マイナスのすうちを使うと引き算になる。"
 
-
 #: js/blocks/BoxesBlocks.js:61
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr "<br><br>マイナスの数値を使うと引き算になる。"
 
-
 #: js/blocks/BoxesBlocks.js:73
 msgid "add"
 msgstr "足す"
-
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:1081
 msgid "to"
 msgstr "箱へ"
 
-
 #: js/blocks/BoxesBlocks.js:118
 msgid "Block does not support incrementing."
 msgstr "ブロックは、増殖をサポートできません"
-
 
 #: js/blocks/BoxesBlocks.js:152
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、１を足す。"
 
-
 #: js/blocks/BoxesBlocks.js:163
 msgid "add 1 to"
 msgstr "箱に１を足す"
-
 
 #: js/blocks/BoxesBlocks.js:211
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "Subtract-1-fromブロックはボックスに保存された値から1を引きます。"
 
-
 #: js/blocks/BoxesBlocks.js:222
 msgid "subtract 1 from"
 msgstr "〜から１引く"
-
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
 msgid "The Box block returns the value stored in a box."
 msgstr "<h2>すうちブロック</h2><br>すうちブロックとして、箱のすうちを使う。"
 
-
 #: js/blocks/BoxesBlocks.js:504
 #: js/blocks/BoxesBlocks.js:580
 msgid "The Store in block will store a value in a box."
 msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、指定したすうちを入れる。"
 
-
 #: js/blocks/BoxesBlocks.js:656
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "Box2ブロックはBox2に保存された値を返します。"
-
 
 #: js/blocks/BoxesBlocks.js:707
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr "Store in Box2ブロックは値をBox2に保存するために使われます。"
 
-
 #: js/blocks/BoxesBlocks.js:719
 msgid "store in box2"
 msgstr "箱２にすうちを入れる"
-
 
 #: js/blocks/BoxesBlocks.js:765
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "Box1ブロックはBox1に保存された値を返します。"
 
-
 #: js/blocks/BoxesBlocks.js:816
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr "Store in Box1ブロックは値をBox1に保存するために使われます。"
-
 
 #: js/blocks/BoxesBlocks.js:830
 msgid "store in box1"
 msgstr "箱１にすうちを入れる"
 
-
 #: js/blocks/ExtrasBlocks.js:33
 msgid "fraction"
 msgstr "分数"
-
 
 #: js/blocks/ExtrasBlocks.js:36
 msgid "Convert a float to a fraction"
 msgstr "小数から分数"
 
-
 #: js/blocks/ExtrasBlocks.js:93
 msgid "save as ABC"
 msgstr "ABCでほぞん"
-
 
 #: js/blocks/ExtrasBlocks.js:96
 #: js/blocks/ExtrasBlocks.js:132
@@ -10950,88 +9100,71 @@ msgstr "ABCでほぞん"
 msgid "title"
 msgstr "名"
 
-
 #: js/blocks/ExtrasBlocks.js:129
 msgid "save as Lilypond"
 msgstr "Lilypondのフォーマットでほぞん"
-
 
 #: js/blocks/ExtrasBlocks.js:165
 msgid "save as SVG"
 msgstr "SVGでほぞん"
 
-
 #: js/blocks/ExtrasBlocks.js:217
 msgid "no background"
 msgstr "バックグラウンドなし"
-
 
 #: js/blocks/ExtrasBlocks.js:220
 msgid "The No background block eliminates the background from the saved SVG output."
 msgstr "ノー・バックグラウンドブロックは保存されたSVG出力の背景を削除します。"
 
-
 #: js/blocks/ExtrasBlocks.js:248
 msgid "show blocks"
 msgstr "ブロックを表示"
-
 
 #: js/blocks/ExtrasBlocks.js:250
 msgid "The Show blocks block shows the blocks."
 msgstr "ショウ・ブロックスブロックはブロックを表示します。"
 
-
 #: js/blocks/ExtrasBlocks.js:278
 msgid "The Hide blocks block hides the blocks."
 msgstr "ハイド・ブロックスブロックはブロックを非表示にします。"
-
 
 #: js/blocks/ExtrasBlocks.js:307
 #: js/blocks/ExtrasBlocks.js:340
 msgid "The Space block is used to add space between blocks."
 msgstr "<h2>スペースブロック</h2><br>ブロックとブロックの間にスペースを入れたいときに使う。"
 
-
 #: js/blocks/ExtrasBlocks.js:378
 msgid "wait"
 msgstr "待つ"
-
 
 #: js/blocks/ExtrasBlocks.js:381
 msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr "ウェイトブロックは指定された秒数だけプログラムを一時停止します。"
 
-
 #: js/blocks/ExtrasBlocks.js:427
 msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
 msgstr "「コメント」ブロックは、プログラムが低速モードで実行されているときに、画面の上部にコメントを出力します。"
-
 
 #: js/blocks/ExtrasBlocks.js:435
 #: plugins/facebook.rtp:30
 msgid "comment"
 msgstr "コメント"
 
-
 #: js/blocks/ExtrasBlocks.js:471
 msgid "print"
 msgstr "結果を表示"
-
 
 #: js/blocks/ExtrasBlocks.js:478
 msgid "The Print block displays text at the top of the screen."
 msgstr "<h2>表示ブロック（結果）</h2><br>画面の上部に、指定した実行結果のすうちや文字を表示する。表示したテキストはクリックすると消すことができる。どこでプログラムがまちがっているかをかくにんする際（デバグ）などによく用いられる。"
 
-
 #: js/blocks/ExtrasBlocks.js:587
 msgid "display grid"
 msgstr "グリッドを表示"
 
-
 #: js/blocks/ExtrasBlocks.js:592
 msgid "The Display Grid Block changes the grid type"
 msgstr "表示グリッド ブロックのグリッド タイプの変更"
-
 
 #: js/blocks/ExtrasBlocks.js:858
 #: js/blocks/ExtrasBlocks.js:870
@@ -11039,147 +9172,120 @@ msgstr "表示グリッド ブロックのグリッド タイプの変更"
 msgid "debugger"
 msgstr "デバッガ"
 
-
 #: js/blocks/ExtrasBlocks.js:861
 msgid "The Debug block adds a debug point in your code. When reached, execution will pause and you can inspect variables."
 msgstr "「デバッガ」ブロックは、コードにデバッグ ポイントを追加します。到達すると、実行が一時停止され、変数を検査できるようになります。"
 
-
 #: js/blocks/PitchBlocks.js:677
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr "ピッチ番号をピッチとオクターヴにマッピングするためのオフセットを設定するために使われるブロックです。"
-
 
 #: js/blocks/MediaBlocks.js:45
 #: js/blocks/MediaBlocks.js:56
 msgid "The Right block returns the position of the right of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの右のｘざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
-
 #: js/blocks/MediaBlocks.js:47
 #: js/blocks/MediaBlocks.js:123
 msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
 msgstr "この例では、マウスはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。"
-
 
 #: js/blocks/MediaBlocks.js:58
 #: js/blocks/MediaBlocks.js:134
 msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
 msgstr "この例では、タートルはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。"
 
-
 #: js/blocks/MediaBlocks.js:121
 #: js/blocks/MediaBlocks.js:132
 msgid "The Left block returns the position of the left of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの左のｘざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上））、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
-
 
 #: js/blocks/MediaBlocks.js:196
 #: js/blocks/MediaBlocks.js:207
 msgid "The Top block returns the position of the top of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの上のｙざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、上（y座標）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
-
 #: js/blocks/MediaBlocks.js:198
 #: js/blocks/MediaBlocks.js:273
 msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
 msgstr "この例では、マウスはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。"
-
 
 #: js/blocks/MediaBlocks.js:209
 #: js/blocks/MediaBlocks.js:284
 msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
 msgstr "この例では、タートルはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。"
 
-
 #: js/blocks/MediaBlocks.js:271
 #: js/blocks/MediaBlocks.js:282
 msgid "The Bottom block returns the position of the bottom of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの下のｙざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
-
 #: js/blocks/PitchBlocks.js:753
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr "Number to octaveブロックはピッチ番号をオクターヴに変換します。"
-
 
 #: js/blocks/MediaBlocks.js:347
 msgid "The Width block returns the width of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
-
 #: js/blocks/MediaBlocks.js:404
 msgid "The Height block returns the height of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
-
 
 #: js/blocks/MediaBlocks.js:453
 #. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "再生を停止"
 
-
 #: js/blocks/MediaBlocks.js:488
 #. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "メディアを消す"
 
-
 #: js/blocks/MediaBlocks.js:493
 msgid "The Erase Media block erases text and images."
 msgstr "「メディアを消す」のブロックは文字と画像を消します。"
-
 
 #: js/blocks/MediaBlocks.js:523
 #. TRANS: play an audio recording
 msgid "play back"
 msgstr "プレーバック"
 
-
 #: js/blocks/MediaBlocks.js:571
 msgid "speak"
 msgstr "しゃべる"
-
 
 #: js/blocks/MediaBlocks.js:579
 msgid "The Speak block outputs to the text-to-speech synthesizer"
 msgstr "<h2>音声ブロック</h2><br>打ち込んだ文字を、機械音声で読み上げる。"
 
-
 #: js/blocks/MediaBlocks.js:630
 msgid "camera"
 msgstr "カメラ"
-
 
 #: js/blocks/MediaBlocks.js:635
 msgid "The Camera block connects a webcam to the Show block."
 msgstr "カメラブロックはウェブカメラをショウブロックに接続します。"
 
-
 #: js/blocks/MediaBlocks.js:658
 msgid "video"
 msgstr "ビデオ"
-
 
 #: js/blocks/MediaBlocks.js:663
 msgid "The Video block selects video for use with the Show block."
 msgstr "ビデオブロックはショウブロックで使用するビデオを選択します。"
 
-
 #: js/blocks/MediaBlocks.js:691
 msgid "The Open file block opens a file for use with the Show block."
 msgstr "オープンファイルブロックはショウブロックで使用するファイルを開きます。"
-
 
 #: js/blocks/MediaBlocks.js:728
 msgid "stop media"
 msgstr "メデイアを停止"
 
-
 #: js/blocks/MediaBlocks.js:733
 msgid "The Stop media block stops audio or video playback."
 msgstr "ストップメディアブロックは音声または動画の再生を停止します。"
-
 
 #: js/blocks/MediaBlocks.js:762
 #: js/blocks/PitchBlocks.js:1633
@@ -11188,7 +9294,6 @@ msgstr "ストップメディアブロックは音声または動画の再生を
 #. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "ヘルツ"
-
 
 #: js/blocks/MediaBlocks.js:775
 #: js/blocks/WidgetBlocks.js:250
@@ -11201,23 +9306,19 @@ msgstr "ヘルツ"
 msgid "frequency"
 msgstr "周波数"
 
-
 #: js/blocks/MediaBlocks.js:775
 #: plugins/rodi.rtp:193
 msgid "duration (MS)"
 msgstr "継続時間（ミリ秒）"
-
 
 #: js/blocks/MediaBlocks.js:811
 #. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "音符の高さを周波数表示へ"
 
-
 #: js/blocks/MediaBlocks.js:819
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr "トゥーフリクエンシーブロックは音名とオクターブをヘルツに変換します。"
-
 
 #: js/blocks/MediaBlocks.js:829
 #: js/blocks/PitchBlocks.js:695
@@ -11226,7 +9327,6 @@ msgstr "トゥーフリクエンシーブロックは音名とオクターブを
 #. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "名前"
-
 
 #: js/blocks/MediaBlocks.js:829
 #: js/blocks/IntervalsBlocks.js:63
@@ -11244,16 +9344,13 @@ msgstr "名前"
 msgid "octave"
 msgstr "オクターヴの高さ"
 
-
 #: js/blocks/MediaBlocks.js:895
 msgid "The Avatar block is used to change the appearance of the mouse."
 msgstr "アバターブロックはマウスの外見を変更するために使われます。"
 
-
 #: js/blocks/MediaBlocks.js:902
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr "アバターブロックはタートルの外見を変更するために使われます。"
-
 
 #: js/blocks/MediaBlocks.js:914
 #: js/blocks/MediaBlocks.js:974
@@ -11261,207 +9358,167 @@ msgstr "アバターブロックはタートルの外見を変更するために
 msgid "size"
 msgstr "大きさ"
 
-
 #: js/blocks/MediaBlocks.js:914
 msgid "image"
 msgstr "がぞうそざい"
 
-
 #: js/blocks/MediaBlocks.js:963
 msgid "The Show block is used to display text or images on the canvas."
 msgstr "<h2>表示ブロック（スタンプ）</h2><br>スタンプは、実行するとネズミの位置に指定した文字またはがぞうを表示する。ネズミの体の下に表れるので、小さい文字やがぞうだとネズミが移動しないと見えない場合がある。"
-
 
 #: js/blocks/MediaBlocks.js:971
 #. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "スタンプ"
 
-
 #: js/blocks/PitchBlocks.js:1065
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr "Registerブロックは後に続く音符のオクターヴ（レジスター）を簡単に変更する方法を提供します。"
-
 
 #: js/blocks/MediaBlocks.js:974
 msgid "obj"
 msgstr "そざい"
 
-
 #: js/blocks/MediaBlocks.js:1021
 msgid "The Media block is used to import an image."
 msgstr "<h2>がぞうブロック</h2><br>がぞうのブロック。ブロックのマークをおすと、コンピューター上からがぞうファイルを読み込むことができる。"
-
 
 #: js/blocks/MediaBlocks.js:1057
 msgid "The Text block holds a text string."
 msgstr "<h2>文字ブロック</h2><br>文字を指定するブロック。"
 
-
 #: js/blocks/NumberBlocks.js:164
 msgid "The Int block returns an integer."
 msgstr "Intブロックは整数を返します。"
-
 
 #: js/blocks/NumberBlocks.js:167
 msgid "int"
 msgstr "整数に"
 
-
 #: js/blocks/NumberBlocks.js:196
 msgid "The Mod block returns the remainder from a division."
 msgstr "Modブロックは割り算の余りを返します。"
-
 
 #: js/blocks/NumberBlocks.js:202
 msgid "mod"
 msgstr "～で割った余り（mod）"
 
-
 #: js/blocks/NumberBlocks.js:242
 msgid "The Power block calculates a power function."
 msgstr "Powerブロックはべき乗を計算します。"
-
 
 #: js/blocks/NumberBlocks.js:289
 msgid "The Sqrt block returns the square root."
 msgstr "Sqrtブロックは平方根を返します。"
 
-
 #: js/blocks/NumberBlocks.js:292
 msgid "sqrt"
 msgstr "平方根"
-
 
 #: js/blocks/NumberBlocks.js:330
 msgid "The Abs block returns the absolute value."
 msgstr "Absブロックは絶対値を返します。"
 
-
 #: js/blocks/NumberBlocks.js:336
 msgid "abs"
 msgstr "絶対値"
 
-
 #: js/blocks/NumberBlocks.js:367
 msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
 msgstr "Distanceブロックは2点間の距離を返します。例えば、マウスと画面中央の距離です。"
-
 
 #: js/blocks/NumberBlocks.js:375
 #: plugins/rodi.rtp:310
 msgid "distance"
 msgstr "距離"
 
-
 #: js/blocks/NumberBlocks.js:427
 msgid "The Divide block is used to divide."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちの割り算した計算結果を表すすうちブロック。上につないだすうちを、下につないだすうちで割る。"
-
 
 #: js/blocks/NumberBlocks.js:487
 msgid "The Multiply block is used to multiply."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちを掛け合わせた計算結果を表すすうちブロック。"
 
-
 #: js/blocks/NumberBlocks.js:613
 msgid "The Minus block is used to subtract."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちの引き算した計算結果を表すすうちブロック。上につないだすうちから、下につないだすうちを引く。"
-
 
 #: js/blocks/NumberBlocks.js:699
 msgid "The Plus block is used to add."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちを足し合わせた計算結果を表すすうちブロック。"
 
-
 #: js/blocks/NumberBlocks.js:814
 msgid "The One-of block returns one of two choices."
 msgstr "<h2>特殊ブロック（ランダム）</h2><br>つないだ２つのブロックのうち、1つだけをランダムに選ぶ。「すうち」「アクション名」など、さまざまなブロックをつなぐことができる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。"
-
 
 #: js/blocks/NumberBlocks.js:821
 #: js/blocks/PitchBlocks.js:653
 msgid "one of"
 msgstr "どちらかランダム"
 
-
 #: js/blocks/NumberBlocks.js:823
 msgid "this"
 msgstr "これか"
-
 
 #: js/blocks/NumberBlocks.js:823
 msgid "that"
 msgstr "それか"
 
-
 #: js/blocks/NumberBlocks.js:878
 msgid "The Random block returns a random number."
 msgstr "<h2>すうちブロック（ランダム）</h2><br>指定したさいしょうちからさいだいちまでのはんいで、ランダムなすうちになる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。"
-
 
 #: js/blocks/NumberBlocks.js:885
 msgid "random"
 msgstr "ランダム"
 
-
 #: js/blocks/NumberBlocks.js:887
 msgid "min"
 msgstr "さいしょうち"
-
 
 #: js/blocks/NumberBlocks.js:887
 msgid "max"
 msgstr "さいだいち"
 
-
 #: js/blocks/NumberBlocks.js:933
 msgid "The Number block holds a number."
 msgstr "<h2>すうちブロック</h2><br>すうちを指定するブロック。"
-
 
 #: js/blocks/PenBlocks.js:30
 msgid "purple"
 msgstr "紫"
 
-
 #: js/blocks/PenBlocks.js:80
 msgid "yellow"
 msgstr "黄色"
-
 
 #: js/blocks/PenBlocks.js:96
 #: plugins/nutrition.rtp:164
 msgid "orange"
 msgstr "オレンジ"
 
-
 #: js/blocks/PenBlocks.js:128
 msgid "white"
 msgstr "白"
-
 
 #: js/blocks/PenBlocks.js:144
 msgid "black"
 msgstr "黒"
 
-
 #: js/blocks/PenBlocks.js:163
 msgid "begin fill"
 msgstr "記入を始める"
 
-
 #: js/blocks/PenBlocks.js:190
 msgid "end fill"
 msgstr "記入を終わらせる"
-
 
 #: js/blocks/PenBlocks.js:212
 #: js/blocks/PenBlocks.js:561
 #. TRANS: set the background color
 msgid "background"
 msgstr "背景"
-
 
 #: js/blocks/PenBlocks.js:259
 #: js/turtleactions/DictActions.js:71
@@ -11470,11 +9527,9 @@ msgstr "背景"
 msgid "grey"
 msgstr "灰色"
 
-
 #: js/blocks/PenBlocks.js:267
 msgid "The Grey block returns the current pen grey value."
 msgstr "グレーブロックは現在のペンのグレー値を返します。"
-
 
 #: js/blocks/PenBlocks.js:329
 #: js/turtleactions/DictActions.js:69
@@ -11483,11 +9538,9 @@ msgstr "グレーブロックは現在のペンのグレー値を返します。
 msgid "shade"
 msgstr "シェード"
 
-
 #: js/blocks/PenBlocks.js:336
 msgid "The Shade block returns the current pen shade value."
 msgstr "シェードブロックは現在のペンのシェード値を返します。"
-
 
 #: js/blocks/PenBlocks.js:398
 #: js/turtleactions/DictActions.js:67
@@ -11496,11 +9549,9 @@ msgstr "シェードブロックは現在のペンのシェード値を返しま
 msgid "color"
 msgstr "いろ"
 
-
 #: js/blocks/PenBlocks.js:408
 msgid "The Color block returns the current pen color."
 msgstr "<h2>ペンブロック</h2><br>げんざいのペンの色を、すうちでひょうじする。"
-
 
 #: js/blocks/PenBlocks.js:467
 #: js/turtleactions/DictActions.js:73
@@ -11509,227 +9560,184 @@ msgstr "<h2>ペンブロック</h2><br>げんざいのペンの色を、すう�
 msgid "pen size"
 msgstr "ペンの大きさ"
 
-
 #: js/blocks/PenBlocks.js:471
 msgid "The Pen size block returns the current pen size value."
 msgstr "ペンサイズブロックは現在のペンのサイズ値を返します。"
-
 
 #: js/blocks/PenBlocks.js:514
 msgid "set font"
 msgstr "フォントの設定"
 
-
 #: js/blocks/PenBlocks.js:519
 msgid "The Set font block sets the font used by the Show block."
 msgstr "フォント設定ブロックはショウブロックで使われるフォントを設定します。"
-
 
 #: js/blocks/PenBlocks.js:568
 msgid "The Background block sets the window background color."
 msgstr "背景ブロックは、カンバスの色をせっていする。"
 
-
 #: js/blocks/PenBlocks.js:599
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr "ホローラインブロックは中空の線を作成します。"
-
 
 #: js/blocks/PenBlocks.js:607
 #. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "（中空の）線"
 
-
 #: js/blocks/PitchBlocks.js:1747
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr "1から始まり、音階の枠組みに関係なく（つまりオクターヴが常に8音とは限らない）"
 
-
 #: js/blocks/PenBlocks.js:676
 msgid "The Fill block fills in a shape with a color."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがいた図形の内がわをぬりつぶす。"
-
 
 #: js/blocks/PenBlocks.js:685
 #. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "ぬりつぶす"
 
-
 #: js/blocks/PenBlocks.js:762
 #. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ペンを上げる"
 
-
 #: js/blocks/PenBlocks.js:769
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがくことをやめる。"
-
 
 #: js/blocks/PenBlocks.js:803
 #. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ペンを下ろす"
 
-
 #: js/blocks/PenBlocks.js:811
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがく。"
-
 
 #: js/blocks/PenBlocks.js:845
 #. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "太さをせってい"
 
-
 #: js/blocks/PenBlocks.js:855
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の太さをせっていする。太さには、0より大きいあたいを使う。"
 
-
 #: js/blocks/PitchBlocks.js:1839
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr "スケールディグリー1は、オクターヴに関係なく常に与えられたスケールの最初の音です。"
-
 
 #: js/blocks/PenBlocks.js:914
 #. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "透明度を設定"
 
-
 #: js/blocks/PenBlocks.js:922
 msgid "The Set translucency block changes the opacity of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線がどのくらいすきとおるかをせっていする。すうちが大きいほど、線がすきとおる。"
-
 
 #: js/blocks/PenBlocks.js:982
 msgid "set hue"
 msgstr "色相を設定"
 
-
 #: js/blocks/PenBlocks.js:990
 msgid "The Set hue block changes the color of the pen."
 msgstr "色相設定ブロックはペンの色を変更します。"
-
 
 #: js/blocks/PenBlocks.js:1048
 msgid "set shade"
 msgstr "色のこさをせってい"
 
-
 #: js/blocks/PenBlocks.js:1058
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の色のこさをせっていする。"
-
 
 #: js/blocks/PenBlocks.js:1112
 #. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "灰色を設定"
 
-
 #: js/blocks/PenBlocks.js:1120
 msgid "The Set grey block changes the vividness of the pen color."
 msgstr "グレー設定ブロックはペンの色の鮮やかさを変更します。"
-
 
 #: js/blocks/PenBlocks.js:1173
 msgid "set color"
 msgstr "色をせってい"
 
-
 #: js/blocks/PenBlocks.js:1183
 msgid "The Set-color block changes the pen color."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の色をせっていする。色は画面上で選ぶほか、それぞれすうちで決めることもできる。色は、0以上で、100より小さいあたいになる。"
 
-
 #: js/blocks/ProgramBlocks.js:33
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "Load-heap-from-appブロックはウェブページからヒープを読み込みます。"
-
 
 #: js/blocks/ProgramBlocks.js:44
 #. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "アプリからヒープをロード"
 
-
 #: js/blocks/ProgramBlocks.js:94
 msgid "404: Page not found"
 msgstr "４０４エラー：ページが見つかりません。"
-
 
 #: js/blocks/ProgramBlocks.js:106
 msgid "Error parsing JSON data:"
 msgstr "JSON データの構文エラーです。"
 
-
 #: js/blocks/ProgramBlocks.js:129
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "Save-heap-to-appブロックはヒープをウェブページに保存します。"
-
 
 #: js/blocks/ProgramBlocks.js:140
 #. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "アプリにヒープを保存"
 
-
 #: js/blocks/ProgramBlocks.js:190
 msgid "Cannot find a valid heap for"
 msgstr "正しいヒープが見つかりません。"
 
-
 #: js/blocks/ProgramBlocks.js:207
 msgid "The Load-heap block loads the heap from a file."
 msgstr "Load-heapブロックはファイルからヒープを読み込みます。"
-
 
 #: js/blocks/ProgramBlocks.js:218
 #. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ヒープをロードする"
 
-
 #: js/blocks/ProgramBlocks.js:271
 msgid "The file you selected does not contain a valid heap."
 msgstr "選んだファイルには、正しいヒープが含まれません。"
-
 
 #: js/blocks/ProgramBlocks.js:277
 msgid "The loadHeap block needs a loadFile block."
 msgstr "ロードヒープのブロックには、ロードファイルブロックが必要です。"
 
-
 #: js/blocks/ProgramBlocks.js:293
 msgid "The Set-heap block loads the heap."
 msgstr "Set-heapブロックはヒープを読み込みます。"
-
 
 #: js/blocks/ProgramBlocks.js:343
 msgid "The block you selected does not contain a valid heap."
 msgstr "選択したブロックには有効なヒープが含まれていません。"
 
-
 #: js/blocks/ProgramBlocks.js:348
 msgid "The Set heap block needs a heap."
 msgstr "Set heapブロックにはヒープが必要です。"
-
 
 #: js/blocks/ProgramBlocks.js:365
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "Load-dictionaryブロックはファイルから辞書を読み込みます。"
 
-
 #: js/blocks/ProgramBlocks.js:376
 #. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "辞書をロード"
-
 
 #: js/blocks/ProgramBlocks.js:394
 #: js/blocks/ProgramBlocks.js:664
@@ -11737,140 +9745,114 @@ msgstr "辞書をロード"
 msgid "file"
 msgstr "ファイル"
 
-
 #: js/blocks/ProgramBlocks.js:448
 msgid "The file you selected does not contain a valid dictionary."
 msgstr "選択したファイルには有効な辞書が含まれていません。"
-
 
 #: js/blocks/ProgramBlocks.js:454
 msgid "The load dictionary block needs a load file block."
 msgstr "load dictionaryブロックにはload fileブロックが必要です。"
 
-
 #: js/blocks/ProgramBlocks.js:471
 msgid "The Set-dictionary block loads a dictionary."
 msgstr "Set-dictionaryブロックは辞書を読み込みます。"
-
 
 #: js/blocks/ProgramBlocks.js:482
 #. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "辞書を設定"
 
-
 #: js/blocks/ProgramBlocks.js:551
 msgid "The block you selected does not contain a valid dictionary."
 msgstr "選択したブロックには有効な辞書が含まれていません。"
-
 
 #: js/blocks/ProgramBlocks.js:556
 msgid "The set dictionary block needs a dictionary."
 msgstr "set dictionaryブロックには辞書が必要です。"
 
-
 #: js/blocks/ProgramBlocks.js:573
 msgid "The Save-heap block saves the heap to a file."
 msgstr "Save-heapブロックはヒープをファイルに保存します。"
-
 
 #: js/blocks/ProgramBlocks.js:584
 #. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ヒープを保存する"
 
-
 #: js/blocks/ProgramBlocks.js:635
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "Save-dictionaryブロックは辞書をファイルに保存します。"
-
 
 #: js/blocks/ProgramBlocks.js:646
 #. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "辞書を保存"
 
-
 #: js/blocks/ProgramBlocks.js:734
 msgid "The Open palette block opens a palette."
 msgstr "Open paletteブロックはパレットを開きます。"
-
 
 #: js/blocks/ProgramBlocks.js:741
 msgid "open palette"
 msgstr "パレットを開きます"
 
-
 #: js/blocks/ProgramBlocks.js:799
 msgid "The Delete block block removes a block."
 msgstr "Delete blockブロックはブロックを削除します。"
-
 
 #: js/blocks/ProgramBlocks.js:811
 #. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ブロックを消す"
 
-
 #: js/blocks/ProgramBlocks.js:875
 msgid "The Move block block moves a block."
 msgstr "Move blockブロックはブロックを移動します。"
-
 
 #: js/blocks/ProgramBlocks.js:883
 #. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ブロックを動かす"
 
-
 #: js/blocks/ProgramBlocks.js:895
 #: js/blocks/ProgramBlocks.js:1058
 msgid "block number"
 msgstr "ブロックの番号"
 
-
 #: js/blocks/ProgramBlocks.js:936
 msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
 msgstr "「ブロックを再生」ブロックはブロックを実行します。ブロック番号またはブロック名の 2 種類の引数を受け入れます。"
-
 
 #: js/blocks/ProgramBlocks.js:949
 #. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ブロックを再生"
 
-
 #: js/blocks/ProgramBlocks.js:1038
 msgid "The Dock block connects two blocks."
 msgstr "Dock blockブロックは2つのブロックを接続します。"
-
 
 #: js/blocks/ProgramBlocks.js:1046
 #. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ブロックを繋ぐ"
 
-
 #: js/blocks/ProgramBlocks.js:1058
 msgid "target block"
 msgstr "目標のブロック"
-
 
 #: js/blocks/ProgramBlocks.js:1058
 msgid "connection number"
 msgstr "接続の番号"
 
-
 #: js/blocks/ProgramBlocks.js:1146
 msgid "The Make block block creates a new block."
 msgstr "Make blockブロックは新しいブロックを作成します。"
-
 
 #: js/blocks/ProgramBlocks.js:1158
 #. TRANS: Create a new block
 msgid "make block"
 msgstr "ブロックを作る"
-
 
 #: js/blocks/ProgramBlocks.js:1192
 #: js/blocks/ProgramBlocks.js:1233
@@ -11887,16 +9869,13 @@ msgstr "ブロックを作る"
 msgid "note"
 msgstr "音符"
 
-
 #: js/blocks/ProgramBlocks.js:1328
 msgid "instrument"
 msgstr "楽器"
 
-
 #: js/blocks/ProgramBlocks.js:1342
 msgid "Cannot find block"
 msgstr "ブロックが見つかりません"
-
 
 #: js/blocks/ProgramBlocks.js:1361
 #: js/blocks/ProgramBlocks.js:1370
@@ -11904,21 +9883,17 @@ msgstr "ブロックが見つかりません"
 msgid "Warning: block argument type mismatch"
 msgstr "注意：ブロックとタイプが合っていません。"
 
-
 #: js/blocks/ProgramBlocks.js:1387
 msgid "Warning: block argument type unhandled:"
 msgstr "警告: ブロック引数の型が処理されません:"
-
 
 #: js/blocks/ProgramBlocks.js:1420
 msgid "The Open project block is used to open a project from a web page."
 msgstr "Open projectブロックはウェブページからプロジェクトを開くために使われます。"
 
-
 #: js/blocks/ProgramBlocks.js:1430
 msgid "open project"
 msgstr "プロジェクトを開く"
-
 
 #: js/blocks/ProgramBlocks.js:1482
 #: js/blocks/ProgramBlocks.js:1495
@@ -11926,16 +9901,13 @@ msgstr "プロジェクトを開く"
 msgid "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
 msgstr "有効なプロジェクト URL (例: /index.html?id=123&run=true) を入力してください。"
 
-
 #: js/blocks/ProgramBlocks.js:1522
 msgid "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
 msgstr "ミュージック・ブロックス プロジェクトのリンクのみが許可されます (同じサイト、musicblocks.sugarlabs.org、musicblocks.net)。"
 
-
 #: js/blocks/ProgramBlocks.js:1532
 msgid "Please allow popups for this site"
 msgstr "このサイトのポップアップを許可してください"
-
 
 #: js/blocks/WidgetBlocks.js:149
 #: js/widgets/timbre.js:905
@@ -11943,62 +9915,51 @@ msgstr "このサイトのポップアップを許可してください"
 msgid "Envelope"
 msgstr "エンベロープ"
 
-
 #: js/blocks/WidgetBlocks.js:157
 #. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "アタック"
-
 
 #: js/blocks/WidgetBlocks.js:159
 #. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "ディケイ"
 
-
 #: js/blocks/WidgetBlocks.js:161
 #. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "サステイン"
-
 
 #: js/blocks/WidgetBlocks.js:163
 #. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "リリース"
 
-
 #: js/blocks/WidgetBlocks.js:181
 msgid "Attack value should be from 0 to 100."
 msgstr "アタック値には 0 以上100以下の数字をいれて下さい。"
-
 
 #: js/blocks/WidgetBlocks.js:184
 msgid "Decay value should be from 0 to 100."
 msgstr "減衰値には 0 以上100以下の数字をいれて下さい。"
 
-
 #: js/blocks/WidgetBlocks.js:187
 msgid "Sustain value should be from 0 to 100."
 msgstr "サステイン値には 0 以上100以下の数字をいれて下さい。"
-
 
 #: js/blocks/WidgetBlocks.js:190
 msgid "Release value should be from 0-100."
 msgstr "リリース値には 0 以上100以下の数字をいれて下さい。"
 
-
 #: js/blocks/WidgetBlocks.js:208
 msgid "You are adding multiple envelope blocks."
 msgstr "封筒ブロックを複数追加しています。"
-
 
 #: js/blocks/WidgetBlocks.js:239
 #: js/widgets/timbre.js:961
 #. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "フィルター"
-
 
 #: js/blocks/WidgetBlocks.js:247
 #: js/blocks/ToneBlocks.js:42
@@ -12009,24 +9970,20 @@ msgstr "フィルター"
 msgid "type"
 msgstr "種類"
 
-
 #: js/blocks/WidgetBlocks.js:249
 #: js/widgets/timbre.js:1932
 #. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "ロールオフ"
 
-
 #: js/blocks/WidgetBlocks.js:281
 #. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "ロールオフ値は -12, -24, -48, -98 デシベル / オクターヴである必要があります。"
 
-
 #: js/blocks/WidgetBlocks.js:321
 msgid "The Temperament tool is used to define custom tuning."
 msgstr "Temperamentツールはカスタムチューニングを定義するために使用されます。"
-
 
 #: js/blocks/WidgetBlocks.js:411
 #: js/blocks/WidgetBlocks.js:1936
@@ -12034,86 +9991,70 @@ msgstr "Temperamentツールはカスタムチューニングを定義するた�
 msgid "Upload a sample and adjust its pitch center."
 msgstr "サンプルをアップロードしてピッチセンターを調整します。"
 
-
 #: js/blocks/WidgetBlocks.js:418
 #. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "サンプラー"
 
-
 #: js/blocks/WidgetBlocks.js:611
 msgid "The Meter block opens a tool to select strong beats for the meter."
 msgstr "<h2>拍子ブロック</h2><br>テーブルの数字をクリックして、強い拍（はく）の位置を決める。<br>★拍子（ひょうし）とは<br>拍（はく）がいくつかまとまったもの。<br>★拍（はく）とは<br>くり返されるリズムのこと。"
-
 
 #: js/blocks/WidgetBlocks.js:673
 msgid "The oscilloscope block opens a tool to visualize waveforms."
 msgstr "Oscilloscopeブロックは波形を可視化するツールを開きます。"
 
-
 #: js/blocks/WidgetBlocks.js:678
 msgid "oscilloscope"
 msgstr "オシロスコープ"
 
-
 #: js/blocks/WidgetBlocks.js:753
 msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
 msgstr "<h2>モード（音階）ブロック</h2><br>いろいろな音階をさがすツールを表示する。音階は、音と音のかんかくを決めながらさがすことができる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
-
 
 #: js/blocks/WidgetBlocks.js:761
 #. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "音階"
 
-
 #: js/blocks/WidgetBlocks.js:818
 msgid "The Tempo block opens a metronome to visualize the beat."
 msgstr "<h2>メトロノームブロック</h2><br>メトロノームを表示する。ボタンをおすと、メトロノームのはやさを変えられる。テーブルには、１分あたりの拍（はく）の数が表示される。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
-
 #: js/blocks/WidgetBlocks.js:888
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr "「アルペジオ」ウィジェットは コード進行 を作るためです。"
-
 
 #: js/blocks/WidgetBlocks.js:894
 #: js/blocks/IntervalsBlocks.js:764
 msgid "arpeggio"
 msgstr "アルペジオ"
 
-
 #: js/blocks/WidgetBlocks.js:972
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "Pitch drumマトリックスはピッチをドラム音にマッピングするために使われます。"
-
 
 #: js/blocks/WidgetBlocks.js:977
 #. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "音高-ドラム・マッパー"
 
-
 #: js/blocks/WidgetBlocks.js:1034
 msgid "You must have at least one pitch block and one drum block in the matrix."
 msgstr "フレーズメーカーブロックには、音の高さブロックとドラムブロックを最低1つずつ入れてください。"
 
-
 #: js/blocks/WidgetBlocks.js:1066
 msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
 msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。また、ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは音の高さを表す周波数。<br>★周波数とは音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。"
-
 
 #: js/blocks/WidgetBlocks.js:1071
 #. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "ヘルツスライダー"
 
-
 #: js/blocks/WidgetBlocks.js:1131
 msgid "chromatic keyboard"
 msgstr "クロマティック・キーボード"
-
 
 #: js/blocks/WidgetBlocks.js:1165
 #: js/blocks/WidgetBlocks.js:1236
@@ -12121,64 +10062,52 @@ msgstr "クロマティック・キーボード"
 msgid "music keyboard"
 msgstr "キーボード"
 
-
 #: js/blocks/WidgetBlocks.js:1217
 #: js/blocks/WidgetBlocks.js:1226
 msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
 msgstr "<h2>キーボードブロック</h2><br>ピアノのキーボードを表示する。作った音をデータ化することができる。<br><br> "
 
-
 #: js/blocks/WidgetBlocks.js:1296
 msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr "Pitch staircaseツールは指定された比率からピッチを生成するために使用されます。"
-
 
 #: js/blocks/WidgetBlocks.js:1303
 #. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "音高の数列を作る"
 
-
 #: js/blocks/WidgetBlocks.js:1399
 msgid "The Rhythm Maker block opens a tool to create drum machines."
 msgstr "<h2>リズムメーカーブロック</h2><br>音の長さでぶんかつしてリズムを作るテーブルを表示する。作ったリズムをデータ化することができる。<br><br>"
-
 
 #: js/blocks/WidgetBlocks.js:1476
 msgid "G major scale"
 msgstr "Gメジャー"
 
-
 #: js/blocks/WidgetBlocks.js:1511
 msgid "C major scale"
 msgstr "Cメジャー"
 
-
 #: js/blocks/WidgetBlocks.js:1552
 msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "<h2>フレーズメーカーブロック</h2><br>フレーズを作るためのテーブルを表示する。作ったフレーズをデータ化することができる。<br><br>★フレーズとは<br>ひとまとまりの音楽。<br><br>"
-
 
 #: js/blocks/WidgetBlocks.js:1559
 #. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "フレーズメーカー"
 
-
 #: js/blocks/WidgetBlocks.js:1621
 msgid "lyrics"
 msgstr "歌詞"
-
 
 #: js/blocks/WidgetBlocks.js:1717
 msgid "You must have at least one pitch block and one rhythm block in the matrix."
 msgstr "フレーズメーカーには、音の高さブロックと音符ブロックを組み合わせてください。"
 
-
 #: js/blocks/WidgetBlocks.js:1779
 msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
 msgstr "<h2>実行じょうきょうブロック</h2><br>ブロックの実行じょうきょうをけんさくするテーブルを表示する。<br>"
-
 
 #: js/blocks/WidgetBlocks.js:1943
 #: js/widgets/aiwidget.js:822
@@ -12186,297 +10115,240 @@ msgstr "<h2>実行じょうきょうブロック</h2><br>ブロックの実行�
 msgid "AI Music"
 msgstr "AI音楽"
 
-
 #: js/blocks/WidgetBlocks.js:1996
 msgid "The Reflection block opens a space for you to think about your learning."
 msgstr "「振り返り」ブロックは、学習について考えるためのスペースを開きます。"
-
 
 #: js/blocks/WidgetBlocks.js:2001
 msgid "reflection"
 msgstr "「振り返り」"
 
-
 #: js/blocks/WidgetBlocks.js:2059
 msgid "The LEGO Bricks block opens a widget for designing virtual LEGO creations."
 msgstr "「レゴブロック」ブロックは、仮想 LEGO 作品をデザインするためのウィジェットを開きます。"
-
 
 #: js/blocks/WidgetBlocks.js:2066
 #. TRANS: LEGO bricks designer
 msgid "LEGO Bricks"
 msgstr "レゴブロック"
 
-
 #: js/blocks/WidgetBlocks.js:2125
 msgid "You must have at least one pitch block in the LEGO bricks widget."
 msgstr "「レゴブロック」ウィジェットには少なくとも 1つの「ピッチ」ブロックが必要です。"
-
 
 #: js/blocks/WidgetBlocks.js:2149
 msgid "Debug your music blocks project with new possibilities and more understanding."
 msgstr "新たな可能性と理解を深めて、ミュージック・ブロックス プロジェクトをデバッグします。"
 
-
 #: js/blocks/DrumBlocks.js:32
 msgid "noise name"
 msgstr "ノイズ名"
-
 
 #: js/blocks/DrumBlocks.js:62
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr "Noise nameブロックはノイズシンセサイザーを選択するために使われます。"
 
-
 #: js/blocks/DrumBlocks.js:78
 msgid "drum name"
 msgstr "ドラム名"
-
 
 #: js/blocks/DrumBlocks.js:108
 msgid "The Drum name block is used to select a drum."
 msgstr "<h2>ドラムブロック</h2><br>ドラムの種類を変えるときに使う。クリックで、いろいろなドラムの音を選ぶことができる。"
 
-
 #: js/blocks/DrumBlocks.js:125
 msgid "effects name"
 msgstr "エフェクト名"
-
 
 #: js/blocks/DrumBlocks.js:155
 msgid "The Effects name block is used to select a sound effect."
 msgstr "<h2>こうかおんブロック</h2><br>こうかおんの種類を変えるときに使う。クリックで、いろいろなおもしろい音を選ぶことができる。"
 
-
 #: js/blocks/DrumBlocks.js:172
 msgid "noise"
 msgstr "ノイズ"
-
 
 #: js/blocks/DrumBlocks.js:186
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr "Play noiseブロックはホワイトノイズ、ピンクノイズ、またはブラウンノイズを生成します。"
 
-
 #: js/blocks/DrumBlocks.js:341
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラム音に置き換えます。"
-
 
 #: js/blocks/DrumBlocks.js:352
 #. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "音符をドラムに変える"
 
-
 #: js/blocks/DrumBlocks.js:406
 #: js/blocks/DrumBlocks.js:415
 msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
 msgstr "「ドラムをせってい」ブロックは、含まれているノートのピッチを置き換えるドラム サウンドを選択します。"
 
-
 #: js/blocks/DrumBlocks.js:419
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
-
 
 #: js/blocks/DrumBlocks.js:431
 #. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムをせってい"
 
-
 #: js/blocks/DrumBlocks.js:475
 msgid "sound effect"
 msgstr "こうかおん"
-
 
 #: js/blocks/DrumBlocks.js:514
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。"
 
-
 #: js/blocks/IntervalsBlocks.js:45
 msgid "set temperament"
 msgstr "音律をせってい"
-
 
 #: js/blocks/IntervalsBlocks.js:53
 msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
 msgstr "「音律をせってい」ブロックは、ミュージック・ブロックスで使用されるチューニング システムを選択するために使用されます。"
 
-
 #: js/blocks/IntervalsBlocks.js:94
 msgid "temperament name"
 msgstr "気質名"
-
 
 #: js/blocks/IntervalsBlocks.js:102
 msgid "The Temperament name block is used to select a tuning method."
 msgstr "<h2>音律（おんりつ）ブロック</h2><br>調律（ちょうりつ）のしかたをせっていする。<br>★音律（おんりつ）とは<br>音程（おんてい）（音どうしのへだたり）の決め方。同じ音階でも、音律（おんりつ）によって音の高さが変わる。<br>★調律（ちょうりつ）とは<br>楽器の音の高さを、音律（おんりつ）にしたがって整えること。"
 
-
 #: js/blocks/IntervalsBlocks.js:170
 msgid "doubly"
 msgstr "重"
-
 
 #: js/blocks/IntervalsBlocks.js:175
 msgid "The Doubly block will double the size of an interval."
 msgstr "Doublyブロックはインターバルのサイズを2倍にします。"
 
-
 #: js/blocks/IntervalsBlocks.js:274
 msgid "interval number"
 msgstr "音程を数で表示"
-
 
 #: js/blocks/IntervalsBlocks.js:279
 msgid "The Interval number block returns the number of scalar steps in the current interval."
 msgstr "「音程を数で表示」ブロックは、現在の音階の数値を返します。"
 
-
 #: js/blocks/IntervalsBlocks.js:332
 msgid "current interval"
 msgstr "現在の音階"
-
 
 #: js/blocks/IntervalsBlocks.js:337
 msgid "The Current interval block returns the name of scalar steps in the current interval."
 msgstr "「現在の音階」ブロックは、現在の音階の名前を返します。"
 
-
 #: js/blocks/IntervalsBlocks.js:395
 msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
 msgstr "「半音階的音程」ブロックは、2つの音符間の距離を半音単位で測定します。"
-
 
 #: js/blocks/IntervalsBlocks.js:403
 #. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "半音階的音程で計る"
 
-
 #: js/blocks/IntervalsBlocks.js:474
 #: js/blocks/IntervalsBlocks.js:595
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr "音程を計る際は、２つの音符を使う必要があります。"
 
-
 #: js/blocks/IntervalsBlocks.js:515
 msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
 msgstr "「音階的な音程」ブロックは現在の調とモードで2つの音の距離を測定します。"
-
 
 #: js/blocks/IntervalsBlocks.js:523
 #. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "全音階的音程で計る"
 
-
 #: js/blocks/IntervalsBlocks.js:698
 msgid "The Semi-tone interval block calculates a relative interval based on half steps."
 msgstr "「半音階的音程」ブロックは、半音に基づいて相対間隔を計算します。"
-
 
 #: js/blocks/IntervalsBlocks.js:702
 msgid "In the figure, we add sol# to sol."
 msgstr "例の画像には<em>ソ</em>が<em>ソ#</em>になります。"
 
-
 #: js/blocks/IntervalsBlocks.js:753
 msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
 msgstr "「アルペジオ」ブロックは各「音符」ブロックを複数回実行し、指定されたコードに基づいて移調を追加します。"
-
 
 #: js/blocks/IntervalsBlocks.js:757
 msgid "The output of the example is: do, mi, sol, sol, ti, mi"
 msgstr "例の解決は「ド、ミ、ソ、ソ、シ、ミ」"
 
-
 #: js/blocks/IntervalsBlocks.js:981
 msgid "The Chord block calculates common chords."
 msgstr "Chordブロックは一般的なコードを計算します。"
-
 
 #: js/blocks/IntervalsBlocks.js:983
 msgid "In the figure, we generate a C-major chord."
 msgstr "図では、Cメジャーコードを生成します。"
 
-
 #: js/blocks/IntervalsBlocks.js:988
 msgid "chord"
 msgstr "の和音"
-
 
 #: js/blocks/IntervalsBlocks.js:1040
 msgid "The Ratio Interval block calculates an interval based on a ratio."
 msgstr "「比で音程」ブロックは比の音程のピッチを経産する。"
 
-
 #: js/blocks/IntervalsBlocks.js:1045
 msgid "ratio interval"
 msgstr "比で音程"
-
 
 #: js/blocks/IntervalsBlocks.js:1116
 msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
 msgstr "「音階的な音程」ブロックは、現在のモードに基づいて相対的な音程を計算し、モード外のピッチをすべてスキップします。"
 
-
 #: js/blocks/IntervalsBlocks.js:1120
 msgid "In the figure, we add la to sol."
 msgstr "<br><br>上の図では、ソの「音符（おんぷ）ブロック」をきじゅんにして、「音階の上下ブロック」のすうちを２にせっていしているので、ソと、ソから２音あがったシの音が同時にえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
-
 #: js/blocks/IntervalsBlocks.js:1169
 msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
 msgstr "「モードを定義する」ブロックを使用すると、ピッチ番号を指定してカスタム モードを定義できます。"
-
 
 #: js/blocks/IntervalsBlocks.js:1178
 #. TRANS: define a custom mode
 msgid "define mode"
 msgstr "モードを定義する"
 
-
 #: js/blocks/IntervalsBlocks.js:1231
 msgid "movable Do"
 msgstr "移動ド"
 
-
 #: js/blocks/IntervalsBlocks.js:1235
 msgid "When Movable do is false, the solfege note names are always tied to specific pitches, eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
 msgstr "「移動ド」が「偽」の場合、ソルフェージュ音名は常に特定のピッチに関連付けられます。たとえば、「移動ド」が「真」の場合、「ド」は常に「ド・メジャー」となり、ソルフェージュ音名はスケール度に割り当てられます。「ド」は常に長音階の 1 度です。"
-
 
 #: js/blocks/IntervalsBlocks.js:1278
 #. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "音階の音数"
 
-
 #: js/blocks/IntervalsBlocks.js:1287
 msgid "The Mode length block is the number of notes in the current scale."
 msgstr "<h2>音階の音数ブロック</h2><br>えんそうされている音階の、音の数を表示する。"
 
-
 #: js/blocks/IntervalsBlocks.js:1289
 msgid "Most Western scales have 7 notes."
 msgstr "西洋のほとんどの音階は、7つの音をもつ。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
-
 
 #: js/blocks/IntervalsBlocks.js:1341
 #. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "現代の音階"
 
-
 #: js/blocks/IntervalsBlocks.js:1397
 #. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "現代の調"
-
 
 #: js/blocks/IntervalsBlocks.js:1452
 #: js/blocks/IntervalsBlocks.js:1497
@@ -12484,72 +10356,59 @@ msgstr "現代の調"
 msgid "set key"
 msgstr "調をせってい"
 
-
 #: js/blocks/IntervalsBlocks.js:1506
 msgid "The Set key block is used to set the key and mode,"
 msgstr "<h2>調をせっていブロック</h2><br>調の部分に音の高さ、音階の部分に音階の種類を選び、調をせっていする。<br><br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。<br>★音階とは<br>順番に並んだ音のまとまり。"
 
-
 #: js/blocks/IntervalsBlocks.js:1512
 msgid "The Set key block is used to set the key and mode, eg C Major"
 msgstr "「調をせってい」ブロックは、調と音階(どメジャーなど) を設定するために使用されます。"
-
 
 #: js/blocks/IntervalsBlocks.js:1572
 #. TRANS: the number of pitches in the current temperament system
 msgid "temperament length"
 msgstr "音律の長さ"
 
-
 #: js/blocks/IntervalsBlocks.js:1577
 msgid "The Temperament length block returns the number of pitches in the current temperament system. For example, 12 for standard equal temperament or 31 for a 31-tone temperament."
 msgstr "「音律の長さ」ブロックは、現在の音律システムにおけるピッチの数を返します。たとえば、標準平均律の場合は「12」、31音律の場合は「31」です。"
-
 
 #: js/blocks/PitchBlocks.js:143
 #. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "移調"
 
-
 #: js/blocks/PitchBlocks.js:170
 #. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "音階内で~度下がる:"
 
-
 #: js/blocks/PitchBlocks.js:174
 msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
 msgstr "Scalar step downブロックは現在の調とモードにおける前の音までの半音数を返します。"
-
 
 #: js/blocks/PitchBlocks.js:194
 #. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "音階内で~度上がる:"
 
-
 #: js/blocks/PitchBlocks.js:198
 msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
 msgstr "Scalar step upブロックは現在の調とモードにおける次の音までの半音数を返します。"
-
 
 #: js/blocks/PitchBlocks.js:218
 #. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "音程の違い"
 
-
 #: js/blocks/PitchBlocks.js:222
 msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
 msgstr "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半音の値で）の違いです。"
-
 
 #: js/blocks/PitchBlocks.js:251
 #. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "音階のよって音程の違い"
-
 
 #: js/blocks/PitchBlocks.js:258
 #: js/blocks/PitchBlocks.js:457
@@ -12563,11 +10422,9 @@ msgstr "音階のよって音程の違い"
 msgid "pitch number"
 msgstr "音の高さを数で表示"
 
-
 #: js/blocks/PitchBlocks.js:264
 msgid "The Pitch number block is the value of the pitch of the note currently being played."
 msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数で表示する。<br>"
-
 
 #: js/blocks/PitchBlocks.js:345
 #: js/blocks/PitchBlocks.js:458
@@ -12575,78 +10432,63 @@ msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数�
 msgid "pitch in hertz"
 msgstr "音の高さをヘルツで表示"
 
-
 #: js/blocks/PitchBlocks.js:350
 msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
 msgstr "<h2>音の高さをヘルツで表示ブロック</h2><br>音の高さをヘルツで表示する。<br>たとえば、オクターヴが４のラの音は、４４０ヘルツというすうちで表すことができる。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>"
-
 
 #: js/blocks/PitchBlocks.js:385
 #: js/turtleactions/DictActions.js:87
 msgid "current pitch"
 msgstr "現代の音の高さ"
 
-
 #: js/blocks/PitchBlocks.js:391
 msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
 msgstr "Current PitchブロックはPitch Converterブロックと共に使用されます。上記の例では、現在のピッチsol 4が392ヘルツとして表示されます。"
-
 
 #: js/blocks/PitchBlocks.js:433
 msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
 msgstr "このブロックは最後に演奏された音のピッチ値をヘルツ、音名、ピッチ番号などの異なる形式に変換します。"
 
-
 #: js/blocks/PitchBlocks.js:459
 msgid "alphabet"
 msgstr "アルファベット"
-
 
 #: js/blocks/PitchBlocks.js:461
 #. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "アルファベット・クラス"
 
-
 #: js/blocks/PitchBlocks.js:462
 msgid "solfege class"
 msgstr "階名"
-
 
 #: js/blocks/PitchBlocks.js:463
 msgid "staff y"
 msgstr "音部記号のｙ座標"
 
-
 #: js/blocks/PitchBlocks.js:464
 msgid "solfege syllable"
 msgstr "階名（ド、レ、ミ）"
-
 
 #: js/blocks/PitchBlocks.js:465
 msgid "pitch class"
 msgstr "ピッチ・クラス"
 
-
 #: js/blocks/PitchBlocks.js:466
 msgid "scalar class"
 msgstr "音階クラス"
-
 
 #: js/blocks/PitchBlocks.js:468
 msgid "nth degree"
 msgstr "ピッチ度"
 
-
 #: js/blocks/PitchBlocks.js:469
 msgid "pitch to shade"
 msgstr "音の高さををシェードに"
 
-
 #: js/blocks/PitchBlocks.js:470
 msgid "pitch to color"
 msgstr "音の高さを色に"
-
 
 #: js/blocks/PitchBlocks.js:666
 #: js/widgets/musickeyboard.js:856
@@ -12654,94 +10496,76 @@ msgstr "音の高さを色に"
 msgid "MIDI"
 msgstr "MIDI"
 
-
 #: js/blocks/PitchBlocks.js:679
 #. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "音高の数字を初期化"
 
-
 #: js/blocks/PitchBlocks.js:682
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr "ピッチ番号をピッチとオクターブにマッピングするためのオフセットを設定するために使われるブロックです。"
-
 
 #: js/blocks/PitchBlocks.js:721
 #. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "数字をピッチに"
 
-
 #: js/blocks/PitchBlocks.js:724
 msgid "The Number to pitch block will convert a pitch number to a pitch name."
 msgstr "「数字をピッチに」ブロックは、数字をピッチ名に変換します。"
-
 
 #: js/blocks/PitchBlocks.js:756
 #. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "数値をオクターヴ表記へ"
 
-
 #: js/blocks/PitchBlocks.js:758
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr "Number to octaveブロックはピッチ番号をオクターブに変換します。"
-
 
 #: js/blocks/PitchBlocks.js:767
 msgid "y to pitch"
 msgstr "音の高さをy座に"
 
-
 #: js/blocks/PitchBlocks.js:770
 msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
 msgstr "五線譜のy位置を対応する音高表記に変換するブロック"
-
 
 #: js/blocks/PitchBlocks.js:884
 msgid "accidental selector"
 msgstr "臨時記号セレクター"
 
-
 #: js/blocks/PitchBlocks.js:890
 msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
 msgstr "<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）から選ぶことができます。"
-
 
 #: js/blocks/PitchBlocks.js:903
 msgid "east indian solfege"
 msgstr "東インドのソルフェージュ"
 
-
 #: js/blocks/PitchBlocks.js:908
 msgid "Pitch can be specified in terms of ni dha pa ma ga re sa."
 msgstr "音の高さを、「sa、re、ga、ma、pa、dha、ni」の７つのインドのソルフェージュでせっていする。"
-
 
 #: js/blocks/PitchBlocks.js:919
 msgid "note name"
 msgstr "音名"
 
-
 #: js/blocks/PitchBlocks.js:924
 msgid "Pitch can be specified in terms of C D E F G A B."
 msgstr "<h2>音の高さブロック</h2><br>音の高さを、CDEFGABの７つのアルファベットでせっていする。たとえば、ドならばＣ、レならばＤであらわされる。"
-
 
 #: js/blocks/PitchBlocks.js:936
 msgid "solfege"
 msgstr "ソルファ"
 
-
 #: js/blocks/PitchBlocks.js:941
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
 msgstr "<h2>音の高さブロック</h2><br>音の高さを、ド、レ、ミ、ファ、ソ、ラ、シの７つのソルフェージュでせっていする。"
 
-
 #: js/blocks/PitchBlocks.js:989
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr "Invertブロックは含まれる音符を対象の音符の周りで反転させます。"
-
 
 #: js/blocks/PitchBlocks.js:996
 #: js/widgets/modewidget.js:179
@@ -12749,148 +10573,122 @@ msgstr "Invertブロックは含まれる音符を対象の音符の周りで反
 msgid "Invert"
 msgstr "転回を"
 
-
 #: js/blocks/PitchBlocks.js:1035
 #. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "転回を （奇数）"
-
 
 #: js/blocks/PitchBlocks.js:1067
 #. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "転回を （偶数）"
 
-
 #: js/blocks/PitchBlocks.js:1088
 #. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "登録"
 
-
 #: js/blocks/PitchBlocks.js:1092
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr "Registerブロックは後に続く音符のオクターブ（レジスター）を簡単に変更する方法を提供します。"
-
 
 #: js/blocks/PitchBlocks.js:1115
 #. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50セント"
 
-
 #: js/blocks/PitchBlocks.js:1146
 msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
 msgstr "<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。"
 
-
 #: js/blocks/PitchBlocks.js:1150
 #.  AUTOTRANSLATED: Google Translate
 msgid "In the example shown above, sol is shifted up to sol#. "
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "上記の例では、ソ（sol）がソ・シャープ（sol#）に半音上げられています。"
 
 #: js/blocks/PitchBlocks.js:1156
 #. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "半音で移調"
 
-
 #: js/blocks/PitchBlocks.js:1188
 msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
 msgstr "「比で移動」ブロックは 音符の中のピッチを比で移動させる。"
-
 
 #: js/blocks/PitchBlocks.js:1196
 #. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "比で移動"
 
-
 #: js/blocks/PitchBlocks.js:1287
 #. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "音階で6度下"
-
 
 #: js/blocks/PitchBlocks.js:1306
 #. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "音階で3度下"
 
-
 #: js/blocks/PitchBlocks.js:1325
 #. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "7度の音"
-
 
 #: js/blocks/PitchBlocks.js:1344
 #. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "6度の音"
 
-
 #: js/blocks/PitchBlocks.js:1363
 #. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "5度の音"
-
 
 #: js/blocks/PitchBlocks.js:1383
 #. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "４度の音"
 
-
 #: js/blocks/PitchBlocks.js:1402
 #. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "3度の音"
-
 
 #: js/blocks/PitchBlocks.js:1421
 #. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "2度の音"
 
-
 #: js/blocks/PitchBlocks.js:1462
 msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
 msgstr "<h2>調を変えるブロック</h2><br>「音符ブロック」内の音の高さを、すべて（音階内で、せっていしたすうち分だけ）上げる、または下げる。"
 
-
 #: js/blocks/PitchBlocks.js:1466
 msgid "In the example shown above, sol is shifted up to la."
 msgstr "<br><br>図の例では、ソがラに、ラがシに、シがドに…と置きかえられている。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。"
-
 
 #: js/blocks/PitchBlocks.js:1473
 #. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "調を変える"
 
-
 #: js/blocks/PitchBlocks.js:1508
 msgid "The Accidental block is used to create sharps and flats"
 msgstr "<em>変化記号</em>ブロックは <em>シャープ(嬰)</em>と<em>フラット(変)</em>を決める機能です。"
-
 
 #: js/blocks/PitchBlocks.js:1515
 #. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "変化記号無視"
 
-
 #: js/blocks/PitchBlocks.js:1638
 msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
 msgstr "<h2>ヘルツブロック</h2><br>音の高さをヘルツ（周波数の単位）でせっていする。「すうちブロック」を組み合わせて使う。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>"
 
-
 #: js/blocks/PitchBlocks.js:1742
 msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
 msgstr "Pitch Numberブロックは番号に対応した音高を再生します。例：0はC、7はG。"
-
 
 #: js/blocks/PitchBlocks.js:1776
 #: js/blocks/PitchBlocks.js:1822
@@ -12899,63 +10697,51 @@ msgstr "Pitch Numberブロックは番号に対応した音高を再生します
 msgid "nth modal pitch"
 msgstr "ピッチ度"
 
-
 #: js/blocks/PitchBlocks.js:1779
 msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
 msgstr "nth Modal Pitchはモードの半音単位の音高パターンを取り、各点をモードの度数にします。"
-
 
 #: js/blocks/PitchBlocks.js:1783
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr "1から始まり、音階の枠組みに関係なく（つまりオクターブが常に8音とは限らない）"
 
-
 #: js/blocks/PitchBlocks.js:1827
 msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
 msgstr "Nth Modal Pitchは番号を入力として受け取り、指定されたモードのnth度数を表します。0は最初の位置、1は2番目、-1は最初の前の音など。"
-
 
 #: js/blocks/PitchBlocks.js:1831
 msgid "The pitches change according to the mode specified without any need for respellings."
 msgstr "音高は指定されたモードに従って変化し、書き換えは不要です。"
 
-
 #: js/blocks/PitchBlocks.js:1874
 msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
 msgstr "スケールディグリーは音楽で一般的な表記法です。スケール内の7つの位置（1-7）を示し、臨時記号で変更可能です。"
 
-
 #: js/blocks/PitchBlocks.js:1878
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr "スケールディグリー1は、オクターブに関係なく常に与えられたスケールの最初の音です。"
-
 
 #: js/blocks/PitchBlocks.js:1902
 #. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "音階内を上る／下りる"
 
-
 #: js/blocks/PitchBlocks.js:1908
 msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
 msgstr "<h2>音階内を上る／下りるブロック</h2><br>音階内を順番に（ある一定のかんかくで）上りながら、または下りながら音をえんそうする。すうちをせっていすることで、次の音は前の音といくつちがうかが決まる。<br>たとえば、すうちを１にせっていした場合、ソの次にはラ（ソの１音上）、ファの次にはソ（ファの１音上）がえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。"
-
 
 #: js/blocks/PitchBlocks.js:1912
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
 msgstr "<br><br>たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>"
 
-
 #: js/blocks/PitchBlocks.js:1949
 msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
 msgstr "<h2>音の高さブロック</h2><br>音の高さをせっていする。名前とオクターヴの高さを決めて使う。音の周波数も同時に決まる。<br><br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br>★オクターヴの高さとは<br>同じ名前でも高さがちがう音を表すすうち。<br><br>"
-
 
 #: js/blocks/ToneBlocks.js:34
 #: js/widgets/timbre.js:858
 msgid "Oscillator"
 msgstr "オシレータ―"
-
 
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1670
@@ -12963,11 +10749,9 @@ msgstr "オシレータ―"
 msgid "partials"
 msgstr "倍音"
 
-
 #: js/blocks/ToneBlocks.js:76
 msgid "You are adding multiple oscillator blocks."
 msgstr "複数のオシレーターブロックを追加しています。"
-
 
 #: js/blocks/ToneBlocks.js:148
 #: js/widgets/timbre.js:1359
@@ -12975,22 +10759,18 @@ msgstr "複数のオシレーターブロックを追加しています。"
 msgid "duo synth"
 msgstr "シーケンサー込みシンセ"
 
-
 #: js/blocks/ToneBlocks.js:153
 msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr "Duo synthブロックは音色を定義するための二重周波数モジュレータです。"
-
 
 #: js/blocks/ToneBlocks.js:161
 #: js/widgets/timbre.js:1585
 msgid "vibrato rate"
 msgstr "ビブラートエフェクタのレート"
 
-
 #: js/blocks/ToneBlocks.js:161
 msgid "vibrato intensity"
 msgstr "ビブラートエフェクタの強度"
-
 
 #: js/blocks/ToneBlocks.js:189
 #: js/widgets/timbre.js:1343
@@ -12998,11 +10778,9 @@ msgstr "ビブラートエフェクタの強度"
 msgid "AM synth"
 msgstr "AM シンセ"
 
-
 #: js/blocks/ToneBlocks.js:193
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr "AMシンセブロックは音色を定義するための振幅変調装置です。"
-
 
 #: js/blocks/ToneBlocks.js:228
 #: js/widgets/timbre.js:1351
@@ -13010,92 +10788,75 @@ msgstr "AMシンセブロックは音色を定義するための振幅変調装�
 msgid "FM synth"
 msgstr "FM シンセ"
 
-
 #: js/blocks/ToneBlocks.js:232
 msgid "The FM synth block is a frequency modulator used to define a timbre."
 msgstr "FMシンセブロックは音色を定義するための周波数変調装置です。"
-
 
 #: js/blocks/ToneBlocks.js:266
 msgid "partial"
 msgstr "倍音"
 
-
 #: js/blocks/ToneBlocks.js:269
 msgid "The Partial block is used to specify a weight for a specific partial harmonic."
 msgstr "Partialブロックは特定の部分倍音の重みを指定するために使われます。"
-
 
 #: js/blocks/ToneBlocks.js:288
 #. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "倍音のウェートは０と１の間である必要があります。"
 
-
 #: js/blocks/ToneBlocks.js:301
 #. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "倍音ブロックが「倍音ウェートブロック」の中にある必要があります。"
 
-
 #: js/blocks/ToneBlocks.js:321
 msgid "The Weighted partials block is used to specify the partials associated with a timbre."
 msgstr "「ウェート倍音」ブロックは、ティンバーに関連付けられた部分音を指定するために使用されます。"
-
 
 #: js/blocks/ToneBlocks.js:329
 #. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ウェート倍音"
 
-
 #: js/blocks/ToneBlocks.js:386
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "Harmonicブロックは含まれる音符に倍音を追加します。"
-
 
 #: js/blocks/ToneBlocks.js:393
 #. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "ハーモニックス"
 
-
 #: js/blocks/ToneBlocks.js:434
 msgid "The Distortion block adds distortion to the pitch."
 msgstr "Distortionブロックは音程に歪みを加えます。"
-
 
 #: js/blocks/ToneBlocks.js:441
 #. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "ディストーション"
 
-
 #: js/blocks/ToneBlocks.js:490
 msgid "The Tremolo block adds a wavering effect."
 msgstr "<h2>トレモロブロック</h2><br>ゆれるような音のひびきにする。はやさで、ゆれのはやさを調節できる。<br>"
-
 
 #: js/blocks/ToneBlocks.js:492
 msgid "Tremolo makes the sound pulse louder and quieter."
 msgstr "トレモロを使用すると、音がパルスのように大きくなったり、小さくなったりします。"
 
-
 #: js/blocks/ToneBlocks.js:494
 msgid "The rate (first argument) controls how fast the sound pulses (cycles per second)."
 msgstr "レート (最初の引数) は、サウンドのパルス速度 (1 秒あたりのサイクル数) を制御します。"
-
 
 #: js/blocks/ToneBlocks.js:498
 msgid "The depth (second argument) controls the strength of the pulsing effect (0-100%)."
 msgstr "深さ (2 番目の引数) は、パルス効果の強さを制御します (0 ～ 100%)。"
 
-
 #: js/blocks/ToneBlocks.js:508
 #. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "トレモロ"
-
 
 #: js/blocks/ToneBlocks.js:513
 #: js/blocks/ToneBlocks.js:582
@@ -13109,7 +10870,6 @@ msgstr "トレモロ"
 msgid "rate"
 msgstr "はやさ"
 
-
 #: js/blocks/ToneBlocks.js:515
 #: js/blocks/ToneBlocks.js:653
 #: js/widgets/timbre.js:2340
@@ -13118,17 +10878,14 @@ msgstr "はやさ"
 msgid "depth"
 msgstr "大きさ"
 
-
 #: js/blocks/ToneBlocks.js:572
 msgid "The Phaser block adds a sweeping sound."
 msgstr "Phaserブロックはスウィープ音を加えます。"
-
 
 #: js/blocks/ToneBlocks.js:579
 #. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "フェーザー"
-
 
 #: js/blocks/ToneBlocks.js:582
 #: js/turtleactions/IntervalsActions.js:157
@@ -13136,92 +10893,75 @@ msgstr "フェーザー"
 msgid "octaves"
 msgstr "オクターヴ"
 
-
 #: js/blocks/ToneBlocks.js:582
 #: js/widgets/timbre.js:2589
 msgid "base frequency"
 msgstr "基本周波数"
 
-
 #: js/blocks/ToneBlocks.js:632
 msgid "The Chorus block adds a chorus effect."
 msgstr "<h2>コーラスブロック</h2><br>広がりのある音のひびきにする。はやさとずれで、ひびきが残る感じを調節できる。<br>"
-
 
 #: js/blocks/ToneBlocks.js:634
 msgid "The rate (first argument) controls the speed of the chorus modulation (cycles per second)."
 msgstr "レート (最初の引数) は、コーラス変調の速度 (1 秒あたりのサイクル数) を制御します。"
 
-
 #: js/blocks/ToneBlocks.js:638
 msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
 msgstr "ディレイ(第 2 引数) は、コーラスボイス間の遅延時間 (ミリ秒) を設定します。"
 
-
 #: js/blocks/ToneBlocks.js:642
 msgid "The depth (third argument) controls the amount of chorus effect (0-100%)."
 msgstr "深さ (3 番目の引数) は、コーラス・エフェクターの量 (0 ～ 100%) を制御します。"
-
 
 #: js/blocks/ToneBlocks.js:650
 #. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "コーラス"
 
-
 #: js/blocks/ToneBlocks.js:653
 #: js/widgets/timbre.js:2496
 msgid "delay (MS)"
 msgstr "ディレイ・エフェクター（ms）"
 
-
 #: js/blocks/ToneBlocks.js:701
 msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr "<h2>ビブラートブロック</h2><br>音の高さに小きざみな変化をつける。"
-
 
 #: js/blocks/ToneBlocks.js:703
 msgid "The intensity (first argument) controls how much the pitch varies (semitones)."
 msgstr "大きさ (最初の引数) は、ピッチの変化量 (半音) を制御します。"
 
-
 #: js/blocks/ToneBlocks.js:707
 msgid "The rate (second argument) controls the speed of the pitch variation (cycles per second)."
 msgstr "レート (2 番目の引数) は、ピッチ変化の速度 (1 秒あたりのサイクル数) を制御します。"
-
 
 #: js/blocks/ToneBlocks.js:717
 #. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "ビブラート"
 
-
 #: js/blocks/ToneBlocks.js:720
 #: js/widgets/timbre.js:2409
 msgid "intensity"
 msgstr "大きさ"
-
 
 #: js/blocks/ToneBlocks.js:764
 #. TRANS: select synthesizer
 msgid "set synth"
 msgstr "シンセを設定"
 
-
 #: js/blocks/ToneBlocks.js:834
 msgid "synth name"
 msgstr "シンセの名前"
-
 
 #: js/blocks/ToneBlocks.js:872
 msgid "set default instrument"
 msgstr "音色標準を設定"
 
-
 #: js/blocks/ToneBlocks.js:875
 msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
 msgstr "音色標準を設定すると、デフォルトの音色が電子シンセから選択した音色に変更されます。"
-
 
 #: js/blocks/ToneBlocks.js:925
 #: js/blocks/ToneBlocks.js:976
@@ -13229,44 +10969,36 @@ msgstr "音色標準を設定すると、デフォルトの音色が電子シン
 msgid "set instrument"
 msgstr "音色をせってい"
 
-
 #: js/blocks/ToneBlocks.js:931
 #: js/blocks/ToneBlocks.js:965
 msgid "The Set instrument block selects a voice for the synthesizer, eg guitar piano violin or cello."
 msgstr "「音色をせってい」ブロックは、シンセサイザーの音声 (ギター、ピアノ、バイオリン、チェロなど) を選択します。"
 
-
 #: js/blocks/ToneBlocks.js:959
 msgid "The Set instrument block selects a voice for the synthesizer,"
 msgstr "<h2>音色をせっていブロック</h2><br>中に入っている「音符（おんぷ）ブロック」の音色を設定する。音色は、ギターやピアノなどの中から選ぶことができる。<br><br> "
-
 
 #: js/blocks/ToneBlocks.js:1048
 msgid "Import a sound file to use as an instrument and set its pitch center."
 msgstr "音色サンプルをアップロードして、音の高さを合わせる"
 
-
 #: js/blocks/ToneBlocks.js:1143
 msgid "Upload a sound file to connect with the sample block."
 msgstr "音色サンプルをアップロードして、音の高さを合わせる"
-
 
 #: js/blocks/RhythmBlocks.js:38
 msgid "The Note value block is the value of the duration of the note currently being played."
 msgstr "「音の長さ」ブロックは、現在演奏されている音符の長さの値です。"
 
-
 #: js/blocks/RhythmBlocks.js:150
 msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
 msgstr "「Milliseconds」ブロックは、音符の長さを指定するために時間 (MS 単位) を使用することを除いて、「音符」ブロックに似ています。"
-
 
 #: js/blocks/RhythmBlocks.js:193
 #: js/blocks/RhythmBlocks.js:1085
 #: js/blocks/RhythmBlocks.js:1156
 msgid "Note value must be greater than 0."
 msgstr "音の長さは、0より大きいあたいをせっていしてください。"
-
 
 #: js/blocks/RhythmBlocks.js:218
 #: js/blocks/RhythmBlocks.js:280
@@ -13275,50 +11007,41 @@ msgstr "音の長さは、0より大きいあたいをせっていしてくだ�
 msgid "swing"
 msgstr "スイング"
 
-
 #: js/blocks/RhythmBlocks.js:342
 msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
 msgstr "「スイング」ブロックは、音符のペア (音符の値で指定) に作用し、最初の音符に一定の長さ (スイング値で指定) を追加し、2 番目の音符から同じ量を取得します。"
-
 
 #: js/blocks/RhythmBlocks.js:356
 #. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "スイングの数値"
 
-
 #: js/blocks/RhythmBlocks.js:420
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr "Skip notesブロックは音符をスキップさせます。"
-
 
 #: js/blocks/RhythmBlocks.js:428
 #. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "音符の省略"
 
-
 #: js/blocks/RhythmBlocks.js:479
 msgid "The Multiply note value block changes the duration of notes by changing their note values."
 msgstr "[音価を～倍にするファクター] ブロックは、音価を変更することで音符の長さを変更します。"
-
 
 #: js/blocks/RhythmBlocks.js:489
 #. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "音価を～倍にするファクター"
 
-
 #: js/blocks/RhythmBlocks.js:542
 msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "<h2>タイブロック</h2><br>２つの音をつなげて１つの音にする。「音の高さブロック」を入れて使う。同じ高さの音だけ、つなぐことができる。"
-
 
 #: js/blocks/RhythmBlocks.js:550
 #. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "タイ"
-
 
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:670
@@ -13326,65 +11049,53 @@ msgstr "タイ"
 msgid "dot"
 msgstr "付点音符"
 
-
 #: js/blocks/RhythmBlocks.js:619
 #: js/turtleactions/RhythmActions.js:237
 msgid "An argument of -1 results in a note value of 0."
 msgstr "ー１は０の音価にします"
 
-
 #: js/blocks/RhythmBlocks.js:660
 msgid "The Dot block extends the duration of a note by 50%."
 msgstr "Dotブロックは音符の長さを50%延長します。"
-
 
 #: js/blocks/RhythmBlocks.js:662
 msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "例：付点四分音符は1拍の3/8（1/4 + 1/8）演奏されます。"
 
-
 #: js/blocks/RhythmBlocks.js:715
 msgid "A rest of the specified note value duration can be constructed using a Silence block."
 msgstr "指定した音符の長さの休符は、「休符」ブロックを使用して構築できます。"
-
 
 #: js/blocks/RhythmBlocks.js:764
 #. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "音符（ドラム）"
 
-
 #: js/blocks/RhythmBlocks.js:828
 msgid "392 hertz"
 msgstr "３９２ヘルツ"
-
 
 #: js/blocks/RhythmBlocks.js:1113
 msgid "The Note block is a container for one or more Pitch blocks."
 msgstr "<h2>音符（おんぷ）ブロック</h2><br>音の長さと高さをせっていする。長さを決め、「音の高さブロック」を入れて使う。"
 
-
 #: js/blocks/RhythmBlocks.js:1115
 msgid "The Note block specifies the duration (note value) of its contents."
 msgstr "<br><br>「音の高さブロック」を２つ以上入れると、音を同時に出すことができる。"
-
 
 #: js/blocks/RhythmBlocks.js:1124
 msgid "value2"
 msgstr "長さ"
 
-
 #: js/blocks/RhythmBlocks.js:1190
 msgid "define frequency"
 msgstr "周波数を明確にする"
-
 
 #: js/blocks/RhythmBlocks.js:1208
 #: js/widgets/temperament.js:996
 #: js/widgets/temperament.js:1790
 msgid "octave space"
 msgstr "オクターヴ・スペース"
-
 
 #: js/blocks/GraphicsBlocks.js:46
 #: js/turtleactions/DictActions.js:77
@@ -13393,76 +11104,61 @@ msgstr "オクターヴ・スペース"
 msgid "heading"
 msgstr "向き（ネズミ）"
 
-
 #: js/blocks/GraphicsBlocks.js:56
 msgid "The Heading block returns the orientation of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミの向いている角度を表すすうちブロック。向きの値は、０以上で、３６０より小さい値になり、プラスだと右回り、マイナスだと左回りに変化する。"
-
 
 #: js/blocks/GraphicsBlocks.js:62
 msgid "The Heading block returns the orientation of the turtle."
 msgstr "ヘディングブロックはタートルの向きを返します。"
 
-
 #: js/blocks/GraphicsBlocks.js:136
 msgid "The Y block returns the vertical position of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミのｙざひょう（たて方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
-
 
 #: js/blocks/GraphicsBlocks.js:143
 msgid "The Y block returns the vertical position of the turtle."
 msgstr "Yブロックはタートルの垂直位置を返します。"
 
-
 #: js/blocks/GraphicsBlocks.js:152
 msgid "y3"
 msgstr "yざひょうち（ネズミ）"
-
 
 #: js/blocks/GraphicsBlocks.js:222
 msgid "The X block returns the horizontal position of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミのｘざひょう（よこ方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
 
-
 #: js/blocks/GraphicsBlocks.js:229
 msgid "The X block returns the horizontal position of the turtle."
 msgstr "Xブロックはタートルの水平方向の位置を返します。"
-
 
 #: js/blocks/GraphicsBlocks.js:238
 msgid "x3"
 msgstr "xざひょうち（ネズミ）"
 
-
 #: js/blocks/GraphicsBlocks.js:298
 msgid "scroll xy"
 msgstr "カンバスを動かす"
-
 
 #: js/blocks/GraphicsBlocks.js:306
 msgid "The Scroll XY block moves the canvas."
 msgstr "<h2>いどうブロック（カンバス）</h2><br>カンバスを上下左右にいどうさせる。カンバスだけがいどうするので結果的に、画面上のすべてのネズミが同時にいどうするように見える。カンバスを右（プラス）にいどうするとネズミは左へ、左（マイナス）にいどうするとネズミは右に動いて見える。同じく、カンバスを上（プラス）にいどうするとネズミは下へ、下（マイナス）にいどうするとネズミは上に動いて見える。"
 
-
 #: js/blocks/GraphicsBlocks.js:316
 msgid "x2"
 msgstr "よこいどう"
-
 
 #: js/blocks/GraphicsBlocks.js:316
 msgid "y2"
 msgstr "たていどう"
 
-
 #: js/blocks/GraphicsBlocks.js:422
 msgid "The Control-point 2 block sets the second control point for the Bezier curve."
 msgstr "コントロールポイント2ブロックはベジエ曲線の第2コントロールポイントを設定します。"
 
-
 #: js/blocks/GraphicsBlocks.js:429
 msgid "control point 2"
 msgstr "コントロール点２"
-
 
 #: js/blocks/GraphicsBlocks.js:432
 #: js/blocks/GraphicsBlocks.js:483
@@ -13471,7 +11167,6 @@ msgstr "コントロール点２"
 msgid "x1"
 msgstr "xざひょう（ネズミ）"
 
-
 #: js/blocks/GraphicsBlocks.js:432
 #: js/blocks/GraphicsBlocks.js:483
 #: js/blocks/GraphicsBlocks.js:530
@@ -13479,52 +11174,42 @@ msgstr "xざひょう（ネズミ）"
 msgid "y1"
 msgstr "yざひょう（ネズミ）"
 
-
 #: js/blocks/GraphicsBlocks.js:473
 msgid "The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr "コントロールポイント1ブロックはベジエ曲線の第1コントロールポイントを設定します。"
-
 
 #: js/blocks/GraphicsBlocks.js:480
 msgid "control point 1"
 msgstr "コントロール点１"
 
-
 #: js/blocks/GraphicsBlocks.js:523
 msgid "The Bezier block draws a Bezier curve."
 msgstr "ベジエブロックはベジエ曲線を描きます。"
-
 
 #: js/blocks/GraphicsBlocks.js:527
 msgid "bezier"
 msgstr "ベジェ曲線"
 
-
 #: js/blocks/GraphicsBlocks.js:589
 #.  AUTOTRANSLATED: Google Translate
 msgid "The Arc block moves the mouse in an arc."
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "アーブロックは、マウスを円弧状に動かします。"
 
 #: js/blocks/GraphicsBlocks.js:596
 msgid "The Arc block moves the turtle in an arc."
 msgstr "アークブロックはタートルを弧を描いて動かします。"
 
-
 #: js/blocks/GraphicsBlocks.js:605
 msgid "arc"
 msgstr "円をえがいていどう"
-
 
 #: js/blocks/GraphicsBlocks.js:608
 msgid "angle"
 msgstr "角度"
 
-
 #: js/blocks/GraphicsBlocks.js:608
 msgid "radius"
 msgstr "半径"
-
 
 #: js/blocks/GraphicsBlocks.js:626
 #: js/blocks/GraphicsBlocks.js:782
@@ -13533,7 +11218,6 @@ msgstr "半径"
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr "ラップモードがオフのとき、値は -5000 から 5000 の範囲でなければなりません。"
 
-
 #: js/blocks/GraphicsBlocks.js:631
 #: js/blocks/GraphicsBlocks.js:790
 #: js/blocks/GraphicsBlocks.js:1039
@@ -13541,46 +11225,37 @@ msgstr "ラップモードがオフのとき、値は -5000 から 5000 の範�
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr "ラップモードがオンのとき、値は -20000 から 20000 の範囲でなければなりません。"
 
-
 #: js/blocks/GraphicsBlocks.js:671
 msgid "set heading"
 msgstr "向きを変える"
-
 
 #: js/blocks/GraphicsBlocks.js:684
 msgid "The Set heading block sets the heading of the turtle."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度に変える。"
 
-
 #: js/blocks/GraphicsBlocks.js:744
 msgid "The Set XY block moves the mouse to a specific position on the screen."
 msgstr "<h2>いどうブロック</h2><br>ネズミの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
-
 
 #: js/blocks/GraphicsBlocks.js:750
 msgid "The Set XY block moves the turtle to a specific position on the screen."
 msgstr "<h2>いどうブロック</h2><br>タートルの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のタートルの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
 
-
 #: js/blocks/GraphicsBlocks.js:758
 msgid "set xy"
 msgstr "指定ざひょうにいどう"
-
 
 #: js/blocks/GraphicsBlocks.js:842
 msgid "The Right block turns the mouse to the right."
 msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度で右回りに回転させる。"
 
-
 #: js/blocks/GraphicsBlocks.js:849
 msgid "The Right block turns the turtle to the right."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度で右回りに回転させる。"
 
-
 #: js/blocks/GraphicsBlocks.js:858
 msgid "right1"
 msgstr "右を向く"
-
 
 #: js/blocks/GraphicsBlocks.js:858
 #: plugins/rodi.rtp:77
@@ -13589,21 +11264,17 @@ msgstr "右を向く"
 msgid "right"
 msgstr "ざひょうち（右）"
 
-
 #: js/blocks/GraphicsBlocks.js:922
 msgid "The Left block turns the mouse to the left."
 msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度で左回りに回転させる。"
-
 
 #: js/blocks/GraphicsBlocks.js:929
 msgid "The Left block turns the turtle to the left."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度で左回りに回転させる。"
 
-
 #: js/blocks/GraphicsBlocks.js:938
 msgid "left1"
 msgstr "左を向く"
-
 
 #: js/blocks/GraphicsBlocks.js:938
 #: plugins/rodi.rtp:79
@@ -13612,7 +11283,6 @@ msgstr "左を向く"
 msgid "left"
 msgstr "ざひょうち（左）"
 
-
 #: js/blocks/GraphicsBlocks.js:990
 #: js/widgets/temperament.js:170
 #: plugins/rodi.rtp:69
@@ -13620,16 +11290,13 @@ msgstr "ざひょうち（左）"
 msgid "back"
 msgstr "後ろへ進む"
 
-
 #: js/blocks/GraphicsBlocks.js:999
 msgid "The Back block moves the mouse backward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、ネズミを後ろにもどす。体の向きは変えない。"
 
-
 #: js/blocks/GraphicsBlocks.js:1006
 msgid "The Back block moves the turtle backward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タートルを後ろにもどす。体の向きは変えない。"
-
 
 #: js/blocks/GraphicsBlocks.js:1079
 #: plugins/rodi.rtp:71
@@ -13637,27 +11304,22 @@ msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タート�
 msgid "forward"
 msgstr "前へ進む"
 
-
 #: js/blocks/GraphicsBlocks.js:1088
 msgid "The Forward block moves the mouse forward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、ネズミを前に進める。"
 
-
 #: js/blocks/GraphicsBlocks.js:1095
 msgid "The Forward block moves the turtle forward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タートルを前に進める。"
-
 
 #: js/blocks/GraphicsBlocks.js:1203
 #: js/blocks/GraphicsBlocks.js:1221
 msgid "wrap"
 msgstr "巻きつける"
 
-
 #: js/blocks/GraphicsBlocks.js:1211
 msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
 msgstr "「巻きつける」ブロックは、その中のグラフィックス アクションの画面ラッピングを有効または無効にします。"
-
 
 #: js/turtleactions/DictActions.js:75
 #: js/turtleactions/DictActions.js:142
@@ -13665,146 +11327,118 @@ msgstr "「巻きつける」ブロックは、その中のグラフィックス
 msgid "font"
 msgstr "フォント"
 
-
 #: js/turtleactions/DictActions.js:257
 msgid "Dictionary with this name does not exist"
 msgstr "この名前の辞書は存在しません。"
-
 
 #: js/turtleactions/DictActions.js:260
 msgid "Key with this name does not exist in %s"
 msgstr "この名前のキー（調）は %s に存在しません"
 
-
 #: js/turtleactions/DrumActions.js:227
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr "音符ブロックを使いますか？"
-
 
 #: js/turtleactions/MeterActions.js:116
 #: js/turtleactions/MeterActions.js:140
 msgid "beats per minute must be greater than %s"
 msgstr "1 分あたりの拍数は %s より大きくなければなりません"
 
-
 #: js/turtleactions/MeterActions.js:124
 #: js/turtleactions/MeterActions.js:148
 msgid "maximum"
 msgstr "最大限"
-
 
 #: js/turtleactions/MeterActions.js:124
 #: js/turtleactions/MeterActions.js:148
 msgid "beats per minute is %s"
 msgstr "1 分あたりの拍数は %s です"
 
-
 #: js/turtleactions/VolumeActions.js:260
 msgid "Synth not found: %s"
 msgstr "シンセが見つかりません: %s"
-
 
 #: js/turtleactions/IntervalsActions.js:147
 msgid "one"
 msgstr "１度"
 
-
 #: js/turtleactions/IntervalsActions.js:148
 msgid "two"
 msgstr "２度"
-
 
 #: js/turtleactions/IntervalsActions.js:149
 msgid "three"
 msgstr "３度"
 
-
 #: js/turtleactions/IntervalsActions.js:150
 msgid "four"
 msgstr "４度"
-
 
 #: js/turtleactions/IntervalsActions.js:151
 msgid "five"
 msgstr "５度"
 
-
 #: js/turtleactions/IntervalsActions.js:152
 msgid "six"
 msgstr "６度"
-
 
 #: js/turtleactions/IntervalsActions.js:153
 msgid "seven"
 msgstr "７度"
 
-
 #: js/turtleactions/IntervalsActions.js:154
 msgid "eight"
 msgstr "８度"
 
-
 #: js/turtleactions/IntervalsActions.js:155
 msgid "nine"
 msgstr "９度"
-
 
 #: js/turtleactions/IntervalsActions.js:163
 #: js/turtleactions/IntervalsActions.js:185
 msgid "below"
 msgstr "下"
 
-
 #: js/turtleactions/IntervalsActions.js:167
 msgid "above"
 msgstr "上"
-
 
 #: js/turtleactions/IntervalsActions.js:177
 msgid "plus"
 msgstr "と"
 
-
 #: js/turtleactions/IntervalsActions.js:192
 #.  AUTOTRANSLATED: Google Translate
 msgid "steps"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "手順"
 
 #: js/turtleactions/IntervalsActions.js:311
 msgid "Adding missing pitch number 0."
 msgstr "ピッチ数値「0」を加える"
 
-
 #: js/turtleactions/IntervalsActions.js:339
 msgid "Ignoring duplicate pitch numbers."
 msgstr "重複しているピッチ数値は無視します"
-
 
 #: js/turtleactions/PitchActions.js:288
 msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
 msgstr "音階的な移調は、カスタム音律の半音移調と同じです。"
 
-
 #: js/turtleactions/OrnamentActions.js:49
 msgid "Staccato value must be non-zero."
 msgstr "スタッカート値はゼロ以外でなければなりません。"
-
 
 #: js/turtleactions/OrnamentActions.js:79
 msgid "Slur value must be non-zero."
 msgstr "スラー値はゼロ以外でなければなりません。"
 
-
 #: js/turtleactions/ToneActions.js:136
 msgid "Vibrato intensity must be between 1 and 100."
 msgstr "ビブラートの大きさは、1から100までのはんいでせっていしてください。"
 
-
 #: js/turtleactions/ToneActions.js:142
 msgid "Vibrato rate must be greater than 0."
 msgstr "ビブラートのはやさは、0より大きいあたいをせっていしてください。"
-
 
 #: js/turtleactions/ToneActions.js:195
 #: js/turtleactions/ToneActions.js:268
@@ -13812,22 +11446,18 @@ msgstr "ビブラートのはやさは、0より大きいあたいをせって�
 msgid "Depth is out of range."
 msgstr "（エフェクタの）深さの数字が変域外です。"
 
-
 #: js/turtleactions/ToneActions.js:304
 msgid "Distortion must be from 0 to 100."
 msgstr "ディストーションは、0から100までのはんいでせっていしてください。"
-
 
 #: js/widgets/temperament.js:1843
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr "オクターヴ比が変わりました。これにより調律が大きく変わります。"
 
-
 #: js/turtleactions/ToneActions.js:335
 #. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "倍音が０以上である必要があります。"
-
 
 #: js/turtleactions/ToneActions.js:381
 #: js/turtleactions/ToneActions.js:420
@@ -13836,180 +11466,145 @@ msgstr "倍音が０以上である必要があります。"
 msgid "Unable to use synth due to existing oscillator."
 msgstr "既存のオシレーターがあるためシンセは使用できません。"
 
-
 #: js/turtleactions/ToneActions.js:391
 #: js/turtleactions/ToneActions.js:430
 msgid "The input cannot be negative."
 msgstr "マイナスの数値をいれることはできません。"
 
-
 #: js/turtleactions/RhythmActions.js:151
 #.  AUTOTRANSLATED: Google Translate
 msgid "Neighbor note value is too large for the current note duration."
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "ネイバーノートの値が、現在の音符の長さに比べて大きすぎます。"
 
 #: js/widgets/jseditor.js:393
 msgid "Reset Code"
 msgstr "コードをリセット"
 
-
 #: js/widgets/jseditor.js:421
 msgid "Convert JavaScript to Blocks"
 msgstr "JavaScript をブロックに変換する"
-
 
 #: js/widgets/jseditor.js:555
 msgid "Toggle Console"
 msgstr "コンソールの切り替え"
 
-
 #: js/widgets/jseditor.js:984
 msgid "JavaScript block conversion is unavailable because its configuration file failed to load."
 msgstr "JavaScript ブロック変換は、構成ファイルのロードに失敗したため使用できません。"
-
 
 #: js/widgets/jseditor.js:987
 msgid "JavaScript block conversion is still loading. Please try again."
 msgstr "JavaScript ブロック変換はまだ読み込み中です。もう一度試してください。"
 
-
 #: js/widgets/plugin-dialog.js:76
 msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "組み込みプラグインの名前を入力するか、空白のままにしてプラグイン ファイルをアップロードします。"
-
 
 #: js/widgets/widgetWindows.js:221
 msgid "Close window"
 msgstr "ウィンドウを閉じる"
 
-
 #: js/widgets/widgetWindows.js:267
 msgid "Minimize"
 msgstr "最小化する"
-
 
 #: js/widgets/widgetWindows.js:269
 msgid "Roll up window"
 msgstr "ウィンドウをロールアップする"
 
-
 #: js/widgets/widgetWindows.js:289
 msgid "Maximize window"
 msgstr "ウィンドウを最大化する"
-
 
 #: js/widgets/aidebugger.js:165
 msgid "Reset conversation"
 msgstr "会話をリセット"
 
-
 #: js/widgets/aidebugger.js:170
 msgid "Export chat"
 msgstr "チャットをエクスポートする"
-
 
 #: js/widgets/aidebugger.js:178
 msgid "Debugger initialized"
 msgstr "デバッガが初期化されました"
 
-
 #: js/widgets/aidebugger.js:388
 msgid "AI Debugger backend is not configured for this host."
 msgstr "AI デバッガー バックエンドはこのホスト用に構成されていません。"
-
 
 #: js/widgets/aidebugger.js:403
 msgid "Debugger error: Could not prepare project data."
 msgstr "デバッガー エラー: プロジェクト データを準備できませんでした。"
 
-
 #: js/widgets/aidebugger.js:449
 msgid "Server error: Invalid response from AI backend."
 msgstr "サーバー エラー: AI バックエンドからの無効な応答。"
-
 
 #: js/widgets/aidebugger.js:458
 msgid "Server error: Unable to connect to AI backend."
 msgstr "サーバー エラー: AI バックエンドに接続できません。"
 
-
 #: js/widgets/aidebugger.js:466
 #: js/widgets/aidebugger.js:738
 #.  AUTOTRANSLATED: Google Translate
 msgid "Could not reach the AI assistant. Please check your connection and try again."
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "AIアシスタントに接続できませんでした。接続状況を確認し、もう一度お試しください。"
 
 #: js/widgets/aidebugger.js:552
 msgid "Before we start"
 msgstr "始める前に"
 
-
 #: js/widgets/aidebugger.js:556
 msgid "The AI Debugger will send your current project data to an external server for analysis. Your project blocks and structure will be shared with:"
 msgstr "AI デバッガーは、分析のために現在のプロジェクト データを外部サーバーに送信します。プロジェクトのブロックと構造は以下と共有されます。"
-
 
 #: js/widgets/aidebugger.js:570
 msgid "Analyze my project"
 msgstr "私のプロジェクトを分析してください"
 
-
 #: js/widgets/aidebugger.js:599
 msgid "AI analysis was not started. You can type a question below, but project data will not be sent until you agree."
 msgstr "AI解析は開始されていません。以下に質問を入力できますが、同意するまでプロジェクト データは送信されません。"
-
 
 #: js/widgets/aidebugger.js:629
 msgid "Debugger error: Invalid project data format."
 msgstr "デバッガー エラー: 無効なプロジェクト データ形式です。"
 
-
 #: js/widgets/aidebugger.js:646
 msgid "Debugger error: Could not load project data."
 msgstr "デバッガ エラー: プロジェクト データをロードできませんでした。"
-
 
 #: js/widgets/aidebugger.js:670
 msgid "AI Debugger is not available on this host. The backend URL could not be determined."
 msgstr "AI デバッガーはこのホストでは使用できません。バックエンド URL を特定できませんでした。"
 
-
 #: js/widgets/aidebugger.js:723
 msgid "Server error: No initial response from AI backend."
 msgstr "サーバー エラー: AI バックエンドからの初期応答がありません。"
-
 
 #: js/widgets/aidebugger.js:730
 msgid "Server error: Failed to initialize AI debugger."
 msgstr "サーバー エラー: AI デバッガーの初期化に失敗しました。"
 
-
 #: js/widgets/aidebugger.js:762
 msgid "Conversation reset."
 msgstr "会話がリセットされました。"
-
 
 #: js/widgets/aidebugger.js:771
 msgid "No conversation to export."
 msgstr "エクスポートする会話はありません。"
 
-
 #: js/widgets/aidebugger.js:786
 msgid "Debugger error: Could not retrieve project data for export."
 msgstr "デバッガー エラー: エクスポートするプロジェクト データを取得できませんでした。"
-
 
 #: js/widgets/aidebugger.js:818
 msgid "Chat exported successfully."
 msgstr "チャットは正常にエクスポートされました。"
 
-
 #: js/widgets/aidebugger.js:867
 msgid "Chat cleared."
 msgstr "チャットがクリアされました。"
-
 
 #: js/widgets/aiwidget.js:136
 #: js/widgets/aiwidget.js:137
@@ -14025,145 +11620,117 @@ msgstr "チャットがクリアされました。"
 msgid "Pause"
 msgstr "止める"
 
-
 #: js/widgets/aiwidget.js:181
 #: js/widgets/sampler.js:298
 msgid "Warning: Sample is bigger than 1MB."
 msgstr "ワーニング：サンプルは１MBより大きいです。"
 
-
 #: js/widgets/aiwidget.js:649
 msgid "New start block generated."
 msgstr "新しい開始ブロックが生成されました。"
 
-
 #: js/widgets/aiwidget.js:651
 msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
 msgstr "「MIDI]を読み込み中です。音符の数とトラックの数によって時間がかかるかもしれません。"
-
 
 #: js/widgets/aiwidget.js:660
 #: js/widgets/sampler.js:323
 msgid "Upload failed: Sample is not a .wav file."
 msgstr "アップロードできませんでした： サンプルは .wavファイルでは ありません。"
 
-
 #: js/widgets/aiwidget.js:792
 msgid "Generate blocks"
 msgstr "ブロックを生成する"
-
 
 #: js/widgets/aiwidget.js:804
 msgid "Set API Key"
 msgstr "APIキーの設定"
 
-
 #: js/widgets/aiwidget.js:807
 msgid "Enter your Groq API Key: %s"
 msgstr "Groq API キーを入力してください: %s"
-
 
 #: js/widgets/aiwidget.js:875
 msgid "Synth error: %s"
 msgstr "シンセのエラー: %s"
 
-
 #: js/widgets/aiwidget.js:878
 msgid "Audio not supported in this browser."
 msgstr "このブラウザでは音声がサポートされていません。"
 
-
 #: js/widgets/aiwidget.js:1108
 msgid "Please set your Groq API Key using the settings button (wrench icon) first."
 msgstr "まず設定ボタン (レンチアイコン) を使用して Groq API キーを設定してください。"
-
 
 #: js/widgets/legobricks.js:355
 #: js/widgets/phrasemaker.js:683
 msgid "Export"
 msgstr "テーブルをほぞん"
 
-
 #: js/widgets/legobricks.js:363
 msgid "Upload Image"
 msgstr "画像をアップロードする"
-
 
 #: js/widgets/legobricks.js:369
 msgid "Webcam"
 msgstr "ウェブカメラ"
 
-
 #: js/widgets/legobricks.js:409
 msgid "LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, Instrument)"
 msgstr "レゴブロック - %s ピッチ行を含むフレーズ・メーカー (周波数、音声順に並べ替え)"
-
 
 #: js/widgets/legobricks.js:856
 msgid "No color data to save. Please scan an image first."
 msgstr "保存するカラー データがありません。まず画像をスキャンしてください。"
 
-
 #: js/widgets/legobricks.js:864
 msgid "No notes detected from color scanning."
 msgstr "カラー スキャンではメモが検出されませんでした。"
-
 
 #: js/widgets/legobricks.js:877
 msgid "LEGO phrase"
 msgstr "レゴ のフレーズ"
 
-
 #: js/widgets/legobricks.js:989
 msgid "LEGO phrase saved as action blocks with %s notes."
 msgstr "レゴ フレーズは %s 音符を含む「アクション」ブロックとして保存されました。"
-
 
 #: js/widgets/legobricks.js:1212
 msgid "Exporting phrase data: %s"
 msgstr "フレーズ データをエクスポートしています: %s"
 
-
 #: js/widgets/legobricks.js:1229
 msgid "Phrase cleared"
 msgstr "フレーズをクリアしました"
-
 
 #: js/widgets/legobricks.js:1269
 msgid "Image uploaded successfully"
 msgstr "画像が正常にアップロードされました"
 
-
 #: js/widgets/legobricks.js:1323
 #.  AUTOTRANSLATED: Google Translate
 msgid "Photo captured"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "写真を撮影しました"
 
 #: js/widgets/legobricks.js:1328
 msgid "Webcam started"
 msgstr "ウェブカメラが開始されました"
 
-
 #: js/widgets/legobricks.js:1331
 msgid "Webcam access denied: %s"
 msgstr "ウェブカメラへのアクセスが拒否されました: %s"
-
 
 #: js/widgets/legobricks.js:1388
 msgid "Eye dropper active - hover over image to preview colors, click to select background color."
 msgstr "スポイトがアクティブ - 画像の上にカーソルを置くと色がプレビューされ、クリックして背景色を選択できます。"
 
-
 #: js/widgets/legobricks.js:1449
 msgid "Background color selected: %s"
 msgstr "選択された背景色: %s"
 
-
 #: js/widgets/legobricks.js:1452
 msgid "Could not sample color - please try clicking on the image."
 msgstr "カラーのサンプルができませんでした - 画像をクリックしてみてください。"
-
 
 #: js/widgets/legobricks.js:1935
 #: js/widgets/legobricks.js:2078
@@ -14171,11 +11738,9 @@ msgstr "カラーのサンプルができませんでした - 画像をクリッ
 msgid "Instrument changed to: %s"
 msgstr "音声は次のように変更されました: %s"
 
-
 #: js/widgets/legobricks.js:2234
 msgid "Scanning image with vertical lines..."
 msgstr "画像をスキャンすると縦線が入ります..."
-
 
 #: js/widgets/meterwidget.js:198
 #: js/widgets/meterwidget.js:199
@@ -14189,27 +11754,22 @@ msgstr "画像をスキャンすると縦線が入ります..."
 msgid "Play all"
 msgstr "全てさいせい"
 
-
 #: js/widgets/meterwidget.js:286
 #: js/widgets/sampler.js:1287
 msgid "Reset"
 msgstr "リセット"
 
-
 #: js/widgets/meterwidget.js:312
 msgid "Click in the circle to select strong beats for the meter."
 msgstr "クリックで強い拍の位置を選べます。"
-
 
 #: js/widgets/modewidget.js:170
 msgid "Rotate counter clockwise"
 msgstr "左回りにずれる"
 
-
 #: js/widgets/modewidget.js:176
 msgid "Rotate clockwise"
 msgstr "右回りにずれる"
-
 
 #: js/widgets/modewidget.js:182
 #: js/widgets/pitchstaircase.js:795
@@ -14218,12 +11778,10 @@ msgstr "右回りにずれる"
 msgid "Undo"
 msgstr "１つもどす"
 
-
 #: js/widgets/modewidget.js:200
 #. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "クリックで音の高さを選んで音階を設定できます。"
-
 
 #: js/widgets/modewidget.js:1015
 #: js/widgets/phrasemaker.js:5131
@@ -14236,58 +11794,47 @@ msgstr "クリックで音の高さを選んで音階を設定できます。"
 msgid "New action block generated."
 msgstr "新しいアクションを作りました。"
 
-
 #: js/widgets/oscilloscope.js:81
 msgid "Zoom In"
 msgstr "ズームイン"
-
 
 #: js/widgets/oscilloscope.js:89
 msgid "Zoom Out"
 msgstr "ズームアウト"
 
-
 #: js/widgets/phrasemaker.js:687
 msgid "Sort"
 msgstr "ならべなおす"
-
 
 #: js/widgets/phrasemaker.js:690
 #: js/widgets/musickeyboard.js:846
 msgid "Add note"
 msgstr "音符を足す"
 
-
 #: js/widgets/phrasemaker.js:1195
 msgid "Click on the table to add notes."
 msgstr "ます目をクリックするとメロディやリズムを作れます。"
-
 
 #: js/widgets/phrasemaker.js:2954
 #: js/widgets/phrasemaker.js:3107
 msgid "tuplet value"
 msgstr "何連符価"
 
-
 #: js/widgets/pitchslider.js:162
 msgid "Move up"
 msgstr "上げる"
-
 
 #: js/widgets/pitchslider.js:173
 msgid "Move down"
 msgstr "下げる"
 
-
 #: js/widgets/pitchslider.js:195
 msgid "Use the up/down buttons or arrow keys to change pitch."
 msgstr "ピッチを変更するには、上下ボタンまたは矢印キーを使用します。"
 
-
 #: js/widgets/pitchslider.js:196
 msgid "Click on the slider to create a note block."
 msgstr "スライダーで音の高さを変えます。"
-
 
 #: js/widgets/pitchstaircase.js:402
 #: js/widgets/pitchstaircase.js:738
@@ -14295,90 +11842,73 @@ msgstr "スライダーで音の高さを変えます。"
 msgid "Play chord"
 msgstr "和音を再生する"
 
-
 #: js/widgets/pitchstaircase.js:445
 #: js/widgets/pitchstaircase.js:758
 #: js/widgets/pitchstaircase.js:768
 msgid "Play scale"
 msgstr "音階を再生する"
 
-
 #: js/widgets/pitchstaircase.js:810
 msgid "Click on a note to create a new step."
 msgstr "ピッチをクリックすると新しい段が作れますよ。"
-
 
 #: js/widgets/reflection.js:142
 msgid "Summary"
 msgstr "まとめ"
 
-
 #: js/widgets/reflection.js:160
 msgid "Talk with Rohan"
 msgstr "ロハンさんと話す"
-
 
 #: js/widgets/reflection.js:167
 msgid "Talk with Alan"
 msgstr "アランさんと話す"
 
-
 #: js/widgets/reflection.js:174
 msgid "Talk with Beethoven"
 msgstr "ベートーヴェンさんとの話す"
-
 
 #: js/widgets/reflection.js:181
 msgid "Refresh"
 msgstr "リフレッシュ"
 
-
 #: js/widgets/reflection.js:231
 msgid "Reflect on your project."
 msgstr "自分のプロジェクトを振り返ってください。"
-
 
 #: js/widgets/reflection.js:378
 #: js/widgets/reflection.js:626
 msgid "Failed to send message."
 msgstr "メッセージの送信に失敗しました。"
 
-
 #: js/widgets/reflection.js:455
 msgid "No changes were detected in your project."
 msgstr "プロジェクト内で変更は検出されませんでした。"
-
 
 #: js/widgets/reflection.js:716
 msgid "No conversation to save."
 msgstr "保存できる会話はありません。"
 
-
 #: js/widgets/rhythmruler.js:664
 msgid "Save rhythms"
 msgstr "リズムだけをほぞん"
 
-
 #: js/widgets/rhythmruler.js:687
 msgid "Save drum machine"
 msgstr "ドラムとしてほぞん"
-
 
 #: js/widgets/rhythmruler.js:748
 #. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "リズムをタップする"
 
-
 #: js/widgets/rhythmruler.js:764
 msgid "Circular view"
 msgstr "円形ビュー"
 
-
 #: js/widgets/rhythmruler.js:999
 msgid "Click on the ruler to divide it."
 msgstr "クリックするとリズムをわけることができます。"
-
 
 #: js/widgets/rhythmruler.js:1167
 #: js/widgets/rhythmruler.js:1367
@@ -14386,62 +11916,50 @@ msgstr "クリックするとリズムをわけることができます。"
 msgid "tap a rhythm"
 msgstr "リズムをタップする"
 
-
 #: js/widgets/rhythmruler.js:1680
 msgid "Maximum value of 256 has been exceeded."
 msgstr "リズムメーカーの音の長さは、最大２５６です。"
-
 
 #: js/widgets/tempo.js:125
 msgid "Save tempo"
 msgstr "テンポを保存"
 
-
 #: js/widgets/tempo.js:162
 msgid "speed up"
 msgstr "速くする"
-
 
 #: js/widgets/tempo.js:171
 msgid "slow down"
 msgstr "遅くする"
 
-
 #: js/widgets/tempo.js:218
 msgid "Adjust the tempo with the buttons."
 msgstr "１分あたりの拍数でテンポを決められます。"
 
-
 #: js/widgets/tempo.js:311
 msgid "Please enter a number between 30 and 1000"
 msgstr "３０から１０００までの数字を入力してください。"
-
 
 #: js/widgets/tempo.js:318
 #: js/widgets/tempo.js:321
 msgid "The beats per minute must be between 30 and 1000."
 msgstr "1分あたりの拍の数は、30から1000までのはんいでせっていしてください。"
 
-
 #: js/widgets/tempo.js:337
 msgid "The beats per minute must be below 1000."
 msgstr "1分あたりの拍の数は、最大1000です。"
-
 
 #: js/widgets/tempo.js:353
 msgid "The beats per minute must be above 30"
 msgstr "１分あたりの拍の数には、３０より大きいあたいをせっていしてください。"
 
-
 #: js/widgets/arpeggio.js:251
 msgid "Click in the grid to add steps to the arpeggio."
 msgstr "テーブルを クリックでアルペジオのピッチを加える。"
 
-
 #: js/widgets/help.js:65
 msgid "Start by dragging a block from the left panel and connect it to the Start block."
 msgstr "はじめに左側のパネルからブロックをドラッグして、それを「スタート」ブロックに接続します。"
-
 
 #: js/widgets/help.js:104
 #: js/widgets/help.js:142
@@ -14452,7 +11970,6 @@ msgstr "はじめに左側のパネルからブロックをドラッグして、
 msgid "Next"
 msgstr "次"
 
-
 #: js/widgets/help.js:111
 #: js/widgets/help.js:148
 #: js/widgets/help.js:149
@@ -14462,7 +11979,6 @@ msgstr "次"
 msgid "Previous"
 msgstr "前の"
 
-
 #: js/widgets/help.js:135
 #: js/widgets/help.js:172
 #: js/widgets/help.js:202
@@ -14470,77 +11986,63 @@ msgstr "前の"
 msgid "Take a tour"
 msgstr "ツアーを始めよう"
 
-
 #: js/widgets/help.js:255
 #: js/widgets/help.js:801
 msgid "Show Palette containing the block"
 msgstr "ブロックを含むパレットを表示"
-
 
 #: js/widgets/help.js:337
 #: js/widgets/help.js:873
 msgid "Load this block"
 msgstr "このブロックをロードします"
 
-
 #: js/widgets/help.js:352
 msgid "This block is only available in advance mode"
 msgstr "このブロックはアドバンスモードでのみ利用可能です"
-
 
 #: js/widgets/help.js:881
 msgid "This block is only available in advance mode."
 msgstr "このブロックはアドバンスモードでのみ使用できます。"
 
-
 #: js/widgets/musickeyboard.js:865
 msgid "Metronome"
 msgstr "メトロノーム"
-
 
 #: js/widgets/musickeyboard.js:1793
 msgid "Note value"
 msgstr "ノートの値"
 
-
 #: js/widgets/musickeyboard.js:2296
 msgid "All 12 pitches are already in the keyboard. Adding duplicate."
 msgstr "12個のピッチ、すべてがすでにキーボードに組み込まれています。重複を追加します。"
 
-
 #: js/widgets/musickeyboard.js:3547
 msgid "New action blocks generated."
 msgstr "新しいアクションを作りました。"
-
 
 #: js/widgets/musickeyboard.js:3681
 #: js/widgets/musickeyboard.js:3689
 msgid "MIDI device present."
 msgstr "MIDIデバイスが見つかりました。"
 
-
 #: js/widgets/musickeyboard.js:3692
 msgid "No MIDI device found."
 msgstr "MIDIデバイスが見つかりません。"
 
-
 #: js/widgets/musickeyboard.js:3702
 msgid "Failed to get MIDI access in browser."
 msgstr "ブラウザはMIDIのアクセスができませんでした。"
-
 
 #: js/widgets/pitchdrummatrix.js:377
 #: js/widgets/pitchdrummatrix.js:722
 msgid "Click in the grid to map notes to drums."
 msgstr "グラフにクリックして音符をどちらのドラムに変えるか決めることができます。"
 
-
 #: js/widgets/temperament.js:170
 #: js/widgets/temperament.js:1193
 #: js/widgets/temperament.js:1357
 msgid "preview"
 msgstr "試す"
-
 
 #: js/widgets/temperament.js:174
 #: js/widgets/temperament.js:680
@@ -14552,21 +12054,17 @@ msgstr "試す"
 msgid "done"
 msgstr "終った"
 
-
 #: js/widgets/temperament.js:391
 msgid "back to 2:1 octave space"
 msgstr "2:1 オクターヴ・スペースに戻る"
-
 
 #: js/widgets/temperament.js:534
 msgid "edit"
 msgstr "編集する"
 
-
 #: js/widgets/temperament.js:657
 msgid "cents"
 msgstr "セント"
-
 
 #: js/widgets/temperament.js:793
 #: js/widgets/temperament.js:798
@@ -14574,207 +12072,167 @@ msgstr "セント"
 msgid "ratio"
 msgstr "比率"
 
-
 #: js/widgets/temperament.js:799
 msgid "interval"
 msgstr "音と音の間の間隔"
-
 
 #: js/widgets/temperament.js:946
 msgid "non scalar"
 msgstr "音階内ではない"
 
-
 #: js/widgets/temperament.js:996
 msgid "ratios"
 msgstr "比率"
-
 
 #: js/widgets/temperament.js:996
 msgid "arbitrary"
 msgstr "自由意思"
 
-
 #: js/widgets/temperament.js:1091
 msgid "number of divisions"
 msgstr "分配の数"
-
 
 #: js/widgets/temperament.js:1129
 msgid "The Number of divisions is too large."
 msgstr "分割数が大きすぎます。"
 
-
 #: js/widgets/temperament.js:1261
 msgid "recursion"
 msgstr "反復"
 
-
 #: js/widgets/temperament.js:1300
 #.  AUTOTRANSLATED: Google Translate
 msgid "Please enter a valid ratio (e.g. 3:2) within the octave space."
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "オクターブの範囲内で、有効な比率（例：3:2）を入力してください。"
 
 #: js/widgets/temperament.js:1832
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr "オクターブ比が変わりました。これにより調律が大きく変わります。"
 
-
 #: js/widgets/temperament.js:1876
 msgid "Invalid temperament: %s. Skipping to next temperament."
 msgstr "無効な音律: %s。次の音律にスキップします。"
-
 
 #: js/widgets/temperament.js:2563
 msgid "Table"
 msgstr "グリッド"
 
-
 #: js/widgets/temperament.js:2623
 msgid "Invalid temperament interval data. Skipping note %s."
 msgstr "無効な音律間隔データです。%sのピッチ をスキップします。"
-
 
 #: js/widgets/temperament.js:2694
 msgid "Add pitches"
 msgstr "音高を足す"
 
-
 #: js/widgets/sampler.js:307
 msgid "Recording started"
 msgstr "録音開始"
-
 
 #: js/widgets/sampler.js:315
 msgid "Recording complete"
 msgstr "録音完了"
 
-
 #: js/widgets/sampler.js:366
 msgid "A new sample block was generated."
 msgstr "新しい「音色サンプル」ブロックが作りました"
 
-
 #: js/widgets/sampler.js:407
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr "ワーニング：音色サンプルは> 1MBであるため 読み込むことができません。"
-
 
 #: js/widgets/sampler.js:578
 #: js/widgets/sampler.js:1106
 msgid "Tuner stopped."
 msgstr "チューナーが停止しました。"
 
-
 #: js/widgets/sampler.js:602
 msgid "Upload sample"
 msgstr "音色サンプルをアップロード"
-
 
 #: js/widgets/sampler.js:657
 msgid "Save sample"
 msgstr "音色 サンプルを 保存"
 
-
 #: js/widgets/sampler.js:670
 msgid "Toggle Mic"
 msgstr "マイクの切り替え"
-
 
 #: js/widgets/sampler.js:672
 msgid "Playback"
 msgstr "再生"
 
-
 #: js/widgets/sampler.js:674
 msgid "Prompt"
 msgstr "プロンプト"
 
-
 #: js/widgets/sampler.js:732
 #.  AUTOTRANSLATED: Google Translate
 msgid "AI Sample Generation"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "AIによるサンプル生成"
 
 #: js/widgets/sampler.js:798
 msgid "Generating audio... (It may take up to 1 minute)"
 msgstr "新しい音声を生成しています... (最大 1 分かかる場合があります)"
 
-
 #: js/widgets/sampler.js:801
 msgid "Generating audio..."
 msgstr "新しい音声を生成しています..."
-
 
 #: js/widgets/sampler.js:811
 msgid "Audio ready!"
 msgstr "新しい音声の準備完了！"
 
-
 #: js/widgets/sampler.js:816
 msgid "Failed to generate audio."
 msgstr "音声の生成に失敗しました。"
 
-
 #: js/widgets/sampler.js:822
 msgid "An error occurred."
 msgstr "エラーが発生しました。"
-
 
 #: js/widgets/sampler.js:920
 #: js/widgets/sampler.js:2232
 msgid "Tuner"
 msgstr "チューナー"
 
-
 #: js/widgets/sampler.js:1030
 msgid "Chromatic"
 msgstr "クロマチック"
-
 
 #: js/widgets/sampler.js:1042
 msgid "Target pitch"
 msgstr "目標ピッチ"
 
-
 #: js/widgets/sampler.js:1104
 msgid "Tuner started."
 msgstr "チューナーが起動しました。"
-
 
 #: js/widgets/sampler.js:1115
 msgid "Cents adjustment"
 msgstr "セント調整"
 
-
 #: js/widgets/sampler.js:2211
 msgid "Microphone access failed: %s"
 msgstr "マイクアクセスに失敗しました: %s"
-
 
 #: js/widgets/sampler.js:2239
 msgid "Start"
 msgstr "スタート"
 
-
 #: js/widgets/sampler.js:2251
 #.  AUTOTRANSLATED: Google Translate
 msgid "Detected Pitch:"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "検出されたピッチ:"
 
 #: js/widgets/sampler.js:2260
 #.  AUTOTRANSLATED: Google Translate
 msgid "Note:"
-msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
-
+msgstr "音符:"
 
 #: js/widgets/timbre.js:839
 msgid "Synthesizer"
 msgstr "シンセサイザー"
-
 
 #: js/widgets/timbre.js:947
 #: planet/js/GlobalTag.js:48
@@ -14782,124 +12240,100 @@ msgstr "シンセサイザー"
 msgid "Effects"
 msgstr "音響効果"
 
-
 #: js/widgets/timbre.js:999
 msgid "Add filter"
 msgstr "フィルターを加える"
-
 
 #: js/widgets/timbre.js:1036
 msgid "Click on buttons to open the timbre design tools."
 msgstr "ボタンをクリックするとカスタム音色ツールが開きます。"
 
-
 #: js/widgets/timbre.js:1410
 msgid "harmonicity"
 msgstr "倍音の音色"
-
 
 #: js/widgets/timbre.js:1474
 #: js/widgets/timbre.js:1540
 msgid "modulation index"
 msgstr "モジュレーションインデックス"
 
-
 #: js/widgets/timbre.js:1594
 msgid "vibrato amount"
 msgstr "ビブラートの速さ"
-
 
 #: js/widgets/timbre.js:2074
 msgid "Filter already present."
 msgstr "フィルターは もう 存在しています。"
 
-
 #: js/widgets/timbre.js:2664
 msgid "distortion amount"
 msgstr "ディストーションの大きさ"
 
-
 #: planet/js/GlobalCard.js:50
 msgid "More Details"
 msgstr "さらに詳しく"
-
 
 #: planet/js/GlobalCard.js:53
 #: planet/js/SaveInterface.js:34
 msgid "Open in Music Blocks"
 msgstr "ミュージック・ブロックスで開きます"
 
-
 #: planet/js/GlobalCard.js:64
 msgid "Share project"
 msgstr "プロジェクトをシェアする"
-
 
 #: planet/js/GlobalCard.js:70
 msgid "Share"
 msgstr "シェア"
 
-
 #: planet/js/GlobalCard.js:72
 msgid "Copy link to clipboard"
 msgstr "リンクをクリップボードにコピー"
-
 
 #: planet/js/GlobalCard.js:76
 msgid "Flags"
 msgstr "旗"
 
-
 #: planet/js/GlobalCard.js:77
 msgid "Run project on startup."
 msgstr "起動時にプロジェクトを実行します。"
-
 
 #: planet/js/GlobalCard.js:80
 msgid "Show code blocks on startup."
 msgstr "起動時にコード ブロックを表示します。"
 
-
 #: planet/js/GlobalCard.js:83
 msgid "Collapse code blocks on startup."
 msgstr "起動時にコード ブロックを折りたたむ。"
-
 
 #: planet/js/GlobalCard.js:90
 msgid "Advanced Options"
 msgstr "詳細オプション"
 
-
 #: planet/js/GlobalCard.js:238
 msgid "Link copied to clipboard!"
 msgstr "リンクがクリップボードにコピーされました!"
-
 
 #: planet/js/GlobalCard.js:245
 msgid "Failed to copy link to clipboard"
 msgstr "リンクをクリップボードにコピーできませんでした"
 
-
 #: planet/js/GlobalPlanet.js:36
 msgid "No results found."
 msgstr "検索の結果に何もはありません"
-
 
 #: planet/js/GlobalPlanet.js:52
 msgid "Remix of"
 msgstr "のリミックス"
 
-
 #: planet/js/GlobalPlanet.js:508
 msgid "Cannot connect to server"
 msgstr "サーバに接続できません"
-
 
 #: planet/js/GlobalTag.js:26
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "全てのプロジェクト"
-
 
 #: planet/js/GlobalTag.js:28
 #: planet/js/StringHelper.js:36
@@ -14907,99 +12341,81 @@ msgstr "全てのプロジェクト"
 msgid "My Projects"
 msgstr "自分のプロジェクト"
 
-
 #: planet/js/GlobalTag.js:30
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "プロジェクトの見本"
-
 
 #: planet/js/GlobalTag.js:34
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "アート"
 
-
 #: planet/js/GlobalTag.js:36
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "算数"
-
 
 #: planet/js/GlobalTag.js:38
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "インタラクティブ"
 
-
 #: planet/js/GlobalTag.js:40
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "デザイン"
-
 
 #: planet/js/GlobalTag.js:42
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ゲーム"
 
-
 #: planet/js/GlobalTag.js:50
 #. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "短いコード"
 
-
 #: planet/js/LocalCard.js:36
 msgid "View published project"
 msgstr "公開されたプロジェクトを見る"
-
 
 #: planet/js/LocalCard.js:44
 #: planet/js/StringHelper.js:37
 msgid "Publish project"
 msgstr "プロジェクトを公開する"
 
-
 #: planet/js/LocalCard.js:55
 msgid "Edit project"
 msgstr "プロジェクトを編集する"
-
 
 #: planet/js/LocalCard.js:58
 msgid "Delete project"
 msgstr "プロジェクトを消す"
 
-
 #: planet/js/LocalCard.js:61
 msgid "Download project"
 msgstr "プロジェクトをダウンロードする"
-
 
 #: planet/js/LocalCard.js:67
 msgid "Duplicate project"
 msgstr "プロジェクトをコピーする"
 
-
 #: planet/js/Planet.js:139
 msgid "New Project"
 msgstr "新しいプロジェクト"
-
 
 #: planet/js/Planet.js:147
 msgid "Unsaved changes will be lost. Are you sure?"
 msgstr "保存されていない変更は失われます。本気ですか？"
 
-
 #: planet/js/ProjectViewer.js:29
 msgid "Error: Report could not be submitted. Try again later."
 msgstr "エラー：通報ができませんでした。後で再度試してください。"
 
-
 #: planet/js/ProjectViewer.js:30
 msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr "このプロジェクトを通報して下さってありがとうございます。モデレータが間もなく、プロジェクトを見ます。"
-
 
 #: planet/js/ProjectViewer.js:33
 #: planet/js/StringHelper.js:64
@@ -15008,452 +12424,363 @@ msgstr "このプロジェクトを通報して下さってありがとうござ
 msgid "Report Project"
 msgstr "プロジェクトを通報する"
 
-
 #: planet/js/ProjectViewer.js:34
 #: planet/js/StringHelper.js:65
 msgid "Project Reported"
 msgstr "プロジェクトは通報されました"
 
-
 #: planet/js/ProjectViewer.js:35
 msgid "Report description required"
 msgstr "レポート表記が必要です"
-
 
 #: planet/js/ProjectViewer.js:36
 msgid "Report description too long"
 msgstr "レポート表記が長すぎます"
 
-
 #: planet/js/Publisher.js:31
 msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
 msgstr "エラー：サーバに接続できません。ミュージック・ブロックスをリロードし、再度試して下さい。"
-
 
 #: planet/js/Publisher.js:216
 #: planet/js/Publisher.js:233
 msgid "This field is required"
 msgstr "この項目は必須項目です"
 
-
 #: planet/js/Publisher.js:223
 msgid "Title too long"
 msgstr "タイトルが長すぎます"
-
 
 #: planet/js/Publisher.js:240
 msgid "Description too long"
 msgstr "表記が長すぎます"
 
-
 #: planet/js/Publisher.js:373
 msgid "Server Error"
 msgstr "サーバーエラー"
-
 
 #: planet/js/Publisher.js:373
 msgid "Try Again"
 msgstr "もう一度使い直してください。"
 
-
 #: planet/js/SaveInterface.js:37
 msgid "Open in Turtle Blocks"
 msgstr "タートル ブロックスで開きます"
-
 
 #: planet/js/StringHelper.js:29
 msgid "Planet"
 msgstr "プラネット"
 
-
 #: planet/js/StringHelper.js:30
 msgid "Close Planet"
 msgstr "プラネットを閉じる"
-
 
 #: planet/js/StringHelper.js:31
 msgid "Open project from file"
 msgstr "ファイルからプロジェクトを開く"
 
-
 #: planet/js/StringHelper.js:33
 msgid "Local"
 msgstr "ローカル"
-
 
 #: planet/js/StringHelper.js:34
 msgid "Global"
 msgstr "グローバル"
 
-
 #: planet/js/StringHelper.js:35
 msgid "Search for a project"
 msgstr "プロジェクト検索"
 
-
 #: planet/js/StringHelper.js:39
 msgid "Tags (max 5)"
 msgstr "タッグ（最大5個）"
-
 
 #: planet/js/StringHelper.js:40
 #: planet/js/StringHelper.js:63
 msgid "Description"
 msgstr "記入"
 
-
 #: planet/js/StringHelper.js:41
 #: planet/js/StringHelper.js:74
 msgid "Submit"
 msgstr "確認"
 
-
 #: planet/js/StringHelper.js:43
 msgid "Delete \"<span id=\"deleter-title\"></span>\"?"
 msgstr "「<span id=\"deleter-title\"></span>」を削除しますか?"
-
 
 #: planet/js/StringHelper.js:46
 msgid "Permanently delete project \"<span id=\"deleter-name\"></span>\"?"
 msgstr "プロジェクト「<span id=\"deleter-name\"></span>」を完全に削除しますか?"
 
-
 #: planet/js/StringHelper.js:50
 msgid "Explore Projects"
 msgstr "プロジェクトを探す"
-
 
 #: planet/js/StringHelper.js:51
 #: planet/js/helper.js:149
 msgid "Show more tags"
 msgstr "タッグをもっと見る"
 
-
 #: planet/js/StringHelper.js:52
 msgid "Most recent"
 msgstr "一番最近"
-
 
 #: planet/js/StringHelper.js:53
 msgid "Most liked"
 msgstr "「いいね」の一番ある"
 
-
 #: planet/js/StringHelper.js:54
 msgid "Most downloaded"
 msgstr "ダウンロードの一番ある"
-
 
 #: planet/js/StringHelper.js:55
 msgid "A-Z"
 msgstr "「A-Z」の順番"
 
-
 #: planet/js/StringHelper.js:56
 msgid "Sort by"
 msgstr "～で整理する"
-
 
 #: planet/js/StringHelper.js:57
 msgid "Load More Projects"
 msgstr "プロジェクトをもっとロードする"
 
-
 #: planet/js/StringHelper.js:58
 msgid "Last Updated"
 msgstr "最後の更新"
-
 
 #: planet/js/StringHelper.js:59
 msgid "Creation Date"
 msgstr "作成日"
 
-
 #: planet/js/StringHelper.js:60
 msgid "Number of Downloads:"
 msgstr "ダウンロード数"
-
 
 #: planet/js/StringHelper.js:61
 msgid "Number of Likes:"
 msgstr "「いいね」の数"
 
-
 #: planet/js/StringHelper.js:62
 msgid "Tags:"
 msgstr "タッグ"
-
 
 #: planet/js/StringHelper.js:69
 msgid "Report projects which violate the <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs Code of Conduct</a>."
 msgstr "<a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs 行動規範</a>に違反するプロジェクトを報告します。"
 
-
 #: planet/js/StringHelper.js:73
 msgid "Reason for reporting project"
 msgstr "プロジェクトを通報する理由"
-
 
 #: planet/js/StringHelper.js:77
 msgid "Download as File"
 msgstr "ファイルでダウンロードする"
 
-
 #: planet/js/helper.js:150
 msgid "Show fewer tags"
 msgstr "タッグを非表示"
-
 
 #: planet/js/ProjectStorage.js:270
 msgid "anonymous"
 msgstr "匿名"
 
-
 #: plugins/accelerometer.rtp:48
 msgid "motion x"
 msgstr "x座標の動き"
-
 
 #: plugins/accelerometer.rtp:56
 msgid "motion y"
 msgstr "y座標の動き"
 
-
 #: plugins/accelerometer.rtp:64
 msgid "motion z"
 msgstr "z座標の動き"
-
 
 #: plugins/facebook.rtp:27
 msgid "publish"
 msgstr "プロジェクトをフェースブックにアップロードする"
 
-
 #: plugins/maths.rtp:62
 msgid "power"
 msgstr "指数"
-
 
 #: plugins/maths.rtp:62
 msgid "base"
 msgstr "ベース"
 
-
 #: plugins/maths.rtp:62
 msgid "exp"
 msgstr "exp"
-
 
 #: plugins/maths.rtp:99
 msgid "floor"
 msgstr "床"
 
-
 #: plugins/maths.rtp:104
 msgid "ceiling"
 msgstr "天井"
-
 
 #: plugins/maths.rtp:109
 msgid "to degrees"
 msgstr "度数法へ変換"
 
-
 #: plugins/maths.rtp:114
 msgid "to radians"
 msgstr "ラジアンへ変換"
-
 
 #: plugins/nutrition.rtp:104
 msgid "get calories"
 msgstr "カロリーをとる"
 
-
 #: plugins/nutrition.rtp:107
 msgid "get protein"
 msgstr "たんぱく質をとる"
-
 
 #: plugins/nutrition.rtp:110
 msgid "get carbs"
 msgstr "炭水化物"
 
-
 #: plugins/nutrition.rtp:113
 msgid "get fiber"
 msgstr "食物繊維をとる"
-
 
 #: plugins/nutrition.rtp:116
 msgid "get fat"
 msgstr "太る"
 
-
 #: plugins/nutrition.rtp:119
 msgid "get name"
 msgstr "名前を獲得する"
-
 
 #: plugins/nutrition.rtp:122
 msgid "calories"
 msgstr "カロリー"
 
-
 #: plugins/nutrition.rtp:128
 msgid "protein"
 msgstr "たんぱく"
-
 
 #: plugins/nutrition.rtp:134
 msgid "carbs"
 msgstr "炭水化物"
 
-
 #: plugins/nutrition.rtp:140
 msgid "fiber"
 msgstr "食物繊維"
-
 
 #: plugins/nutrition.rtp:146
 msgid "fat"
 msgstr "脂肪"
 
-
 #: plugins/nutrition.rtp:152
 msgid "eat"
 msgstr "食べる"
-
 
 #: plugins/nutrition.rtp:155
 msgid "digest meal"
 msgstr "食事を熟す"
 
-
 #: plugins/nutrition.rtp:158
 msgid "apple"
 msgstr "りんご"
-
 
 #: plugins/nutrition.rtp:161
 msgid "banana"
 msgstr "バナナ"
 
-
 #: plugins/nutrition.rtp:167
 msgid "wheat bread"
 msgstr "麦パン"
-
 
 #: plugins/nutrition.rtp:170
 msgid "corn"
 msgstr "コーン"
 
-
 #: plugins/nutrition.rtp:173
 msgid "potato"
 msgstr "芋"
-
 
 #: plugins/nutrition.rtp:176
 msgid "sweet potato"
 msgstr "スイートポテト"
 
-
 #: plugins/nutrition.rtp:179
 msgid "tomato"
 msgstr "トマト"
-
 
 #: plugins/nutrition.rtp:182
 msgid "broccoli"
 msgstr "ブロッコリー"
 
-
 #: plugins/nutrition.rtp:185
 msgid "rice and beans"
 msgstr "ご飯と豆"
-
 
 #: plugins/nutrition.rtp:188
 msgid "tamale"
 msgstr "タマレ"
 
-
 #: plugins/nutrition.rtp:191
 msgid "cheese"
 msgstr "チーズ"
-
 
 #: plugins/nutrition.rtp:194
 msgid "chicken"
 msgstr "鶏肉"
 
-
 #: plugins/nutrition.rtp:197
 msgid "fish"
 msgstr "魚"
-
 
 #: plugins/nutrition.rtp:200
 msgid "beef"
 msgstr "牛肉"
 
-
 #: plugins/nutrition.rtp:203
 msgid "cake"
 msgstr "ケーキ"
-
 
 #: plugins/nutrition.rtp:206
 msgid "cookie"
 msgstr "クッキー"
 
-
 #: plugins/nutrition.rtp:209
 msgid "water"
 msgstr "水"
-
 
 #: plugins/rodi.rtp:172
 msgid "blink"
 msgstr "点滅する"
 
-
 #: plugins/rodi.rtp:246
 msgid "led"
 msgstr "発光ダイオード"
-
 
 #: plugins/rodi.rtp:265
 msgid "light intensity"
 msgstr "光の強さ"
 
-
 #: plugins/rodi.rtp:282
 msgid "infrared light (left)"
 msgstr "赤外光 （左）"
-
 
 #: plugins/rodi.rtp:296
 msgid "infrared light (right)"
 msgstr "赤外光 （右）"
 
-
 #: plugins/rodi.rtp:338
 msgid "move"
 msgstr "動き出し"
-
 
 #: plugins/weather.rtp:68
 #: plugins/weather.rtp:97
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "日にちは -１から５までの数でなくてはなりません"
 
-
 #: plugins/weather.rtp:122
 msgid "forecast"
 msgstr "天気予報"
-
 
 #: plugins/weather.rtp:123
 #: plugins/weather.rtp:137
@@ -15461,642 +12788,357 @@ msgstr "天気予報"
 msgid "city"
 msgstr "市"
 
-
 #: plugins/weather.rtp:124
 #: plugins/weather.rtp:138
 #: plugins/weather.rtp:151
 msgid "day"
 msgstr "曜日"
 
-
 #: plugins/weather.rtp:136
 msgid "high"
 msgstr "高"
-
 
 #: plugins/weather.rtp:149
 msgid "low"
 msgstr "低"
 
-
 #: js/utils/utils-logic.js:324
-
 #~ msgid "Invalid input passed to rationalSum"
 #~ msgstr ""
 
-
 #: js/activity.js:2014
-
 #: js/activity.js:2092
-
 #~ msgid "Save recording"
 #~ msgstr "録音を保存する"
 
-
 #: js/activity.js:2021
-
 #: js/activity.js:2071
-
 #~ msgid "File save canceled"
 #~ msgstr "ファイルの保存がキャンセルされました"
 
-
 #: js/activity.js:2042
-
 #: js/activity.js:2052
-
 #~ msgid "Recorded file is empty. File not saved."
 #~ msgstr "録音されたファイルは空です。ファイルが保存されていません。"
 
-
 #: js/activity.js:2069
-
 #: js/activity.js:2099
-
 #~ msgid "Enter file name"
 #~ msgstr "ファイル名を入力してください"
 
-
 #: js/activity.js:2082
-
 #~ msgid "Saved! Check your Downloads folder."
 #~ msgstr "保存しました！ダウンロードフォルダーを確認してください。"
 
-
 #: js/activity.js:2089
-
 #~ msgid "Recording stopped. File saved."
 #~ msgstr "録音が停止されました。ファイルが保存されました。"
 
-
 #: js/activity.js:2094
-
 #~ msgid "recording"
 #~ msgstr "録音中"
 
-
 #: js/activity.js:2131
-
 #~ msgid "Recording started. Click stop to finish."
 #~ msgstr "録音が開始されました。終了するには「停止」をクリックします。"
 
-
 #: js/activity.js:2211
-
 #~ msgid "Recording failed: %s"
 #~ msgstr "録音に失敗しました: %s"
 
-
 #: js/activity.js:2671
-
 #~ msgid "show Cartesian"
 #~ msgstr "ほうがん（ざひょう）を表示"
 
-
 #: js/activity.js:3340
-
 #~ msgid "output tools"
 #~ msgstr "出力ツール"
 
-
 #: js/activity.js:3343
-
 #~ msgid "custom note"
 #~ msgstr "カスタムノート"
 
-
 #: js/activity.js:3346
-
 #~ msgid "accidental name"
 #~ msgstr "偶然の名前"
 
-
 #: js/activity.js:3361
-
 #~ msgid "chord name"
 #~ msgstr "chord name"
 
-
 #: js/activity.js:3367
-
 #~ msgid "filter type"
 #~ msgstr "フィルターの種類"
 
-
 #: js/activity.js:3370
-
 #~ msgid "oscillator type"
 #~ msgstr "発振器の種類"
 
-
 #: js/activity.js:3385
-
 #~ msgid "wrap mode"
 #~ msgstr "ラップモード"
 
-
 #: js/activity.js:3388
-
 #~ msgid "load file"
 #~ msgstr "ロード ファイル "
 
-
 #: js/activity.js:3717
-
 #: js/activity.js:7467
-
 #~ msgid "This block is deprecated."
 #~ msgstr "このブロックはもうありません。"
 
-
 #: js/activity.js:3719
-
 #: js/activity.js:7469
-
 #~ msgid "Block cannot be found."
 #~ msgstr "ブロックが見つかりません。"
 
-
 #: js/activity.js:7080
-
 #~ msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
 #~ msgstr "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。"
 
-
 #: js/activity.js:7586
-
 #~ msgid "You can type d to create a do block and r to create a re block etc."
 #~ msgstr "キーボードを使うと、パレットボタンからブロックをドラッグして配置するだけでなく、ボタンをおすだけでちょくせつブロックを置くことができる。★ショートカットキー d …… 「ド」（４分音符、４オクターヴ） r …… 「レ」（４分音符、４オクターヴ） m …… 「ミ」（４分音符、４オクターヴ） f</em> …… 「ファ」（４分音符、４オクターヴ s …… 「ソ」（４分音符、４オクターヴ） l …… 「ラ」（４分音符、４オクターヴ） t …… 「シ」（４分音符、４オクターヴ）"
 
-
 #: js/activity.js:8099
-
 #~ msgid "Select is enabled."
 #~ msgstr "選択モードが有効です。"
 
-
 #: js/activity.js:8100
-
 #~ msgid "Select is disabled."
 #~ msgstr "選択モードが無効です。"
 
-
 #: js/activity.js:9291
-
 #~ msgid "Error regenerating palettes. Please refresh the page."
 #~ msgstr "パレットの再生成に失敗しました。ページを更新してください。"
 
-
 #: js/blocks/PitchBlocks.js:1123
-
 #~ msgid "In the example shown above, sol is shifted up to sol#. "
 #~ msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
 
-
 #: js/widgets/sampler.js:615
-
 #~ msgid "Trim"
 #~ msgstr "トリム"
 
-
 #: js/turtleactions/MeterActions.js:148
-
 #: js/themebox.js:375
-
 #: js/utils/utils.js:627
-
 #: js/activity.js:7597
-
 #: js/activity.js:7601
-
 #: js/activity.js:7605
-
 #: js/activity.js:7609
-
 #: js/activity.js:7613
-
 #: js/activity.js:7621
-
 #: js/activity.js:7634
-
 #: js/activity.js:7638
-
 #: js/activity.js:7644
-
 #: js/activity.js:7648
-
 #: js/activity.js:7660
-
 #: js/activity.js:7667
-
 #: js/activity.js:7671
-
 #: js/activity.js:7675
-
 #: js/activity.js:7684
-
 #: js/activity.js:7688
-
 #: js/activity.js:7700
-
 #: js/activity.js:7704
-
 #: js/activity.js:2211
-
 #: js/utils/utils.js:627
-
 #: js/blocks/ToneBlocks.js:926
-
 #: js/blocks/ToneBlocks.js:960
-
 #: js/blocks/VolumeBlocks.js:531
-
 #: js/blocks/VolumeBlocks.js:533
-
 #: js/blocks/IntervalsBlocks.js:1495
-
 #: js/turtleactions/MeterActions.js:120
-
 #: js/turtleactions/MeterActions.js:158
-
 #: js/turtleactions/ToneActions.js:379
-
 #: js/turtleactions/ToneActions.js:418
-
 #: js/turtleactions/ToneActions.js:457
-
 #: js/widgets/timbre.js:815
-
 #: js/turtleactions/DictActions.js:260
-
 #: js/widgets/aiwidget.js:645
-
 #: js/widgets/aiwidget.js:802
-
 #: js/widgets/aiwidget.js:868
-
 #: js/widgets/sampler.js:713
-
 #: js/widgets/sampler.js:716
-
 #: js/widgets/sampler.js:731
-
 #: js/widgets/sampler.js:736
-
 #: js/widgets/sampler.js:997
-
 #: js/widgets/sampler.js:1190
-
 #: js/widgets/sampler.js:1188
-
 #: js/widgets/legobricks.js:334
-
 #: js/widgets/legobricks.js:906
-
 #: js/widgets/legobricks.js:906
-
 #: js/widgets/legobricks.js:1127
-
 #: js/widgets/legobricks.js:1230
-
 #: js/widgets/legobricks.js:1345
-
 #: js/widgets/legobricks.js:1347
-
 #: js/widgets/legobricks.js:1911
-
 #: js/widgets/legobricks.js:2052
-
 #: js/widgets/legobricks.js:2078
-
 #: js/widgets/reflection.js:375
-
 #: js/widgets/reflection.js:618
-
 #: js/widgets/temperament.js:1880
-
 #: js/widgets/temperament.js:1882
-
 #: js/widgets/temperament.js:2655
-
 #: js/SaveInterface.js:614
-
 #: js/SaveInterface.js:654
-
 #: js/logo.js:2142
-
 #: js/SaveInterface.js:844
-
 #: js/SaveInterface.js:902
-
 #: js/logo.js:2130
-
 #: js/SaveInterface.js:927
-
 #: js/turtledefs.js:647
-
 #: js/turtledefs.js:652
-
 #: js/turtledefs.js:657
-
 #: js/toolbar.js:146
-
 #: js/toolbar.js:218
-
 #: js/toolbar.js:294
-
 #: js/toolbar.js:360
-
 #: js/toolbar.js:167
-
 #: js/toolbar.js:245
-
 #: js/toolbar.js:309
-
 #: js/toolbar.js:375
-
 #: js/toolbar.js:168
-
 #: js/toolbar.js:246
-
 #: js/toolbar.js:310
-
 #: js/toolbar.js:376
-
 #: js/toolbar.js:169
-
 #: js/toolbar.js:247
-
 #: js/toolbar.js:311
-
 #: js/toolbar.js:377
-
 #: js/toolbar.js:170
-
 #: js/toolbar.js:171
-
 #: js/toolbar.js:249
-
 #: js/toolbar.js:313
-
 #: js/toolbar.js:379
-
 #: js/toolbar.js:172
-
 #: js/toolbar.js:250
-
 #: js/toolbar.js:314
-
 #: js/toolbar.js:380
-
 #: js/toolbar.js:173
-
 #: js/toolbar.js:251
-
 #: js/toolbar.js:315
-
 #: js/toolbar.js:381
-
 #: js/toolbar.js:174
-
 #: js/toolbar.js:252
-
 #: js/toolbar.js:316
-
 #: js/toolbar.js:382
-
 #: js/toolbar.js:175
-
 #: js/toolbar.js:253
-
 #: js/toolbar.js:317
-
 #: js/toolbar.js:383
-
 #: js/toolbar.js:176
-
 #: js/toolbar.js:254
-
 #: js/toolbar.js:318
-
 #: js/toolbar.js:384
-
 #: js/toolbar.js:177
-
 #: js/toolbar.js:255
-
 #: js/toolbar.js:319
-
 #: js/toolbar.js:385
-
 #: js/toolbar.js:178
-
 #: js/toolbar.js:256
-
 #: js/toolbar.js:320
-
 #: js/toolbar.js:386
-
 #: js/toolbar.js:179
-
 #: js/toolbar.js:257
-
 #: js/toolbar.js:321
-
 #: js/toolbar.js:387
-
 #: js/toolbar.js:180
-
 #: js/toolbar.js:258
-
 #: js/toolbar.js:322
-
 #: js/toolbar.js:388
-
 #: js/toolbar.js:181
-
 #: js/toolbar.js:260
-
 #: js/toolbar.js:323
-
 #: js/toolbar.js:390
-
 #: js/toolbar.js:182
-
 #: js/toolbar.js:261
-
 #: js/toolbar.js:324
-
 #: js/toolbar.js:391
-
 #: js/toolbar.js:183
-
 #: js/toolbar.js:259
-
 #: js/toolbar.js:325
-
 #: js/toolbar.js:389
-
 #: js/toolbar.js:184
-
 #: js/toolbar.js:326
-
 #: js/toolbar.js:185
-
 #: js/toolbar.js:262
-
 #: js/toolbar.js:327
-
 #: js/toolbar.js:392
-
 #: js/toolbar.js:186
-
 #: js/toolbar.js:263
-
 #: js/toolbar.js:328
-
 #: js/toolbar.js:393
-
 #: js/toolbar.js:248
-
 #: js/toolbar.js:312
-
 #: js/toolbar.js:378
-
 #: js/activity.js:1588
-
 #: js/activity.js:1647
-
 #: js/activity.js:2211
-
 #: js/themebox.js:375
-
 #: js/utils/musicutils.js:1172
-
 #: js/utils/utils.js:627
-
 #: js/blocks/ProgramBlocks.js:1386
-
 #: js/blocks/WidgetBlocks.js:2118
-
 #: js/widgets/aiwidget.js:868
-
 #: js/widgets/legobricks.js:906
-
 #: js/widgets/legobricks.js:906
-
 #: js/widgets/legobricks.js:1127
-
 #: js/widgets/legobricks.js:1230
-
 #: js/widgets/legobricks.js:1345
-
 #: js/widgets/legobricks.js:1911
-
 #: js/widgets/legobricks.js:2052
-
 #: js/widgets/legobricks.js:2078
-
 #: js/widgets/legobricks.js:1922
-
 #: js/widgets/legobricks.js:1923
-
 #: js/widgets/legobricks.js:1924
-
 #: js/widgets/legobricks.js:1925
-
 #: js/widgets/legobricks.js:1926
-
 #: js/widgets/legobricks.js:1927
-
 #: js/widgets/legobricks.js:1928
-
 #: js/widgets/legobricks.js:1929
-
 #: js/widgets/legobricks.js:1930
-
 #: js/widgets/legobricks.js:1931
-
 #: js/widgets/legobricks.js:1932
-
 #: js/widgets/legobricks.js:1933
-
 #: js/widgets/legobricks.js:1934
-
 #: js/widgets/legobricks.js:1935
-
 #: js/widgets/legobricks.js:1936
-
 #: js/widgets/legobricks.js:1937
-
 #: js/widgets/legobricks.js:1938
-
 #: js/widgets/legobricks.js:1939
-
 #: js/widgets/legobricks.js:1940
-
 #: js/widgets/legobricks.js:1941
-
 #: js/widgets/legobricks.js:1942
-
 #: js/widgets/temperament.js:1880
-
 #: js/widgets/temperament.js:1882
-
 #: js/widgets/temperament.js:2655
-
 #: js/SaveInterface.js:59
-
 #: js/SaveInterface.js:61
-
 #: js/SaveInterface.js:93
-
 #: js/activity.js:1598
-
 #: js/activity.js:6493
-
 #: js/toolbar.js:52
-
 #: js/toolbar.js:53
-
 #: js/toolbar.js:118
-
 #: js/toolbar.js:119
-
 #: js/toolbar.js:189
-
 #: js/toolbar.js:190
-
 #: js/toolbar.js:250
-
 #: js/toolbar.js:251
-
 #: js/turtledefs.js:703
-
 #: js/turtledefs.js:709
-
 #: js/turtledefs.js:715
-
 #: js/blocks/ProgramBlocks.js:1410
-
 #: js/blocks/PitchBlocks.js:682
-
 #: js/turtleactions/IntervalsActions.js:266
-
 #: planet/js/StringHelper.js:44
-
 #: planet/js/StringHelper.js:45
-
 #: planet/js/StringHelper.js:65
-
 #: index.html (record dropdown)
-
 #~ msgid "Record canvas and toolbars"
 #~ msgstr "キャンバスとツールバーを録画"
 
-
 #: index.html (record dropdown)
-
 #~ msgid "Record canvas only"
 #~ msgstr "キャンバスのみ録画"
-

--- a/po/ja.po
+++ b/po/ja.po
@@ -198,12 +198,14 @@ msgstr ""
 msgid "action"
 msgstr "アクション"
 
+
 #: js/macros.js:711
 #: js/utils/musicutils.js:1443
 #: js/utils/synthutils.js:216
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "duck"
 msgstr "あひる"
+
 
 #: js/turtle-painter.js:1361
 #: js/turtle-painter.js:1362
@@ -218,9 +220,11 @@ msgstr "あひる"
 msgid "start"
 msgstr "スタート"
 
+
 #: js/keyboard-controller.js:165
 msgid "Saving block artwork"
 msgstr "ブロックのアートを保存中"
+
 
 #: js/keyboard-controller.js:169
 #: js/turtledefs.js:644
@@ -228,9 +232,11 @@ msgstr "ブロックのアートを保存中"
 msgid "Copy"
 msgstr "コピー"
 
+
 #: js/keyboard-controller.js:173
 msgid "Erase"
 msgstr "消す"
+
 
 #: js/keyboard-controller.js:178
 #: js/turtledefs.js:430
@@ -294,6 +300,7 @@ msgstr "消す"
 msgid "Play"
 msgstr "実行"
 
+
 #: js/keyboard-controller.js:209
 #: js/turtledefs.js:435
 #: js/turtledefs.js:471
@@ -327,75 +334,93 @@ msgstr "実行"
 msgid "Stop"
 msgstr "停止"
 
+
 #: js/keyboard-controller.js:213
 #: js/keyboard-controller.js:243
 msgid "Paste"
 msgstr "貼り付け"
 
+
 #: js/keyboard-controller.js:217
 msgid "Save block help"
 msgstr "ブロックの ヘルプを 保存"
+
 
 #: js/keyboard-controller.js:285
 msgid "Jumping to the bottom of the page."
 msgstr "画面の下にジャンプしています"
 
+
 #: js/keyboard-controller.js:291
 msgid "Scrolling up."
 msgstr "上にスクロールしています"
+
 
 #: js/keyboard-controller.js:296
 msgid "Scrolling down."
 msgstr "下にスクロールしています"
 
+
 #: js/keyboard-controller.js:301
 msgid "Extracting block"
 msgstr "ブロックを取り出しています"
+
 
 #: js/keyboard-controller.js:309
 msgid "Moving block up."
 msgstr "ブロックを上に動かしています"
 
+
 #: js/keyboard-controller.js:330
 msgid "Moving block down."
 msgstr "ブロックを下に動かしています"
+
 
 #: js/keyboard-controller.js:352
 msgid "Moving block left."
 msgstr "ブロックを左に動かしています"
 
+
 #: js/keyboard-controller.js:369
 msgid "Moving block right."
 msgstr "ブロックを右に動かしています"
 
+
 #: js/keyboard-controller.js:384
 msgid "Jump to home position."
 msgstr "まんなかにジャンプする"
+
 
 #: js/keyboard-controller.js:404
 #: js/blocks/ExtrasBlocks.js:276
 msgid "Hide blocks"
 msgstr "ブロックを非表示"
 
+
 #: js/languagebox.js:293
 msgid "Refresh your browser to change your language preference."
 msgstr "言語を変えるには、ブラウザをこうしんしてください。"
+
 
 #: js/languagebox.js:329
 msgid "Music Blocks is already set to this language."
 msgstr " Music Blocksは既にこの言語に設定されています。"
 
+
 #: js/palette.js:624
 msgid "Block Palettes"
 msgstr "ブロックパレット"
+
 
 #: js/palette.js:635
 msgid "Palette Categories"
 msgstr "パレットのカテゴリ"
 
+
 #: js/palette.js:656
 msgid "Toggle Palette"
 msgstr "パレットの切り替え"
+
 
 #: js/palette.js:1184
 #: js/palette.js:1313
@@ -414,11 +439,13 @@ msgstr "パレットの切り替え"
 msgid "box"
 msgstr "箱"
 
+
 #: js/palette.js:1246
 #: js/turtledefs.js:674
 #: js/turtles.js:992
 msgid "Grid"
 msgstr "グリッド"
+
 
 #: js/palette.js:1249
 #: js/blocks.js:2739
@@ -426,6 +453,7 @@ msgstr "グリッド"
 #: js/blocks/MediaBlocks.js:1046
 msgid "text"
 msgstr "文字そざい"
+
 
 #: js/palette.js:1252
 #: js/turtledefs.js:129
@@ -442,38 +470,46 @@ msgstr "文字そざい"
 msgid "drum"
 msgstr "ドラム"
 
+
 #: js/palette.js:1255
 msgid "effect"
 msgstr "こうかおん"
+
 
 #: js/palette.js:1261
 msgid "sargam"
 msgstr "Sargam (インドの ソルファ)"
 
+
 #: js/palette.js:1264
 #: js/blocks/PitchBlocks.js:467
 #: js/blocks/PitchBlocks.js:1868
 #: js/blocks/RhythmBlocks.js:922
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "音度"
+
 
 #: js/palette.js:1267
 msgid "mode name"
 msgstr "モード名"
 
+
 #: js/palette.js:1270
 msgid "invert mode"
 msgstr "モードを反転させる"
+
 
 #: js/palette.js:1273
 msgid "voice name"
 msgstr "音名"
 
+
 #: js/palette.js:1276
 #: js/blocks/PitchBlocks.js:1257
 msgid "custom pitch"
 msgstr "カスタムピッチ"
+
 
 #: js/palette.js:1280
 #: js/block.js:1674
@@ -483,13 +519,16 @@ msgstr "カスタムピッチ"
 msgid "temperament"
 msgstr "音律"
 
+
 #: js/palette.js:1284
 msgid "accidental"
 msgstr "変化記号"
 
+
 #: js/palette.js:1290
 msgid "interval name"
 msgstr "音程名"
+
 
 #: js/palette.js:1293
 #: js/block.js:4223
@@ -510,10 +549,12 @@ msgstr "音程名"
 msgid "true"
 msgstr "真"
 
+
 #: js/palette.js:1308
 #: js/blocks/PitchBlocks.js:425
 msgid "pitch converter"
 msgstr "音の高さを調節"
+
 
 #: js/palette.js:1314
 #: js/palette.js:1319
@@ -523,6 +564,7 @@ msgstr "音の高さを調節"
 msgid "store in"
 msgstr "入れる"
 
+
 #: js/palette.js:1316
 #: js/palette.js:1317
 #: js/blocks.js:2937
@@ -530,11 +572,13 @@ msgstr "入れる"
 msgid "store in box"
 msgstr "箱にほぞん"
 
+
 #: js/palette.js:1328
 #: js/blocks.js:1929
 #: js/blocks/MediaBlocks.js:686
 msgid "open file"
 msgstr "ファイルを開く"
+
 
 #: js/palette.js:1555
 #: js/piemenu-block-context.js:103
@@ -548,27 +592,33 @@ msgstr "ファイルを開く"
 msgid "Close"
 msgstr "閉じる"
 
+
 #: js/themebox.js:391
 msgid "Theme switched to %s mode."
 msgstr "テーマが %s モードに切り替わりました。"
+
 
 #: js/themebox.js:584
 msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocksはすでにこのテーマに設定されています。"
 
+
 #: js/turtledefs.js:43
-#.TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
+#. TRANS: put the URL to the guide here, e.g., Docs/guide/README.md
 msgid "guide url"
 msgstr "Docs/guide-ja/music_blocks_operation_manual.pdf"
+
 
 #: js/turtledefs.js:88
 msgid "Turtle Blocks"
 msgstr "タートル・ブロックス"
 
+
 #: js/turtledefs.js:121
 #: js/turtledefs.js:219
 msgid "search"
 msgstr "検索"
+
 
 #: js/turtledefs.js:122
 #: js/turtledefs.js:220
@@ -581,17 +631,19 @@ msgstr "検索"
 #: js/widgets/rhythmruler.js:2328
 #: js/widgets/rhythmruler.js:2335
 #: js/widgets/rhythmruler.js:2414
-#.TRANS: an arrangement of notes based on duration
+#. TRANS: an arrangement of notes based on duration
 msgid "rhythm"
 msgstr "音符"
+
 
 #: js/turtledefs.js:123
 #: js/turtledefs.js:221
 #: js/blocks/MeterBlocks.js:1391
 #: js/blocks/WidgetBlocks.js:616
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "meter"
 msgstr "拍子"
+
 
 #: js/turtledefs.js:124
 #: js/turtledefs.js:222
@@ -603,15 +655,17 @@ msgstr "拍子"
 #: js/blocks/PitchBlocks.js:1944
 #: js/widgets/phrasemaker.js:1286
 #: js/widgets/musickeyboard.js:2218
-#.TRANS: pitch number
-#.TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
+#. TRANS: pitch number
+#. TRANS: we specify pitch in terms of a name and an octave. The name can be CDEFGAB or Do Re Mi Fa Sol La Ti. Octave is a number between 1 and 8.
 msgid "pitch"
 msgstr "音の高さ"
+
 
 #: js/turtledefs.js:125
 #: js/turtledefs.js:223
 msgid "intervals"
 msgstr "音程"
+
 
 #: js/turtledefs.js:126
 #: js/turtledefs.js:224
@@ -619,10 +673,12 @@ msgstr "音程"
 msgid "tone"
 msgstr "音色"
 
+
 #: js/turtledefs.js:127
 #: js/turtledefs.js:225
 msgid "ornament"
 msgstr "そうしょく"
+
 
 #: js/turtledefs.js:128
 #: js/turtledefs.js:226
@@ -633,21 +689,25 @@ msgstr "そうしょく"
 msgid "volume"
 msgstr "音量"
 
+
 #: js/turtledefs.js:130
 #: js/turtledefs.js:228
 #: js/rubrics.js:539
 msgid "flow"
 msgstr "実行手順"
 
+
 #: js/turtledefs.js:132
 #: js/turtledefs.js:230
 msgid "boxes"
 msgstr "数の箱"
 
+
 #: js/turtledefs.js:133
 #: js/turtledefs.js:231
 msgid "widgets"
 msgstr "ツール"
+
 
 #: js/turtledefs.js:134
 #: js/turtledefs.js:232
@@ -655,12 +715,14 @@ msgstr "ツール"
 msgid "graphics"
 msgstr "ネズミの動き"
 
+
 #: js/turtledefs.js:135
 #: js/turtledefs.js:233
 #: js/rubrics.js:537
 #: js/widgets/phrasemaker.js:1290
 msgid "pen"
 msgstr "ペン"
+
 
 #: js/turtledefs.js:136
 #: js/turtledefs.js:234
@@ -671,27 +733,31 @@ msgstr "ペン"
 msgid "number"
 msgstr "すうち"
 
+
 #: js/turtledefs.js:137
 #: js/turtledefs.js:235
 msgid "boolean"
 msgstr "比べる"
+
 
 #: js/turtledefs.js:138
 #: js/turtledefs.js:236
 #: js/rubrics.js:542
 #: js/blocks/MediaBlocks.js:1013
 #: planet/js/GlobalTag.js:44
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "media"
 msgstr "メディア"
+
 
 #: js/turtledefs.js:139
 #: js/turtledefs.js:237
 #: js/rubrics.js:541
 #: planet/js/GlobalTag.js:46
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "sensors"
 msgstr "センサー"
+
 
 #: js/turtledefs.js:140
 #: js/turtledefs.js:238
@@ -700,6 +766,7 @@ msgstr "センサー"
 msgid "heap"
 msgstr "ヒープ"
 
+
 #: js/turtledefs.js:141
 #: js/turtledefs.js:239
 #: js/blocks/DictBlocks.js:142
@@ -707,55 +774,66 @@ msgstr "ヒープ"
 msgid "dictionary"
 msgstr "辞書"
 
+
 #: js/turtledefs.js:142
 #: js/turtledefs.js:240
 msgid "ensemble"
 msgstr "合奏"
+
 
 #: js/turtledefs.js:143
 #: js/turtledefs.js:241
 msgid "extras"
 msgstr "その他"
 
+
 #: js/turtledefs.js:145
 #: js/turtledefs.js:242
-#.TRANS: program as in computer program
+#. TRANS: program as in computer program
 msgid "program"
 msgstr "プログラム"
+
 
 #: js/turtledefs.js:146
 #: js/turtledefs.js:243
 msgid "my blocks"
 msgstr "自分のブロック"
 
+
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
 msgid "artwork"
 msgstr "アート"
+
 
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
 msgid "logic"
 msgstr "論理"
 
+
 #: js/turtledefs.js:185
 #: js/turtledefs.js:269
 #: planet/js/GlobalTag.js:32
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Music"
 msgstr "音楽"
+
 
 #: js/turtledefs.js:187
 msgid "Music Blocks"
 msgstr "ミュージック・ブロックス"
 
+
 #: js/turtledefs.js:423
 msgid "Welcome to Turtle Blocks"
 msgstr "タートル・ブロックへようこそ"
 
+
 #: js/turtledefs.js:424
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr "タートル・ブロックスはアートと数学を求めるビジュアル・プログラミング言語だ。"
+
 
 #: js/turtledefs.js:426
 #: js/turtledefs.js:446
@@ -763,6 +841,7 @@ msgstr "タートル・ブロックスはアートと数学を求めるビジュ
 #: js/turtledefs.js:780
 msgid "The current version is"
 msgstr "ミュージック・ブロックスの最新バージョンは"
+
 
 #: js/turtledefs.js:430
 #: js/turtledefs.js:466
@@ -833,10 +912,12 @@ msgstr "ミュージック・ブロックスの最新バージョンは"
 msgid "Play"
 msgstr "実行"
 
+
 #: js/turtledefs.js:431
 #: js/turtledefs.js:467
 msgid "Click the run button to run the project in fast mode."
 msgstr "クリックをすると、ふつうのスピードでプログラムを実行することができる。"
+
 
 #: js/turtledefs.js:435
 #: js/turtledefs.js:471
@@ -871,40 +952,49 @@ msgstr "クリックをすると、ふつうのスピードでプログラムを
 msgid "Stop"
 msgstr "停止"
 
+
 #: js/turtledefs.js:436
 msgid "Stop the turtle."
 msgstr "タータルを止める"
+
 
 #: js/turtledefs.js:436
 #: js/turtledefs.js:472
 msgid "You can also type Alt-S to stop."
 msgstr "プログラムは、このボタンをおすかわりに、キーボードで「Altキーと Sキーの同時おし」でも止めることができる。"
 
+
 #: js/turtledefs.js:443
 #: js/widgets/help.js:547
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへようこそ"
 
+
 #: js/turtledefs.js:444
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr "音楽と算数とプログラミングをむすびつけ、深く楽しむことができるツール。それが、ミュージック・ブロックスだ。"
+
 
 #: js/turtledefs.js:450
 #: js/widgets/help.js:548
 msgid "Meet Mr. Mouse!"
 msgstr "ミスター・マウスに会おう！"
 
+
 #: js/turtledefs.js:451
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr "ミスター・マウスは、ミュージック・ブロックスの指揮者。"
+
 
 #: js/turtledefs.js:453
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr "ミスター・マウスと一緒に、ミュージック・ブロックスの世界をたんきゅうしよう。"
 
+
 #: js/turtledefs.js:455
 msgid "Let us start our tour!"
 msgstr "では、ツアーを始めよう。"
+
 
 #: js/turtledefs.js:459
 #: js/turtledefs.js:737
@@ -912,13 +1002,16 @@ msgstr "では、ツアーを始めよう。"
 msgid "Guide"
 msgstr "もっとくわしく知るには"
 
+
 #: js/turtledefs.js:460
 msgid "A detailed guide to Music Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
+
 #: js/turtledefs.js:472
 msgid "Stop the music (and the mice)."
 msgstr "実行しているプログラムを止める。"
+
 
 #: js/turtledefs.js:479
 #: js/toolbar.js:122
@@ -928,9 +1021,11 @@ msgstr "実行しているプログラムを止める。"
 msgid "Record"
 msgstr "録音"
 
+
 #: js/turtledefs.js:480
 msgid "Record your project as video."
 msgstr "再生されているビデオを録音する"
+
 
 #: js/turtledefs.js:485
 #: js/toolbar.js:125
@@ -940,9 +1035,11 @@ msgstr "再生されているビデオを録音する"
 msgid "Toggle Fullscreen"
 msgstr "フルスクリーンの切り替え"
 
+
 #: js/turtledefs.js:486
 msgid "Toggle Fullscreen mode."
 msgstr "フルスクリーンの切り替え"
+
 
 #: js/turtledefs.js:490
 #: js/toolbar.js:126
@@ -954,9 +1051,11 @@ msgstr "フルスクリーンの切り替え"
 msgid "New project"
 msgstr "新しいプロジェクト"
 
+
 #: js/turtledefs.js:491
 msgid "Initialize a new project."
 msgstr "新しいプロジェクトを作る。"
+
 
 #: js/turtledefs.js:495
 #: js/toolbar.js:127
@@ -966,9 +1065,11 @@ msgstr "新しいプロジェクトを作る。"
 msgid "Load project from file"
 msgstr "プロジェクトを読みこむ"
 
+
 #: js/turtledefs.js:496
 msgid "You can also load projects from the file system."
 msgstr "コンピューターに保存してあるファイルから、ミュージック・ブロックスのプロジェクトを読み込んで開く。"
+
 
 #: js/turtledefs.js:501
 #: js/turtledefs.js:509
@@ -980,6 +1081,7 @@ msgstr "コンピューターに保存してあるファイルから、ミュー
 #: js/toolbar.js:323
 msgid "Save project"
 msgstr "プロジェクトをほぞん"
+
 
 #: js/turtledefs.js:502
 #: js/turtledefs.js:529
@@ -998,6 +1100,7 @@ msgstr "プロジェクトをほぞん"
 msgid "Save project as HTML"
 msgstr "HTMLをほぞん"
 
+
 #: js/turtledefs.js:502
 #: js/toolbar.js:155
 #: js/toolbar.js:159
@@ -1005,9 +1108,11 @@ msgstr "HTMLをほぞん"
 msgid "Save mouse artwork as PNG"
 msgstr "PNGでほぞん"
 
+
 #: js/turtledefs.js:511
 msgid "Save your project to a file."
 msgstr "げんざい開いているプロジェクトをほぞんする。"
+
 
 #: js/turtledefs.js:513
 #: js/toolbar.js:240
@@ -1016,9 +1121,11 @@ msgstr "げんざい開いているプロジェクトをほぞんする。"
 msgid "Save turtle artwork as SVG"
 msgstr "アートをSVGで保存"
 
+
 #: js/turtledefs.js:515
 msgid "Save graphics from your project to as SVG."
 msgstr "プロジェクトのグラフィックをSVGで保存"
+
 
 #: js/turtledefs.js:517
 #: js/toolbar.js:238
@@ -1030,9 +1137,11 @@ msgstr "プロジェクトのグラフィックをSVGで保存"
 msgid "Save turtle artwork as PNG"
 msgstr "アートをPNGで保存"
 
+
 #: js/turtledefs.js:519
 msgid "Save graphics from your project as PNG."
 msgstr "プロジェクトのグラフィックをPNGで保存"
+
 
 #: js/turtledefs.js:521
 #: js/toolbar.js:164
@@ -1043,9 +1152,11 @@ msgstr "プロジェクトのグラフィックをPNGで保存"
 msgid "Save block artwork as SVG"
 msgstr "ブロックのアートをほぞん"
 
+
 #: js/turtledefs.js:523
 msgid "Save block artwork as an SVG file."
 msgstr "ブロックのグラフィックをSVGで保存"
+
 
 #: js/turtledefs.js:531
 #: js/toolbar.js:157
@@ -1053,39 +1164,48 @@ msgstr "ブロックのグラフィックをSVGで保存"
 msgid "Save project as MIDI"
 msgstr "プロジェクトをMIDIとして保存"
 
+
 #: js/turtledefs.js:533
 #: js/toolbar.js:160
 #: js/toolbar.js:230
 msgid "Save music as WAV"
 msgstr "WAVでほぞん"
 
+
 #: js/turtledefs.js:535
 msgid "Save sheet music as ABC, Lilypond or MusicXML"
 msgstr "楽譜をABC、Lilypond、またはMusicXMLとして保存する。"
+
 
 #: js/turtledefs.js:537
 msgid "Save block artwork as SVG or PNG"
 msgstr "ブロックのアートワークをSVGまたはPNGとして保存する。"
 
+
 #: js/turtledefs.js:543
 msgid "Load samples from server"
 msgstr "みんなの作品"
+
 
 #: js/turtledefs.js:544
 msgid "This button opens a viewer for loading example projects."
 msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
 
+
 #: js/turtledefs.js:548
 msgid "Expand/collapse option toolbar"
 msgstr "オプションツールバーを表示"
+
 
 #: js/turtledefs.js:549
 msgid "Click this button to expand or collapse the auxiliary toolbar."
 msgstr "このボタンをクリックすると「サブメニュー」を開いたり、折りたたんだりすることができる。"
 
+
 #: js/turtledefs.js:554
 msgid "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
 msgstr "メインおよび補助ツールバー、ブロックとキャンバスの右クリックコンテキストメニュー、パレットのヘルプメッセージを表示します。"
+
 
 #: js/turtledefs.js:560
 #: js/toolbar.js:136
@@ -1095,9 +1215,11 @@ msgstr "メインおよび補助ツールバー、ブロックとキャンバス
 msgid "Run slowly"
 msgstr "ゆっくり実行する"
 
+
 #: js/turtledefs.js:561
 msgid "Click to run the project in slow mode."
 msgstr "クリックをすると、ゆっくりとしたスピードでプログラムを実行することができる。"
+
 
 #: js/turtledefs.js:565
 #: js/toolbar.js:137
@@ -1107,9 +1229,11 @@ msgstr "クリックをすると、ゆっくりとしたスピードでプログ
 msgid "Run step by step"
 msgstr "ブロックを１つずつ実行する"
 
+
 #: js/turtledefs.js:566
 msgid "Click to run the project step by step."
 msgstr "クリックをすると、とてもゆっくり、ブロックを１つずつ実行する。プログラムがうまくはたらかず、どのブロックが原因なのかを調べたいときなどに便利だ。"
+
 
 #: js/turtledefs.js:571
 #: js/toolbar.js:138
@@ -1119,9 +1243,11 @@ msgstr "クリックをすると、とてもゆっくり、ブロックを１つ
 msgid "Display statistics"
 msgstr "とうけいを表示する"
 
+
 #: js/turtledefs.js:572
 msgid "Display statistics about your Music project."
 msgstr "プロジェクトに含まれているブロックの種類、わりあいなど、とうけいてきなじょうほうを表示する。"
+
 
 #: js/turtledefs.js:576
 #: js/toolbar.js:139
@@ -1131,9 +1257,11 @@ msgstr "プロジェクトに含まれているブロックの種類、わりあ
 msgid "Load plugin"
 msgstr "プラグインを読みこむ"
 
+
 #: js/turtledefs.js:577
 msgid "Load a selected plugin."
 msgstr "選択したプラグインを読み込みます。"
+
 
 #: js/turtledefs.js:581
 #: js/toolbar.js:140
@@ -1143,17 +1271,21 @@ msgstr "選択したプラグインを読み込みます。"
 msgid "Delete plugin"
 msgstr "プラグインを消す"
 
+
 #: js/turtledefs.js:582
 msgid "Delete a selected plugin."
 msgstr "せんたくしたプラグインを消す。"
+
 
 #: js/turtledefs.js:586
 msgid "Enable scrolling"
 msgstr "自由な方向に／たて方向にスクロール"
 
+
 #: js/turtledefs.js:587
 msgid "You can scroll the blocks on the canvas."
 msgstr "カンバス上をドラッグそうさしたときに、画面をスクロールさせることができる方向を上下だけと上下左右に変える。"
+
 
 #: js/turtledefs.js:592
 #: js/toolbar.js:143
@@ -1164,9 +1296,11 @@ msgstr "カンバス上をドラッグそうさしたときに、画面をスク
 msgid "Change theme"
 msgstr "テーマを変更"
 
+
 #: js/turtledefs.js:593
 msgid "Switch between dark and light mode."
 msgstr "ダークモードとライトモードを切り替えます。"
+
 
 #: js/turtledefs.js:597
 #: js/toolbar.js:147
@@ -1179,17 +1313,21 @@ msgstr "ダークモードとライトモードを切り替えます。"
 msgid "Merge with current project"
 msgstr "プロジェクトを組みあわせる"
 
+
 #: js/turtledefs.js:598
 msgid "Click to add another project into the current one."
 msgstr "クリックして別のプロジェクトを現在のプロジェクトに追加します。"
+
 
 #: js/turtledefs.js:602
 msgid "Wrap Turtle"
 msgstr "アートを包む"
 
+
 #: js/turtledefs.js:603
 msgid "Turn Turtle wrapping On or Off."
 msgstr "アートを包むか・包まない"
+
 
 #: js/turtledefs.js:607
 #: js/toolbar.js:148
@@ -1197,9 +1335,11 @@ msgstr "アートを包むか・包まない"
 msgid "Set Pitch Preview"
 msgstr "変化記号を設定"
 
+
 #: js/turtledefs.js:608
 msgid "Click to set the current pitch."
 msgstr "クリックして現在の音高を設定します。"
+
 
 #: js/turtledefs.js:613
 #: js/toolbar.js:149
@@ -1209,9 +1349,11 @@ msgstr "クリックして現在の音高を設定します。"
 msgid "JavaScript Editor"
 msgstr "JavaScript エディタ"
 
+
 #: js/turtledefs.js:614
 msgid "Converts Music Block programs to JavaScript."
 msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
+
 
 #: js/turtledefs.js:619
 #: js/toolbar.js:150
@@ -1221,17 +1363,21 @@ msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
 msgid "Restore"
 msgstr "すてたブロックをもどす"
 
+
 #: js/turtledefs.js:620
 msgid "Restore blocks from the trash."
 msgstr "ゴミ箱にすててしまったブロックを取り出してもどす。ふくすうのブロックをすててあるときは新しい順に、ゴミ箱が空になるまでブロックを拾いもどすことができる。"
+
 
 #: js/turtledefs.js:624
 msgid "Switch mode"
 msgstr "はってんモード／かんたんモードにする"
 
+
 #: js/turtledefs.js:625
 msgid "Switch between beginner and advance modes."
 msgstr "ミュージック・ブロックスをかんたんモード／はってんモードに切りかえる。モードによって使えるきのうやブロックの種類が変わる。"
+
 
 #: js/turtledefs.js:629
 #: js/toolbar.js:153
@@ -1242,27 +1388,33 @@ msgstr "ミュージック・ブロックスをかんたんモード／はって
 msgid "Select language"
 msgstr "言語をえらぶ"
 
+
 #: js/turtledefs.js:630
 msgid "Select your language preference."
 msgstr "ブロックの名前などに表示される言語をえらぶ。"
+
 
 #: js/turtledefs.js:634
 #: js/widgets/help.js:564
 msgid "Contextual Menu for Blocks"
 msgstr "ブロックのコンテキストメニュー"
 
+
 #: js/turtledefs.js:635
 msgid "Right-click on a block to access common actions."
 msgstr "ブロックを右クリックして共通操作にアクセスします。"
+
 
 #: js/turtledefs.js:639
 #: planet/js/StringHelper.js:48
 msgid "Delete"
 msgstr "消す"
 
+
 #: js/turtledefs.js:640
 msgid "To delete a block, right-click on it. Then you will see the delete option."
 msgstr "ブロックを削除するには、ブロックを右クリックします。次に、削除オプションが表示されます。"
+
 
 #: js/turtledefs.js:644
 #: js/activity.js:3871
@@ -1270,31 +1422,38 @@ msgstr "ブロックを削除するには、ブロックを右クリックしま
 msgid "Copy"
 msgstr "コピー"
 
+
 #: js/turtledefs.js:645
 msgid "To copy a block, right-click on it. Then you will see the copy option."
 msgstr "ブロックをコピーするには、ブロックを右クリックします。次に、コピーオプションが表示されます。"
 
+
 #: js/turtledefs.js:650
 msgid "To extract a block, right-click on it. Then you will see the extract option."
 msgstr "ブロックを抽出するには、ブロックを右クリックします。次に、抽出オプションが表示されます。"
+
 
 #: js/turtledefs.js:659
 #: js/widgets/help.js:563
 msgid "Tab Navigation"
 msgstr "タブのナビゲーション"
 
+
 #: js/turtledefs.js:660
 msgid "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
 msgstr "キーボードの Tab キーを押すと、ワークスペース、ツールバー、パレットからを魔法のようにジャンプできます。"
+
 
 #: js/turtledefs.js:668
 #: js/widgets/help.js:565
 msgid "Contextual Menu for Canvas"
 msgstr "キャンバスのコンテキストメニュー"
 
+
 #: js/turtledefs.js:669
 msgid "Right-click on the canvas to perform additional canvas-related tasks."
 msgstr "キャンバスを右クリックして追加のキャンバス関連タスクを実行します。"
+
 
 #: js/turtledefs.js:674
 #: js/turtles.js:982
@@ -1302,13 +1461,16 @@ msgstr "キャンバスを右クリックして追加のキャンバス関連タ
 msgid "Grid"
 msgstr "グリッド"
 
+
 #: js/turtledefs.js:675
 msgid "Turn on/off lines for cartesian or polar grids."
 msgstr "デカルト座標または極座標グリッドの線をオン/オフにします。"
 
+
 #: js/turtledefs.js:677
 msgid "Turn on/off music staffs."
 msgstr "五線譜の表示/非表示を切り替えます。"
+
 
 #: js/turtledefs.js:681
 #: js/turtles.js:999
@@ -1323,95 +1485,116 @@ msgstr "五線譜の表示/非表示を切り替えます。"
 #: js/widgets/rhythmruler.js:755
 #: js/widgets/temperament.js:327
 #: js/widgets/temperament.js:358
-#. TRANS: clear all subdivisions from the ruler.
+#.  TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "もとにもどす"
+
 
 #: js/turtledefs.js:682
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr "ネズミを元の位置にもどし、ペンでえがいた線をすべて消す。"
+
 
 #: js/turtledefs.js:686
 #: js/turtles.js:1020
 msgid "Collapse"
 msgstr "カンバスをしゅくしょう"
 
+
 #: js/turtledefs.js:687
 msgid "Collapse the graphics window."
 msgstr "ネズミがいどうしたり、ペンで線をえがいたりできる「カンバス」の表示サイズを しゅくしょうしたり、かくだいしたりする。カンバスをしゅくしょうした場合は、プログラムをふつうのそくどで実行しても、ブロックがかくれない。ふつうの実行そくどでプログラムの動作かくにんをしたいときなどに便利だ。"
+
 
 #: js/turtledefs.js:691
 #: js/activity.js:7131
 msgid "Home"
 msgstr "ホーム"
 
+
 #: js/turtledefs.js:692
 msgid "Return all blocks to the center of the screen."
 msgstr "すべてのブロックを、カンバスのまんなかに配置する。"
+
 
 #: js/turtledefs.js:696
 #: js/activity.js:7148
 msgid "Show/hide blocks"
 msgstr "ブロックを表示する／かくす"
 
+
 #: js/turtledefs.js:697
 msgid "Hide or show the blocks and the palettes."
 msgstr "クリックすると、パレットボタンとプログラムのブロックを画面上に表示させたり、かくしたりすることができる。"
+
 
 #: js/turtledefs.js:701
 #: js/activity.js:7164
 msgid "Expand/collapse blocks"
 msgstr "ブロックを広げる/折りたたむ"
 
+
 #: js/turtledefs.js:702
 msgid "Expand or collapse start and action stacks."
 msgstr "クリックすると、「スタート」と「アクション」に使われているブロックを、広げて表示したり、折りたたんでかくしたりすることができる。"
+
 
 #: js/turtledefs.js:706
 #: js/activity.js:7180
 msgid "Decrease block size"
 msgstr "ブロックの表示を小さくする"
 
+
 #: js/turtledefs.js:707
 msgid "Decrease the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを小さくする。"
+
 
 #: js/turtledefs.js:711
 #: js/activity.js:7196
 msgid "Increase block size"
 msgstr "ブロックの表示を大きくする"
 
+
 #: js/turtledefs.js:712
 msgid "Increase the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを大きくする。"
+
 
 #: js/turtledefs.js:717
 msgid "Select"
 msgstr "選択"
 
+
 #: js/turtledefs.js:718
 msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr "ワークスペースを左クリックしてドラッグすると複数のブロックを選択できます。"
+
 
 #: js/turtledefs.js:724
 msgid "Palette buttons"
 msgstr "パレットボタン"
 
+
 #: js/turtledefs.js:725
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr "ミュージック・ブロックスの左側には、プログラミングに使うさまざまなブロックをグループ分けした「パレットボタン」がある。"
+
 
 #: js/turtledefs.js:729
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr "それぞれのパレットボタンをクリックし、「音符（おんぷ）」「アクション」「ペン」などから好きなブロックを選んで、カンバス上にドラッグして置いてみよう。"
 
+
 #: js/turtledefs.js:738
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
+
 #: js/turtledefs.js:741
 msgid "Turtle Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
+
 
 #: js/turtledefs.js:744
 #: js/turtledefs.js:769
@@ -1419,21 +1602,26 @@ msgstr "ミュージック・ブロックスガイド"
 msgid "About"
 msgstr "ミュージック・ブロックスについて"
 
+
 #: js/turtledefs.js:745
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
+
 
 #: js/turtledefs.js:749
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
 
+
 #: js/turtledefs.js:753
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
+
 #: js/turtledefs.js:760
 msgid "Turtle Blocks GitHub repository"
 msgstr "タータル・ブロックスのリポジトリ"
+
 
 #: js/turtledefs.js:763
 #: js/widgets/help.js:494
@@ -1441,47 +1629,58 @@ msgstr "タータル・ブロックスのリポジトリ"
 msgid "Congratulations."
 msgstr "おめでとうございます！"
 
+
 #: js/turtledefs.js:764
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr "ツアーはここで終わり。タータル・ブロックスを自由に楽しもう。"
+
 
 #: js/turtledefs.js:770
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
 
+
 #: js/turtledefs.js:774
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
+
 
 #: js/turtledefs.js:778
 msgid "Music Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
+
 #: js/turtledefs.js:783
 msgid "Music Blocks GitHub repository"
 msgstr "ミュージック・ブロックスのリポジトリ"
+
 
 #: js/turtledefs.js:786
 #: js/widgets/help.js:552
 msgid "Congratulations!"
 msgstr "おめでとうございます！"
 
+
 #: js/turtledefs.js:787
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr "ミスター・マウスのツアーはここで終わり。ミュージック・ブロックスを自由に楽しもう。"
+
 
 #: js/turtles.js:1088
 msgid "Expand"
 msgstr "カンバスをかくだい"
 
+
 #: js/rubrics.js:543
 msgid "mice"
 msgstr "ネズミ達の関係"
+
 
 #: js/toolbar.js:119
 #: js/toolbar.js:191
 msgid "About Music Blocks"
 msgstr "ミュージック・ブロックスについて"
+
 
 #: js/toolbar.js:123
 #: js/toolbar.js:124
@@ -1494,12 +1693,14 @@ msgstr "ミュージック・ブロックスについて"
 msgid "Enter Fullscreen"
 msgstr "全画面表示に入る"
 
+
 #: js/toolbar.js:130
 #: js/toolbar.js:202
 #: js/toolbar.js:259
 #: js/toolbar.js:325
 msgid "Find and share projects"
 msgstr "みんなの作品"
+
 
 #: js/toolbar.js:131
 #: js/toolbar.js:203
@@ -1508,6 +1709,7 @@ msgstr "みんなの作品"
 msgid "Offline. Sharing is unavailable"
 msgstr "オフライン。シェア機能が使えません"
 
+
 #: js/toolbar.js:132
 #: js/toolbar.js:204
 #: js/toolbar.js:261
@@ -1515,12 +1717,14 @@ msgstr "オフライン。シェア機能が使えません"
 msgid "Auxiliary menu"
 msgstr "サブメニュー"
 
+
 #: js/toolbar.js:133
 #: js/toolbar.js:205
 #: js/toolbar.js:262
 #: js/toolbar.js:328
 msgid "Help and shortcuts"
 msgstr "ヘルプとショートカット"
+
 
 #: js/toolbar.js:135
 #: js/toolbar.js:207
@@ -1531,12 +1735,14 @@ msgstr "ヘルプとショートカット"
 msgid "Keyboard shortcuts"
 msgstr "キーボードのショートカット"
 
+
 #: js/toolbar.js:141
 #: js/toolbar.js:213
 #: js/toolbar.js:270
 #: js/toolbar.js:336
 msgid "Enable horizontal scrolling"
 msgstr "自由な方向にスクロール"
+
 
 #: js/toolbar.js:142
 #: js/toolbar.js:214
@@ -1545,12 +1751,14 @@ msgstr "自由な方向にスクロール"
 msgid "Disable horizontal scrolling"
 msgstr "たて方向にスクロール"
 
+
 #: js/toolbar.js:144
 #: js/toolbar.js:216
 #: js/toolbar.js:273
 #: js/toolbar.js:339
 msgid "Light Mode"
 msgstr "ライトモード"
+
 
 #: js/toolbar.js:145
 #: js/toolbar.js:217
@@ -1559,12 +1767,14 @@ msgstr "ライトモード"
 msgid "Dark Mode"
 msgstr "ダークモード"
 
+
 #: js/toolbar.js:146
 #: js/toolbar.js:218
 #: js/toolbar.js:275
 #: js/toolbar.js:341
 msgid "High-contrast Mode"
 msgstr "ハイコントラストモード"
+
 
 #: js/toolbar.js:151
 #: js/toolbar.js:223
@@ -1573,6 +1783,7 @@ msgstr "ハイコントラストモード"
 msgid "Switch to beginner mode"
 msgstr "かんたんモードにする"
 
+
 #: js/toolbar.js:152
 #: js/toolbar.js:224
 #: js/toolbar.js:280
@@ -1580,24 +1791,29 @@ msgstr "かんたんモードにする"
 msgid "Switch to advanced mode"
 msgstr "はってんモードにする"
 
+
 #: js/toolbar.js:158
 #: js/toolbar.js:228
 msgid "Save mouse artwork as SVG"
 msgstr "SVGでほぞん"
+
 
 #: js/toolbar.js:161
 #: js/toolbar.js:231
 msgid "Save sheet music as ABC"
 msgstr "ABCのフォーマットでほぞん"
 
+
 #: js/toolbar.js:162
 #: js/toolbar.js:232
 msgid "Save sheet music as Lilypond"
 msgstr "がくふ(Lilypondのフォーマット)でほぞん"
 
+
 #: js/toolbar.js:163
 msgid "Save sheet music as MusicXML"
 msgstr "プロジェクトをMusicXML楽譜でほぞん"
+
 
 #: js/toolbar.js:165
 #: js/toolbar.js:234
@@ -1606,6 +1822,7 @@ msgstr "プロジェクトをMusicXML楽譜でほぞん"
 #: js/toolbar.js:354
 msgid "Save block artwork as PNG"
 msgstr "ブロックのアートワークをPNGで保存"
+
 
 #: js/toolbar.js:166
 #: js/toolbar.js:235
@@ -1619,24 +1836,29 @@ msgstr "ブロックのアートワークをPNGで保存"
 msgid "Confirm"
 msgstr "作成する"
 
+
 #: js/toolbar.js:248
 #: js/toolbar.js:314
 msgid "About Turtle Blocks"
 msgstr "タートル・ブロックスについて"
+
 
 #: js/toolbar.js:470
 #: js/activity.js:7546
 msgid "Play project"
 msgstr "プロジェクトを再生"
 
+
 #: js/toolbar.js:532
 #: js/activity.js:7550
 msgid "Stop project"
 msgstr "プロジェクトを停止する"
 
+
 #: js/toolbar.js:574
 msgid "Are you sure you want to create a new project?"
 msgstr "新しいプロジェクトを作成してもよろしいですか？"
+
 
 #: js/toolbar.js:766
 #: js/toolbar.js:777
@@ -1646,6 +1868,7 @@ msgstr "新しいプロジェクトを作成してもよろしいですか？"
 msgid "Turtle Wrap Off"
 msgstr "画面の境界を無視しない"
 
+
 #: js/toolbar.js:778
 #: js/toolbar.js:787
 #: js/toolbar.js:820
@@ -1653,186 +1876,228 @@ msgstr "画面の境界を無視しない"
 msgid "Turtle Wrap On"
 msgstr "画面の境界を無視する"
 
+
 #: js/activity.js:509
 #: js/activity.js:514
 msgid "Search for blocks"
 msgstr "ブロックを検索"
 
+
 #: js/activity.js:1580
 msgid "Import MIDI"
 msgstr "MIDIをインポートする"
+
 
 #: js/activity.js:1588
 msgid "Set the max blocks to generate:"
 msgstr "生成する最大ブロックを設定します。"
 
+
 #: js/activity.js:1647
 msgid "Clear workspace"
 msgstr "すっきりとしたワークスペース"
 
+
 #: js/activity.js:1653
 msgid "Are you sure you want to clear the workspace?"
 msgstr "ワークスペースを本当にクリアしますか？"
+
 
 #: js/activity.js:2014
 #: js/activity.js:2092
 msgid "Save recording"
 msgstr "録音を保存する"
 
+
 #: js/activity.js:2021
 #: js/activity.js:2071
 msgid "File save canceled"
 msgstr "ファイルの保存がキャンセルされました"
+
 
 #: js/activity.js:2042
 #: js/activity.js:2052
 msgid "Recorded file is empty. File not saved."
 msgstr "録音されたファイルは空です。ファイルが保存されていません。"
 
+
 #: js/activity.js:2069
 #: js/activity.js:2099
 msgid "Enter file name"
 msgstr "ファイル名を入力してください"
 
+
 #: js/activity.js:2082
 msgid "Saved! Check your Downloads folder."
 msgstr "保存しました！ダウンロードフォルダーを確認してください。"
+
 
 #: js/activity.js:2089
 msgid "Recording stopped. File saved."
 msgstr "録音が停止されました。ファイルが保存されました。"
 
+
 #: js/activity.js:2094
 msgid "recording"
 msgstr "録音中"
+
 
 #: js/activity.js:2131
 msgid "Recording started. Click stop to finish."
 msgstr "録音が開始されました。終了するには「停止」をクリックします。"
 
+
 #: js/activity.js:2211
 msgid "Recording failed: %s"
 msgstr "録音に失敗しました: %s"
+
 
 #: js/activity.js:2412
 msgid "Horizontal scrolling enabled."
 msgstr "水平スクロールが有効になりました。"
 
+
 #: js/activity.js:2421
 msgid "Horizontal scrolling disabled."
 msgstr "水平スクロールが無効になっています。"
+
 
 #: js/activity.js:2432
 msgid "Catching mice"
 msgstr "ネズミをつかまえているよ"
 
+
 #: js/activity.js:2433
 msgid "Cleaning the instruments"
 msgstr "楽器のおていれをしているよ"
+
 
 #: js/activity.js:2434
 msgid "Testing key pieces"
 msgstr "キーボードの音をたしかめているよ"
 
+
 #: js/activity.js:2435
 msgid "Sight-reading"
 msgstr "がくふをよみこんでいるよ"
+
 
 #: js/activity.js:2436
 msgid "Combining math and music"
 msgstr "音楽と算数をくっつけているよ"
 
+
 #: js/activity.js:2437
 msgid "Generating more blocks"
 msgstr "ブロックをたくさんつくっているよ"
+
 
 #: js/activity.js:2438
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr "ド　レ　ミ　ファ　ソ　ラ　シ　ド"
 
+
 #: js/activity.js:2439
 msgid "Tuning string instruments"
 msgstr "弦楽器のチューニングをしているよ"
+
 
 #: js/activity.js:2440
 msgid "Pressing random keys"
 msgstr "キーボードでおんがくをつくっているよ"
 
+
 #: js/activity.js:2662
 msgid "plugins will be removed upon restart."
 msgstr "プラグインは再起動時に削除されます。"
 
+
 #: js/activity.js:2671
 msgid "show Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
+
 
 #: js/activity.js:3331
 #: js/palette.js:1258
 #: js/blocks/RhythmBlocks.js:925
 #: js/blocks/PitchBlocks.js:462
 #: js/blocks/PitchBlocks.js:1831
-#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#.  TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "scale degree"
 msgstr "音度"
+
 
 #: js/activity.js:3334
 #: js/palette.js:1267
 msgid "voice name"
 msgstr "音名"
 
+
 #: js/activity.js:3337
 #: js/palette.js:1264
 msgid "invert mode"
 msgstr "モードを反転させる"
 
+
 #: js/activity.js:3340
 msgid "output tools"
 msgstr "出力ツール"
+
 
 #: js/activity.js:3343
 msgid "custom note"
 msgstr "カスタムノート"
 
+
 #: js/activity.js:3346
 msgid "accidental name"
 msgstr "偶然の名前"
+
 
 #: js/activity.js:3349
 #: js/blocks/PitchBlocks.js:895
 msgid "east indian solfege"
 msgstr "東インドのソルフェージュ"
 
+
 #: js/activity.js:3352
 #: js/blocks/PitchBlocks.js:909
 msgid "note name"
 msgstr "音名"
+
 
 #: js/activity.js:3355
 #: js/blocks/IntervalsBlocks.js:94
 msgid "temperament name"
 msgstr "気質名"
 
+
 #: js/activity.js:3358
 #: js/palette.js:1261
 msgid "mode name"
 msgstr "モード名"
 
+
 #: js/activity.js:3361
 msgid "chord name"
 msgstr "chord name"
+
 
 #: js/activity.js:3364
 #: js/palette.js:1284
 msgid "interval name"
 msgstr "音程名"
 
+
 #: js/activity.js:3367
 msgid "filter type"
 msgstr "フィルターの種類"
 
+
 #: js/activity.js:3370
 msgid "oscillator type"
 msgstr "発振器の種類"
+
 
 #: js/activity.js:3373
 #: js/blocks.js:2685
@@ -1840,243 +2105,301 @@ msgstr "発振器の種類"
 msgid "audio file"
 msgstr "オーディオファイル"
 
+
 #: js/activity.js:3376
 #: js/blocks/DrumBlocks.js:32
 msgid "noise name"
 msgstr "ノイズ名"
+
 
 #: js/activity.js:3379
 #: js/blocks/DrumBlocks.js:75
 msgid "drum name"
 msgstr "ドラム名"
 
+
 #: js/activity.js:3382
 #: js/blocks/DrumBlocks.js:119
 msgid "effects name"
 msgstr "エフェクト名"
 
+
 #: js/activity.js:3385
 msgid "wrap mode"
 msgstr "ラップモード"
 
+
 #: js/activity.js:3388
 msgid "load file"
 msgstr "ロード ファイル "
+
 
 #: js/activity.js:3717
 #: js/activity.js:7467
 msgid "This block is deprecated."
 msgstr "このブロックはもうありません。"
 
+
 #: js/activity.js:3719
 #: js/activity.js:7469
 msgid "Block cannot be found."
 msgstr "ブロックが見つかりません。"
 
+
 #: js/activity.js:3867
 msgid "Saving block artwork"
 msgstr "ブロックのアートを保存中"
 
+
 #: js/activity.js:3875
 msgid "Erase"
 msgstr "消す"
+
 
 #: js/activity.js:3919
 #: js/activity.js:3949
 msgid "Paste"
 msgstr "貼り付け"
 
+
 #: js/activity.js:3923
 msgid "Save block help"
 msgstr "ブロックの ヘルプを 保存"
+
 
 #: js/activity.js:3995
 msgid "Jumping to the bottom of the page."
 msgstr "画面の下にジャンプしています"
 
+
 #: js/activity.js:4001
 msgid "Scrolling up."
 msgstr "上にスクロールしています"
+
 
 #: js/activity.js:4006
 msgid "Scrolling down."
 msgstr "下にスクロールしています"
 
+
 #: js/activity.js:4011
 msgid "Extracting block"
 msgstr "ブロックを取り出しています"
+
 
 #: js/activity.js:4019
 msgid "Moving block up."
 msgstr "ブロックを上に動かしています"
 
+
 #: js/activity.js:4040
 msgid "Moving block down."
 msgstr "ブロックを下に動かしています"
+
 
 #: js/activity.js:4062
 msgid "Moving block left."
 msgstr "ブロックを左に動かしています"
 
+
 #: js/activity.js:4079
 msgid "Moving block right."
 msgstr "ブロックを右に動かしています"
 
+
 #: js/activity.js:4094
 msgid "Jump to home position."
 msgstr "まんなかにジャンプする"
+
 
 #: js/activity.js:4114
 #: js/blocks/ExtrasBlocks.js:275
 msgid "Hide blocks"
 msgstr "ブロックを非表示"
 
+
 #: js/activity.js:4498
 #: js/activity.js:4516
 msgid "Trash can is empty."
 msgstr "ゴミ箱は空です。"
+
 
 #: js/activity.js:4520
 #: js/activity.js:4652
 msgid "Item restored from the trash."
 msgstr "ゴミ箱からアイテムを復元しました。"
 
+
 #: js/activity.js:4724
 msgid "Restore last item"
 msgstr "先のアイテムを復元"
+
 
 #: js/activity.js:4725
 msgid "Restore all items"
 msgstr "すべてのアイテムを復元"
 
+
 #: js/activity.js:5393
 msgid "Click the run button to run the project."
 msgstr "プロジェクトを再生するため、再生のボタンをクリックしてください。"
+
 
 #: js/activity.js:6009
 msgid "Loading Complete!"
 msgstr "読み込み完了！"
 
+
 #: js/activity.js:7068
 msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "組み込みプラグインの名前を入力するか、空白のままにしてプラグイン ファイルをアップロードします。"
+
 
 #: js/activity.js:7080
 msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
 msgstr "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。"
 
+
 #: js/activity.js:7538
 msgid "Windows/Linux"
 msgstr "Windows/Linux"
+
 
 #: js/activity.js:7538
 msgid "Mac"
 msgstr "マック"
 
+
 #: js/activity.js:7542
 msgid "Workspace"
 msgstr "ワークスペース"
+
 
 #: js/activity.js:7554
 msgid "Play or stop depending on the current state"
 msgstr "現在の状態に応じて再生または停止します"
 
+
 #: js/activity.js:7558
 msgid "Play or stop when no text input or widget is active"
 msgstr "アクティブなテキスト入力またはウィジェットがない場合は再生または停止します"
+
 
 #: js/activity.js:7562
 msgid "Toggle stage scale"
 msgstr "ステージスケールの切り替え"
 
+
 #: js/activity.js:7566
 msgid "Jump to home position"
 msgstr "ホームポジションに戻る"
+
 
 #: js/activity.js:7570
 msgid "Jump to the bottom of the workspace"
 msgstr "ワークスペースの一番下にジャンプします"
 
+
 #: js/activity.js:7574
 msgid "Scroll workspace up"
 msgstr "ワークスペースを上にスクロールする"
+
 
 #: js/activity.js:7578
 msgid "Scroll workspace down"
 msgstr "ワークスペースを下にスクロールします"
 
+
 #: js/activity.js:7582
 msgid "Hide block search when it is open"
 msgstr "ブロック検索が開いているときに非表示にする"
+
 
 #: js/activity.js:7586
 msgid "You can type d to create a do block and r to create a re block etc."
 msgstr "キーボードを使うと、パレットボタンからブロックをドラッグして配置するだけでなく、ボタンをおすだけでちょくせつブロックを置くことができる。★ショートカットキー d …… 「ド」（４分音符、４オクターヴ） r …… 「レ」（４分音符、４オクターヴ） m …… 「ミ」（４分音符、４オクターヴ） f</em> …… 「ファ」（４分音符、４オクターヴ s …… 「ソ」（４分音符、４オクターヴ） l …… 「ラ」（４分音符、４オクターヴ） t …… 「シ」（４分音符、４オクターヴ）"
 
+
 #: js/activity.js:7593
 msgid "Editing"
 msgstr "編集"
+
 
 #: js/activity.js:7597
 msgid "Copy selected stack."
 msgstr "選択したスタックをコピーします。"
 
+
 #: js/activity.js:7601
 msgid "Paste previous stack."
 msgstr "この前のスタックを貼り付けます。"
+
 
 #: js/activity.js:7605
 msgid "Open the JSON paste box."
 msgstr "JSON 貼り付けボックスを開きます。"
 
+
 #: js/activity.js:7609
 msgid "Paste JSON when the paste box is focused."
 msgstr "貼り付けボックスにフォーカスがあるときに JSON を貼り付けます。"
+
 
 #: js/activity.js:7613
 msgid "Extract the active block."
 msgstr "アクティブなブロックを抽出します。"
 
+
 #: js/activity.js:7617
 msgid "Clear workspace."
 msgstr "すっきりとしたワークスペース。"
+
 
 #: js/activity.js:7621
 msgid "Save block artwork."
 msgstr "ブロックアートワークを保存します。"
 
+
 #: js/activity.js:7625
 msgid "Save block help."
 msgstr "ブロックのヘルプを保存します。"
+
 
 #: js/activity.js:7630
 msgid "Navigation"
 msgstr "ナビゲーション"
 
+
 #: js/activity.js:7634
 msgid "Move focus between the toolbar, palettes, and workspace."
 msgstr "ツールバー、パレット、ワークスペースの中からフォーカスを移動します。"
+
 
 #: js/activity.js:7637
 #: js/activity.js:7703
 msgid "Arrow keys"
 msgstr "矢印キー"
 
+
 #: js/activity.js:7638
 msgid "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
 msgstr "コンテキストに応じて、アクティブなブロックの移動、パレットのスクロール、テンポ ウィジェットの調整、またはワークスペースのパンを行います。"
+
 
 #: js/activity.js:7644
 msgid "Pan workspace right when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを右に移動します。"
 
+
 #: js/activity.js:7648
 msgid "Pan workspace left when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを左に移動します。"
 
+
 #: js/activity.js:7653
 msgid "Toolbar"
 msgstr "ツールバー"
+
 
 #: js/activity.js:7657
 #: js/activity.js:7658
@@ -2085,66 +2408,82 @@ msgstr "ツールバー"
 msgid "Arrow Left / Arrow Right"
 msgstr "左矢印 / 右矢印"
 
+
 #: js/activity.js:7660
 msgid "Move focus within the current toolbar."
 msgstr "現在のツールバー内でフォーカスを移動します。"
+
 
 #: js/activity.js:7664
 #: js/activity.js:7665
 msgid "Arrow Up / Arrow Down"
 msgstr "上矢印 / 下矢印"
 
+
 #: js/activity.js:7667
 msgid "Move focus between main and auxiliary toolbars."
 msgstr "メイン ツールバーと補助ツールバーの間でフォーカスを移動します。"
+
 
 #: js/activity.js:7671
 msgid "Activate the focused toolbar button."
 msgstr "フォーカスされたツールバーからのボタンをアクティブにします。"
 
+
 #: js/activity.js:7675
 msgid "Exit toolbar keyboard navigation."
 msgstr "ツールバーのキーボードナビゲーションを終了します。"
+
 
 #: js/activity.js:7680
 msgid "Widget Windows"
 msgstr "ウィジェット・ウィンドウ"
 
+
 #: js/activity.js:7684
 msgid "Close the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを閉じます。"
+
 
 #: js/activity.js:7688
 msgid "Maximize or restore the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを最大化または復元します。"
 
+
 #: js/activity.js:7693
 msgid "Help and Pitch Slider"
 msgstr "ヘルプとピッチ・スライダー"
+
 
 #: js/activity.js:7700
 msgid "Move between help pages when Help is open."
 msgstr "ヘルプが開いているときにヘルプ・ページの中から移動します。"
 
+
 #: js/activity.js:7704
 msgid "Adjust pitch by semitone when Pitch Slider is open."
 msgstr "ピッチ・スライダーが開いているときに半音単位でピッチを調整します。"
+
 
 #: js/activity.js:7739
 msgid "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
 msgstr "ショートカットは状況に依存します。一部の機能は、関連するパネル、ウィジェット、またはモードがアクティブな場合にのみ機能します。 Windows/Linux および Mac の同等のものを一緒に示します。"
 
+
 #: js/activity.js:7873
 msgid "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
 msgstr "クリップボードデータが無効です。ブロックを貼り付けるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストを貼り付けるには、入力フィールド内をクリックします。"
+
 
 #: js/activity.js:8099
 msgid "Select is enabled."
 msgstr "選択モードが有効です。"
 
+
 #: js/activity.js:8100
 msgid "Select is disabled."
 msgstr "選択モードが無効です。"
+
 
 #: js/activity.js:8561
 #: js/activity.js:8626
@@ -2155,17 +2494,21 @@ msgstr "選択モードが無効です。"
 msgid "Cannot load project from the file. Please check the file type."
 msgstr "プロジェクトを読みこめません。ファイルの種類をかくにんしてください。"
 
+
 #: js/activity.js:8987
 msgid "Something went wrong reading JSON-encoded project data."
 msgstr "JSON エンコードされたプロジェクト データの読み取り中に問題が発生しました。"
+
 
 #: js/activity.js:8998
 msgid "Invalid parameters"
 msgstr "無効なパラメータ"
 
+
 #: js/activity.js:9291
 msgid "Error regenerating palettes. Please refresh the page."
 msgstr "パレットの再生成に失敗しました。ページを更新してください。"
+
 
 #: js/block.js:1738
 #: js/block.js:1857
@@ -2175,9 +2518,11 @@ msgstr "パレットの再生成に失敗しました。ページを更新して
 msgid "temperament"
 msgstr "音律"
 
+
 #: js/block.js:1752
 msgid "matrix"
 msgstr "フレーズメーカー"
+
 
 #: js/block.js:1759
 #: js/blocks/WidgetBlocks.js:1743
@@ -2185,53 +2530,63 @@ msgstr "フレーズメーカー"
 msgid "status"
 msgstr "実行じょうきょう"
 
+
 #: js/block.js:1766
 msgid "drum mapper"
 msgstr "ドラム・ピッチ行列"
+
 
 #: js/block.js:1773
 msgid "ruler"
 msgstr "リズムメーカー"
 
+
 #: js/block.js:1780
 #: js/blocks/WidgetBlocks.js:457
-#. TRANS: timbre is the character or quality of a musical sound
+#.  TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "音色"
+
 
 #: js/block.js:1787
 msgid "stair"
 msgstr "階段"
 
+
 #: js/block.js:1794
 #: js/blocks/ProgramBlocks.js:1278
 #: js/blocks/WidgetBlocks.js:782
-#. TRANS: the speed at music is should be played.
+#.  TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "メトロノーム"
+
 
 #: js/block.js:1801
 #: js/block.js:1864
 #: js/blocks/IntervalsBlocks.js:1506
-#. TRANS: mode, e.g., Major in C Major
+#.  TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "モード（音階）"
+
 
 #: js/block.js:1808
 msgid "slider"
 msgstr "スライダー"
+
 
 #: js/block.js:1815
 #: js/blocks/SensorsBlocks.js:943
 msgid "keyboard"
 msgstr "キーボード"
 
+
 #: js/block.js:1829
 #: js/blocks/WidgetBlocks.js:1319
 #: js/blocks/WidgetBlocks.js:1357
-#. TRANS: widget for subdividing a measure into distinct rhythmic elements
+#.  TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
+
 
 #: js/block.js:1836
 #: js/block.js:2650
@@ -2254,26 +2609,30 @@ msgstr "リズムメーカー"
 #: js/widgets/phrasemaker.js:2742
 #: js/widgets/phrasemaker.js:2791
 #: js/widgets/phrasemaker.js:2910
-#. TRANS: the value (e.g., 1/4 note) of the note being played.
+#.  TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "音の長さ"
+
 
 #: js/block.js:1843
 #: js/blocks/IntervalsBlocks.js:1108
 #: js/blocks/OrnamentBlocks.js:312
-#. TRANS: calculate a relative step between notes based on semi-tones
+#.  TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "音階の上下"
+
 
 #: js/block.js:1850
 #: js/blocks/RhythmBlocks.js:154
 msgid "milliseconds"
 msgstr "ミリ秒"
 
+
 #: js/block.js:2575
 #: js/block.js:2598
 msgid "scalar interval %s"
 msgstr "音階の上下 %s"
+
 
 #: js/block.js:2648
 #: js/block.js:2652
@@ -2286,29 +2645,34 @@ msgstr "音階の上下 %s"
 msgid "silence"
 msgstr "休符"
 
+
 #: js/block.js:2744
 #: js/block.js:3844
 #: js/block.js:3861
 #: js/utils/musicutils.js:4405
 #: js/utils/musicutils.js:6055
-#. TRANS: the note names must be separated by single spaces
-#. TRANS: the note names must be separated by single spaces
+#.  TRANS: the note names must be separated by single spaces
+#.  TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
+
 #: js/block.js:2832
 #: js/blocks/IntervalsBlocks.js:627
-#. TRANS: scalar step
+#.  TRANS: scalar step
 msgid "down"
 msgstr "下"
+
 
 #: js/block.js:2833
 msgid "up"
 msgstr "上"
 
+
 #: js/block.js:3300
 msgid "Silence block cannot be removed."
 msgstr "「休符」は取り出すことができません。"
+
 
 #: js/block.js:4191
 #: js/blocks.js:2813
@@ -2329,6 +2693,7 @@ msgstr "「休符」は取り出すことができません。"
 msgid "true"
 msgstr "真"
 
+
 #: js/block.js:4191
 #: js/blocks.js:2815
 #: js/blocks.js:3434
@@ -2346,11 +2711,13 @@ msgstr "真"
 msgid "false"
 msgstr "偽"
 
+
 #: js/block.js:4201
 #: js/block.js:4205
 #: js/blocks/ExtrasBlocks.js:618
 msgid "Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
+
 
 #: js/block.js:4201
 #: js/block.js:4206
@@ -2358,11 +2725,13 @@ msgstr "ほうがん（ざひょう）を表示"
 msgid "polar"
 msgstr "極座標を表示"
 
+
 #: js/block.js:4201
 #: js/block.js:4207
 #: js/blocks/ExtrasBlocks.js:626
 msgid "Cartesian/Polar"
 msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
+
 
 #: js/block.js:4201
 #: js/block.js:4214
@@ -2370,39 +2739,46 @@ msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
 msgid "none"
 msgstr "なし"
 
+
 #: js/block.js:4208
 #: js/blocks/ExtrasBlocks.js:631
 msgid "treble"
 msgstr "トレブル記号"
+
 
 #: js/block.js:4209
 #: js/blocks/ExtrasBlocks.js:635
 msgid "grand staff"
 msgstr "トレブルとバス記号"
 
+
 #: js/block.js:4210
 #: js/blocks/ExtrasBlocks.js:639
 msgid "mezzo-soprano"
 msgstr "メゾソプラノ記号"
+
 
 #: js/block.js:4211
 #: js/blocks/ExtrasBlocks.js:643
 msgid "alto"
 msgstr "アルト記号"
 
+
 #: js/block.js:4212
 #: js/blocks/ExtrasBlocks.js:647
 msgid "tenor"
 msgstr "テノール記号"
+
 
 #: js/block.js:4213
 #: js/utils/musicutils.js:1168
 #: js/utils/synthutils.js:88
 #: js/blocks/ExtrasBlocks.js:651
 #: js/widgets/legobricks.js:1932
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "bass"
 msgstr "コントラバス"
+
 
 #: js/block.js:4258
 #: js/blocks.js:2806
@@ -2410,23 +2786,28 @@ msgstr "コントラバス"
 msgid "on2"
 msgstr "オン"
 
+
 #: js/block.js:4260
 #: js/blocks.js:2808
 #: js/blocks.js:3427
 msgid "off"
 msgstr "オフ"
 
+
 #: js/block.js:4731
 msgid "Not a number"
 msgstr "数字ではありません"
+
 
 #: js/block.js:4742
 msgid "Octave value must be between 1 and 8."
 msgstr "オクターヴの値が「１」から「8」までの範囲でなければなりません。"
 
+
 #: js/block.js:4750
 msgid "Numbers can have at most 10 digits."
 msgstr "数字は最大１０桁までです。"
+
 
 #: js/blocks.js:1423
 #: js/blocks.js:3657
@@ -2445,15 +2826,18 @@ msgstr "数字は最大１０桁までです。"
 msgid "box"
 msgstr "箱"
 
+
 #: js/blocks.js:1949
 msgid "Consider breaking this stack into parts."
 msgstr "アクションブロックを使ってプログラムをまとめませんか"
+
 
 #: js/blocks.js:2678
 #: js/palette.js:1322
 #: js/blocks/MediaBlocks.js:686
 msgid "open file"
 msgstr "ファイルを開く"
+
 
 #: js/blocks.js:3461
 #: js/palette.js:1243
@@ -2462,12 +2846,14 @@ msgstr "ファイルを開く"
 msgid "text"
 msgstr "文字そざい"
 
+
 #: js/blocks.js:3656
 #: js/palette.js:1310
 #: js/palette.js:1311
 #: js/blocks/BoxesBlocks.js:517
 msgid "store in box"
 msgstr "箱にほぞん"
+
 
 #: js/blocks.js:3661
 #: js/blocks.js:4144
@@ -2479,6 +2865,7 @@ msgstr "箱にほぞん"
 msgid "box1"
 msgstr "箱１"
 
+
 #: js/blocks.js:3663
 #: js/blocks.js:4146
 #: js/blocks.js:4192
@@ -2489,6 +2876,7 @@ msgstr "箱１"
 msgid "box2"
 msgstr "箱２"
 
+
 #: js/blocks.js:4411
 #: js/palette.js:1308
 #: js/palette.js:1313
@@ -2496,6 +2884,7 @@ msgstr "箱２"
 #: js/blocks/BoxesBlocks.js:594
 msgid "store in"
 msgstr "入れる"
+
 
 #: js/blocks.js:4411
 #: js/blocks/BoxesBlocks.js:598
@@ -2514,6 +2903,7 @@ msgstr "入れる"
 msgid "name"
 msgstr "名前"
 
+
 #: js/blocks.js:4411
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:598
@@ -2524,47 +2914,57 @@ msgstr "名前"
 msgid "value"
 msgstr "値"
 
+
 #: js/blocks.js:4749
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr "「ずっとくり返す」状態が「音符」の中にある。"
+
 
 #: js/blocks.js:5296
 msgid "There is no block selected."
 msgstr "ブロックが選ばれていません"
 
+
 #: js/blocks.js:5408
 #: js/blocks/MediaBlocks.js:886
-#. TRANS: Avatar is the image used to determine the appearance of the mouse.
+#.  TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
+
 
 #: js/blocks.js:5411
 #: js/utils/synthutils.js:3615
 #: js/blocks/ToneBlocks.js:1036
 #: js/widgets/sampler.js:1988
-#. TRANS: The sound sample that the user uploads.
+#.  TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "音色サンプル"
+
 
 #: js/languagebox.js:256
 msgid "Refresh your browser to change your language preference."
 msgstr "言語を変えるには、ブラウザをこうしんしてください。"
 
+
 #: js/languagebox.js:288
 msgid "Music Blocks is already set to this language."
 msgstr " Music Blocksは既にこの言語に設定されています。"
+
 
 #: js/loader.js:431
 msgid "Failed to load EaselJS. Please refresh the page."
 msgstr "EaselJS のロードに失敗しました。ページを更新してください。"
 
+
 #: js/loader.js:453
 msgid "Failed to load Music Blocks. Please refresh the page."
 msgstr "ミュージック・ブロックスの読み込みに失敗しました。ページを更新してください。"
 
+
 #: js/loader.js:460
 msgid "Failed to initialize Music Blocks core. Please refresh the page.\n\nError: %s"
 msgstr "ミュージック・ブロックス コアの初期化に失敗しました。ページを更新してください。\n\nエラー: %s"
+
 
 #: js/logo.js:663
 #: js/blocks/ProgramBlocks.js:259
@@ -2572,108 +2972,132 @@ msgstr "ミュージック・ブロックス コアの初期化に失敗しま�
 msgid "You must select a file."
 msgstr "ファイルをえらんでください。"
 
+
 #: js/logo.js:1655
 msgid "Infinite loop detected. Execution stopped to prevent browser freeze."
 msgstr "無限ループが検出されました。ブラウザのフリーズを防ぐために実行が停止されました。"
+
 
 #: js/logo.js:1852
 #: js/blocks/MediaBlocks.js:338
 msgid "width"
 msgstr "カンバスのよこはば"
 
+
 #: js/logo.js:1853
 #: js/blocks/MediaBlocks.js:395
 msgid "height"
 msgstr "カンバスのたてはば"
 
+
 #: js/logo.js:1854
 #: js/blocks/MediaBlocks.js:35
-#. TRANS: right side of the screen
+#.  TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "ざひょうち（右）"
 
+
 #: js/logo.js:1855
 #: js/blocks/MediaBlocks.js:111
-#. TRANS: left side of the screen
+#.  TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち（左）"
+
 
 #: js/logo.js:1856
 #: js/blocks/MediaBlocks.js:186
 msgid "top (screen)"
 msgstr "ざひょうち（上）"
 
+
 #: js/logo.js:1857
 #: js/blocks/MediaBlocks.js:261
 msgid "bottom (screen)"
 msgstr "ざひょうち（下）"
 
+
 #: js/logo.js:2159
 msgid "Playback is ready."
 msgstr "コンパイル完了"
+
 
 #: js/palette.js:618
 msgid "Block Palettes"
 msgstr "ブロックパレット"
 
+
 #: js/palette.js:629
 msgid "Palette Categories"
 msgstr "パレットのカテゴリ"
+
 
 #: js/palette.js:650
 msgid "Toggle Palette"
 msgstr "パレットの切り替え"
 
+
 #: js/palette.js:1249
 msgid "effect"
 msgstr "こうかおん"
 
+
 #: js/palette.js:1255
 msgid "sargam"
 msgstr "Sargam (インドの ソルファ)"
+
 
 #: js/palette.js:1270
 #: js/blocks/PitchBlocks.js:1230
 msgid "custom pitch"
 msgstr "カスタムピッチ"
 
+
 #: js/palette.js:1278
 msgid "accidental"
 msgstr "変化記号"
+
 
 #: js/palette.js:1302
 #: js/blocks/PitchBlocks.js:423
 msgid "pitch converter"
 msgstr "音の高さを調節"
 
+
 #: js/planetInterface.js:151
 msgid "project undefined"
 msgstr "プロジェクト未定義"
+
 
 #: js/planetInterface.js:282
 msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
 msgstr "エラー: ローカル ストレージが不足しているため、保存できません。保存されているプロジェクトをいくつか削除してみてください。"
 
+
 #: js/themebox.js:375
 msgid "Theme switched to %s mode."
 msgstr "テーマが %s モードに切り替わりました。"
+
 
 #: js/themebox.js:568
 msgid "Music Blocks is already set to this theme."
 msgstr "Music Blocksはすでにこのテーマに設定されています。"
 
+
 #: js/turtle-singer.js:1509
-#. TRANS: partials are weighted components in a harmonic series
+#.  TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。"
+
 
 #: js/turtle-singer.js:1726
 msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
 msgstr "同じピッチの音符のみを結ぶことができます。スラーを使うつもりでしたか？"
 
+
 #: js/turtle-singer.js:2298
 msgid "synth cannot play chords."
 msgstr "このシンセでは和音ができません"
+
 
 #: js/utils/musicutils.js:536
 #: js/utils/musicutils.js:676
@@ -2682,382 +3106,468 @@ msgstr "このシンセでは和音ができません"
 msgid "rest"
 msgstr "休符"
 
+
 #: js/utils/musicutils.js:719
 msgid "Perfect unison"
 msgstr "完全1度"
+
 
 #: js/utils/musicutils.js:719
 msgid "Diminished second"
 msgstr "減2度"
 
+
 #: js/utils/musicutils.js:720
 msgid "Minor second"
 msgstr "短2度"
+
 
 #: js/utils/musicutils.js:720
 msgid "Augmented unison"
 msgstr "増1度"
 
+
 #: js/utils/musicutils.js:721
 msgid "Major second"
 msgstr "長2度"
+
 
 #: js/utils/musicutils.js:721
 msgid "Diminished third"
 msgstr "減3度"
 
+
 #: js/utils/musicutils.js:722
 msgid "Minor third"
 msgstr "短3度"
+
 
 #: js/utils/musicutils.js:722
 msgid "Augmented second"
 msgstr "増2度"
 
+
 #: js/utils/musicutils.js:723
 msgid "Major third"
 msgstr "長3度"
+
 
 #: js/utils/musicutils.js:723
 msgid "Diminished fourth"
 msgstr "減4度"
 
+
 #: js/utils/musicutils.js:724
 msgid "Perfect fourth"
 msgstr "完全4度"
+
 
 #: js/utils/musicutils.js:724
 msgid "Augmented third"
 msgstr "増3度"
 
+
 #: js/utils/musicutils.js:725
 msgid "Diminished fifth"
 msgstr "減5度"
+
 
 #: js/utils/musicutils.js:725
 msgid "Augmented fourth"
 msgstr "増4度"
 
+
 #: js/utils/musicutils.js:726
 msgid "Perfect fifth"
 msgstr "完全5度"
+
 
 #: js/utils/musicutils.js:726
 msgid "Diminished sixth"
 msgstr "減6度"
 
+
 #: js/utils/musicutils.js:727
 msgid "Minor sixth"
 msgstr "短6度"
+
 
 #: js/utils/musicutils.js:727
 msgid "Augmented fifth"
 msgstr "増5度"
 
+
 #: js/utils/musicutils.js:728
 msgid "Major sixth"
 msgstr "長6度"
+
 
 #: js/utils/musicutils.js:728
 msgid "Diminished seventh"
 msgstr "減7度"
 
+
 #: js/utils/musicutils.js:729
 msgid "Minor seventh"
 msgstr "短7度"
+
 
 #: js/utils/musicutils.js:729
 msgid "Augmented sixth"
 msgstr "増6度"
 
+
 #: js/utils/musicutils.js:730
 msgid "Major seventh"
 msgstr "長7度"
+
 
 #: js/utils/musicutils.js:730
 msgid "Diminished octave"
 msgstr "減8度"
 
+
 #: js/utils/musicutils.js:731
 msgid "Perfect octave"
 msgstr "完全8度"
+
 
 #: js/utils/musicutils.js:731
 msgid "Augmented seventh"
 msgstr "増7度"
 
+
 #: js/utils/musicutils.js:732
 msgid "Minor ninth"
 msgstr "短9度"
+
 
 #: js/utils/musicutils.js:732
 msgid "Augmented octave"
 msgstr "増8度"
 
+
 #: js/utils/musicutils.js:733
 msgid "Major ninth"
 msgstr "長9度"
+
 
 #: js/utils/musicutils.js:733
 msgid "Diminished tenth"
 msgstr "減10度"
 
+
 #: js/utils/musicutils.js:734
 msgid "Minor tenth"
 msgstr "短10度"
+
 
 #: js/utils/musicutils.js:734
 msgid "Augmented ninth"
 msgstr "増9度"
 
+
 #: js/utils/musicutils.js:735
 msgid "Major tenth"
 msgstr "長10度"
+
 
 #: js/utils/musicutils.js:735
 msgid "Diminished eleventh"
 msgstr "減11度"
 
+
 #: js/utils/musicutils.js:736
 msgid "Perfect eleventh"
 msgstr "完全11度"
+
 
 #: js/utils/musicutils.js:736
 msgid "Augmented tenth"
 msgstr "増10度"
 
+
 #: js/utils/musicutils.js:737
 msgid "Diminished twelfth"
 msgstr "減12度"
+
 
 #: js/utils/musicutils.js:737
 msgid "Augmented eleventh"
 msgstr "増11度"
 
+
 #: js/utils/musicutils.js:738
 msgid "Perfect twelfth"
 msgstr "完全12度"
+
 
 #: js/utils/musicutils.js:738
 msgid "Diminished thirteenth"
 msgstr "減13度"
 
+
 #: js/utils/musicutils.js:739
 msgid "Minor thirteenth"
 msgstr "短13度"
+
 
 #: js/utils/musicutils.js:739
 msgid "Augmented fifth, plus an octave"
 msgstr "増12度"
 
+
 #: js/utils/musicutils.js:740
 msgid "Major thirteenth"
 msgstr "長13度"
+
 
 #: js/utils/musicutils.js:740
 msgid "Diminished seventh, plus an octave"
 msgstr "減14度"
 
+
 #: js/utils/musicutils.js:868
-#. TRANS: ordinal number. Please keep exactly one space between each number.
+#.  TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
+
 
 #: js/utils/musicutils.js:1061
 #: js/utils/musicutils.js:1247
 #: js/utils/musicutils.js:1475
-#. TRANS: augmented is a music term related to intervals
+#.  TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "オーギュメント（増）"
+
 
 #: js/utils/musicutils.js:1063
 #: js/utils/musicutils.js:1248
 #: js/utils/musicutils.js:1474
-#. TRANS: diminished is a music term related to intervals and mode
+#.  TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（減）"
+
 
 #: js/utils/musicutils.js:1069
 #: js/utils/musicutils.js:1472
 #: js/blocks/IntervalsBlocks.js:661
 #: js/turtleactions/IntervalsActions.js:160
 #: js/turtleactions/IntervalsActions.js:164
-#. TRANS: perfect is a music term related to intervals
+#.  TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "パーフェクト（完全）"
 
+
 #: js/utils/musicutils.js:1071
-#. TRANS: twelve semi-tone scale for music
+#.  TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック音階"
+
 
 #: js/utils/musicutils.js:1072
 msgid "algerian"
 msgstr "アルジェリア音階"
 
+
 #: js/utils/musicutils.js:1073
 msgid "spanish"
 msgstr "スペイン音階"
 
+
 #: js/utils/musicutils.js:1075
-#. TRANS: modal scale in music
+#.  TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
+
 #: js/utils/musicutils.js:1077
-#. TRANS: harmonic major scale in music
+#.  TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長音階）"
 
+
 #: js/utils/musicutils.js:1079
-#. TRANS: natural minor scales in music
+#.  TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "自然短音階"
 
+
 #: js/utils/musicutils.js:1081
-#. TRANS: harmonic minor scale in music
+#.  TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "和声短音階"
 
+
 #: js/utils/musicutils.js:1083
-#. TRANS: melodic minor scale in music
+#.  TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "旋律短音階"
 
+
 #: js/utils/musicutils.js:1087
-#. TRANS: modal scale for music
+#.  TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン音階"
 
+
 #: js/utils/musicutils.js:1089
-#. TRANS: modal scale for music
+#.  TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン音階"
 
+
 #: js/utils/musicutils.js:1091
-#. TRANS: modal scale for music
+#.  TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン音階"
 
+
 #: js/utils/musicutils.js:1093
-#. TRANS: modal scale for music
+#.  TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン音階"
 
+
 #: js/utils/musicutils.js:1097
-#. TRANS: modal scale for music
+#.  TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン音階"
 
+
 #: js/utils/musicutils.js:1099
-#. TRANS: minor jazz scale for music
+#.  TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード音階"
 
+
 #: js/utils/musicutils.js:1101
-#. TRANS: bebop scale for music
+#.  TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ音階"
+
 
 #: js/utils/musicutils.js:1102
 msgid "arabic"
 msgstr "アラビア音階"
 
+
 #: js/utils/musicutils.js:1103
 msgid "byzantine"
 msgstr "ビザンティン"
 
+
 #: js/utils/musicutils.js:1105
-#. TRANS: musical scale for music by Verdi
+#.  TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディの音階"
+
 
 #: js/utils/musicutils.js:1106
 msgid "ethiopian"
 msgstr "エチオピア音階"
 
+
 #: js/utils/musicutils.js:1108
-#. TRANS: Ethiopic scale for music
+#.  TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ音階"
+
 
 #: js/utils/musicutils.js:1109
 msgid "hindu"
 msgstr "ヒンドゥー音階"
 
+
 #: js/utils/musicutils.js:1110
 msgid "hungarian"
 msgstr "ハンガリー音階"
 
+
 #: js/utils/musicutils.js:1112
-#. TRANS: minor Romanian scale for music
+#.  TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー音階"
+
 
 #: js/utils/musicutils.js:1113
 msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー音階"
 
+
 #: js/utils/musicutils.js:1115
-#. TRANS: musical scale for Mid-Eastern music
+#.  TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム音階"
 
+
 #: js/utils/musicutils.js:1117
-#. TRANS: minor blues scale for music
+#.  TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース音階"
 
+
 #: js/utils/musicutils.js:1119
-#. TRANS: major blues scale for music
+#.  TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース音階"
+
 
 #: js/utils/musicutils.js:1120
 msgid "whole tone"
 msgstr "ホールトーン音階"
 
+
 #: js/utils/musicutils.js:1122
-#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#.  TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック音階"
 
+
 #: js/utils/musicutils.js:1124
-#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#.  TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニック音階"
+
 
 #: js/utils/musicutils.js:1125
 msgid "chinese"
 msgstr "中国音階"
 
+
 #: js/utils/musicutils.js:1126
 msgid "egyptian"
 msgstr "エジプト音階"
 
+
 #: js/utils/musicutils.js:1128
-#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#.  TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "平調子"
+
 
 #: js/utils/musicutils.js:1129
 msgid "Japan"
 msgstr "日本"
 
+
 #: js/utils/musicutils.js:1131
-#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#.  TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "陰音階"
 
+
 #: js/utils/musicutils.js:1133
-#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#.  TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "民謡音階"
 
+
 #: js/utils/musicutils.js:1135
-#. TRANS: Italian mathematician
+#.  TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ音階"
+
 
 #: js/utils/musicutils.js:1136
 #: js/utils/musicutils.js:1190
@@ -3072,76 +3582,87 @@ msgstr "フィボナッチ音階"
 #: js/blocks/WidgetBlocks.js:464
 #: js/turtleactions/VolumeActions.js:231
 #: js/widgets/modewidget.js:903
-#. TRANS: customize voice
+#.  TRANS: customize voice
 msgid "custom"
 msgstr "オリジナル"
+
 
 #: js/utils/musicutils.js:1138
 #: js/utils/musicutils.js:1694
 #: js/blocks/WidgetBlocks.js:222
-#. TRANS: highpass filter
+#.  TRANS: highpass filter
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
+
 #: js/utils/musicutils.js:1140
 #: js/utils/musicutils.js:1695
-#. TRANS: lowpass filter
+#.  TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
 
+
 #: js/utils/musicutils.js:1142
 #: js/utils/musicutils.js:1696
-#. TRANS: bandpass filter
+#.  TRANS: bandpass filter
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
+
 #: js/utils/musicutils.js:1144
 #: js/utils/musicutils.js:1697
-#. TRANS: high-shelf filter
+#.  TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
 
+
 #: js/utils/musicutils.js:1146
 #: js/utils/musicutils.js:1698
-#. TRANS: low-shelf filter
+#.  TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
+
 #: js/utils/musicutils.js:1148
 #: js/utils/musicutils.js:1699
-#. TRANS: notch-shelf filter
+#.  TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
 
+
 #: js/utils/musicutils.js:1150
 #: js/utils/musicutils.js:1700
-#. TRANS: all-pass filter
+#.  TRANS: all-pass filter
 msgid "allpass"
 msgstr "オールパスフィルター"
 
+
 #: js/utils/musicutils.js:1152
 #: js/utils/musicutils.js:1701
-#. TRANS: peaking filter
+#.  TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
+
 
 #: js/utils/musicutils.js:1153
 #: js/utils/musicutils.js:1709
 #: js/utils/synthutils.js:140
 #: js/blocks/PitchBlocks.js:85
 #: js/widgets/legobricks.js:1941
-#. TRANS: sine wave
+#.  TRANS: sine wave
 msgid "sine"
 msgstr "サイン波"
+
 
 #: js/utils/musicutils.js:1154
 #: js/utils/musicutils.js:1710
 #: js/utils/synthutils.js:142
 #: js/blocks/PitchBlocks.js:39
 #: js/widgets/legobricks.js:1942
-#. TRANS: square wave
+#.  TRANS: square wave
 msgid "square"
 msgstr "四角の波"
+
 
 #: js/utils/musicutils.js:1155
 #: js/utils/musicutils.js:1711
@@ -3149,36 +3670,40 @@ msgstr "四角の波"
 #: js/blocks/ToneBlocks.js:39
 #: js/blocks/PitchBlocks.js:62
 #: js/widgets/legobricks.js:1944
-#. TRANS: triangle wave
+#.  TRANS: triangle wave
 msgid "triangle"
 msgstr "三角の波"
+
 
 #: js/utils/musicutils.js:1156
 #: js/utils/musicutils.js:1712
 #: js/utils/synthutils.js:144
 #: js/blocks/PitchBlocks.js:108
 #: js/widgets/legobricks.js:1943
-#. TRANS: sawtooth wave
+#.  TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの波"
+
 
 #: js/utils/musicutils.js:1158
 #: js/utils/musicutils.js:1462
 #: js/blocks/PitchBlocks.js:971
 #: js/blocks/PitchBlocks.js:977
 #: js/turtleactions/PitchActions.js:568
-#. TRANS: even numbers
-#. TRANS: invert based on even or odd number or musical scale
+#.  TRANS: even numbers
+#.  TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "偶数"
+
 
 #: js/utils/musicutils.js:1160
 #: js/utils/musicutils.js:1463
 #: js/blocks/PitchBlocks.js:977
 #: js/turtleactions/PitchActions.js:570
-#. TRANS: odd numbers
+#.  TRANS: odd numbers
 msgid "odd"
 msgstr "奇数"
+
 
 #: js/utils/musicutils.js:1161
 #: js/utils/musicutils.js:1464
@@ -3187,532 +3712,625 @@ msgstr "奇数"
 msgid "scalar"
 msgstr "音階的"
 
+
 #: js/utils/musicutils.js:1162
 #: js/utils/synthutils.js:80
 #: js/blocks/VolumeBlocks.js:47
 #: js/widgets/legobricks.js:1925
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "piano"
 msgstr "ピアノ"
+
 
 #: js/utils/musicutils.js:1163
 #: js/utils/synthutils.js:82
 #: js/widgets/legobricks.js:1929
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
+
 
 #: js/utils/musicutils.js:1164
 #: js/utils/synthutils.js:84
 #: js/widgets/legobricks.js:1930
-#. TRANS: viola musical instrument
+#.  TRANS: viola musical instrument
 msgid "viola"
 msgstr "ビオラ"
 
+
 #: js/utils/musicutils.js:1165
 #: js/utils/synthutils.js:128
-#. TRANS: xylophone musical instrument
+#.  TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "木琴"
 
+
 #: js/utils/musicutils.js:1166
 #: js/utils/synthutils.js:150
-#. TRANS: vibraphone musical instrument
+#.  TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "鉄琴"
+
 
 #: js/utils/musicutils.js:1167
 #: js/utils/synthutils.js:86
 #: js/widgets/legobricks.js:1931
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "cello"
 msgstr "チェロ"
 
+
 #: js/utils/musicutils.js:1169
 #: js/utils/synthutils.js:90
-#. TRANS: viola musical instrument
+#.  TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
+
 
 #: js/utils/musicutils.js:1170
 #: js/utils/synthutils.js:98
 #: js/widgets/legobricks.js:1926
 #: js/widgets/rhythmruler.js:2729
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "guitar"
 msgstr "ギター"
 
+
 #: js/utils/musicutils.js:1171
 #: js/utils/synthutils.js:92
-#. TRANS: sitar musical instrument
+#.  TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "シタール"
 
+
 #: js/utils/musicutils.js:1172
 #: js/utils/synthutils.js:94
-#. TRANS: harmonium musical instrument
+#.  TRANS: harmonium musical instrument
 msgid "harmonium"
 msgstr "ハルモニウム"
 
+
 #: js/utils/musicutils.js:1173
 #: js/utils/synthutils.js:96
-#. TRANS: mandolin musical instrument
+#.  TRANS: mandolin musical instrument
 msgid "mandolin"
 msgstr "マンドリン"
+
 
 #: js/utils/musicutils.js:1174
 #: js/utils/synthutils.js:100
 #: js/widgets/legobricks.js:1927
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "アコースティック"
+
 
 #: js/utils/musicutils.js:1175
 #: js/utils/synthutils.js:102
 #: js/widgets/legobricks.js:1933
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
+
 
 #: js/utils/musicutils.js:1176
 #: js/utils/synthutils.js:104
 #: js/widgets/legobricks.js:1934
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "clarinet"
 msgstr "クラリネット"
+
 
 #: js/utils/musicutils.js:1177
 #: js/utils/synthutils.js:106
 #: js/widgets/legobricks.js:1935
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
+
 
 #: js/utils/musicutils.js:1178
 #: js/utils/synthutils.js:108
 #: js/widgets/legobricks.js:1939
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "tuba"
 msgstr "チューバ"
+
 
 #: js/utils/musicutils.js:1179
 #: js/utils/synthutils.js:110
 #: js/widgets/legobricks.js:1936
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
+
 
 #: js/utils/musicutils.js:1180
 #: js/utils/synthutils.js:112
 #: js/widgets/legobricks.js:1938
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "oboe"
 msgstr "オーボエ"
+
 
 #: js/utils/musicutils.js:1181
 #: js/utils/synthutils.js:114
 #: js/widgets/legobricks.js:1937
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
+
 
 #: js/utils/musicutils.js:1182
 #: js/utils/synthutils.js:130
 #: js/widgets/legobricks.js:1924
-#. TRANS: polytone synthesizer
+#.  TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
+
 #: js/utils/musicutils.js:1183
 #: js/utils/synthutils.js:132
-#. TRANS: simple monotone synthesizer
+#.  TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
+
 
 #: js/utils/musicutils.js:1184
 msgid "simple 2"
 msgstr "シンプル２"
 
+
 #: js/utils/musicutils.js:1185
 msgid "simple 3"
 msgstr "シンプル３"
+
 
 #: js/utils/musicutils.js:1186
 msgid "simple 4"
 msgstr "シンプル４"
 
+
 #: js/utils/musicutils.js:1187
 #: js/utils/synthutils.js:66
 #: js/blocks/DrumBlocks.js:191
-#. TRANS: white noise synthesizer
+#.  TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ホワイトノイズ"
 
+
 #: js/utils/musicutils.js:1188
 #: js/utils/synthutils.js:68
-#. TRANS: brown noise synthesizer
+#.  TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
+
 #: js/utils/musicutils.js:1189
 #: js/utils/synthutils.js:70
-#. TRANS: pink noise synthesizer
+#.  TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
+
 
 #: js/utils/musicutils.js:1191
 #: js/utils/synthutils.js:162
 #: js/widgets/rhythmruler.js:2275
 #: js/widgets/rhythmruler.js:2537
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "snare drum"
 msgstr "スネアドラム"
 
+
 #: js/utils/musicutils.js:1192
 #: js/utils/synthutils.js:164
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
 
+
 #: js/utils/musicutils.js:1193
 #: js/utils/synthutils.js:166
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "tom tom"
 msgstr "タムタム"
 
+
 #: js/utils/musicutils.js:1194
 #: js/utils/synthutils.js:168
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
 
+
 #: js/utils/musicutils.js:1195
 #: js/utils/synthutils.js:170
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "bass drum"
 msgstr "バスドラム"
 
+
 #: js/utils/musicutils.js:1196
 #: js/utils/synthutils.js:172
-#. TRANS: a drum made from an inverted cup
+#.  TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
 
+
 #: js/utils/musicutils.js:1197
 #: js/utils/synthutils.js:174
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
+
 #: js/utils/musicutils.js:1198
 #: js/utils/synthutils.js:178
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
 
+
 #: js/utils/musicutils.js:1199
 #: js/utils/synthutils.js:180
-#. TRANS: a small metal bell
+#.  TRANS: a small metal bell
 msgid "ride bell"
 msgstr "ライドベル"
 
+
 #: js/utils/musicutils.js:1200
 #: js/utils/synthutils.js:182
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
+
 
 #: js/utils/musicutils.js:1201
 msgid "japanese drum"
 msgstr "太鼓"
 
+
 #: js/utils/musicutils.js:1202
 #: js/utils/synthutils.js:188
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "japanese bell"
 msgstr "鉦"
 
+
 #: js/utils/musicutils.js:1203
 #: js/utils/synthutils.js:184
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
 
+
 #: js/utils/musicutils.js:1204
 #: js/utils/synthutils.js:186
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "フィンガーシンバル"
 
+
 #: js/utils/musicutils.js:1205
 #: js/utils/synthutils.js:190
-#. TRANS: a musically tuned set of bells
+#.  TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
 
+
 #: js/utils/musicutils.js:1206
 #: js/utils/synthutils.js:192
-#. TRANS: a musical instrument
+#.  TRANS: a musical instrument
 msgid "gong"
 msgstr "ドラ"
 
+
 #: js/utils/musicutils.js:1207
 #: js/utils/synthutils.js:194
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
 
+
 #: js/utils/musicutils.js:1208
 #: js/utils/synthutils.js:196
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "crash"
 msgstr "クラッシュ"
 
+
 #: js/utils/musicutils.js:1209
 #: js/utils/synthutils.js:198
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "bottle"
 msgstr "空きびん"
 
+
 #: js/utils/musicutils.js:1210
 #: js/utils/synthutils.js:200
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "clap"
 msgstr "てびょうし"
 
+
 #: js/utils/musicutils.js:1211
 #: js/utils/synthutils.js:202
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
 
+
 #: js/utils/musicutils.js:1212
 #: js/utils/synthutils.js:204
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "splash"
 msgstr "しぶき"
 
+
 #: js/utils/musicutils.js:1213
 #: js/utils/synthutils.js:206
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
 
+
 #: js/utils/musicutils.js:1214
 #: js/utils/synthutils.js:208
-#. TRANS: sound effect
+#.  TRANS: sound effect
 msgid "raindrop"
 msgstr "雨のしずく"
 
+
 #: js/utils/musicutils.js:1215
 #: js/utils/synthutils.js:210
-#. TRANS: animal sound effect
+#.  TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
 
+
 #: js/utils/musicutils.js:1216
 #: js/utils/synthutils.js:212
-#. TRANS: animal sound effect
+#.  TRANS: animal sound effect
 msgid "cricket"
 msgstr "こおろぎ"
 
+
 #: js/utils/musicutils.js:1217
 #: js/utils/synthutils.js:214
-#. TRANS: animal sound effect
+#.  TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
+
 
 #: js/utils/musicutils.js:1219
 #: js/utils/synthutils.js:116
 #: js/widgets/legobricks.js:1940
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "banjo"
 msgstr "バンジョー"
 
+
 #: js/utils/musicutils.js:1220
 #: js/utils/synthutils.js:118
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
+
 #: js/utils/musicutils.js:1221
 #: js/utils/synthutils.js:120
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
+
 
 #: js/utils/musicutils.js:1222
 #: js/utils/synthutils.js:122
 #: js/widgets/legobricks.js:1928
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "electric guitar"
 msgstr "エレキギター"
 
+
 #: js/utils/musicutils.js:1223
 #: js/utils/synthutils.js:124
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
 
+
 #: js/utils/musicutils.js:1224
 #: js/utils/synthutils.js:126
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "celeste"
 msgstr "セレスタ"
 
+
 #: js/utils/musicutils.js:1226
 #: js/widgets/temperament.js:923
-#. TRANS: musical temperament
+#.  TRANS: musical temperament
 msgid "equal"
 msgstr "平均律"
 
+
 #: js/utils/musicutils.js:1228
-#. TRANS: musical temperament
+#.  TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス音律 "
 
+
 #: js/utils/musicutils.js:1230
-#. TRANS: musical temperament
+#.  TRANS: musical temperament
 msgid "just intonation"
 msgstr "純正律"
+
 
 #: js/utils/musicutils.js:1232
 #: js/utils/musicutils.js:1727
 #: js/utils/musicutils.js:1728
 #: js/utils/musicutils.js:1743
 #: js/utils/musicutils.js:1744
-#. TRANS: musical temperament
+#.  TRANS: musical temperament
 msgid "Meantone"
 msgstr "中全音律"
+
 
 #: js/utils/musicutils.js:1249
 msgid "major 7th"
 msgstr "長七の和音（メイジャー・セブンス)"
 
+
 #: js/utils/musicutils.js:1250
 msgid "minor 7th"
 msgstr "短七の和音（マイナー・セブンス）"
+
 
 #: js/utils/musicutils.js:1251
 msgid "dominant 7th"
 msgstr "属七の和音（ドミナント・セブンス）"
 
+
 #: js/utils/musicutils.js:1252
 msgid "minor-major 7th"
 msgstr "短三長七の和音（マイナー・メイジャー・セブンス）"
+
 
 #: js/utils/musicutils.js:1253
 msgid "fully-diminished 7th"
 msgstr "減七の和音（ディミニッシュト・セブンス）"
 
+
 #: js/utils/musicutils.js:1254
 msgid "half-diminished 7th"
 msgstr "減五短七の和音（ハーフ・ディミニッシュト）"
+
 
 #: js/utils/musicutils.js:1720
 #: js/utils/musicutils.js:1736
 msgid "Equal (12EDO)"
 msgstr "12平均律"
 
+
 #: js/utils/musicutils.js:1721
 #: js/utils/musicutils.js:1737
 msgid "Equal (5EDO)"
 msgstr "5平均律"
+
 
 #: js/utils/musicutils.js:1722
 #: js/utils/musicutils.js:1738
 msgid "Equal (7EDO)"
 msgstr "7平均律"
 
+
 #: js/utils/musicutils.js:1723
 #: js/utils/musicutils.js:1739
 msgid "Equal (19EDO)"
 msgstr "19平均律"
+
 
 #: js/utils/musicutils.js:1724
 #: js/utils/musicutils.js:1740
 msgid "Equal (31EDO)"
 msgstr "31平均律"
 
+
 #: js/utils/musicutils.js:1725
 #: js/utils/musicutils.js:1741
 msgid "5-limit Just Intonation"
 msgstr "5限界純正律"
+
 
 #: js/utils/musicutils.js:1726
 #: js/utils/musicutils.js:1742
 msgid "Pythagorean (3-limit JI)"
 msgstr "ピタゴラス音律"
 
+
 #: js/utils/musicutils.js:4051
 #: js/widgets/temperament.js:2602
 msgid "Invalid temperament. Falling back to equal temperament."
 msgstr "無効な気質。平均律に戻ります。"
+
 
 #: js/utils/musicutils.js:6174
 #: js/utils/musicutils.js:6217
 msgid "current"
 msgstr "現在の"
 
+
 #: js/utils/musicutils.js:6177
 #: js/utils/musicutils.js:6208
 msgid "next"
 msgstr "この次の"
+
 
 #: js/utils/musicutils.js:6180
 #: js/utils/musicutils.js:6213
 msgid "previous"
 msgstr "この前の"
 
+
 #: js/utils/synthutils.js:134
-#. TRANS: simple monotone synthesizer
+#.  TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
+
 #: js/utils/synthutils.js:136
-#. TRANS: simple monotone synthesizer
+#.  TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
+
 #: js/utils/synthutils.js:138
-#. TRANS: simple monotone synthesizer
+#.  TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
+
 #: js/utils/synthutils.js:176
-#. TRANS: musical instrument
+#.  TRANS: musical instrument
 msgid "taiko"
 msgstr "太鼓"
+
 
 #: js/utils/synthutils.js:2091
 msgid "⚠️ Sound is disabled!\n\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
 msgstr "⚠⚠ 音声は ブロックされています。。。ブラウザー の設定 (サイトの せってい > 音声) を確認して、ミュージック・ブロックスの 音声を 許可して ください。"
 
+
 #: js/utils/synthutils.js:3548
 msgid "Cents Adjustment"
 msgstr "セント調整"
 
+
 #: js/utils/synthutils.js:3577
 #: js/widgets/sampler.js:1992
-#. TRANS: The reference tone is a sound used for comparison.
+#.  TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "参照ピッチ"
+
 
 #: js/utils/utils.js:619
 msgid "Security Warning"
 msgstr "セキュリティ警告"
 
+
 #: js/utils/utils.js:621
 msgid "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
 msgstr "このプラグインには、ブラウザで実行されるコードが含まれています。組み込みのプラグイン ディレクトリからロードされていないため、安全でないコードが含まれている可能性があります。"
+
 
 #: js/utils/utils.js:625
 msgid "Do you want to allow this plugin to run?"
 msgstr "このプラグインの実行を許可しますか?"
 
+
 #: js/utils/utils.js:627
 msgid "Source: %s"
 msgstr "ソース: %s"
+
 
 #: js/utils/utils.js:627
 #: js/blocks/ExtrasBlocks.js:692
@@ -3726,27 +4344,33 @@ msgstr "ソース: %s"
 msgid "unknown"
 msgstr "不明"
 
+
 #: js/blocks/ActionBlocks.js:58
 msgid "The Return block will return a value from an action."
 msgstr "Returnブロックはアクションから値を返します。"
+
 
 #: js/blocks/ActionBlocks.js:75
 msgid "return"
 msgstr "リターン"
 
+
 #: js/blocks/ActionBlocks.js:136
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Return to URLブロックは値をウェブページに返します。"
 
+
 #: js/blocks/ActionBlocks.js:153
 msgid "return to URL"
 msgstr "URLに戻ります"
+
 
 #: js/blocks/ActionBlocks.js:186
 #: js/blocks/ProgramBlocks.js:86
 #: js/blocks/ProgramBlocks.js:181
 msgid "Invalid URL"
 msgstr "無効な URL"
+
 
 #: js/blocks/ActionBlocks.js:238
 #: js/blocks/ActionBlocks.js:295
@@ -3755,19 +4379,22 @@ msgstr "無効な URL"
 msgid "The Calculate block returns a value calculated by an action."
 msgstr "Calculateブロックはアクションで計算された値を返します。"
 
+
 #: js/blocks/ActionBlocks.js:256
 #: js/blocks/ActionBlocks.js:521
 #: js/blocks/ActionBlocks.js:711
 msgid "calculate"
 msgstr "計算する"
 
+
 #: js/blocks/ActionBlocks.js:381
 #: js/blocks/ActionBlocks.js:597
 #: js/blocks/ActionBlocks.js:946
 #: js/blocks/ActionBlocks.js:1396
-#. TRANS: do is the do something or take an action.
+#.  TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（指定）</h2><br>指定したアクションブロックを実行する。"
+
 
 #: js/blocks/ActionBlocks.js:395
 #: js/blocks/ActionBlocks.js:614
@@ -3776,6 +4403,7 @@ msgstr "<h2>アクションブロック（指定）</h2><br>指定したアク�
 #: js/blocks/MeterBlocks.js:804
 msgid "do1"
 msgstr "アクション実行"
+
 
 #: js/blocks/ActionBlocks.js:395
 #: js/blocks/ActionBlocks.js:614
@@ -3787,15 +4415,18 @@ msgstr "アクション実行"
 msgid "do"
 msgstr "アクション"
 
+
 #: js/blocks/ActionBlocks.js:795
 #: js/blocks/ActionBlocks.js:869
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr "Argブロックはアクションに渡された引数の値を含みます。"
 
+
 #: js/blocks/ActionBlocks.js:810
 #: js/blocks/ActionBlocks.js:882
 msgid "arg"
 msgstr "引数"
+
 
 #: js/blocks/ActionBlocks.js:840
 #: js/blocks/ActionBlocks.js:904
@@ -3803,22 +4434,27 @@ msgstr "引数"
 msgid "Invalid argument"
 msgstr "無効な議論"
 
+
 #: js/blocks/ActionBlocks.js:948
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr "<br><br>図の例は、決まったアクションではなく、２つのうちどちらか１つのアクションをランダムに実行させる。"
+
 
 #: js/blocks/ActionBlocks.js:1022
 #: js/blocks/ActionBlocks.js:1029
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr "<h2>イベントブロック（受け取り）</h2><br>特定のイベントに対して、その発生を受け取るたびに実行するアクションを１つ決めておくことができる。"
 
+
 #: js/blocks/ActionBlocks.js:1031
 msgid "When the event happens, an action is taken."
 msgstr "<br><br>イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
 
+
 #: js/blocks/ActionBlocks.js:1048
 msgid "on"
 msgstr "のとき"
+
 
 #: js/blocks/ActionBlocks.js:1051
 #: js/blocks/ActionBlocks.js:1052
@@ -3826,111 +4462,138 @@ msgstr "のとき"
 msgid "event"
 msgstr "イベント"
 
+
 #: js/blocks/ActionBlocks.js:1141
 msgid "The Broadcast block is used to trigger an event."
 msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
+
 
 #: js/blocks/ActionBlocks.js:1159
 msgid "broadcast"
 msgstr "イベント発生"
 
+
 #: js/blocks/ActionBlocks.js:1216
 msgid "Each Start block is a separate voice."
 msgstr "<h2>スタートブロック</h2><br>実行ボタンがおされると、スタートブロックが実行される。"
+
 
 #: js/blocks/ActionBlocks.js:1218
 msgid "All of the Start blocks run at the same time when the Play button is pressed."
 msgstr "[再生] ボタンを押すと、すべての Start ブロックが同時に実行されます。"
 
+
 #: js/blocks/ActionBlocks.js:1308
 msgid "The Action block is used to group together blocks so that they can be used more than once."
 msgstr "アクション ブロックは、複数のブロックをグループ化して複数回使用できるようにするために使用されます。"
+
 
 #: js/blocks/ActionBlocks.js:1312
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr "<br><br>何度も実行する音楽のフレーズなどにアクションを作っておくと便利。"
 
+
 #: js/blocks/ActionBlocks.js:1501
 msgid "define temperament"
 msgstr "音律を明確にする"
+
 
 #: js/blocks/BooleanBlocks.js:44
 msgid "The Not block is the logical not operator."
 msgstr "「ではない」ブロックは論理的なNOT演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:62
 msgid "not"
 msgstr "ではない"
+
 
 #: js/blocks/BooleanBlocks.js:133
 msgid "The And block is the logical and operator."
 msgstr "「かつ」ブロックは論理積（AND）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:151
 msgid "and"
 msgstr "かつ"
+
 
 #: js/blocks/BooleanBlocks.js:217
 msgid "The Or block is the logical or operator."
 msgstr "「または」ブロックは論理和（OR）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:235
 msgid "or"
 msgstr "または"
+
 
 #: js/blocks/BooleanBlocks.js:301
 msgid "The XOR block is the logical XOR operator."
 msgstr "XORブロックは排他的論理和（XOR）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:319
 msgid "xor"
 msgstr "XOR（エクスクルーシブ・オア）"
+
 
 #: js/blocks/BooleanBlocks.js:391
 msgid "The Greater-than block returns True if the top number is greater than the bottom number."
 msgstr "「＞」ブロックは、上の数値が下の数値より大きい場合に「実」を返します。"
 
+
 #: js/blocks/BooleanBlocks.js:496
 msgid "The Less-than block returns True if the top number is less than the bottom number."
 msgstr "「＜」ブロックは、上の数値が下の数値より小さい場合に「実」を返します。"
+
 
 #: js/blocks/BooleanBlocks.js:596
 msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
 msgstr "「≦」ブロックは、上の数値が下の数値以下の場合に「実」を返します。"
 
+
 #: js/blocks/BooleanBlocks.js:696
 msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
 msgstr "「≥」ブロックは、上の数値が下の数値以上である場合に「実」を返します。"
+
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "<h2>しんぎブロック（等しい）</h2><br>２つのすうちをくらべて、同じすうちであるかどうかはんていする。「＝」は、２つのすうちが同じであれば「真（しん）」、同じでなければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
+
 #: js/blocks/BooleanBlocks.js:901
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr "「≠」ブロックは2つの数字が等しくない場合に「実」を返します。"
 
+
 #: js/blocks/BooleanBlocks.js:1001
 msgid "The Boolean block is used to specify true or false."
 msgstr "「比べる」ブロックは「実」または「偽」を指定するために使われます。"
+
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、好きなすうちを足す。マイナスのすうちを使うと引き算になる。"
 
+
 #: js/blocks/BoxesBlocks.js:61
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr "<br><br>マイナスの数値を使うと引き算になる。"
+
 
 #: js/blocks/BoxesBlocks.js:73
 msgid "add"
 msgstr "足す"
 
+
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:1001
 msgid "to"
 msgstr "箱へ"
+
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/blocks/BoxesBlocks.js:598
@@ -3938,35 +4601,43 @@ msgstr "箱へ"
 msgid "value1"
 msgstr "すうち"
 
+
 #: js/blocks/BoxesBlocks.js:118
 msgid "Block does not support incrementing."
 msgstr "ブロックは、増殖をサポートできません"
+
 
 #: js/blocks/BoxesBlocks.js:152
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、１を足す。"
 
+
 #: js/blocks/BoxesBlocks.js:163
 msgid "add 1 to"
 msgstr "箱に１を足す"
+
 
 #: js/blocks/BoxesBlocks.js:211
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "Subtract-1-fromブロックはボックスに保存された値から1を引きます。"
 
+
 #: js/blocks/BoxesBlocks.js:222
 msgid "subtract 1 from"
 msgstr "〜から１引く"
+
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
 msgid "The Box block returns the value stored in a box."
 msgstr "<h2>すうちブロック</h2><br>すうちブロックとして、箱のすうちを使う。"
 
+
 #: js/blocks/BoxesBlocks.js:503
 #: js/blocks/BoxesBlocks.js:579
 msgid "The Store in block will store a value in a box."
 msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、指定したすうちを入れる。"
+
 
 #: js/blocks/BoxesBlocks.js:598
 #: js/blocks/EnsembleBlocks.js:408
@@ -3974,37 +4645,46 @@ msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、�
 msgid "name1"
 msgstr "箱へ"
 
+
 #: js/blocks/BoxesBlocks.js:655
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "Box2ブロックはBox2に保存された値を返します。"
+
 
 #: js/blocks/BoxesBlocks.js:706
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr "Store in Box2ブロックは値をBox2に保存するために使われます。"
 
+
 #: js/blocks/BoxesBlocks.js:718
 msgid "store in box2"
 msgstr "箱２にすうちを入れる"
+
 
 #: js/blocks/BoxesBlocks.js:764
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "Box1ブロックはBox1に保存された値を返します。"
 
+
 #: js/blocks/BoxesBlocks.js:815
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr "Store in Box1ブロックは値をBox1に保存するために使われます。"
+
 
 #: js/blocks/BoxesBlocks.js:829
 msgid "store in box1"
 msgstr "箱１にすうちを入れる"
 
+
 #: js/blocks/DictBlocks.js:62
 msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
 msgstr "「辞書を表す」ブロックは、画面の上部に辞書の内容を表示します。"
 
+
 #: js/blocks/DictBlocks.js:77
 msgid "show dictionary"
 msgstr "辞書を表す"
+
 
 #: js/blocks/DictBlocks.js:80
 #: js/blocks/DictBlocks.js:145
@@ -4016,20 +4696,24 @@ msgstr "辞書を表す"
 msgid "My Dictionary"
 msgstr "私の辞書"
 
+
 #: js/blocks/DictBlocks.js:129
 msgid "The Dictionary block returns a dictionary."
 msgstr "Dictionaryブロックは辞書を返します。"
+
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックは指定されたキーの辞書の値を返します。"
 
+
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#. TRANS: retrieve a value from the dictionary with a given key
+#.  TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "数価を表す"
+
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -4041,6 +4725,7 @@ msgstr "数価を表す"
 msgid "key2"
 msgstr "キーワード"
 
+
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
 #: js/blocks/DictBlocks.js:289
@@ -4049,87 +4734,106 @@ msgstr "キーワード"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1504
-#. TRANS: key, e.g., C in C Major
+#.  TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "調"
+
 
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックは指定されたキーに辞書の値を設定します。"
 
+
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#. TRANS: set a value in the dictionary for a given key
+#.  TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "値を設定"
+
 
 #: js/blocks/DrumBlocks.js:59
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr "Noise nameブロックはノイズシンセサイザーを選択するために使われます。"
 
+
 #: js/blocks/DrumBlocks.js:102
 msgid "The Drum name block is used to select a drum."
 msgstr "<h2>ドラムブロック</h2><br>ドラムの種類を変えるときに使う。クリックで、いろいろなドラムの音を選ぶことができる。"
+
 
 #: js/blocks/DrumBlocks.js:146
 msgid "The Effects name block is used to select a sound effect."
 msgstr "<h2>こうかおんブロック</h2><br>こうかおんの種類を変えるときに使う。クリックで、いろいろなおもしろい音を選ぶことができる。"
 
+
 #: js/blocks/DrumBlocks.js:163
 msgid "noise"
 msgstr "ノイズ"
+
 
 #: js/blocks/DrumBlocks.js:177
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr "Play noiseブロックはホワイトノイズ、ピンクノイズ、またはブラウンノイズを生成します。"
 
+
 #: js/blocks/DrumBlocks.js:332
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラム音に置き換えます。"
 
+
 #: js/blocks/DrumBlocks.js:343
-#. TRANS: map a pitch to a drum sound
+#.  TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "音符をドラムに変える"
+
 
 #: js/blocks/DrumBlocks.js:397
 #: js/blocks/DrumBlocks.js:406
 msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
 msgstr "「ドラムをせってい」ブロックは、含まれているノートのピッチを置き換えるドラム サウンドを選択します。"
 
+
 #: js/blocks/DrumBlocks.js:410
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
 
+
 #: js/blocks/DrumBlocks.js:422
-#. TRANS: set the current drum sound for playback
+#.  TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムをせってい"
+
 
 #: js/blocks/DrumBlocks.js:466
 msgid "sound effect"
 msgstr "こうかおん"
 
+
 #: js/blocks/DrumBlocks.js:504
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。"
+
 
 #: js/blocks/EnsembleBlocks.js:90
 msgid "mouse index heap"
 msgstr "ネズミヒープに番号をふる"
 
+
 #: js/blocks/EnsembleBlocks.js:90
 msgid "turtle index heap"
 msgstr "タートル ヒープに番号をふる"
+
 
 #: js/blocks/EnsembleBlocks.js:97
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr "指定されたマウスの指定された位置のヒープ内の値を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:104
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr "指定されたタートルの指定された位置のヒープ内の値を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:114
 #: js/blocks/EnsembleBlocks.js:189
@@ -4151,21 +4855,25 @@ msgstr "指定されたタートルの指定された位置のヒープ内の値
 msgid "Yertle"
 msgstr "ヤートル"
 
+
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/EnsembleBlocks.js:1106
 msgid "mouse name"
 msgstr "ネズミの名前"
+
 
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/EnsembleBlocks.js:1115
 msgid "turtle name"
 msgstr "ネズミの名前"
 
+
 #: js/blocks/EnsembleBlocks.js:116
 #: js/blocks/HeapBlocks.js:544
-#. TRANS: value1 is a numeric value (JAPANESE ONLY)
+#.  TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
+
 
 #: js/blocks/EnsembleBlocks.js:144
 #: js/blocks/EnsembleBlocks.js:1223
@@ -4174,27 +4882,33 @@ msgstr "インデックス"
 msgid "Index must be > 0."
 msgstr "インデクス番号は 0 より大きい必要があります。"
 
+
 #: js/blocks/EnsembleBlocks.js:149
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 msgid "Maximum heap size is 1000."
 msgstr "ヒープの大きさは、最大1000です。"
 
+
 #: js/blocks/EnsembleBlocks.js:167
 msgid "stop mouse"
 msgstr "ネズミを止める"
+
 
 #: js/blocks/EnsembleBlocks.js:169
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "指定されたマウスを停止します。"
 
+
 #: js/blocks/EnsembleBlocks.js:180
 msgid "stop turtle"
 msgstr "ネズミを止める"
 
+
 #: js/blocks/EnsembleBlocks.js:182
 msgid "The Stop turtle block stops the specified turtle."
 msgstr "指定されたタートルを停止します。"
+
 
 #: js/blocks/EnsembleBlocks.js:206
 #: js/blocks/EnsembleBlocks.js:266
@@ -4208,6 +4922,7 @@ msgstr "指定されたタートルを停止します。"
 msgid "Cannot find mouse"
 msgstr "ネズミが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:208
 #: js/blocks/EnsembleBlocks.js:268
 #: js/blocks/EnsembleBlocks.js:432
@@ -4220,75 +4935,92 @@ msgstr "ネズミが見つかりません。"
 msgid "Cannot find turtle"
 msgstr "タートルが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:227
 msgid "start mouse"
 msgstr "ネズミをスタート"
+
 
 #: js/blocks/EnsembleBlocks.js:230
 msgid "The Start mouse block starts the specified mouse."
 msgstr "指定されたマウスを開始します。"
 
+
 #: js/blocks/EnsembleBlocks.js:241
 msgid "start turtle"
 msgstr "ネズミをスタートする"
+
 
 #: js/blocks/EnsembleBlocks.js:244
 msgid "The Start turtle block starts the specified turtle."
 msgstr "指定されたタートルを開始します。"
 
+
 #: js/blocks/EnsembleBlocks.js:275
 msgid "Mouse is already running."
 msgstr "ネズミはすでに動いています。"
+
 
 #: js/blocks/EnsembleBlocks.js:277
 msgid "Turtle is already running."
 msgstr "タートルはすでに動いています。"
 
+
 #: js/blocks/EnsembleBlocks.js:299
 msgid "Cannot find start block"
 msgstr "「スタート」ブロックが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:309
-#. TRANS: pen color for this mouse
+#.  TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの色"
+
 
 #: js/blocks/EnsembleBlocks.js:311
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "指定されたマウスのペンの色を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:323
-#. TRANS: pen color for this turtle
+#.  TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルの色"
+
 
 #: js/blocks/EnsembleBlocks.js:325
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "指定されたタートルのペンの色を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:355
-#. TRANS: heading (compass direction) for this mouse
+#.  TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの進む角度"
+
 
 #: js/blocks/EnsembleBlocks.js:357
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "指定されたマウスの向きを返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:369
-#. TRANS: heading (compass direction) for this turtle
+#.  TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルの進む角度"
+
 
 #: js/blocks/EnsembleBlocks.js:371
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr "指定されたタートルの向きを返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:401
 #: js/blocks/EnsembleBlocks.js:458
-#. TRANS: set xy position for this mouse
+#.  TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "ネズミを設定"
+
 
 #: js/blocks/EnsembleBlocks.js:408
 #: js/blocks/EnsembleBlocks.js:419
@@ -4302,6 +5034,7 @@ msgstr "ネズミを設定"
 msgid "x"
 msgstr "xざひょう（よこ）"
 
+
 #: js/blocks/EnsembleBlocks.js:408
 #: js/blocks/EnsembleBlocks.js:419
 #: js/blocks/GraphicsBlocks.js:152
@@ -4314,247 +5047,304 @@ msgstr "xざひょう（よこ）"
 msgid "y"
 msgstr "yざひょう（たて）"
 
+
 #: js/blocks/EnsembleBlocks.js:412
 #: js/blocks/EnsembleBlocks.js:473
-#. TRANS: set xy position for this turtle
+#.  TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "タートルを設定"
+
 
 #: js/blocks/EnsembleBlocks.js:450
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr "指定されたマウスに実行するブロックのスタックを送ります。"
 
+
 #: js/blocks/EnsembleBlocks.js:465
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr "指定されたタートルに実行するブロックのスタックを送ります。"
 
+
 #: js/blocks/EnsembleBlocks.js:501
-#. TRANS: y position for this mouse
+#.  TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミのy座標"
+
 
 #: js/blocks/EnsembleBlocks.js:503
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "指定されたマウスのY座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:515
-#. TRANS: y position for this turtle
+#.  TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "タートルのy座標"
+
 
 #: js/blocks/EnsembleBlocks.js:517
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "指定されたタートルのY座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:546
-#. TRANS: x position for this mouse
+#.  TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミのx座標"
+
 
 #: js/blocks/EnsembleBlocks.js:548
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "指定されたマウスのX座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:560
-#. TRANS: x position for this turtle
+#.  TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "タートルのx座標"
+
 
 #: js/blocks/EnsembleBlocks.js:562
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "指定されたタートルのX座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:592
-#. TRANS: notes played by this mouse
+#.  TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの演奏した音符の数"
+
 
 #: js/blocks/EnsembleBlocks.js:594
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr "指定されたマウスが演奏したノート数を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:608
-#. TRANS: notes played by this turtle
+#.  TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルの演奏した音符の数"
+
 
 #: js/blocks/EnsembleBlocks.js:610
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr "指定されたタートルが演奏したノート数を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:646
-#. TRANS: convert current note for this turtle to piano key (1-88)
+#.  TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
+
 
 #: js/blocks/EnsembleBlocks.js:648
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr "指定されたマウスが現在演奏しているピッチ番号を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:662
-#. TRANS: convert current note for this turtle to piano key (1-88)
+#.  TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルの音高数字"
+
 
 #: js/blocks/EnsembleBlocks.js:664
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr "指定されたタートルが現在演奏しているピッチ番号を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:768
 #: js/blocks/EnsembleBlocks.js:840
-#. TRANS: note value is the duration of the note played by this mouse
+#.  TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "ネズミの音価"
 
+
 #: js/blocks/EnsembleBlocks.js:778
-#. TRANS: note value is the duration of the note played by this turtle
+#.  TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルの音価"
 
+
 #: js/blocks/EnsembleBlocks.js:851
-#. TRANS: sync is short for synchronization
+#.  TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを同期させる"
+
 
 #: js/blocks/EnsembleBlocks.js:853
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "マウス間のビート数を同期させるブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:865
-#. TRANS: sync is short for synchronization
+#.  TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルを同期させる"
+
 
 #: js/blocks/EnsembleBlocks.js:867
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr "タートル間のビート数を同期させるブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:907
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr "指定されたマウスが見つかった場合に「実」を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:915
 msgid "found mouse"
 msgstr "ネズミを見つけた"
 
+
 #: js/blocks/EnsembleBlocks.js:925
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr "指定されたタートルが見つかった場合に「実」を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:933
 msgid "found turtle"
 msgstr "タートル見つかった"
 
+
 #: js/blocks/EnsembleBlocks.js:956
 msgid "new mouse"
 msgstr "新しいネズミ"
+
 
 #: js/blocks/EnsembleBlocks.js:958
 msgid "The New mouse block will create a new mouse."
 msgstr "新しいマウスを作成するブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:969
 msgid "new turtle"
 msgstr "新しいタートル"
+
 
 #: js/blocks/EnsembleBlocks.js:971
 msgid "The New turtle block will create a new turtle."
 msgstr "新しいタートルを作成するブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:1034
 msgid "set mouse color"
 msgstr "ネズミ色を設定"
+
 
 #: js/blocks/EnsembleBlocks.js:1037
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr "「ネズミ色を設定」ブロックは ネズミの色を選ぶことに使います。"
 
+
 #: js/blocks/EnsembleBlocks.js:1043
 msgid "set turtle color"
 msgstr "タートル色を設定"
+
 
 #: js/blocks/EnsembleBlocks.js:1046
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr "タートルの色を設定するためのブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:1109
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "<h2>文字ブロック</h2><br>このプログラムを実行しているネズミの名前（文字列）を表す。"
+
 
 #: js/blocks/EnsembleBlocks.js:1118
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr "タートルの名前を返すブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:1141
 msgid "mouse count"
 msgstr "何匹のネズミ"
+
 
 #: js/blocks/EnsembleBlocks.js:1144
 msgid "The Mouse-count block returns the number of mice."
 msgstr "「何匹のネズミ」のブロックはネズミを数えって数字を表す。"
 
+
 #: js/blocks/EnsembleBlocks.js:1150
 msgid "turtle count"
 msgstr "何匹のタートル"
+
 
 #: js/blocks/EnsembleBlocks.js:1153
 msgid "The Turtle-count block returns the number of turtles."
 msgstr "タートルカウントブロックはタートルの数を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:1175
 msgid "nth mouse name"
 msgstr "何匹目のネズミの名前"
+
 
 #: js/blocks/EnsembleBlocks.js:1178
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr "エヌス・マウス・ネームブロックはエヌ番目のマウスの名前を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:1184
 msgid "nth turtle name"
 msgstr "何匹目のタートルの名前"
 
+
 #: js/blocks/EnsembleBlocks.js:1187
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr "エヌス・タートル・ネームブロックはエヌ番目のタートルの名前を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:1231
 #: js/blocks/EnsembleBlocks.js:1291
 msgid "set name"
 msgstr "ネズミに名前をつける"
 
+
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "source"
 msgstr "ソース"
+
 
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "target"
 msgstr "ターゲット"
 
+
 #: js/blocks/EnsembleBlocks.js:1297
 msgid "The Set-name block is used to name a mouse."
 msgstr "<h2>文字ブロック</h2><br>ネズミに指定した名前をつけることができる。"
+
 
 #: js/blocks/EnsembleBlocks.js:1310
 msgid "The Set-name block is used to name a turtle."
 msgstr "<h2>文字ブロック</h2><br>タートルに指定した名前をつけることができる。"
 
+
 #: js/blocks/ExtrasBlocks.js:33
 msgid "fraction"
 msgstr "分数"
+
 
 #: js/blocks/ExtrasBlocks.js:36
 msgid "Convert a float to a fraction"
 msgstr "小数から分数"
 
+
 #: js/blocks/ExtrasBlocks.js:93
 msgid "save as ABC"
 msgstr "ABCでほぞん"
 
+
 #: js/turtledefs.js:424
 msgid "Turtle Blocks is a Logo-inspired turtle that draws colorful pictures with snap-together visual-programming blocks."
 msgstr "タートル・ブロックスはアートと数学を求めるビジュアル・プログラミング言語だ。"
+
 
 #: js/turtledefs.js:426
 #: js/turtledefs.js:446
@@ -4563,45 +5353,55 @@ msgstr "タートル・ブロックスはアートと数学を求めるビジュ
 msgid "The current version is"
 msgstr "ミュージック・ブロックスの最新バージョンは"
 
+
 #: js/turtledefs.js:431
 #: js/turtledefs.js:467
 msgid "Click the run button to run the project in fast mode."
 msgstr "クリックをすると、ふつうのスピードでプログラムを実行することができる。"
 
+
 #: js/turtledefs.js:436
 msgid "Stop the turtle."
 msgstr "タータルを止める"
+
 
 #: js/turtledefs.js:436
 #: js/turtledefs.js:472
 msgid "You can also type Alt-S to stop."
 msgstr "プログラムは、このボタンをおすかわりに、キーボードで「Altキーと Sキーの同時おし」でも止めることができる。"
 
+
 #: js/turtledefs.js:443
 #: js/widgets/help.js:548
 msgid "Welcome to Music Blocks"
 msgstr "ミュージック・ブロックスへようこそ"
 
+
 #: js/turtledefs.js:444
 msgid "Music Blocks is a collection of tools for exploring fundamental musical concepts in a fun way."
 msgstr "音楽と算数とプログラミングをむすびつけ、深く楽しむことができるツール。それが、ミュージック・ブロックスだ。"
+
 
 #: js/turtledefs.js:450
 #: js/widgets/help.js:549
 msgid "Meet Mr. Mouse!"
 msgstr "ミスター・マウスに会おう！"
 
+
 #: js/turtledefs.js:451
 msgid "Mr Mouse is our Music Blocks conductor."
 msgstr "ミスター・マウスは、ミュージック・ブロックスの指揮者。"
+
 
 #: js/turtledefs.js:453
 msgid "Mr Mouse encourages you to explore Music Blocks."
 msgstr "ミスター・マウスと一緒に、ミュージック・ブロックスの世界をたんきゅうしよう。"
 
+
 #: js/turtledefs.js:455
 msgid "Let us start our tour!"
 msgstr "では、ツアーを始めよう。"
+
 
 #: js/turtledefs.js:459
 #: js/turtledefs.js:737
@@ -4609,18 +5409,22 @@ msgstr "では、ツアーを始めよう。"
 msgid "Guide"
 msgstr "もっとくわしく知るには"
 
+
 #: js/turtledefs.js:460
 msgid "A detailed guide to Music Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
+
 
 #: js/turtledefs.js:463
 #: js/SaveInterface.js:93
 msgid "Music Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
 
+
 #: js/turtledefs.js:472
 msgid "Stop the music (and the mice)."
 msgstr "実行しているプログラムを止める。"
+
 
 #: js/turtledefs.js:479
 #: js/toolbar-ui.js:131
@@ -4630,9 +5434,11 @@ msgstr "実行しているプログラムを止める。"
 msgid "Record"
 msgstr "録音"
 
+
 #: js/turtledefs.js:480
 msgid "Record your project as video."
 msgstr "再生されているビデオを録音する"
+
 
 #: js/turtledefs.js:485
 #: js/toolbar-ui.js:134
@@ -4642,9 +5448,11 @@ msgstr "再生されているビデオを録音する"
 msgid "Toggle Fullscreen"
 msgstr "フルスクリーンの切り替え"
 
+
 #: js/turtledefs.js:486
 msgid "Toggle Fullscreen mode."
 msgstr "フルスクリーンの切り替え"
+
 
 #: js/turtledefs.js:490
 #: js/toolbar-ui.js:135
@@ -4656,9 +5464,11 @@ msgstr "フルスクリーンの切り替え"
 msgid "New project"
 msgstr "新しいプロジェクト"
 
+
 #: js/turtledefs.js:491
 msgid "Initialize a new project."
 msgstr "新しいプロジェクトを作る。"
+
 
 #: js/turtledefs.js:495
 #: js/toolbar-ui.js:136
@@ -4668,9 +5478,11 @@ msgstr "新しいプロジェクトを作る。"
 msgid "Load project from file"
 msgstr "プロジェクトを読みこむ"
 
+
 #: js/turtledefs.js:496
 msgid "You can also load projects from the file system."
 msgstr "コンピューターに保存してあるファイルから、ミュージック・ブロックスのプロジェクトを読み込んで開く。"
+
 
 #: js/turtledefs.js:501
 #: js/turtledefs.js:509
@@ -4682,6 +5494,7 @@ msgstr "コンピューターに保存してあるファイルから、ミュー
 #: js/toolbar-ui.js:340
 msgid "Save project"
 msgstr "プロジェクトをほぞん"
+
 
 #: js/turtledefs.js:502
 #: js/turtledefs.js:529
@@ -4700,12 +5513,14 @@ msgstr "プロジェクトをほぞん"
 msgid "Save project as HTML"
 msgstr "HTMLをほぞん"
 
+
 #: js/turtledefs.js:502
 #: js/toolbar-ui.js:164
 #: js/toolbar-ui.js:168
 #: js/toolbar-ui.js:242
 msgid "Save mouse artwork as PNG"
 msgstr "PNGでほぞん"
+
 
 #: js/turtledefs.js:508
 #: js/SaveInterface.js:256
@@ -4724,9 +5539,11 @@ msgstr "PNGでほぞん"
 msgid "Save"
 msgstr "保存する"
 
+
 #: js/turtledefs.js:511
 msgid "Save your project to a file."
 msgstr "げんざい開いているプロジェクトをほぞんする。"
+
 
 #: js/turtledefs.js:513
 #: js/toolbar-ui.js:253
@@ -4735,9 +5552,11 @@ msgstr "げんざい開いているプロジェクトをほぞんする。"
 msgid "Save turtle artwork as SVG"
 msgstr "アートをSVGで保存"
 
+
 #: js/turtledefs.js:515
 msgid "Save graphics from your project to as SVG."
 msgstr "プロジェクトのグラフィックをSVGで保存"
+
 
 #: js/turtledefs.js:517
 #: js/toolbar-ui.js:251
@@ -4749,9 +5568,11 @@ msgstr "プロジェクトのグラフィックをSVGで保存"
 msgid "Save turtle artwork as PNG"
 msgstr "アートをPNGで保存"
 
+
 #: js/turtledefs.js:519
 msgid "Save graphics from your project as PNG."
 msgstr "プロジェクトのグラフィックをPNGで保存"
+
 
 #: js/turtledefs.js:521
 #: js/toolbar-ui.js:173
@@ -4762,9 +5583,11 @@ msgstr "プロジェクトのグラフィックをPNGで保存"
 msgid "Save block artwork as SVG"
 msgstr "ブロックのアートをほぞん"
 
+
 #: js/turtledefs.js:523
 msgid "Save block artwork as an SVG file."
 msgstr "ブロックのグラフィックをSVGで保存"
+
 
 #: js/turtledefs.js:531
 #: js/toolbar-ui.js:166
@@ -4772,35 +5595,43 @@ msgstr "ブロックのグラフィックをSVGで保存"
 msgid "Save project as MIDI"
 msgstr "プロジェクトをMIDIとして保存"
 
+
 #: js/turtledefs.js:533
 #: js/toolbar-ui.js:169
 #: js/toolbar-ui.js:243
 msgid "Save music as WAV"
 msgstr "WAVでほぞん"
 
+
 #: js/turtledefs.js:535
 msgid "Save sheet music as ABC, Lilypond or MusicXML"
 msgstr "楽譜をABC、Lilypond、またはMusicXMLとして保存する。"
+
 
 #: js/turtledefs.js:537
 msgid "Save block artwork as SVG or PNG"
 msgstr "ブロックのアートワークをSVGまたはPNGとして保存する。"
 
+
 #: js/turtledefs.js:543
 msgid "Load samples from server"
 msgstr "みんなの作品"
+
 
 #: js/turtledefs.js:544
 msgid "This button opens a viewer for loading example projects."
 msgstr "インターネットの「プラネット（わくせい）」というページから、ほかの人が作ったプロジェクトを選んで、読みこむことができる。"
 
+
 #: js/turtledefs.js:548
 msgid "Expand/collapse option toolbar"
 msgstr "オプションツールバーを表示"
 
+
 #: js/turtledefs.js:549
 msgid "Click this button to expand or collapse the auxiliary toolbar."
 msgstr "このボタンをクリックすると「サブメニュー」を開いたり、折りたたんだりすることができる。"
+
 
 #: js/turtledefs.js:553
 #: js/toolbar-ui.js:143
@@ -4812,9 +5643,11 @@ msgstr "このボタンをクリックすると「サブメニュー」を開い
 msgid "Help"
 msgstr "説明"
 
+
 #: js/turtledefs.js:554
 msgid "Displays help messages for the main and auxiliary toolbar, right-click contextual menu for blocks and canvas, and palettes."
 msgstr "メインおよび補助ツールバー、ブロックとキャンバスの右クリックコンテキストメニュー、パレットのヘルプメッセージを表示します。"
+
 
 #: js/turtledefs.js:560
 #: js/toolbar-ui.js:145
@@ -4824,9 +5657,11 @@ msgstr "メインおよび補助ツールバー、ブロックとキャンバス
 msgid "Run slowly"
 msgstr "ゆっくり実行する"
 
+
 #: js/turtledefs.js:561
 msgid "Click to run the project in slow mode."
 msgstr "クリックをすると、ゆっくりとしたスピードでプログラムを実行することができる。"
+
 
 #: js/turtledefs.js:565
 #: js/toolbar-ui.js:146
@@ -4836,9 +5671,11 @@ msgstr "クリックをすると、ゆっくりとしたスピードでプログ
 msgid "Run step by step"
 msgstr "ブロックを１つずつ実行する"
 
+
 #: js/turtledefs.js:566
 msgid "Click to run the project step by step."
 msgstr "クリックをすると、とてもゆっくり、ブロックを１つずつ実行する。プログラムがうまくはたらかず、どのブロックが原因なのかを調べたいときなどに便利だ。"
+
 
 #: js/turtledefs.js:571
 #: js/toolbar-ui.js:147
@@ -4848,9 +5685,11 @@ msgstr "クリックをすると、とてもゆっくり、ブロックを１つ
 msgid "Display statistics"
 msgstr "とうけいを表示する"
 
+
 #: js/turtledefs.js:572
 msgid "Display statistics about your Music project."
 msgstr "プロジェクトに含まれているブロックの種類、わりあいなど、とうけいてきなじょうほうを表示する。"
+
 
 #: js/turtledefs.js:576
 #: js/toolbar-ui.js:148
@@ -4860,9 +5699,11 @@ msgstr "プロジェクトに含まれているブロックの種類、わりあ
 msgid "Load plugin"
 msgstr "プラグインを読みこむ"
 
+
 #: js/turtledefs.js:577
 msgid "Load a selected plugin."
 msgstr "選択したプラグインを読み込みます。"
+
 
 #: js/turtledefs.js:581
 #: js/toolbar-ui.js:149
@@ -4872,17 +5713,21 @@ msgstr "選択したプラグインを読み込みます。"
 msgid "Delete plugin"
 msgstr "プラグインを消す"
 
+
 #: js/turtledefs.js:582
 msgid "Delete a selected plugin."
 msgstr "せんたくしたプラグインを消す。"
+
 
 #: js/turtledefs.js:586
 msgid "Enable scrolling"
 msgstr "自由な方向に／たて方向にスクロール"
 
+
 #: js/turtledefs.js:587
 msgid "You can scroll the blocks on the canvas."
 msgstr "カンバス上をドラッグそうさしたときに、画面をスクロールさせることができる方向を上下だけと上下左右に変える。"
+
 
 #: js/turtledefs.js:592
 #: js/toolbar-ui.js:152
@@ -4893,9 +5738,11 @@ msgstr "カンバス上をドラッグそうさしたときに、画面をスク
 msgid "Change theme"
 msgstr "テーマを変更"
 
+
 #: js/turtledefs.js:593
 msgid "Switch between dark and light mode."
 msgstr "ダークモードとライトモードを切り替えます。"
+
 
 #: js/turtledefs.js:597
 #: js/toolbar-ui.js:156
@@ -4908,17 +5755,21 @@ msgstr "ダークモードとライトモードを切り替えます。"
 msgid "Merge with current project"
 msgstr "プロジェクトを組みあわせる"
 
+
 #: js/turtledefs.js:598
 msgid "Click to add another project into the current one."
 msgstr "クリックして別のプロジェクトを現在のプロジェクトに追加します。"
+
 
 #: js/turtledefs.js:602
 msgid "Wrap Turtle"
 msgstr "アートを包む"
 
+
 #: js/turtledefs.js:603
 msgid "Turn Turtle wrapping On or Off."
 msgstr "アートを包むか・包まない"
+
 
 #: js/turtledefs.js:607
 #: js/toolbar-ui.js:157
@@ -4926,9 +5777,11 @@ msgstr "アートを包むか・包まない"
 msgid "Set Pitch Preview"
 msgstr "変化記号を設定"
 
+
 #: js/turtledefs.js:608
 msgid "Click to set the current pitch."
 msgstr "クリックして現在の音高を設定します。"
+
 
 #: js/turtledefs.js:613
 #: js/toolbar-ui.js:158
@@ -4938,9 +5791,11 @@ msgstr "クリックして現在の音高を設定します。"
 msgid "JavaScript Editor"
 msgstr "JavaScript エディタ"
 
+
 #: js/turtledefs.js:614
 msgid "Converts Music Block programs to JavaScript."
 msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
+
 
 #: js/turtledefs.js:619
 #: js/toolbar-ui.js:159
@@ -4950,17 +5805,21 @@ msgstr "Music BlocksのプログラムをJavaScriptに変換します。"
 msgid "Restore"
 msgstr "すてたブロックをもどす"
 
+
 #: js/turtledefs.js:620
 msgid "Restore blocks from the trash."
 msgstr "ゴミ箱にすててしまったブロックを取り出してもどす。ふくすうのブロックをすててあるときは新しい順に、ゴミ箱が空になるまでブロックを拾いもどすことができる。"
+
 
 #: js/turtledefs.js:624
 msgid "Switch mode"
 msgstr "はってんモード／かんたんモードにする"
 
+
 #: js/turtledefs.js:625
 msgid "Switch between beginner and advance modes."
 msgstr "ミュージック・ブロックスをかんたんモード／はってんモードに切りかえる。モードによって使えるきのうやブロックの種類が変わる。"
+
 
 #: js/turtledefs.js:629
 #: js/toolbar-ui.js:162
@@ -4971,66 +5830,81 @@ msgstr "ミュージック・ブロックスをかんたんモード／はって
 msgid "Select language"
 msgstr "言語をえらぶ"
 
+
 #: js/turtledefs.js:630
 msgid "Select your language preference."
 msgstr "ブロックの名前などに表示される言語をえらぶ。"
+
 
 #: js/turtledefs.js:634
 #: js/widgets/help.js:565
 msgid "Contextual Menu for Blocks"
 msgstr "ブロックのコンテキストメニュー"
 
+
 #: js/turtledefs.js:635
 msgid "Right-click on a block to access common actions."
 msgstr "ブロックを右クリックして共通操作にアクセスします。"
+
 
 #: js/turtledefs.js:639
 #: planet/js/StringHelper.js:48
 msgid "Delete"
 msgstr "消す"
 
+
 #: js/turtledefs.js:640
 msgid "To delete a block, right-click on it. Then you will see the delete option."
 msgstr "ブロックを削除するには、ブロックを右クリックします。次に、削除オプションが表示されます。"
 
+
 #: js/turtledefs.js:645
 msgid "To copy a block, right-click on it. Then you will see the copy option."
 msgstr "ブロックをコピーするには、ブロックを右クリックします。次に、コピーオプションが表示されます。"
+
 
 #: js/turtledefs.js:649
 #: js/piemenu-block-context.js:101
 msgid "Extract"
 msgstr "取り出す"
 
+
 #: js/turtledefs.js:650
 msgid "To extract a block, right-click on it. Then you will see the extract option."
 msgstr "ブロックを抽出するには、ブロックを右クリックします。次に、抽出オプションが表示されます。"
+
 
 #: js/turtledefs.js:659
 #: js/widgets/help.js:564
 msgid "Tab Navigation"
 msgstr "タブのナビゲーション"
 
+
 #: js/turtledefs.js:660
 msgid "Press the Tab key on your keyboard to magically jump between the workspace, toolbar, and palette!"
 msgstr "キーボードの Tab キーを押すと、ワークスペース、ツールバー、パレットからを魔法のようにジャンプできます。"
+
 
 #: js/turtledefs.js:668
 #: js/widgets/help.js:566
 msgid "Contextual Menu for Canvas"
 msgstr "キャンバスのコンテキストメニュー"
 
+
 #: js/turtledefs.js:669
 msgid "Right-click on the canvas to perform additional canvas-related tasks."
 msgstr "キャンバスを右クリックして追加のキャンバス関連タスクを実行します。"
+
 
 #: js/turtledefs.js:675
 msgid "Turn on/off lines for cartesian or polar grids."
 msgstr "デカルト座標または極座標グリッドの線をオン/オフにします。"
 
+
 #: js/turtledefs.js:677
 msgid "Turn on/off music staffs."
 msgstr "五線譜の表示/非表示を切り替えます。"
+
 
 #: js/turtledefs.js:681
 #: js/turtles.js:1009
@@ -5045,95 +5919,116 @@ msgstr "五線譜の表示/非表示を切り替えます。"
 #: js/widgets/pitchdrummatrix.js:178
 #: js/widgets/temperament.js:387
 #: js/widgets/temperament.js:418
-#.TRANS: clear all subdivisions from the ruler.
+#. TRANS: clear all subdivisions from the ruler.
 msgid "Clear"
 msgstr "もとにもどす"
+
 
 #: js/turtledefs.js:682
 msgid "Clear the screen and return the mice to their initial positions."
 msgstr "ネズミを元の位置にもどし、ペンでえがいた線をすべて消す。"
+
 
 #: js/turtledefs.js:686
 #: js/turtles.js:1030
 msgid "Collapse"
 msgstr "カンバスをしゅくしょう"
 
+
 #: js/turtledefs.js:687
 msgid "Collapse the graphics window."
 msgstr "ネズミがいどうしたり、ペンで線をえがいたりできる「カンバス」の表示サイズを しゅくしょうしたり、かくだいしたりする。カンバスをしゅくしょうした場合は、プログラムをふつうのそくどで実行しても、ブロックがかくれない。ふつうの実行そくどでプログラムの動作かくにんをしたいときなどに便利だ。"
+
 
 #: js/turtledefs.js:691
 #: js/context-menu-controller.js:191
 msgid "Home"
 msgstr "ホーム"
 
+
 #: js/turtledefs.js:692
 msgid "Return all blocks to the center of the screen."
 msgstr "すべてのブロックを、カンバスのまんなかに配置する。"
+
 
 #: js/turtledefs.js:696
 #: js/context-menu-controller.js:208
 msgid "Show/hide blocks"
 msgstr "ブロックを表示する／かくす"
 
+
 #: js/turtledefs.js:697
 msgid "Hide or show the blocks and the palettes."
 msgstr "クリックすると、パレットボタンとプログラムのブロックを画面上に表示させたり、かくしたりすることができる。"
+
 
 #: js/turtledefs.js:701
 #: js/context-menu-controller.js:224
 msgid "Expand/collapse blocks"
 msgstr "ブロックを広げる/折りたたむ"
 
+
 #: js/turtledefs.js:702
 msgid "Expand or collapse start and action stacks."
 msgstr "クリックすると、「スタート」と「アクション」に使われているブロックを、広げて表示したり、折りたたんでかくしたりすることができる。"
+
 
 #: js/turtledefs.js:706
 #: js/context-menu-controller.js:240
 msgid "Decrease block size"
 msgstr "ブロックの表示を小さくする"
 
+
 #: js/turtledefs.js:707
 msgid "Decrease the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを小さくする。"
+
 
 #: js/turtledefs.js:711
 #: js/context-menu-controller.js:255
 msgid "Increase block size"
 msgstr "ブロックの表示を大きくする"
 
+
 #: js/turtledefs.js:712
 msgid "Increase the size of the blocks."
 msgstr "画面に表示されるブロックのサイズを大きくする。"
+
 
 #: js/turtledefs.js:717
 msgid "Select"
 msgstr "選択"
 
+
 #: js/turtledefs.js:718
 msgid "Left-click and drag on workspace to select multiple blocks."
 msgstr "ワークスペースを左クリックしてドラッグすると複数のブロックを選択できます。"
+
 
 #: js/turtledefs.js:724
 msgid "Palette buttons"
 msgstr "パレットボタン"
 
+
 #: js/turtledefs.js:725
 msgid "This toolbar contains the palette buttons including Rhythm Pitch Tone Action and more."
 msgstr "ミュージック・ブロックスの左側には、プログラミングに使うさまざまなブロックをグループ分けした「パレットボタン」がある。"
+
 
 #: js/turtledefs.js:729
 msgid "Click to show the palettes of blocks and drag blocks from the palettes onto the canvas to use them."
 msgstr "それぞれのパレットボタンをクリックし、「音符（おんぷ）」「アクション」「ペン」などから好きなブロックを選んで、カンバス上にドラッグして置いてみよう。"
 
+
 #: js/turtledefs.js:738
 msgid "A detailed guide to Turtle Blocks is available."
 msgstr "インターネットから、ミュージック・ブロックスのさらにくわしいガイドページを見ることができる。次のリンク先を開いてみよう。"
 
+
 #: js/turtledefs.js:741
 msgid "Turtle Blocks Guide"
 msgstr "ミュージック・ブロックスガイド"
+
 
 #: js/turtledefs.js:744
 #: js/turtledefs.js:769
@@ -5141,21 +6036,26 @@ msgstr "ミュージック・ブロックスガイド"
 msgid "About"
 msgstr "ミュージック・ブロックスについて"
 
+
 #: js/turtledefs.js:745
 msgid "Turtle Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
+
 
 #: js/turtledefs.js:749
 msgid "A full list of contributors can be found in the Turtle Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
 
+
 #: js/turtledefs.js:753
 msgid "Turtle Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
+
 #: js/turtledefs.js:760
 msgid "Turtle Blocks GitHub repository"
 msgstr "タータル・ブロックスのリポジトリ"
+
 
 #: js/turtledefs.js:763
 #: js/widgets/help.js:495
@@ -5163,38 +6063,47 @@ msgstr "タータル・ブロックスのリポジトリ"
 msgid "Congratulations."
 msgstr "おめでとうございます！"
 
+
 #: js/turtledefs.js:764
 msgid "You have finished the tour. Please enjoy Turtle Blocks!"
 msgstr "ツアーはここで終わり。タータル・ブロックスを自由に楽しもう。"
+
 
 #: js/turtledefs.js:770
 msgid "Music Blocks is an open source collection of tools for exploring musical concepts."
 msgstr "ミュージック・ブロックスは、音楽のコンセプトをたんきゅうするためにつくられた、オープンソースのツールだ。"
 
+
 #: js/turtledefs.js:774
 msgid "A full list of contributors can be found in the Music Blocks GitHub repository."
 msgstr "ミュージック・ブロックスにかかわってきた人のいちらんは、GitHub（ギットハブ）のリポジトリで見ることができる。"
+
 
 #: js/turtledefs.js:778
 msgid "Music Blocks is licensed under the AGPL."
 msgstr "ミュージック・ブロックスのプログラムは、だれでも自由にみることができる。"
 
+
 #: js/turtledefs.js:783
 msgid "Music Blocks GitHub repository"
 msgstr "ミュージック・ブロックスのリポジトリ"
+
 
 #: js/turtledefs.js:786
 #: js/widgets/help.js:553
 msgid "Congratulations!"
 msgstr "おめでとうございます！"
 
+
 #: js/turtledefs.js:787
 msgid "You have finished the tour. Please enjoy Music Blocks!"
 msgstr "ミスター・マウスのツアーはここで終わり。ミュージック・ブロックスを自由に楽しもう。"
 
+
 #: js/turtles.js:1098
 msgid "Expand"
 msgstr "カンバスをかくだい"
+
 
 #: js/SaveInterface.js:25
 #: js/project-manager.js:262
@@ -5207,84 +6116,104 @@ msgstr "カンバスをかくだい"
 msgid "My Project"
 msgstr "自分のプロジェクト"
 
+
 #: js/SaveInterface.js:26
 #: js/blocks.js:4607
 #: js/blocks/MediaBlocks.js:971
 msgid "Show"
 msgstr "プロジェクトのコードを表示する"
 
+
 #: js/SaveInterface.js:27
 msgid "Hide"
 msgstr "プロジェクトのコードを非表示にする"
+
 
 #: js/SaveInterface.js:80
 msgid "This project was created in Music Blocks"
 msgstr "このプロジェクトは、ミュージック・ブロックスで作成されました。"
 
+
 #: js/SaveInterface.js:84
 msgid "Music Blocks is a Free/Libre Software application."
 msgstr "ミュージック・ブロックスは、音楽のちしきを楽しみながら身につけることのできる、オープンソースのソフトです。"
+
 
 #: js/SaveInterface.js:86
 msgid "The source code can be accessed at"
 msgstr "ミュージック・ブロックスのソースコードは、こちらのURLから見ることができます。"
 
+
 #: js/SaveInterface.js:89
 msgid "For more information, please consult the"
 msgstr "もっと詳しく知りたい場合は、ミュージック・ブロックスのガイドを参照してください。"
+
 
 #: js/SaveInterface.js:96
 msgid "To run this project, open Music Blocks in a web browser and drag and drop this file into the browser window."
 msgstr "このプロジェクトを実行するには、ブラウザでミュージック・ブロックスを開き、このファイルをブラウザ・ウィンドウにドラッグ・アンド・ドロップします。"
 
+
 #: js/SaveInterface.js:100
 msgid "Alternatively, open the file in Music Blocks using the Load project button."
 msgstr "「ファイルからプロジェクトを読みこむ」ボタンをおして、ファイルをひらいてください。"
+
 
 #: js/SaveInterface.js:102
 msgid "Project Code"
 msgstr "プロジェクトのコード"
 
+
 #: js/SaveInterface.js:104
 msgid "This code stores data about the blocks in a project."
 msgstr "このコードは、がいとうする場合、へんしゅうされたバージョンのプロジェクトといっしょに、プロジェクトの中のブロックに関するデータをほぞんします。"
+
 
 #: js/SaveInterface.js:109
 msgid "Copy to Clipboard"
 msgstr "クリップボードにコピー"
 
+
 #: js/SaveInterface.js:138
 msgid "Project code copied to clipboard!"
 msgstr "プロジェクトのコードがクリップボードにコピーされました。"
+
 
 #: js/SaveInterface.js:142
 msgid "Failed to copy."
 msgstr "コピーのエラーが発生しました。"
 
+
 #: js/SaveInterface.js:212
 msgid "Enter a filename to save your project:"
 msgstr "ファイル名を入力してプロジェクトを保存します。"
+
 
 #: js/SaveInterface.js:227
 msgid "Recording saved! Check Downloads."
 msgstr "録音が保存されました!ダウンロードを確認します。"
 
+
 #: js/SaveInterface.js:229
 msgid "Project saved! Check Downloads."
 msgstr "プロジェクトが保存されました!ダウンロードを確認します。"
+
 
 #: js/SaveInterface.js:231
 msgid "File saved! Check Downloads."
 msgstr "ファイルが保存されました!ダウンロードを確認します。"
 
+
 #: js/SaveInterface.js:253
 msgid "Save file"
 msgstr "ファイルを保存"
+
 
 #: js/SaveInterface.js:254
 #: js/SaveInterface.js:261
 msgid "Filename:"
 msgstr "ファイル名："
+
 
 #: js/SaveInterface.js:257
 #: js/project-manager.js:706
@@ -5298,14 +6227,17 @@ msgstr "ファイル名："
 msgid "Cancel"
 msgstr "キャンセル"
 
+
 #: js/SaveInterface.js:325
 #: planet/js/SaveInterface.js:90
 msgid "No description provided"
 msgstr "記入がありません"
 
+
 #: js/SaveInterface.js:585
 msgid "Your recording is in progress."
 msgstr "録音中"
+
 
 #: js/SaveInterface.js:639
 #: js/SaveInterface.js:679
@@ -5313,36 +6245,43 @@ msgstr "録音中"
 msgid "Error generating ABC output."
 msgstr "ABC 出力の生成中にエラーが発生しました。"
 
+
 #: js/SaveInterface.js:742
-#.TRANS: File name prompt for save as Lilypond
+#. TRANS: File name prompt for save as Lilypond
 msgid "File name"
 msgstr "ファイル名"
 
+
 #: js/SaveInterface.js:744
 #: planet/js/StringHelper.js:38
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project title"
 msgstr "曲名"
 
+
 #: js/SaveInterface.js:746
-#.TRANS: Project title prompt for save as Lilypond
+#. TRANS: Project title prompt for save as Lilypond
 msgid "Project author"
 msgstr "作曲家"
 
+
 #: js/SaveInterface.js:748
-#.TRANS: MIDI prompt for save as Lilypond
+#. TRANS: MIDI prompt for save as Lilypond
 msgid "Include MIDI output?"
 msgstr "MIDIのアウトプットがくふにもまとめましょうか？"
 
+
 #: js/SaveInterface.js:750
-#.TRANS: Guitar prompt for save as Lilypond
+#. TRANS: Guitar prompt for save as Lilypond
 msgid "Include guitar tablature output?"
 msgstr "ギターのTABもがくふにまとめましょうか？"
 
+
 #: js/SaveInterface.js:752
-#.TRANS: Lilypond is a scripting language for generating sheet music
+#. TRANS: Lilypond is a scripting language for generating sheet music
 msgid "Save as Lilypond"
 msgstr "Lilypondがくふのフォーマットでほぞん"
+
 
 #: js/SaveInterface.js:764
 #: js/SaveInterface.js:767
@@ -5363,10 +6302,11 @@ msgstr "Lilypondがくふのフォーマットでほぞん"
 #: js/blocks/EnsembleBlocks.js:970
 #: js/blocks/EnsembleBlocks.js:1238
 #: js/blocks/EnsembleBlocks.js:1306
-#.TRANS: default project title when saving as Lilypond
-#.TRANS: default project author when saving as Lilypond
+#. TRANS: default project title when saving as Lilypond
+#. TRANS: default project author when saving as Lilypond
 msgid "Mr. Mouse"
 msgstr "ミスター・マウス"
+
 
 #: js/SaveInterface.js:871
 #: js/SaveInterface.js:930
@@ -5374,17 +6314,21 @@ msgstr "ミスター・マウス"
 msgid "Error generating Lilypond output."
 msgstr "Lilypond 出力の生成中にエラーが発生しました。"
 
+
 #: js/SaveInterface.js:955
 msgid "The Lilypond code is copied to clipboard. You can paste it here:"
 msgstr "Lilypond コードがクリップボードにコピーされます。ここに貼り付けることができます:"
+
 
 #: js/SaveInterface.js:1017
 msgid "Failed to convert Lilypond to PDF. Please try saving as .ly file instead."
 msgstr "Lilypond を PDF に変換できませんでした。代わりに .ly ファイルとして保存してみてください。"
 
+
 #: js/block-drag-controller.js:534
 msgid "Consider breaking this stack into parts."
 msgstr "アクションブロックを使ってプログラムをまとめませんか"
+
 
 #: js/context-menu-controller.js:438
 #: js/trash-controller.js:57
@@ -5392,130 +6336,161 @@ msgstr "アクションブロックを使ってプログラムをまとめませ
 msgid "Trash can is empty."
 msgstr "ゴミ箱は空です。"
 
+
 #: js/context-menu-controller.js:444
 #: js/trash-controller.js:79
 #: js/trash-controller.js:215
 msgid "Item restored from the trash."
 msgstr "ゴミ箱からアイテムを復元しました。"
 
+
 #: js/help-controller.js:92
 msgid "Windows/Linux"
 msgstr "Windows/Linux"
+
 
 #: js/help-controller.js:92
 msgid "Mac"
 msgstr "マック"
 
+
 #: js/help-controller.js:96
 msgid "Workspace"
 msgstr "ワークスペース"
+
 
 #: js/help-controller.js:100
 #: js/toolbar-ui.js:493
 msgid "Play project"
 msgstr "プロジェクトを再生"
 
+
 #: js/help-controller.js:104
 #: js/toolbar-ui.js:555
 msgid "Stop project"
 msgstr "プロジェクトを停止する"
 
+
 #: js/help-controller.js:108
 msgid "Play or stop depending on the current state"
 msgstr "現在の状態に応じて再生または停止します"
+
 
 #: js/help-controller.js:112
 msgid "Play or stop when no text input or widget is active"
 msgstr "アクティブなテキスト入力またはウィジェットがない場合は再生または停止します"
 
+
 #: js/help-controller.js:116
 msgid "Toggle stage scale"
 msgstr "ステージスケールの切り替え"
+
 
 #: js/help-controller.js:120
 msgid "Jump to home position"
 msgstr "ホームポジションに戻る"
 
+
 #: js/help-controller.js:124
 msgid "Jump to the bottom of the workspace"
 msgstr "ワークスペースの一番下にジャンプします"
+
 
 #: js/help-controller.js:128
 msgid "Scroll workspace up"
 msgstr "ワークスペースを上にスクロールする"
 
+
 #: js/help-controller.js:132
 msgid "Scroll workspace down"
 msgstr "ワークスペースを下にスクロールします"
+
 
 #: js/help-controller.js:136
 msgid "Hide block search when it is open"
 msgstr "ブロック検索が開いているときに非表示にする"
 
+
 #: js/help-controller.js:141
 msgid "Editing"
 msgstr "編集"
+
 
 #: js/help-controller.js:145
 msgid "Copy selected stack."
 msgstr "選択したスタックをコピーします。"
 
+
 #: js/help-controller.js:149
 msgid "Paste previous stack."
 msgstr "この前のスタックを貼り付けます。"
+
 
 #: js/help-controller.js:153
 msgid "Open the JSON paste box."
 msgstr "JSON 貼り付けボックスを開きます。"
 
+
 #: js/help-controller.js:157
 msgid "Paste JSON when the paste box is focused."
 msgstr "貼り付けボックスにフォーカスがあるときに JSON を貼り付けます。"
+
 
 #: js/help-controller.js:161
 msgid "Extract the active block."
 msgstr "アクティブなブロックを抽出します。"
 
+
 #: js/help-controller.js:165
 msgid "Clear workspace."
 msgstr "すっきりとしたワークスペース。"
+
 
 #: js/help-controller.js:169
 msgid "Save block artwork."
 msgstr "ブロックアートワークを保存します。"
 
+
 #: js/help-controller.js:173
 msgid "Save block help."
 msgstr "ブロックのヘルプを保存します。"
+
 
 #: js/help-controller.js:178
 msgid "Navigation"
 msgstr "ナビゲーション"
 
+
 #: js/help-controller.js:182
 msgid "Move focus between the toolbar, palettes, and workspace."
 msgstr "ツールバー、パレット、ワークスペースの中からフォーカスを移動します。"
+
 
 #: js/help-controller.js:185
 #: js/help-controller.js:248
 msgid "Arrow keys"
 msgstr "矢印キー"
 
+
 #: js/help-controller.js:186
 msgid "Move the active block, scroll palettes, adjust the tempo widget, or pan the workspace depending on context."
 msgstr "コンテキストに応じて、アクティブなブロックの移動、パレットのスクロール、テンポ ウィジェットの調整、またはワークスペースのパンを行います。"
+
 
 #: js/help-controller.js:192
 msgid "Pan workspace right when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを右に移動します。"
 
+
 #: js/help-controller.js:196
 msgid "Pan workspace left when horizontal scrolling is enabled."
 msgstr "水平スクロールが有効な場合、ワークスペースを左に移動します。"
 
+
 #: js/help-controller.js:201
 msgid "Toolbar"
 msgstr "ツールバー"
+
 
 #: js/help-controller.js:205
 #: js/help-controller.js:206
@@ -5524,49 +6499,61 @@ msgstr "ツールバー"
 msgid "Arrow Left / Arrow Right"
 msgstr "左矢印 / 右矢印"
 
+
 #: js/help-controller.js:208
 msgid "Move focus within the current toolbar."
 msgstr "現在のツールバー内でフォーカスを移動します。"
+
 
 #: js/help-controller.js:211
 msgid "Arrow Up / Arrow Down"
 msgstr "上矢印 / 下矢印"
 
+
 #: js/help-controller.js:212
 msgid "Move focus between main and auxiliary toolbars."
 msgstr "メイン ツールバーと補助ツールバーの間でフォーカスを移動します。"
+
 
 #: js/help-controller.js:216
 msgid "Activate the focused toolbar button."
 msgstr "フォーカスされたツールバーからのボタンをアクティブにします。"
 
+
 #: js/help-controller.js:220
 msgid "Exit toolbar keyboard navigation."
 msgstr "ツールバーのキーボードナビゲーションを終了します。"
+
 
 #: js/help-controller.js:225
 msgid "Widget Windows"
 msgstr "ウィジェット・ウィンドウ"
 
+
 #: js/help-controller.js:229
 msgid "Close the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを閉じます。"
+
 
 #: js/help-controller.js:233
 msgid "Maximize or restore the focused widget window."
 msgstr "フォーカスされたウィジェット・ウィンドウを最大化または復元します。"
 
+
 #: js/help-controller.js:238
 msgid "Help and Pitch Slider"
 msgstr "ヘルプとピッチ・スライダー"
+
 
 #: js/help-controller.js:245
 msgid "Move between help pages when Help is open."
 msgstr "ヘルプが開いているときにヘルプ・ページの中から移動します。"
 
+
 #: js/help-controller.js:249
 msgid "Adjust pitch by semitone when Pitch Slider is open."
 msgstr "ピッチ・スライダーが開いているときに半音単位でピッチを調整します。"
+
 
 #: js/help-controller.js:257
 #: js/help-controller.js:280
@@ -5577,9 +6564,11 @@ msgstr "ピッチ・スライダーが開いているときに半音単位でピ
 msgid "Keyboard shortcuts"
 msgstr "キーボードのショートカット"
 
+
 #: js/help-controller.js:284
 msgid "Shortcuts are context-sensitive. Some only work when a related panel, widget, or mode is active. Windows/Linux and Mac equivalents are shown together."
 msgstr "ショートカットは状況に依存します。一部の機能は、関連するパネル、ウィジェット、またはモードがアクティブな場合にのみ機能します。 Windows/Linux および Mac の同等のものを一緒に示します。"
+
 
 #: js/lilypond.js:619
 #: js/lilypond.js:909
@@ -5589,49 +6578,61 @@ msgstr "ショートカットは状況に依存します。一部の機能は、
 msgid "mouse"
 msgstr "ネズミ"
 
+
 #: js/lilypond.js:620
 msgid "brown rat"
 msgstr "茶色のドブネズミ"
+
 
 #: js/lilypond.js:621
 msgid "mole"
 msgstr "土竜"
 
+
 #: js/lilypond.js:622
 msgid "chipmunk"
 msgstr "リス"
+
 
 #: js/lilypond.js:623
 msgid "red squirrel"
 msgstr "赤いリス"
 
+
 #: js/lilypond.js:624
 msgid "guinea pig"
 msgstr "ギニーピッグ"
+
 
 #: js/lilypond.js:625
 msgid "capybara"
 msgstr "カピバラ"
 
+
 #: js/lilypond.js:626
 msgid "coypu"
 msgstr "ヌートリア"
+
 
 #: js/lilypond.js:627
 msgid "black rat"
 msgstr "黒い鼠"
 
+
 #: js/lilypond.js:628
 msgid "grey squirrel"
 msgstr "灰色のリス"
+
 
 #: js/lilypond.js:629
 msgid "flying squirrel"
 msgstr "モモンガ"
 
+
 #: js/lilypond.js:630
 msgid "bat"
 msgstr "蝙蝠"
+
 
 #: js/lilypond.js:758
 #: js/lilypond.js:915
@@ -5641,69 +6642,87 @@ msgstr "蝙蝠"
 msgid "start drum"
 msgstr "ドラム・スタート"
 
+
 #: js/logoconstants.js:42
 msgid "Not a valid pitch name"
 msgstr "選ばれた音名が適切ではありません。"
+
 
 #: js/blocks/HeapBlocks.js:254
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "Heap-empty?ブロックはヒープが空の場合に「実」を返します。"
 
+
 #: js/logoconstants.js:44
+#.  AUTOTRANSLATED: Google Translate
 msgid "Pitch index exceeds EDO range"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/project-manager.js:60
 msgid "Catching mice"
 msgstr "ネズミをつかまえているよ"
 
+
 #: js/project-manager.js:61
 msgid "Cleaning the instruments"
 msgstr "楽器のおていれをしているよ"
+
 
 #: js/project-manager.js:62
 msgid "Testing key pieces"
 msgstr "キーボードの音をたしかめているよ"
 
+
 #: js/project-manager.js:63
 msgid "Sight-reading"
 msgstr "がくふをよみこんでいるよ"
+
 
 #: js/project-manager.js:64
 msgid "Combining math and music"
 msgstr "音楽と算数をくっつけているよ"
 
+
 #: js/project-manager.js:65
 msgid "Generating more blocks"
 msgstr "ブロックをたくさんつくっているよ"
+
 
 #: js/project-manager.js:66
 msgid "Do Re Mi Fa Sol La Ti Do"
 msgstr "ド　レ　ミ　ファ　ソ　ラ　シ　ド"
 
+
 #: js/project-manager.js:67
 msgid "Tuning string instruments"
 msgstr "楽器のチューニングをしているよ"
+
 
 #: js/project-manager.js:68
 msgid "Pressing random keys"
 msgstr "キーボードでおんがくをつくっているよ"
 
+
 #: js/project-manager.js:102
 msgid "Loading Complete!"
 msgstr "読み込み完了！"
+
 
 #: js/project-manager.js:320
 msgid "Click the run button to run the project."
 msgstr "プロジェクトを再生するため、再生のボタンをクリックしてください。"
 
+
 #: js/project-manager.js:659
 msgid "Import MIDI"
 msgstr "MIDIをインポートする"
 
+
 #: js/project-manager.js:667
 msgid "Set the max blocks to generate:"
 msgstr "生成する最大ブロックを設定します。"
+
 
 #: js/project-manager.js:686
 #: js/toolbar-ui.js:175
@@ -5717,6 +6736,7 @@ msgstr "生成する最大ブロックを設定します。"
 msgid "Confirm"
 msgstr "作成する"
 
+
 #: js/project-manager.js:775
 #: js/project-manager.js:832
 #: js/project-manager.js:854
@@ -5726,32 +6746,40 @@ msgstr "作成する"
 msgid "Cannot load project from the file. Please check the file type."
 msgstr "プロジェクトを読みこめません。ファイルの種類をかくにんしてください。"
 
+
 #: js/project-manager.js:787
 #: js/project-manager.js:902
+#.  AUTOTRANSLATED: Google Translate
 msgid "Cannot find project data in this HTML file."
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/project-manager.js:1076
 msgid "Something went wrong reading JSON-encoded project data."
 msgstr "JSON エンコードされたプロジェクト データの読み取り中に問題が発生しました。"
 
+
 #: js/project-manager.js:1087
 msgid "Invalid parameters"
 msgstr "無効なパラメータ"
 
+
 #: js/rubrics.js:543
 msgid "mice"
 msgstr "ネズミ達の関係"
+
 
 #: js/search-ui.js:127
 #: js/activity.js:581
 msgid "Search for blocks"
 msgstr "ブロックを検索"
 
+
 #: js/toolbar-ui.js:128
 #: js/toolbar-ui.js:204
 msgid "About Music Blocks"
 msgstr "ミュージック・ブロックスについて"
+
 
 #: js/toolbar-ui.js:132
 #: js/toolbar-ui.js:133
@@ -5764,12 +6792,14 @@ msgstr "ミュージック・ブロックスについて"
 msgid "Enter Fullscreen"
 msgstr "全画面表示に入る"
 
+
 #: js/toolbar-ui.js:139
 #: js/toolbar-ui.js:215
 #: js/toolbar-ui.js:272
 #: js/toolbar-ui.js:342
 msgid "Find and share projects"
 msgstr "みんなの作品"
+
 
 #: js/toolbar-ui.js:140
 #: js/toolbar-ui.js:216
@@ -5778,12 +6808,14 @@ msgstr "みんなの作品"
 msgid "Offline. Sharing is unavailable"
 msgstr "オフライン。シェア機能が使えません"
 
+
 #: js/toolbar-ui.js:141
 #: js/toolbar-ui.js:217
 #: js/toolbar-ui.js:274
 #: js/toolbar-ui.js:344
 msgid "Auxiliary menu"
 msgstr "サブメニュー"
+
 
 #: js/toolbar-ui.js:142
 #: js/toolbar-ui.js:218
@@ -5792,12 +6824,14 @@ msgstr "サブメニュー"
 msgid "Help and shortcuts"
 msgstr "ヘルプとショートカット"
 
+
 #: js/toolbar-ui.js:150
 #: js/toolbar-ui.js:226
 #: js/toolbar-ui.js:283
 #: js/toolbar-ui.js:353
 msgid "Enable horizontal scrolling"
 msgstr "自由な方向にスクロール"
+
 
 #: js/toolbar-ui.js:151
 #: js/toolbar-ui.js:227
@@ -5806,12 +6840,14 @@ msgstr "自由な方向にスクロール"
 msgid "Disable horizontal scrolling"
 msgstr "たて方向にスクロール"
 
+
 #: js/toolbar-ui.js:153
 #: js/toolbar-ui.js:229
 #: js/toolbar-ui.js:286
 #: js/toolbar-ui.js:356
 msgid "Light Mode"
 msgstr "ライトモード"
+
 
 #: js/toolbar-ui.js:154
 #: js/toolbar-ui.js:230
@@ -5820,12 +6856,14 @@ msgstr "ライトモード"
 msgid "Dark Mode"
 msgstr "ダークモード"
 
+
 #: js/toolbar-ui.js:155
 #: js/toolbar-ui.js:231
 #: js/toolbar-ui.js:288
 #: js/toolbar-ui.js:358
 msgid "High-contrast Mode"
 msgstr "ハイコントラストモード"
+
 
 #: js/toolbar-ui.js:160
 #: js/toolbar-ui.js:236
@@ -5834,6 +6872,7 @@ msgstr "ハイコントラストモード"
 msgid "Switch to beginner mode"
 msgstr "かんたんモードにする"
 
+
 #: js/toolbar-ui.js:161
 #: js/toolbar-ui.js:237
 #: js/toolbar-ui.js:293
@@ -5841,24 +6880,29 @@ msgstr "かんたんモードにする"
 msgid "Switch to advanced mode"
 msgstr "はってんモードにする"
 
+
 #: js/toolbar-ui.js:167
 #: js/toolbar-ui.js:241
 msgid "Save mouse artwork as SVG"
 msgstr "SVGでほぞん"
+
 
 #: js/toolbar-ui.js:170
 #: js/toolbar-ui.js:244
 msgid "Save sheet music as ABC"
 msgstr "ABCのフォーマットでほぞん"
 
+
 #: js/toolbar-ui.js:171
 #: js/toolbar-ui.js:245
 msgid "Save sheet music as Lilypond"
 msgstr "がくふ(Lilypondのフォーマット)でほぞん"
 
+
 #: js/toolbar-ui.js:172
 msgid "Save sheet music as MusicXML"
 msgstr "プロジェクトをMusicXML楽譜でほぞん"
+
 
 #: js/toolbar-ui.js:174
 #: js/toolbar-ui.js:247
@@ -5868,14 +6912,17 @@ msgstr "プロジェクトをMusicXML楽譜でほぞん"
 msgid "Save block artwork as PNG"
 msgstr "ブロックのアートワークをPNGで保存"
 
+
 #: js/toolbar-ui.js:261
 #: js/toolbar-ui.js:331
 msgid "About Turtle Blocks"
 msgstr "タートル・ブロックスについて"
 
+
 #: js/toolbar-ui.js:597
 msgid "Are you sure you want to create a new project?"
 msgstr "新しいプロジェクトを作成してもよろしいですか？"
+
 
 #: js/toolbar-ui.js:792
 #: js/toolbar-ui.js:803
@@ -5885,6 +6932,7 @@ msgstr "新しいプロジェクトを作成してもよろしいですか？"
 msgid "Turtle Wrap Off"
 msgstr "画面の境界を無視しない"
 
+
 #: js/toolbar-ui.js:804
 #: js/toolbar-ui.js:813
 #: js/toolbar-ui.js:846
@@ -5892,67 +6940,83 @@ msgstr "画面の境界を無視しない"
 msgid "Turtle Wrap On"
 msgstr "画面の境界を無視する"
 
+
 #: js/trash-controller.js:286
 msgid "Restore last item"
 msgstr "先のアイテムを復元"
+
 
 #: js/trash-controller.js:287
 msgid "Restore all items"
 msgstr "すべてのアイテムを復元"
 
+
 #: js/turtle-singer.js:1576
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "You must have at least one Partial block inside of a Weighted-partial block"
 msgstr "「倍音ウェート」ブロックの中に一つ以上の倍音ブロックが入っている必要があります。"
+
 
 #: js/turtle-singer.js:1793
 msgid "You can only tie notes of the same pitch. Did you mean to use slur?"
 msgstr "同じピッチの音符のみを結ぶことができます。スラーを使うつもりでしたか？"
 
+
 #: js/turtle-singer.js:2391
 msgid "synth cannot play chords."
 msgstr "このシンセでは和音ができません"
+
 
 #: js/activity.js:751
 msgid "Clear workspace"
 msgstr "すっきりとしたワークスペース"
 
+
 #: js/activity.js:757
 msgid "Are you sure you want to clear the workspace?"
 msgstr "ワークスペースを本当にクリアしますか？"
+
 
 #: js/activity.js:1077
 msgid "Horizontal scrolling enabled."
 msgstr "水平スクロールが有効になりました。"
 
+
 #: js/activity.js:1086
 msgid "Horizontal scrolling disabled."
 msgstr "水平スクロールが無効になっています。"
+
 
 #: js/activity.js:1110
 msgid "plugins will be removed upon restart."
 msgstr "プラグインは再起動時に削除されます。"
 
+
 #: js/activity.js:1753
+#.  AUTOTRANSLATED: Google Translate
 msgid "Firefox performance may be affected because the canvas is unusually large. For the best experience, consider resetting the browser zoom to 100%."
-msgstr ""
+msgstr "キャンバスが異常に大きいため、Firefox のパフォーマンスが影響を受ける可能性があります。最高のエクスペリエンスを得るには、ブラウザーのズームを 100% にリセットすることを検討してください。"
+
 
 #: js/activity.js:2554
 msgid "Invalid clipboard data. To paste blocks, first copy them from the Music Blocks canvas. To paste text, click inside an input field."
 msgstr "クリップボードデータが無効です。ブロックを貼り付けるには、まずミュージック・ブロックスのキャンバスからブロックをコピーします。テキストを貼り付けるには、入力フィールド内をクリックします。"
 
+
 #: js/block.js:1475
 #: js/piemenus.js:3357
 #: js/utils/musicutils.js:1284
 #: js/blocks/PitchBlocks.js:1440
-#.TRANS: unison is a music term related to intervals
-#.TRANS: unison means the note is the same as the current note
+#. TRANS: unison is a music term related to intervals
+#. TRANS: unison means the note is the same as the current note
 msgid "unison"
 msgstr "ユニゾン（同度）"
+
 
 #: js/block.js:1688
 msgid "matrix"
 msgstr "フレーズメーカー"
+
 
 #: js/block.js:1695
 #: js/blocks/WidgetBlocks.js:1787
@@ -5960,53 +7024,63 @@ msgstr "フレーズメーカー"
 msgid "status"
 msgstr "実行じょうきょう"
 
+
 #: js/block.js:1702
 msgid "drum mapper"
 msgstr "ドラム・ピッチ行列"
+
 
 #: js/block.js:1709
 msgid "ruler"
 msgstr "リズムメーカー"
 
+
 #: js/block.js:1716
 #: js/blocks/WidgetBlocks.js:483
-#.TRANS: timbre is the character or quality of a musical sound
+#. TRANS: timbre is the character or quality of a musical sound
 msgid "timbre"
 msgstr "音色"
+
 
 #: js/block.js:1723
 msgid "stair"
 msgstr "階段"
 
+
 #: js/block.js:1730
 #: js/blocks/ProgramBlocks.js:1279
 #: js/blocks/WidgetBlocks.js:825
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "tempo"
 msgstr "メトロノーム"
+
 
 #: js/block.js:1737
 #: js/block.js:1800
 #: js/blocks/IntervalsBlocks.js:1527
-#.TRANS: mode, e.g., Major in C Major
+#. TRANS: mode, e.g., Major in C Major
 msgid "mode"
 msgstr "モード（音階）"
+
 
 #: js/block.js:1744
 msgid "slider"
 msgstr "スライダー"
+
 
 #: js/block.js:1751
 #: js/blocks/SensorsBlocks.js:963
 msgid "keyboard"
 msgstr "キーボード"
 
+
 #: js/block.js:1765
 #: js/blocks/WidgetBlocks.js:1366
 #: js/blocks/WidgetBlocks.js:1405
-#.TRANS: widget for subdividing a measure into distinct rhythmic elements
+#. TRANS: widget for subdividing a measure into distinct rhythmic elements
 msgid "rhythm maker"
 msgstr "リズムメーカー"
+
 
 #: js/block.js:1772
 #: js/block.js:2640
@@ -6029,26 +7103,30 @@ msgstr "リズムメーカー"
 #: js/widgets/phrasemaker.js:2930
 #: js/widgets/phrasemaker.js:2979
 #: js/widgets/phrasemaker.js:3098
-#.TRANS: the value (e.g., 1/4 note) of the note being played.
+#. TRANS: the value (e.g., 1/4 note) of the note being played.
 msgid "note value"
 msgstr "音の長さ"
+
 
 #: js/block.js:1779
 #: js/blocks/OrnamentBlocks.js:312
 #: js/blocks/IntervalsBlocks.js:1127
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "scalar interval"
 msgstr "音階の上下"
+
 
 #: js/block.js:1786
 #: js/blocks/RhythmBlocks.js:159
 msgid "milliseconds"
 msgstr "ミリ秒"
 
+
 #: js/block.js:2565
 #: js/block.js:2588
 msgid "scalar interval %s"
 msgstr "音階の上下 %s"
+
 
 #: js/block.js:2638
 #: js/block.js:2642
@@ -6061,37 +7139,45 @@ msgstr "音階の上下 %s"
 msgid "silence"
 msgstr "休符"
 
+
 #: js/block.js:2734
 #: js/block.js:3876
 #: js/block.js:3893
 #: js/utils/musicutils.js:7340
-#.TRANS: the note names must be separated by single spaces
-#.TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
+#. TRANS: the note names must be separated by single spaces
 msgid "ti la sol fa mi re do"
 msgstr "シ ラ ソ ファ ミ レ ド"
 
+
 #: js/block.js:2822
 #: js/blocks/IntervalsBlocks.js:639
-#.TRANS: scalar step
+#. TRANS: scalar step
 msgid "down"
 msgstr "下"
+
 
 #: js/block.js:2823
 msgid "up"
 msgstr "上"
 
+
 #: js/block.js:3295
 msgid "Silence block cannot be removed."
 msgstr "「休符」は取り出すことができません。"
 
+
 #: js/block.js:3314
+#.  AUTOTRANSLATED: Google Translate
 msgid "picked up"
-msgstr ""
+msgstr "拾った"
+
 
 #: js/block.js:3563
 #: js/piemenu-block-context.js:160
 msgid "You can restore deleted blocks from the trash with the Restore From Trash button."
 msgstr "削除されたブロックは「ゴミ箱から復元」ボタンで復元できます。"
+
 
 #: js/block.js:4223
 #: js/blocks.js:2066
@@ -6110,11 +7196,13 @@ msgstr "削除されたブロックは「ゴミ箱から復元」ボタンで復
 msgid "false"
 msgstr "偽"
 
+
 #: js/block.js:4233
 #: js/block.js:4237
 #: js/blocks/ExtrasBlocks.js:620
 msgid "Cartesian"
 msgstr "ほうがん（ざひょう）を表示"
+
 
 #: js/block.js:4233
 #: js/block.js:4238
@@ -6122,11 +7210,13 @@ msgstr "ほうがん（ざひょう）を表示"
 msgid "polar"
 msgstr "極座標を表示"
 
+
 #: js/block.js:4233
 #: js/block.js:4239
 #: js/blocks/ExtrasBlocks.js:628
 msgid "Cartesian/Polar"
 msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
+
 
 #: js/block.js:4233
 #: js/block.js:4246
@@ -6134,43 +7224,51 @@ msgstr "中心の角度とほうがん（ざひょう）をひょうじ"
 msgid "none"
 msgstr "なし"
 
+
 #: js/blocks/MediaBlocks.js:819
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr "トゥーフリクエンシーブロックは音名とオクターヴをヘルツに変換します。"
+
 
 #: js/block.js:4240
 #: js/blocks/ExtrasBlocks.js:633
 msgid "treble"
 msgstr "トレブル記号"
 
+
 #: js/block.js:4241
 #: js/blocks/ExtrasBlocks.js:637
 msgid "grand staff"
 msgstr "トレブルとバス記号"
+
 
 #: js/block.js:4242
 #: js/blocks/ExtrasBlocks.js:641
 msgid "mezzo-soprano"
 msgstr "メゾソプラノ記号"
 
+
 #: js/block.js:4243
 #: js/blocks/ExtrasBlocks.js:645
 msgid "alto"
 msgstr "アルト記号"
+
 
 #: js/block.js:4244
 #: js/blocks/ExtrasBlocks.js:649
 msgid "tenor"
 msgstr "テノール記号"
 
+
 #: js/block.js:4245
 #: js/utils/musicutils.js:1393
 #: js/utils/synthutils.js:88
 #: js/blocks/ExtrasBlocks.js:653
 #: js/widgets/legobricks.js:1955
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass"
 msgstr "コントラバス"
+
 
 #: js/block.js:4290
 #: js/blocks.js:2057
@@ -6178,35 +7276,43 @@ msgstr "コントラバス"
 msgid "on2"
 msgstr "オン"
 
+
 #: js/block.js:4292
 #: js/blocks.js:2059
 #: js/blocks.js:2704
 msgid "off"
 msgstr "オフ"
 
+
 #: js/block.js:4777
 msgid "Not a number"
 msgstr "数字ではありません"
+
 
 #: js/block.js:4788
 msgid "Octave value must be between 1 and 8."
 msgstr "オクターヴの値が「１」から「8」までの範囲でなければなりません。"
 
+
 #: js/block.js:4796
 msgid "Numbers can have at most 10 digits."
 msgstr "数字は最大１０桁までです。"
+
 
 #: js/loader.js:536
 msgid "Failed to load EaselJS. Please refresh the page."
 msgstr "EaselJS のロードに失敗しました。ページを更新してください。"
 
+
 #: js/loader.js:558
 msgid "Failed to load Music Blocks. Please refresh the page."
 msgstr "ミュージック・ブロックスの読み込みに失敗しました。ページを更新してください。"
 
+
 #: js/loader.js:565
 msgid "Failed to initialize Music Blocks core. Please refresh the page.\n\nError: %s"
 msgstr "ミュージック・ブロックス コアの初期化に失敗しました。ページを更新してください。\n\nエラー: %s"
+
 
 #: js/logo.js:694
 #: js/blocks/ProgramBlocks.js:259
@@ -6214,62 +7320,75 @@ msgstr "ミュージック・ブロックス コアの初期化に失敗しま�
 msgid "You must select a file."
 msgstr "ファイルをえらんでください。"
 
+
 #: js/logo.js:1854
 msgid "Infinite loop detected. Execution stopped to prevent browser freeze."
 msgstr "無限ループが検出されました。ブラウザのフリーズを防ぐために実行が停止されました。"
+
 
 #: js/logo.js:2037
 #: js/blocks/MediaBlocks.js:338
 msgid "width"
 msgstr "カンバスのよこはば"
 
+
 #: js/logo.js:2038
 #: js/blocks/MediaBlocks.js:395
 msgid "height"
 msgstr "カンバスのたてはば"
 
+
 #: js/logo.js:2039
 #: js/blocks/MediaBlocks.js:35
-#.TRANS: right side of the screen
+#. TRANS: right side of the screen
 msgid "right (screen)"
 msgstr "ざひょうち（右）"
 
+
 #: js/logo.js:2040
 #: js/blocks/MediaBlocks.js:111
-#.TRANS: left side of the screen
+#. TRANS: left side of the screen
 msgid "left (screen)"
 msgstr "ざひょうち（左）"
+
 
 #: js/logo.js:2041
 #: js/blocks/MediaBlocks.js:186
 msgid "top (screen)"
 msgstr "ざひょうち（上）"
 
+
 #: js/logo.js:2042
 #: js/blocks/MediaBlocks.js:261
 msgid "bottom (screen)"
 msgstr "ざひょうち（下）"
 
+
 #: js/logo.js:2349
 msgid "Playback is ready."
 msgstr "コンパイル完了"
+
 
 #: js/piemenu-block-context.js:100
 #: js/blocks/FlowBlocks.js:136
 msgid "Duplicate"
 msgstr "複製する"
 
+
 #: js/piemenu-block-context.js:102
 msgid "Move to trash"
 msgstr "すてる"
+
 
 #: js/piemenu-block-context.js:109
 msgid "Save stack"
 msgstr "スタックをほぞん"
 
+
 #: js/piemenu-block-context.js:138
 msgid "In order to copy a sample, you must reload the widget, import the sample again, and export it."
 msgstr "サンプルをコピーするため、ツールを再度試して、またサンプルをロード読み込で、保存することが必要です。"
+
 
 #: js/piemenus.js:447
 #: js/utils/musicutils.js:1468
@@ -6277,9 +7396,10 @@ msgstr "サンプルをコピーするため、ツールを再度試して、ま
 #: js/widgets/phrasemaker.js:2202
 #: js/widgets/musickeyboard.js:2680
 #: js/widgets/sampler.js:1681
-#.TRANS: double sharp is a music term related to pitch
+#. TRANS: double sharp is a music term related to pitch
 msgid "double sharp"
 msgstr "ダブルシャープ"
+
 
 #: js/piemenus.js:448
 #: js/utils/musicutils.js:1466
@@ -6289,10 +7409,11 @@ msgstr "ダブルシャープ"
 #: js/widgets/phrasemaker.js:2203
 #: js/widgets/musickeyboard.js:2681
 #: js/widgets/sampler.js:1682
-#.TRANS: sharp is a music term related to pitch
-#.TRANS: sharp is a half-step up in pitch
+#. TRANS: sharp is a music term related to pitch
+#. TRANS: sharp is a half-step up in pitch
 msgid "sharp"
 msgstr "シャープ"
+
 
 #: js/piemenus.js:449
 #: js/utils/musicutils.js:1464
@@ -6300,9 +7421,10 @@ msgstr "シャープ"
 #: js/widgets/phrasemaker.js:2204
 #: js/widgets/musickeyboard.js:2682
 #: js/widgets/sampler.js:1683
-#.TRANS: natural is a music term related to pitch
+#. TRANS: natural is a music term related to pitch
 msgid "natural"
 msgstr "ナチュラル"
+
 
 #: js/piemenus.js:450
 #: js/utils/musicutils.js:1462
@@ -6312,10 +7434,11 @@ msgstr "ナチュラル"
 #: js/widgets/phrasemaker.js:2205
 #: js/widgets/musickeyboard.js:2683
 #: js/widgets/sampler.js:1684
-#.TRANS: flat is a music term related to pitch
-#.TRANS: flat is a half-step down in pitch
+#. TRANS: flat is a music term related to pitch
+#. TRANS: flat is a half-step down in pitch
 msgid "flat"
 msgstr "フラット"
+
 
 #: js/piemenus.js:451
 #: js/utils/musicutils.js:1460
@@ -6323,58 +7446,67 @@ msgstr "フラット"
 #: js/widgets/phrasemaker.js:2206
 #: js/widgets/musickeyboard.js:2684
 #: js/widgets/sampler.js:1685
-#.TRANS: double flat is a music term related to pitch
+#. TRANS: double flat is a music term related to pitch
 msgid "double flat"
 msgstr "ダブルフラット"
+
 
 #: js/piemenus.js:3517
 #: js/piemenus.js:3591
 #: js/utils/musicutils.js:1292
 #: js/utils/musicutils.js:1470
 #: js/utils/musicutils.js:1701
-#.TRANS: major is a music term related to intervals and mode
+#. TRANS: major is a music term related to intervals and mode
 msgid "major"
 msgstr "メジャー"
+
 
 #: js/piemenus.js:3517
 #: js/piemenus.js:3591
 #: js/utils/musicutils.js:1310
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "ionian"
 msgstr "アイオニアン音階"
+
 
 #: js/piemenus.js:3519
 #: js/piemenus.js:3595
 #: js/utils/musicutils.js:1290
 #: js/utils/musicutils.js:1471
 #: js/utils/musicutils.js:1698
-#.TRANS: minor is a music term related to intervals and mode
+#. TRANS: minor is a music term related to intervals and mode
 msgid "minor"
 msgstr "マイナー（短）"
+
 
 #: js/piemenus.js:3519
 #: js/piemenus.js:3595
 #: js/utils/musicutils.js:1320
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "aeolian"
 msgstr "エオリアン音階"
+
 
 #: js/piemenus.js:4154
 msgid "You have chosen key for your pitch preview."
 msgstr "ピッチプレビューのキーを選択しました。"
 
+
 #: js/planetInterface.js:152
 msgid "project undefined"
 msgstr "プロジェクト未定義"
+
 
 #: js/planetInterface.js:279
 msgid "Error: Unable to save because you ran out of local storage. Try deleting some saved projects."
 msgstr "エラー: ローカル ストレージが不足しているため、保存できません。保存されているプロジェクトをいくつか削除してみてください。"
 
+
 #: js/blocks.js:1936
 #: js/blocks.js:1944
 msgid "audio file"
 msgstr "オーディオファイル"
+
 
 #: js/blocks.js:2942
 #: js/blocks.js:3347
@@ -6386,6 +7518,7 @@ msgstr "オーディオファイル"
 msgid "box1"
 msgstr "箱１"
 
+
 #: js/blocks.js:2944
 #: js/blocks.js:3349
 #: js/blocks.js:3395
@@ -6395,6 +7528,7 @@ msgstr "箱１"
 #: js/blocks/BoxesBlocks.js:667
 msgid "box2"
 msgstr "箱２"
+
 
 #: js/blocks.js:3616
 #: js/blocks/DictBlocks.js:215
@@ -6413,6 +7547,7 @@ msgstr "箱２"
 msgid "name"
 msgstr "名前"
 
+
 #: js/blocks.js:3616
 #: js/blocks/DictBlocks.js:289
 #: js/blocks/DictBlocks.js:430
@@ -6423,63 +7558,86 @@ msgstr "名前"
 msgid "value"
 msgstr "値"
 
+
 #: js/blocks.js:3954
 msgid "Forever loop detected inside a note value block. Unexpected things may happen."
 msgstr "「ずっとくり返す」状態が「音符」の中にある。"
+
 
 #: js/blocks.js:4501
 msgid "There is no block selected."
 msgstr "ブロックが選ばれていません"
 
+
 #: js/blocks.js:4613
 #: js/blocks/MediaBlocks.js:886
-#.TRANS: Avatar is the image used to determine the appearance of the mouse.
+#. TRANS: Avatar is the image used to determine the appearance of the mouse.
 msgid "avatar"
 msgstr "ネズミへんこう"
+
 
 #: js/blocks.js:4616
 #: js/utils/synthutils.js:3854
 #: js/blocks/ToneBlocks.js:1043
 #: js/widgets/sampler.js:1921
-#.TRANS: The sound sample that the user uploads.
+#. TRANS: The sound sample that the user uploads.
 msgid "sample"
 msgstr "音色サンプル"
 
+
 #: js/blocks.js:6720
+#.  AUTOTRANSLATED: Google Translate
 msgid "block sent to trash"
-msgstr ""
+msgstr "ブロックがゴミ箱に送られる"
+
 
 #: js/svgAssetSelector.js:63
+#.  AUTOTRANSLATED: Google Translate
 msgid "Choose an image"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/svgAssetSelector.js:83
+#.  AUTOTRANSLATED: Google Translate
 msgid "Built-in images"
-msgstr ""
+msgstr "内蔵イメージ"
+
 
 #: js/svgAssetSelector.js:92
+#.  AUTOTRANSLATED: Google Translate
 msgid "Upload from device"
-msgstr ""
+msgstr "デバイスからアップロード"
+
 
 #: js/svgAssetSelector.js:156
+#.  AUTOTRANSLATED: Google Translate
 msgid "Choose file"
-msgstr ""
+msgstr "ファイルを選択してください"
+
 
 #: js/svgAssetSelector.js:160
+#.  AUTOTRANSLATED: Google Translate
 msgid "Supports PNG, JPG, SVG, GIF, and other image formats"
-msgstr ""
+msgstr "PNG、JPG、SVG、GIF、その他の画像形式をサポート"
+
 
 #: js/svgAssetSelector.js:176
+#.  AUTOTRANSLATED: Google Translate
 msgid "Apply"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/utils/utils-logic.js:324
+#.  AUTOTRANSLATED: Google Translate
 msgid "Invalid input passed to rational sum"
-msgstr ""
+msgstr "無効な入力が有理合計に渡されました"
+
 
 #: js/utils/utils-logic.js:331
+#.  AUTOTRANSLATED: Google Translate
 msgid "Note calculation failed: zero denominator"
-msgstr ""
+msgstr "ノートの計算が失敗しました: 分母がゼロです"
+
 
 #: js/utils/musicutils.js:595
 #: js/utils/musicutils.js:735
@@ -6488,382 +7646,468 @@ msgstr ""
 msgid "rest"
 msgstr "休符"
 
+
 #: js/utils/musicutils.js:778
 msgid "Perfect unison"
 msgstr "完全1度"
+
 
 #: js/utils/musicutils.js:778
 msgid "Diminished second"
 msgstr "減2度"
 
+
 #: js/utils/musicutils.js:779
 msgid "Minor second"
 msgstr "短2度"
+
 
 #: js/utils/musicutils.js:779
 msgid "Augmented unison"
 msgstr "増1度"
 
+
 #: js/utils/musicutils.js:780
 msgid "Major second"
 msgstr "長2度"
+
 
 #: js/utils/musicutils.js:780
 msgid "Diminished third"
 msgstr "減3度"
 
+
 #: js/utils/musicutils.js:781
 msgid "Minor third"
 msgstr "短3度"
+
 
 #: js/utils/musicutils.js:781
 msgid "Augmented second"
 msgstr "増2度"
 
+
 #: js/utils/musicutils.js:782
 msgid "Major third"
 msgstr "長3度"
+
 
 #: js/utils/musicutils.js:782
 msgid "Diminished fourth"
 msgstr "減4度"
 
+
 #: js/utils/musicutils.js:783
 msgid "Perfect fourth"
 msgstr "完全4度"
+
 
 #: js/utils/musicutils.js:783
 msgid "Augmented third"
 msgstr "増3度"
 
+
 #: js/utils/musicutils.js:784
 msgid "Diminished fifth"
 msgstr "減5度"
+
 
 #: js/utils/musicutils.js:784
 msgid "Augmented fourth"
 msgstr "増4度"
 
+
 #: js/utils/musicutils.js:785
 msgid "Perfect fifth"
 msgstr "完全5度"
+
 
 #: js/utils/musicutils.js:785
 msgid "Diminished sixth"
 msgstr "減6度"
 
+
 #: js/utils/musicutils.js:786
 msgid "Minor sixth"
 msgstr "短6度"
+
 
 #: js/utils/musicutils.js:786
 msgid "Augmented fifth"
 msgstr "増5度"
 
+
 #: js/utils/musicutils.js:787
 msgid "Major sixth"
 msgstr "長6度"
+
 
 #: js/utils/musicutils.js:787
 msgid "Diminished seventh"
 msgstr "減7度"
 
+
 #: js/utils/musicutils.js:788
 msgid "Minor seventh"
 msgstr "短7度"
+
 
 #: js/utils/musicutils.js:788
 msgid "Augmented sixth"
 msgstr "増6度"
 
+
 #: js/utils/musicutils.js:789
 msgid "Major seventh"
 msgstr "長7度"
+
 
 #: js/utils/musicutils.js:789
 msgid "Diminished octave"
 msgstr "減8度"
 
+
 #: js/utils/musicutils.js:790
 msgid "Perfect octave"
 msgstr "完全8度"
+
 
 #: js/utils/musicutils.js:790
 msgid "Augmented seventh"
 msgstr "増7度"
 
+
 #: js/utils/musicutils.js:791
 msgid "Minor ninth"
 msgstr "短9度"
+
 
 #: js/utils/musicutils.js:791
 msgid "Augmented octave"
 msgstr "増8度"
 
+
 #: js/utils/musicutils.js:792
 msgid "Major ninth"
 msgstr "長9度"
+
 
 #: js/utils/musicutils.js:792
 msgid "Diminished tenth"
 msgstr "減10度"
 
+
 #: js/utils/musicutils.js:793
 msgid "Minor tenth"
 msgstr "短10度"
+
 
 #: js/utils/musicutils.js:793
 msgid "Augmented ninth"
 msgstr "増9度"
 
+
 #: js/utils/musicutils.js:794
 msgid "Major tenth"
 msgstr "長10度"
+
 
 #: js/utils/musicutils.js:794
 msgid "Diminished eleventh"
 msgstr "減11度"
 
+
 #: js/utils/musicutils.js:795
 msgid "Perfect eleventh"
 msgstr "完全11度"
+
 
 #: js/utils/musicutils.js:795
 msgid "Augmented tenth"
 msgstr "増10度"
 
+
 #: js/utils/musicutils.js:796
 msgid "Diminished twelfth"
 msgstr "減12度"
+
 
 #: js/utils/musicutils.js:796
 msgid "Augmented eleventh"
 msgstr "増11度"
 
+
 #: js/utils/musicutils.js:797
 msgid "Perfect twelfth"
 msgstr "完全12度"
+
 
 #: js/utils/musicutils.js:797
 msgid "Diminished thirteenth"
 msgstr "減13度"
 
+
 #: js/utils/musicutils.js:798
 msgid "Minor thirteenth"
 msgstr "短13度"
+
 
 #: js/utils/musicutils.js:798
 msgid "Augmented fifth, plus an octave"
 msgstr "増12度"
 
+
 #: js/utils/musicutils.js:799
 msgid "Major thirteenth"
 msgstr "長13度"
+
 
 #: js/utils/musicutils.js:799
 msgid "Diminished seventh, plus an octave"
 msgstr "減14度"
 
+
 #: js/utils/musicutils.js:927
-#.TRANS: ordinal number. Please keep exactly one space between each number.
+#. TRANS: ordinal number. Please keep exactly one space between each number.
 msgid "1st 2nd 3rd 4th 5th 6th 7th 8th 9th 10th 11th 12th"
 msgstr "１度 2度 3度 4度 5度 6度 7度 8度 9度 10度 11度 12度"
+
 
 #: js/utils/musicutils.js:1286
 #: js/utils/musicutils.js:1472
 #: js/utils/musicutils.js:1700
-#.TRANS: augmented is a music term related to intervals
+#. TRANS: augmented is a music term related to intervals
 msgid "augmented"
 msgstr "オーギュメント（増）"
+
 
 #: js/utils/musicutils.js:1288
 #: js/utils/musicutils.js:1473
 #: js/utils/musicutils.js:1699
-#.TRANS: diminished is a music term related to intervals and mode
+#. TRANS: diminished is a music term related to intervals and mode
 msgid "diminished"
 msgstr "ディミニッシュ（減）"
+
 
 #: js/utils/musicutils.js:1294
 #: js/utils/musicutils.js:1697
 #: js/blocks/IntervalsBlocks.js:673
 #: js/turtleactions/IntervalsActions.js:163
 #: js/turtleactions/IntervalsActions.js:167
-#.TRANS: perfect is a music term related to intervals
+#. TRANS: perfect is a music term related to intervals
 msgid "perfect"
 msgstr "パーフェクト（完全）"
 
+
 #: js/utils/musicutils.js:1296
-#.TRANS: twelve semi-tone scale for music
+#. TRANS: twelve semi-tone scale for music
 msgid "chromatic"
 msgstr "クロマティック音階"
+
 
 #: js/utils/musicutils.js:1297
 msgid "algerian"
 msgstr "アルジェリア音階"
 
+
 #: js/utils/musicutils.js:1298
 msgid "spanish"
 msgstr "スペイン音階"
 
+
 #: js/utils/musicutils.js:1300
-#.TRANS: modal scale in music
+#. TRANS: modal scale in music
 msgid "octatonic"
 msgstr "オクタトニック・スケール"
 
+
 #: js/utils/musicutils.js:1302
-#.TRANS: harmonic major scale in music
+#. TRANS: harmonic major scale in music
 msgid "harmonic major"
 msgstr "ハーモニック・メジャー（和声長音階）"
 
+
 #: js/utils/musicutils.js:1304
-#.TRANS: natural minor scales in music
+#. TRANS: natural minor scales in music
 msgid "natural minor"
 msgstr "自然短音階"
 
+
 #: js/utils/musicutils.js:1306
-#.TRANS: harmonic minor scale in music
+#. TRANS: harmonic minor scale in music
 msgid "harmonic minor"
 msgstr "和声短音階"
 
+
 #: js/utils/musicutils.js:1308
-#.TRANS: melodic minor scale in music
+#. TRANS: melodic minor scale in music
 msgid "melodic minor"
 msgstr "旋律短音階"
 
+
 #: js/utils/musicutils.js:1312
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "dorian"
 msgstr "ドリアン音階"
 
+
 #: js/utils/musicutils.js:1314
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "phrygian"
 msgstr "フリジアン音階"
 
+
 #: js/utils/musicutils.js:1316
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "lydian"
 msgstr "リディアン音階"
 
+
 #: js/utils/musicutils.js:1318
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "mixolydian"
 msgstr "ミクソリディアン音階"
 
+
 #: js/utils/musicutils.js:1322
-#.TRANS: modal scale for music
+#. TRANS: modal scale for music
 msgid "locrian"
 msgstr "ロクリアン音階"
 
+
 #: js/utils/musicutils.js:1324
-#.TRANS: minor jazz scale for music
+#. TRANS: minor jazz scale for music
 msgid "jazz minor"
 msgstr "オルタード音階"
 
+
 #: js/utils/musicutils.js:1326
-#.TRANS: bebop scale for music
+#. TRANS: bebop scale for music
 msgid "bebop"
 msgstr "ビバップ音階"
+
 
 #: js/utils/musicutils.js:1327
 msgid "arabic"
 msgstr "アラビア音階"
 
+
 #: js/utils/musicutils.js:1328
 msgid "byzantine"
 msgstr "ビザンティン"
 
+
 #: js/utils/musicutils.js:1330
-#.TRANS: musical scale for music by Verdi
+#. TRANS: musical scale for music by Verdi
 msgid "enigmatic"
 msgstr "ヴェルディの音階"
+
 
 #: js/utils/musicutils.js:1331
 msgid "ethiopian"
 msgstr "エチオピア音階"
 
+
 #: js/utils/musicutils.js:1333
-#.TRANS: Ethiopic scale for music
+#. TRANS: Ethiopic scale for music
 msgid "geez"
 msgstr "ゲエズ音階"
+
 
 #: js/utils/musicutils.js:1334
 msgid "hindu"
 msgstr "ヒンドゥー音階"
 
+
 #: js/utils/musicutils.js:1335
 msgid "hungarian"
 msgstr "ハンガリー音階"
 
+
 #: js/utils/musicutils.js:1337
-#.TRANS: minor Romanian scale for music
+#. TRANS: minor Romanian scale for music
 msgid "romanian minor"
 msgstr "ルーマニア・マイナー音階"
+
 
 #: js/utils/musicutils.js:1338
 msgid "spanish gypsy"
 msgstr "スパニッシュ・ジプシー音階"
 
+
 #: js/utils/musicutils.js:1340
-#.TRANS: musical scale for Mid-Eastern music
+#. TRANS: musical scale for Mid-Eastern music
 msgid "maqam"
 msgstr "マカーム音階"
 
+
 #: js/utils/musicutils.js:1342
-#.TRANS: minor blues scale for music
+#. TRANS: minor blues scale for music
 msgid "minor blues"
 msgstr "マイナー・ブルース音階"
 
+
 #: js/utils/musicutils.js:1344
-#.TRANS: major blues scale for music
+#. TRANS: major blues scale for music
 msgid "major blues"
 msgstr "メジャー・ブルース音階"
+
 
 #: js/utils/musicutils.js:1345
 msgid "whole tone"
 msgstr "ホールトーン音階"
 
+
 #: js/utils/musicutils.js:1347
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "minor pentatonic"
 msgid "minor pentatonic"
 msgstr "マイナー・ペンタトニック音階"
 
+
 #: js/utils/musicutils.js:1349
-#.TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
+#. TRANS: pentatonic is a general term that means "five note scale". This scale is typically known as "major pentatonic"
 msgid "major pentatonic"
 msgstr "メジャー・ペンタトニック音階"
+
 
 #: js/utils/musicutils.js:1350
 msgid "chinese"
 msgstr "中国音階"
 
+
 #: js/utils/musicutils.js:1351
 msgid "egyptian"
 msgstr "エジプト音階"
 
+
 #: js/utils/musicutils.js:1353
-#.TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
+#. TRANS: https://en.wikipedia.org/wiki/Hirajoshi_scale NOTE: There are three different versions of this scale
 msgid "hirajoshi"
 msgstr "平調子"
+
 
 #: js/utils/musicutils.js:1354
 msgid "Japan"
 msgstr "日本"
 
+
 #: js/utils/musicutils.js:1356
-#.TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
+#. TRANS: https://en.wikipedia.org/wiki/In_scale and https://en.wikipedia.org/wiki/Sakura_Sakura
 msgid "in"
 msgstr "陰音階"
 
+
 #: js/utils/musicutils.js:1358
-#.TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
+#. TRANS: https://en.wikipedia.org/wiki/Miny%C5%8D_scale
 msgid "minyo"
 msgstr "民謡音階"
 
+
 #: js/utils/musicutils.js:1360
-#.TRANS: Italian mathematician
+#. TRANS: Italian mathematician
 msgid "fibonacci"
 msgstr "フィボナッチ音階"
+
 
 #: js/utils/musicutils.js:1361
 #: js/utils/musicutils.js:1415
@@ -6878,76 +8122,87 @@ msgstr "フィボナッチ音階"
 #: js/blocks/ToneBlocks.js:979
 #: js/turtleactions/VolumeActions.js:231
 #: js/widgets/modewidget.js:917
-#.TRANS: customize voice
+#. TRANS: customize voice
 msgid "custom"
 msgstr "オリジナル"
+
 
 #: js/utils/musicutils.js:1363
 #: js/utils/musicutils.js:1919
 #: js/blocks/WidgetBlocks.js:244
-#.TRANS: highpass filter
+#. TRANS: highpass filter
 msgid "highpass"
 msgstr "ハイパス・フィルター"
 
+
 #: js/utils/musicutils.js:1365
 #: js/utils/musicutils.js:1920
-#.TRANS: lowpass filter
+#. TRANS: lowpass filter
 msgid "lowpass"
 msgstr "ローパス・フィルター"
 
+
 #: js/utils/musicutils.js:1367
 #: js/utils/musicutils.js:1921
-#.TRANS: bandpass filter
+#. TRANS: bandpass filter
 msgid "bandpass"
 msgstr "バンドパス・フィルター"
 
+
 #: js/utils/musicutils.js:1369
 #: js/utils/musicutils.js:1922
-#.TRANS: high-shelf filter
+#. TRANS: high-shelf filter
 msgid "highshelf"
 msgstr "ハイシェルフ・フィルター"
 
+
 #: js/utils/musicutils.js:1371
 #: js/utils/musicutils.js:1923
-#.TRANS: low-shelf filter
+#. TRANS: low-shelf filter
 msgid "lowshelf"
 msgstr "ローシェルフ・フィルター"
 
+
 #: js/utils/musicutils.js:1373
 #: js/utils/musicutils.js:1924
-#.TRANS: notch-shelf filter
+#. TRANS: notch-shelf filter
 msgid "notch"
 msgstr "ノッチ・フィルター"
 
+
 #: js/utils/musicutils.js:1375
 #: js/utils/musicutils.js:1925
-#.TRANS: all-pass filter
+#. TRANS: all-pass filter
 msgid "allpass"
 msgstr "オールパスフィルター"
 
+
 #: js/utils/musicutils.js:1377
 #: js/utils/musicutils.js:1926
-#.TRANS: peaking filter
+#. TRANS: peaking filter
 msgid "peaking"
 msgstr "ピーク・フィルタ"
+
 
 #: js/utils/musicutils.js:1378
 #: js/utils/musicutils.js:1934
 #: js/utils/synthutils.js:140
 #: js/blocks/PitchBlocks.js:85
 #: js/widgets/legobricks.js:1964
-#.TRANS: sine wave
+#. TRANS: sine wave
 msgid "sine"
 msgstr "サイン波"
+
 
 #: js/utils/musicutils.js:1379
 #: js/utils/musicutils.js:1935
 #: js/utils/synthutils.js:142
 #: js/blocks/PitchBlocks.js:39
 #: js/widgets/legobricks.js:1965
-#.TRANS: square wave
+#. TRANS: square wave
 msgid "square"
 msgstr "四角の波"
+
 
 #: js/utils/musicutils.js:1380
 #: js/utils/musicutils.js:1936
@@ -6955,36 +8210,40 @@ msgstr "四角の波"
 #: js/blocks/PitchBlocks.js:62
 #: js/blocks/ToneBlocks.js:39
 #: js/widgets/legobricks.js:1967
-#.TRANS: triangle wave
+#. TRANS: triangle wave
 msgid "triangle"
 msgstr "三角の波"
+
 
 #: js/utils/musicutils.js:1381
 #: js/utils/musicutils.js:1937
 #: js/utils/synthutils.js:144
 #: js/blocks/PitchBlocks.js:108
 #: js/widgets/legobricks.js:1966
-#.TRANS: sawtooth wave
+#. TRANS: sawtooth wave
 msgid "sawtooth"
 msgstr "ぎざぎざの波"
+
 
 #: js/utils/musicutils.js:1383
 #: js/utils/musicutils.js:1687
 #: js/blocks/PitchBlocks.js:998
 #: js/blocks/PitchBlocks.js:1004
 #: js/turtleactions/PitchActions.js:587
-#.TRANS: even numbers
-#.TRANS: invert based on even or odd number or musical scale
+#. TRANS: even numbers
+#. TRANS: invert based on even or odd number or musical scale
 msgid "even"
 msgstr "偶数"
+
 
 #: js/utils/musicutils.js:1385
 #: js/utils/musicutils.js:1688
 #: js/blocks/PitchBlocks.js:1004
 #: js/turtleactions/PitchActions.js:589
-#.TRANS: odd numbers
+#. TRANS: odd numbers
 msgid "odd"
 msgstr "奇数"
+
 
 #: js/utils/musicutils.js:1386
 #: js/utils/musicutils.js:1689
@@ -6993,537 +8252,632 @@ msgstr "奇数"
 msgid "scalar"
 msgstr "音階的"
 
+
 #: js/utils/musicutils.js:1387
 #: js/utils/synthutils.js:80
 #: js/blocks/VolumeBlocks.js:47
 #: js/widgets/legobricks.js:1948
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "piano"
 msgstr "ピアノ"
+
 
 #: js/utils/musicutils.js:1388
 #: js/utils/synthutils.js:82
 #: js/widgets/legobricks.js:1952
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "violin"
 msgstr "バイオリン"
+
 
 #: js/utils/musicutils.js:1389
 #: js/utils/synthutils.js:84
 #: js/widgets/legobricks.js:1953
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "viola"
 msgstr "ビオラ"
 
+
 #: js/utils/musicutils.js:1390
 #: js/utils/synthutils.js:128
-#.TRANS: xylophone musical instrument
+#. TRANS: xylophone musical instrument
 msgid "xylophone"
 msgstr "木琴"
 
+
 #: js/utils/musicutils.js:1391
 #: js/utils/synthutils.js:150
-#.TRANS: vibraphone musical instrument
+#. TRANS: vibraphone musical instrument
 msgid "vibraphone"
 msgstr "鉄琴"
+
 
 #: js/utils/musicutils.js:1392
 #: js/utils/synthutils.js:86
 #: js/widgets/legobricks.js:1954
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cello"
 msgstr "チェロ"
 
+
 #: js/utils/musicutils.js:1394
 #: js/utils/synthutils.js:90
-#.TRANS: viola musical instrument
+#. TRANS: viola musical instrument
 msgid "double bass"
 msgstr "ダブルベース"
+
 
 #: js/utils/musicutils.js:1395
 #: js/utils/synthutils.js:98
 #: js/widgets/legobricks.js:1949
 #: js/widgets/rhythmruler.js:2706
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "guitar"
 msgstr "ギター"
 
+
 #: js/utils/musicutils.js:1396
 #: js/utils/synthutils.js:92
-#.TRANS: sitar musical instrument
+#. TRANS: sitar musical instrument
 msgid "sitar"
 msgstr "シタール"
 
+
 #: js/utils/musicutils.js:1397
 #: js/utils/synthutils.js:94
-#.TRANS: harmonium musical instrument
+#. TRANS: harmonium musical instrument
 msgid "harmonium"
 msgstr "ハルモニウム"
 
+
 #: js/utils/musicutils.js:1398
 #: js/utils/synthutils.js:96
-#.TRANS: mandolin musical instrument
+#. TRANS: mandolin musical instrument
 msgid "mandolin"
 msgstr "マンドリン"
+
 
 #: js/utils/musicutils.js:1399
 #: js/utils/synthutils.js:100
 #: js/widgets/legobricks.js:1950
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "acoustic guitar"
 msgstr "アコースティック"
+
 
 #: js/utils/musicutils.js:1400
 #: js/utils/synthutils.js:102
 #: js/widgets/legobricks.js:1956
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "flute"
 msgstr "フルート"
+
 
 #: js/utils/musicutils.js:1401
 #: js/utils/synthutils.js:104
 #: js/widgets/legobricks.js:1957
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "clarinet"
 msgstr "クラリネット"
+
 
 #: js/utils/musicutils.js:1402
 #: js/utils/synthutils.js:106
 #: js/widgets/legobricks.js:1958
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "saxophone"
 msgstr "サクソフォン"
+
 
 #: js/utils/musicutils.js:1403
 #: js/utils/synthutils.js:108
 #: js/widgets/legobricks.js:1962
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tuba"
 msgstr "チューバ"
+
 
 #: js/utils/musicutils.js:1404
 #: js/utils/synthutils.js:110
 #: js/widgets/legobricks.js:1959
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trumpet"
 msgstr "トランペット"
+
 
 #: js/utils/musicutils.js:1405
 #: js/utils/synthutils.js:112
 #: js/widgets/legobricks.js:1961
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "oboe"
 msgstr "オーボエ"
+
 
 #: js/utils/musicutils.js:1406
 #: js/utils/synthutils.js:114
 #: js/widgets/legobricks.js:1960
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "trombone"
 msgstr "トロンボーン"
+
 
 #: js/utils/musicutils.js:1407
 #: js/utils/synthutils.js:130
 #: js/widgets/legobricks.js:1947
-#.TRANS: polytone synthesizer
+#. TRANS: polytone synthesizer
 msgid "electronic synth"
 msgstr "シンセサイザー"
 
+
 #: js/utils/musicutils.js:1408
 #: js/utils/synthutils.js:132
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple 1"
 msgstr "シンプル１"
+
 
 #: js/utils/musicutils.js:1409
 msgid "simple 2"
 msgstr "シンプル２"
 
+
 #: js/utils/musicutils.js:1410
 msgid "simple 3"
 msgstr "シンプル３"
+
 
 #: js/utils/musicutils.js:1411
 msgid "simple 4"
 msgstr "シンプル４"
 
+
 #: js/utils/musicutils.js:1412
 #: js/utils/synthutils.js:66
 #: js/blocks/DrumBlocks.js:200
-#.TRANS: white noise synthesizer
+#. TRANS: white noise synthesizer
 msgid "white noise"
 msgstr "ホワイトノイズ"
 
+
 #: js/utils/musicutils.js:1413
 #: js/utils/synthutils.js:68
-#.TRANS: brown noise synthesizer
+#. TRANS: brown noise synthesizer
 msgid "brown noise"
 msgstr "ブラウンノイズ"
 
+
 #: js/utils/musicutils.js:1414
 #: js/utils/synthutils.js:70
-#.TRANS: pink noise synthesizer
+#. TRANS: pink noise synthesizer
 msgid "pink noise"
 msgstr "ピンクノイズ"
+
 
 #: js/utils/musicutils.js:1416
 #: js/utils/synthutils.js:162
 #: js/widgets/rhythmruler.js:2252
 #: js/widgets/rhythmruler.js:2514
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "snare drum"
 msgstr "スネアドラム"
 
+
 #: js/utils/musicutils.js:1417
 #: js/utils/synthutils.js:164
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "kick drum"
 msgstr "キックドラム"
 
+
 #: js/utils/musicutils.js:1418
 #: js/utils/synthutils.js:166
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "tom tom"
 msgstr "タムタム"
 
+
 #: js/utils/musicutils.js:1419
 #: js/utils/synthutils.js:168
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "floor tom"
 msgstr "フロアタム"
 
+
 #: js/utils/musicutils.js:1420
 #: js/utils/synthutils.js:170
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bass drum"
 msgstr "バスドラム"
 
+
 #: js/utils/musicutils.js:1421
 #: js/utils/synthutils.js:172
-#.TRANS: a drum made from an inverted cup
+#. TRANS: a drum made from an inverted cup
 msgid "cup drum"
 msgstr "カップドラム"
 
+
 #: js/utils/musicutils.js:1422
 #: js/utils/synthutils.js:174
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "darbuka drum"
 msgstr "ダブカドラム"
 
+
 #: js/utils/musicutils.js:1423
 #: js/utils/synthutils.js:178
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "hi hat"
 msgstr "ハイハット"
 
+
 #: js/utils/musicutils.js:1424
 #: js/utils/synthutils.js:180
-#.TRANS: a small metal bell
+#. TRANS: a small metal bell
 msgid "ride bell"
 msgstr "ライドベル"
 
+
 #: js/utils/musicutils.js:1425
 #: js/utils/synthutils.js:182
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "cow bell"
 msgstr "カウベル"
+
 
 #: js/utils/musicutils.js:1426
 msgid "japanese drum"
 msgstr "太鼓"
 
+
 #: js/utils/musicutils.js:1427
 #: js/utils/synthutils.js:188
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "japanese bell"
 msgstr "鉦"
 
+
 #: js/utils/musicutils.js:1428
 #: js/utils/synthutils.js:184
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "triangle bell"
 msgstr "トライアングル"
 
+
 #: js/utils/musicutils.js:1429
 #: js/utils/synthutils.js:186
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "finger cymbals"
 msgstr "フィンガーシンバル"
 
+
 #: js/utils/musicutils.js:1430
 #: js/utils/synthutils.js:190
-#.TRANS: a musically tuned set of bells
+#. TRANS: a musically tuned set of bells
 msgid "chime"
 msgstr "チャイム"
 
+
 #: js/utils/musicutils.js:1431
 #: js/utils/synthutils.js:192
-#.TRANS: a musical instrument
+#. TRANS: a musical instrument
 msgid "gong"
 msgstr "ドラ"
 
+
 #: js/utils/musicutils.js:1432
 #: js/utils/synthutils.js:194
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clang"
 msgstr "カチャカチャ"
 
+
 #: js/utils/musicutils.js:1433
 #: js/utils/synthutils.js:196
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "crash"
 msgstr "クラッシュ"
 
+
 #: js/utils/musicutils.js:1434
 #: js/utils/synthutils.js:198
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bottle"
 msgstr "空きびん"
 
+
 #: js/utils/musicutils.js:1435
 #: js/utils/synthutils.js:200
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "clap"
 msgstr "てびょうし"
 
+
 #: js/utils/musicutils.js:1436
 #: js/utils/synthutils.js:202
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "slap"
 msgstr "ピシャリ"
 
+
 #: js/utils/musicutils.js:1437
 #: js/utils/synthutils.js:204
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "splash"
 msgstr "しぶき"
 
+
 #: js/utils/musicutils.js:1438
 #: js/utils/synthutils.js:206
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "bubbles"
 msgstr "あわ"
 
+
 #: js/utils/musicutils.js:1439
 #: js/utils/synthutils.js:208
-#.TRANS: sound effect
+#. TRANS: sound effect
 msgid "raindrop"
 msgstr "雨のしずく"
 
+
 #: js/utils/musicutils.js:1440
 #: js/utils/synthutils.js:210
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cat"
 msgstr "ねこ"
 
+
 #: js/utils/musicutils.js:1441
 #: js/utils/synthutils.js:212
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "cricket"
 msgstr "こおろぎ"
 
+
 #: js/utils/musicutils.js:1442
 #: js/utils/synthutils.js:214
-#.TRANS: animal sound effect
+#. TRANS: animal sound effect
 msgid "dog"
 msgstr "いぬ"
+
 
 #: js/utils/musicutils.js:1444
 #: js/utils/synthutils.js:116
 #: js/widgets/legobricks.js:1963
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "banjo"
 msgstr "バンジョー"
 
+
 #: js/utils/musicutils.js:1445
 #: js/utils/synthutils.js:118
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "koto"
 msgstr "こと"
 
+
 #: js/utils/musicutils.js:1446
 #: js/utils/synthutils.js:120
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "dulcimer"
 msgstr "ダルシマー"
+
 
 #: js/utils/musicutils.js:1447
 #: js/utils/synthutils.js:122
 #: js/widgets/legobricks.js:1951
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "electric guitar"
 msgstr "エレキギター"
 
+
 #: js/utils/musicutils.js:1448
 #: js/utils/synthutils.js:124
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "bassoon"
 msgstr "バスーン"
 
+
 #: js/utils/musicutils.js:1449
 #: js/utils/synthutils.js:126
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "celeste"
 msgstr "セレスタ"
 
+
 #: js/utils/musicutils.js:1451
 #: js/widgets/temperament.js:996
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "equal"
 msgstr "平均律"
 
+
 #: js/utils/musicutils.js:1453
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Pythagorean"
 msgstr "ピタゴラス音律 "
 
+
 #: js/utils/musicutils.js:1455
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "just intonation"
 msgstr "純正律"
+
 
 #: js/utils/musicutils.js:1457
 #: js/utils/musicutils.js:1953
 #: js/utils/musicutils.js:1954
 #: js/utils/musicutils.js:1970
 #: js/utils/musicutils.js:1971
-#.TRANS: musical temperament
+#. TRANS: musical temperament
 msgid "Meantone"
 msgstr "中全音律"
+
 
 #: js/utils/musicutils.js:1474
 msgid "major 7th"
 msgstr "長七の和音（メイジャー・セブンス)"
 
+
 #: js/utils/musicutils.js:1475
 msgid "minor 7th"
 msgstr "短七の和音（マイナー・セブンス）"
+
 
 #: js/utils/musicutils.js:1476
 msgid "dominant 7th"
 msgstr "属七の和音（ドミナント・セブンス）"
 
+
 #: js/utils/musicutils.js:1477
 msgid "minor-major 7th"
 msgstr "短三長七の和音（マイナー・メイジャー・セブンス）"
+
 
 #: js/utils/musicutils.js:1478
 msgid "fully-diminished 7th"
 msgstr "減七の和音（ディミニッシュト・セブンス）"
 
+
 #: js/utils/musicutils.js:1479
 msgid "half-diminished 7th"
 msgstr "減五短七の和音（ハーフ・ディミニッシュト）"
+
 
 #: js/utils/musicutils.js:1945
 #: js/utils/musicutils.js:1962
 msgid "Equal (12EDO)"
 msgstr "12平均律"
 
+
 #: js/utils/musicutils.js:1946
 #: js/utils/musicutils.js:1963
 msgid "Equal (5EDO)"
 msgstr "5平均律"
+
 
 #: js/utils/musicutils.js:1947
 #: js/utils/musicutils.js:1964
 msgid "Equal (7EDO)"
 msgstr "7平均律"
 
+
 #: js/utils/musicutils.js:1948
 #: js/utils/musicutils.js:1965
+#.  AUTOTRANSLATED: Google Translate
 msgid "Equal (17EDO)"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/utils/musicutils.js:1949
 #: js/utils/musicutils.js:1966
 msgid "Equal (19EDO)"
 msgstr "19平均律"
 
+
 #: js/utils/musicutils.js:1950
 #: js/utils/musicutils.js:1967
 msgid "Equal (31EDO)"
 msgstr "31平均律"
+
 
 #: js/utils/musicutils.js:1951
 #: js/utils/musicutils.js:1968
 msgid "5-limit Just Intonation"
 msgstr "5限界純正律"
 
+
 #: js/utils/musicutils.js:1952
 #: js/utils/musicutils.js:1969
 msgid "Pythagorean (3-limit JI)"
 msgstr "ピタゴラス音律"
+
 
 #: js/utils/musicutils.js:4915
 #: js/widgets/temperament.js:2569
 msgid "Invalid temperament. Falling back to equal temperament."
 msgstr "無効な気質。平均律に戻ります。"
 
+
 #: js/utils/musicutils.js:7511
 #: js/utils/musicutils.js:7554
 msgid "current"
 msgstr "現在の"
+
 
 #: js/utils/musicutils.js:7514
 #: js/utils/musicutils.js:7545
 msgid "next"
 msgstr "この次の"
 
+
 #: js/utils/musicutils.js:7517
 #: js/utils/musicutils.js:7550
 msgid "previous"
 msgstr "この前の"
 
+
 #: js/utils/synthutils.js:134
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-2"
 msgstr "シンプル・シンセ２"
 
+
 #: js/utils/synthutils.js:136
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-3"
 msgstr "シンプル・シンセ３"
 
+
 #: js/utils/synthutils.js:138
-#.TRANS: simple monotone synthesizer
+#. TRANS: simple monotone synthesizer
 msgid "simple-4"
 msgstr "シンプル・シンセ４"
 
+
 #: js/utils/synthutils.js:176
-#.TRANS: musical instrument
+#. TRANS: musical instrument
 msgid "taiko"
 msgstr "太鼓"
+
 
 #: js/utils/synthutils.js:2260
 msgid "⚠️ Sound is disabled!\n\nPlease check your browser settings (Site Settings > Sound) to allow audio for Music Blocks."
 msgstr "⚠️ サウンドは無効になっています。\n\nブラウザの設定 (サイト設定 > サウンド) を確認して、ミュージック・ブロックスの音声を許可してください。"
 
+
 #: js/utils/synthutils.js:3787
 msgid "Cents Adjustment"
 msgstr "セント調整"
 
+
 #: js/utils/synthutils.js:3816
 #: js/widgets/sampler.js:1925
-#.TRANS: The reference tone is a sound used for comparison.
+#. TRANS: The reference tone is a sound used for comparison.
 msgid "reference tone"
 msgstr "参照ピッチ"
+
 
 #: js/utils/utils.js:474
 msgid "Security Warning"
 msgstr "セキュリティ警告"
 
+
 #: js/utils/utils.js:476
 msgid "This plugin contains code that will be executed in your browser. It has not been loaded from the built-in plugins directory and may contain unsafe code."
 msgstr "このプラグインには、ブラウザで実行されるコードが含まれています。組み込みのプラグイン ディレクトリからロードされていないため、安全でないコードが含まれている可能性があります。"
+
 
 #: js/utils/utils.js:480
 msgid "Do you want to allow this plugin to run?"
 msgstr "このプラグインの実行を許可しますか?"
 
+
 #: js/utils/utils.js:482
 msgid "Source: %s"
 msgstr "ソース: %s"
+
 
 #: js/utils/utils.js:482
 #: js/blocks/ExtrasBlocks.js:696
@@ -7537,13 +8891,16 @@ msgstr "ソース: %s"
 msgid "unknown"
 msgstr "不明"
 
+
 #: js/blocks/DictBlocks.js:62
 msgid "The Show-dictionary block displays the contents of the dictionary at the top of the screen."
 msgstr "「辞書を表す」ブロックは、画面の上部に辞書の内容を表示します。"
 
+
 #: js/blocks/DictBlocks.js:77
 msgid "show dictionary"
 msgstr "辞書を表す"
+
 
 #: js/blocks/DictBlocks.js:80
 #: js/blocks/DictBlocks.js:145
@@ -7555,20 +8912,24 @@ msgstr "辞書を表す"
 msgid "My Dictionary"
 msgstr "私の辞書"
 
+
 #: js/blocks/DictBlocks.js:129
 msgid "The Dictionary block returns a dictionary."
 msgstr "Dictionaryブロックは辞書を返します。"
+
 
 #: js/blocks/DictBlocks.js:197
 #: js/blocks/DictBlocks.js:339
 msgid "The Get-dict block returns a value in the dictionary for a specified key."
 msgstr "Get-dictブロックは指定されたキーの辞書の値を返します。"
 
+
 #: js/blocks/DictBlocks.js:212
 #: js/blocks/DictBlocks.js:354
-#.TRANS: retrieve a value from the dictionary with a given key
+#. TRANS: retrieve a value from the dictionary with a given key
 msgid "get value"
 msgstr "数価を表す"
+
 
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
@@ -7580,6 +8941,7 @@ msgstr "数価を表す"
 msgid "key2"
 msgstr "キーワード"
 
+
 #: js/blocks/DictBlocks.js:215
 #: js/blocks/DictBlocks.js:216
 #: js/blocks/DictBlocks.js:289
@@ -7588,77 +8950,93 @@ msgstr "キーワード"
 #: js/blocks/DictBlocks.js:430
 #: js/blocks/DictBlocks.js:431
 #: js/blocks/IntervalsBlocks.js:1525
-#.TRANS: key, e.g., C in C Major
+#. TRANS: key, e.g., C in C Major
 msgid "key"
 msgstr "調"
+
 
 #: js/blocks/DictBlocks.js:271
 #: js/blocks/DictBlocks.js:411
 msgid "The Set-dict block sets a value in the dictionary for a specified key."
 msgstr "Set-dictブロックは指定されたキーに辞書の値を設定します。"
 
+
 #: js/blocks/DictBlocks.js:286
 #: js/blocks/DictBlocks.js:427
-#.TRANS: set a value in the dictionary for a given key
+#. TRANS: set a value in the dictionary for a given key
 msgid "set value"
 msgstr "値を設定"
+
 
 #: js/blocks/HeapBlocks.js:49
 msgid "The Heap block returns the heap."
 msgstr "Heapブロックはヒープを返します。"
 
+
 #: js/blocks/HeapBlocks.js:118
 msgid "The Show-heap block displays the contents of the heap at the top of the screen."
 msgstr "「ヒープを表示する」ブロックは、ヒープの内容を画面の上部に表示します。"
+
 
 #: js/blocks/HeapBlocks.js:133
 msgid "show heap"
 msgstr "ヒープを表示する"
 
+
 #: js/blocks/HeapBlocks.js:181
 msgid "The Heap-length block returns the length of the heap."
 msgstr "Heap-lengthブロックはヒープの長さを返します。"
+
 
 #: js/blocks/HeapBlocks.js:195
 msgid "heap length"
 msgstr "ヒープの長さ"
 
+
 #: js/blocks/HeapBlocks.js:254
 msgid "The Heap-empty? block returns true if the heap is empty."
 msgstr "Heap-empty?ブロックはヒープが空の場合にtrueを返します。"
 
+
 #: js/blocks/HeapBlocks.js:268
-#.TRANS: Is the heap empty?
+#. TRANS: Is the heap empty?
 msgid "heap empty?"
 msgstr "ヒープは空ですか？"
+
 
 #: js/blocks/HeapBlocks.js:317
 msgid "The Empty-heap block empties the heap."
 msgstr "Empty-heapブロックはヒープを空にします。"
 
+
 #: js/blocks/HeapBlocks.js:327
 #: js/blocks/HeapBlocks.js:647
-#.TRANS: empty the heap
+#. TRANS: empty the heap
 msgid "empty heap"
 msgstr "空のヒープ"
+
 
 #: js/blocks/HeapBlocks.js:371
 msgid "The Reverse-heap block reverses the order of the heap."
 msgstr "Reverse-heapブロックはヒープの順序を逆にします。"
 
+
 #: js/blocks/HeapBlocks.js:384
-#.TRANS: reverse the order of the heap
+#. TRANS: reverse the order of the heap
 msgid "reverse heap"
 msgstr "ヒープを逆にする"
+
 
 #: js/blocks/HeapBlocks.js:428
 msgid "The Index-heap block returns a value in the heap at a specified location."
 msgstr "Index-heapブロックは指定された位置のヒープの値を返します。"
 
+
 #: js/blocks/HeapBlocks.js:443
-#.TRANS: retrieve a value from the heap at index position in the heap
+#. TRANS: retrieve a value from the heap at index position in the heap
 msgid "index heap"
 msgstr "ヒープに番号をふる"
+
 
 #: js/blocks/HeapBlocks.js:474
 #: js/blocks/HeapBlocks.js:572
@@ -7667,27 +9045,32 @@ msgstr "ヒープに番号をふる"
 msgid "Index must be > 0."
 msgstr "インデクス番号は 0 より大きい必要があります。"
 
+
 #: js/blocks/HeapBlocks.js:479
 #: js/blocks/HeapBlocks.js:577
 #: js/blocks/EnsembleBlocks.js:150
 msgid "Maximum heap size is 1000."
 msgstr "ヒープの大きさは、最大1000です。"
 
+
 #: js/blocks/HeapBlocks.js:523
 msgid "The Set-heap entry block sets a value in the heap at the specified location."
 msgstr "Set-heapエントリーブロックは指定された位置のヒープに値を設定します。"
 
+
 #: js/blocks/HeapBlocks.js:539
 #: js/blocks/ProgramBlocks.js:301
-#.TRANS: load the heap from a JSON encoding
+#. TRANS: load the heap from a JSON encoding
 msgid "set heap"
 msgstr "ヒープを設定する"
 
+
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/EnsembleBlocks.js:117
-#.TRANS: value1 is a numeric value (JAPANESE ONLY)
+#. TRANS: value1 is a numeric value (JAPANESE ONLY)
 msgid "index"
 msgstr "インデックス"
+
 
 #: js/blocks/HeapBlocks.js:544
 #: js/blocks/BoxesBlocks.js:75
@@ -7695,39 +9078,48 @@ msgstr "インデックス"
 msgid "value1"
 msgstr "すうち"
 
+
 #: js/blocks/HeapBlocks.js:619
 msgid "The Pop block removes the value at the top of the heap."
 msgstr "Popブロックはヒープの先頭の値を削除します。"
 
+
 #: js/blocks/HeapBlocks.js:633
-#.TRANS: pop a value off the top of the heap
+#. TRANS: pop a value off the top of the heap
 msgid "pop"
 msgstr "ポップ"
+
 
 #: js/blocks/HeapBlocks.js:680
 msgid "The Push block adds a value to the top of the heap."
 msgstr "Pushブロックは値をヒープの先頭に追加します。"
 
+
 #: js/blocks/HeapBlocks.js:696
-#.TRANS: push a value onto the top of the heap
+#. TRANS: push a value onto the top of the heap
 msgid "push"
 msgstr "プッシュ"
+
 
 #: js/blocks/EnsembleBlocks.js:91
 msgid "mouse index heap"
 msgstr "ネズミヒープに番号をふる"
 
+
 #: js/blocks/EnsembleBlocks.js:91
 msgid "turtle index heap"
 msgstr "タートル ヒープに番号をふる"
+
 
 #: js/blocks/EnsembleBlocks.js:98
 msgid "The Mouse index heap block returns a value in the heap at a specified location for a specified mouse."
 msgstr "指定されたマウスの指定された位置のヒープ内の値を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:105
 msgid "The Turtle index heap block returns a value in the heap at a specified location for a specified turtle."
 msgstr "指定されたタートルの指定された位置のヒープ内の値を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:115
 #: js/blocks/EnsembleBlocks.js:190
@@ -7749,31 +9141,38 @@ msgstr "指定されたタートルの指定された位置のヒープ内の値
 msgid "Yertle"
 msgstr "ヤートル"
 
+
 #: js/blocks/EnsembleBlocks.js:117
 #: js/blocks/EnsembleBlocks.js:1106
 msgid "mouse name"
 msgstr "ネズミの名前"
+
 
 #: js/blocks/EnsembleBlocks.js:117
 #: js/blocks/EnsembleBlocks.js:1115
 msgid "turtle name"
 msgstr "ネズミの名前"
 
+
 #: js/blocks/EnsembleBlocks.js:168
 msgid "stop mouse"
 msgstr "ネズミを止める"
+
 
 #: js/blocks/EnsembleBlocks.js:170
 msgid "The Stop mouse block stops the specified mouse."
 msgstr "指定されたマウスを停止します。"
 
+
 #: js/blocks/EnsembleBlocks.js:181
 msgid "stop turtle"
 msgstr "ネズミを止める"
 
+
 #: js/blocks/EnsembleBlocks.js:183
 msgid "The Stop turtle block stops the specified turtle."
 msgstr "指定されたタートルを停止します。"
+
 
 #: js/blocks/EnsembleBlocks.js:207
 #: js/blocks/EnsembleBlocks.js:267
@@ -7787,6 +9186,7 @@ msgstr "指定されたタートルを停止します。"
 msgid "Cannot find mouse"
 msgstr "ネズミが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:209
 #: js/blocks/EnsembleBlocks.js:269
 #: js/blocks/EnsembleBlocks.js:433
@@ -7799,85 +9199,104 @@ msgstr "ネズミが見つかりません。"
 msgid "Cannot find turtle"
 msgstr "タートルが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:228
 msgid "start mouse"
 msgstr "ネズミをスタート"
+
 
 #: js/blocks/EnsembleBlocks.js:231
 msgid "The Start mouse block starts the specified mouse."
 msgstr "指定されたマウスを開始します。"
 
+
 #: js/blocks/EnsembleBlocks.js:242
 msgid "start turtle"
 msgstr "ネズミをスタートする"
+
 
 #: js/blocks/EnsembleBlocks.js:245
 msgid "The Start turtle block starts the specified turtle."
 msgstr "指定されたタートルを開始します。"
 
+
 #: js/blocks/EnsembleBlocks.js:276
 msgid "Mouse is already running."
 msgstr "ネズミはすでに動いています。"
+
 
 #: js/blocks/EnsembleBlocks.js:278
 msgid "Turtle is already running."
 msgstr "タートルはすでに動いています。"
 
+
 #: js/blocks/EnsembleBlocks.js:300
 msgid "Cannot find start block"
 msgstr "「スタート」ブロックが見つかりません。"
 
+
 #: js/blocks/EnsembleBlocks.js:310
-#.TRANS: pen color for this mouse
+#. TRANS: pen color for this mouse
 msgid "mouse color"
 msgstr "ネズミの色"
+
 
 #: js/blocks/EnsembleBlocks.js:312
 msgid "The Mouse color block returns the pen color of the specified mouse."
 msgstr "指定されたマウスのペンの色を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:324
-#.TRANS: pen color for this turtle
+#. TRANS: pen color for this turtle
 msgid "turtle color"
 msgstr "タートルの色"
+
 
 #: js/blocks/EnsembleBlocks.js:326
 msgid "The Turtle color block returns the pen color of the specified turtle."
 msgstr "指定されたタートルのペンの色を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:356
-#.TRANS: heading (compass direction) for this mouse
+#. TRANS: heading (compass direction) for this mouse
 msgid "mouse heading"
 msgstr "ネズミの進む角度"
+
 
 #: js/blocks/EnsembleBlocks.js:358
 msgid "The Mouse heading block returns the heading of the specified mouse."
 msgstr "指定されたマウスの向きを返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:370
-#.TRANS: heading (compass direction) for this turtle
+#. TRANS: heading (compass direction) for this turtle
 msgid "turtle heading"
 msgstr "タートルの進む角度"
+
 
 #: js/blocks/EnsembleBlocks.js:372
 msgid "The Turtle heading block returns the heading of the specified turtle."
 msgstr "指定されたタートルの向きを返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:402
 #: js/blocks/EnsembleBlocks.js:459
-#.TRANS: set xy position for this mouse
+#. TRANS: set xy position for this mouse
 msgid "set mouse"
 msgstr "ネズミを設定"
+
 
 #: js/blocks/ToneBlocks.js:634
 msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
 msgstr "ディレイ(第 2 引数) は、コーラス・ボイス間の遅延時間 (ミリ秒) を設定します。"
+
 
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
 #: js/blocks/BoxesBlocks.js:599
 msgid "name1"
 msgstr "箱へ"
+
 
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
@@ -7891,6 +9310,7 @@ msgstr "箱へ"
 msgid "x"
 msgstr "xざひょう（よこ）"
 
+
 #: js/blocks/EnsembleBlocks.js:409
 #: js/blocks/EnsembleBlocks.js:420
 #: js/blocks/ProgramBlocks.js:895
@@ -7903,331 +9323,408 @@ msgstr "xざひょう（よこ）"
 msgid "y"
 msgstr "yざひょう（たて）"
 
+
 #: js/blocks/EnsembleBlocks.js:413
 #: js/blocks/EnsembleBlocks.js:474
-#.TRANS: set xy position for this turtle
+#. TRANS: set xy position for this turtle
 msgid "set turtle"
 msgstr "タートルを設定"
+
 
 #: js/blocks/EnsembleBlocks.js:451
 msgid "The Set mouse block sends a stack of blocks to be run by the specified mouse."
 msgstr "指定されたマウスに実行するブロックのスタックを送ります。"
 
+
 #: js/blocks/EnsembleBlocks.js:466
 msgid "The Set turtle block sends a stack of blocks to be run by the specified turtle."
 msgstr "指定されたタートルに実行するブロックのスタックを送ります。"
 
+
 #: js/blocks/EnsembleBlocks.js:502
-#.TRANS: y position for this mouse
+#. TRANS: y position for this mouse
 msgid "mouse y"
 msgstr "ネズミのy座標"
+
 
 #: js/blocks/EnsembleBlocks.js:504
 msgid "The Y mouse block returns the Y position of the specified mouse."
 msgstr "指定されたマウスのY座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:516
-#.TRANS: y position for this turtle
+#. TRANS: y position for this turtle
 msgid "turtle y"
 msgstr "タートルのy座標"
+
 
 #: js/blocks/EnsembleBlocks.js:518
 msgid "The Y turtle block returns the Y position of the specified turtle."
 msgstr "指定されたタートルのY座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:547
-#.TRANS: x position for this mouse
+#. TRANS: x position for this mouse
 msgid "mouse x"
 msgstr "ネズミのx座標"
+
 
 #: js/blocks/EnsembleBlocks.js:549
 msgid "The X mouse block returns the X position of the specified mouse."
 msgstr "指定されたマウスのX座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:561
-#.TRANS: x position for this turtle
+#. TRANS: x position for this turtle
 msgid "turtle x"
 msgstr "タートルのx座標"
+
 
 #: js/blocks/EnsembleBlocks.js:563
 msgid "The X turtle block returns the X position of the specified turtle."
 msgstr "指定されたタートルのX座標を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:593
-#.TRANS: notes played by this mouse
+#. TRANS: notes played by this mouse
 msgid "mouse notes played"
 msgstr "ネズミの演奏した音符の数"
+
 
 #: js/blocks/EnsembleBlocks.js:595
 msgid "The Mouse elapse notes block returns the number of notes played by the specified mouse."
 msgstr "指定されたマウスが演奏したノート数を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:609
-#.TRANS: notes played by this turtle
+#. TRANS: notes played by this turtle
 msgid "turtle notes played"
 msgstr "タートルの演奏した音符の数"
+
 
 #: js/blocks/EnsembleBlocks.js:611
 msgid "The Turtle elapse notes block returns the number of notes played by the specified turtle."
 msgstr "指定されたタートルが演奏したノート数を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:647
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "mouse pitch number"
 msgstr "ネズミの音高数字"
+
 
 #: js/blocks/EnsembleBlocks.js:649
 msgid "The Mouse pitch block returns the current pitch number being played by the specified mouse."
 msgstr "指定されたマウスが現在演奏しているピッチ番号を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:663
-#.TRANS: convert current note for this turtle to piano key (1-88)
+#. TRANS: convert current note for this turtle to piano key (1-88)
 msgid "turtle pitch number"
 msgstr "タートルの音高数字"
+
 
 #: js/blocks/EnsembleBlocks.js:665
 msgid "The Turtle pitch block returns the current pitch number being played by the specified turtle."
 msgstr "指定されたタートルが現在演奏しているピッチ番号を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:772
 #: js/blocks/EnsembleBlocks.js:844
-#.TRANS: note value is the duration of the note played by this mouse
+#. TRANS: note value is the duration of the note played by this mouse
 msgid "mouse note value"
 msgstr "ネズミの音価"
 
+
 #: js/blocks/EnsembleBlocks.js:782
-#.TRANS: note value is the duration of the note played by this turtle
+#. TRANS: note value is the duration of the note played by this turtle
 msgid "turtle note value"
 msgstr "タートルの音価"
 
+
 #: js/blocks/EnsembleBlocks.js:855
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "mouse sync"
 msgstr "ネズミを同期させる"
+
 
 #: js/blocks/EnsembleBlocks.js:857
 msgid "The Mouse sync block aligns the beat count between mice."
 msgstr "マウス間のビート数を同期させるブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:869
-#.TRANS: sync is short for synchronization
+#. TRANS: sync is short for synchronization
 msgid "turtle sync"
 msgstr "タートルを同期させる"
+
 
 #: js/blocks/EnsembleBlocks.js:871
 msgid "The Turtle sync block aligns the beat count between turtles."
 msgstr "タートル間のビート数を同期させるブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:911
 msgid "The Found mouse block will return true if the specified mouse can be found."
 msgstr "指定されたマウスが見つかった場合にtrueを返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:919
 msgid "found mouse"
 msgstr "ネズミを見つけた"
 
+
 #: js/blocks/EnsembleBlocks.js:929
 msgid "The Found turtle block will return true if the specified turtle can be found."
 msgstr "指定されたタートルが見つかった場合にtrueを返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:937
 msgid "found turtle"
 msgstr "タートル見つかった"
 
+
 #: js/blocks/EnsembleBlocks.js:960
 msgid "new mouse"
 msgstr "新しいネズミ"
+
 
 #: js/blocks/EnsembleBlocks.js:962
 msgid "The New mouse block will create a new mouse."
 msgstr "新しいマウスを作成するブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:973
 msgid "new turtle"
 msgstr "新しいタートル"
+
 
 #: js/blocks/EnsembleBlocks.js:975
 msgid "The New turtle block will create a new turtle."
 msgstr "新しいタートルを作成するブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:1034
 msgid "set mouse color"
 msgstr "ネズミ色を設定"
+
 
 #: js/blocks/EnsembleBlocks.js:1037
 msgid "The Set-mouse-color block is used to set the color of a mouse."
 msgstr "「ネズミ色を設定」ブロックは ネズミの色を選ぶことに使います。"
 
+
 #: js/blocks/VolumeBlocks.js:35
 msgid "synth volume"
 msgstr "シンセの音量"
+
 
 #: js/blocks/EnsembleBlocks.js:1043
 msgid "set turtle color"
 msgstr "タートル色を設定"
 
+
 #: js/blocks/EnsembleBlocks.js:1046
 msgid "The Set-turtle-color block is used to set the color of a turtle."
 msgstr "タートルの色を設定するためのブロックです。"
+
 
 #: js/blocks/VolumeBlocks.js:39
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr "「シンセの音量」ブロックは現在のシンセサイザーの音量を返します。"
 
+
 #: js/blocks/EnsembleBlocks.js:1109
 msgid "The Mouse-name block returns the name of a mouse."
 msgstr "<h2>文字ブロック</h2><br>このプログラムを実行しているネズミの名前（文字列）を表す。"
+
 
 #: js/blocks/EnsembleBlocks.js:1118
 msgid "The Turtle-name block returns the name of a turtle."
 msgstr "タートルの名前を返すブロックです。"
 
+
 #: js/blocks/EnsembleBlocks.js:1141
 msgid "mouse count"
 msgstr "何匹のネズミ"
+
 
 #: js/blocks/EnsembleBlocks.js:1144
 msgid "The Mouse-count block returns the number of mice."
 msgstr "「何匹のネズミ」のブロックはネズミを数えって数字を表す。"
 
+
 #: js/blocks/EnsembleBlocks.js:1150
 msgid "turtle count"
 msgstr "何匹のタートル"
 
+
 #: js/blocks/EnsembleBlocks.js:1153
 msgid "The Turtle-count block returns the number of turtles."
 msgstr "タートルカウントブロックはタートルの数を返します。"
+
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:525
 msgid "set synth volume"
 msgstr "シンセの音量をせってい"
 
+
 #: js/blocks/EnsembleBlocks.js:1175
 msgid "nth mouse name"
 msgstr "何匹目のネズミの名前"
 
+
 #: js/blocks/EnsembleBlocks.js:1178
 msgid "The Nth-Mouse name block returns the name of the nth mouse."
 msgstr "エヌス・マウス・ネームブロックはエヌ番目のマウスの名前を返します。"
+
 
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:546
 msgid "synth"
 msgstr "シンセ"
 
+
 #: js/blocks/EnsembleBlocks.js:1184
 msgid "nth turtle name"
 msgstr "何匹目のタートルの名前"
 
+
 #: js/blocks/EnsembleBlocks.js:1187
 msgid "The Nth-Turtle name block returns the name of the nth turtle."
 msgstr "エヌス・タートル・ネームブロックはエヌ番目のタートルの名前を返します。"
+
 
 #: js/blocks/EnsembleBlocks.js:1231
 #: js/blocks/EnsembleBlocks.js:1291
 msgid "set name"
 msgstr "ネズミに名前をつける"
 
+
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "source"
 msgstr "ソース"
 
+
 #: js/blocks/VolumeBlocks.js:440
 msgid "Synth not found"
 msgstr "シンセ（楽器）が見つかりません"
+
 
 #: js/blocks/EnsembleBlocks.js:1240
 #: js/blocks/EnsembleBlocks.js:1247
 msgid "target"
 msgstr "ターゲット"
 
+
 #: js/blocks/EnsembleBlocks.js:1297
 msgid "The Set-name block is used to name a mouse."
 msgstr "<h2>文字ブロック</h2><br>ネズミに指定した名前をつけることができる。"
+
 
 #: js/blocks/EnsembleBlocks.js:1310
 msgid "The Set-name block is used to name a turtle."
 msgstr "<h2>文字ブロック</h2><br>タートルに指定した名前をつけることができる。"
 
+
 #: js/blocks/FlowBlocks.js:41
 msgid "The Backward block runs code in reverse order (Musical retrograde)."
 msgstr "<h2>実行ブロック（ぎゃく実行）</h2><br>はさまれているブロックを、つうじょうとはぎゃくの順じょで、下から上に向かって実行する。"
+
 
 #: js/blocks/VolumeBlocks.js:531
 msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
 msgstr "「シンセの音量をせってい」ブロックは、ギター、バイオリン、スネアドラムなどの特定のシンセサイザーの音量を変更します。"
 
+
 #: js/blocks/FlowBlocks.js:48
 msgid "backward"
 msgstr "ぎゃく向きに実行"
+
 
 #: js/blocks/FlowBlocks.js:124
 msgid "The Duplicate block will run each block multiple times."
 msgstr "Duplicateブロックは各ブロックを複数回実行します。"
 
+
 #: js/blocks/FlowBlocks.js:126
 msgid "The output of the example is: Sol, Sol, Sol, Sol, Re, Re, Re, Re, Sol, Sol, Sol, Sol."
 msgstr "この例の出力は、ソ、ソ、ソ、ソ、レ、レ、レ、レ、ソ、ソ、ソ、ソ です。"
+
 
 #: js/blocks/FlowBlocks.js:372
 msgid "The Default block is used inside of a Switch to define the default action."
 msgstr "DefaultブロックはSwitch内でデフォルトの動作を定義するために使われます。"
 
+
 #: js/blocks/FlowBlocks.js:380
 msgid "default"
 msgstr "ひょうじゅん"
+
 
 #: js/blocks/FlowBlocks.js:399
 #: js/blocks/FlowBlocks.js:456
 msgid "The Case Block must be used inside of a Switch Block."
 msgstr "ケースブロックはスイッチブロックの中にある必要があります。"
 
+
 #: js/blocks/FlowBlocks.js:427
 msgid "The Case block is used inside of a Switch to define matches."
 msgstr "CaseブロックはSwitch内で一致条件を定義するために使われます。"
+
 
 #: js/blocks/FlowBlocks.js:435
 msgid "case"
 msgstr "ケース"
 
+
 #: js/blocks/FlowBlocks.js:484
 msgid "The Switch block will run the code in the matching Case."
 msgstr "Switchブロックは一致するCase内のコードを実行します。"
+
 
 #: js/blocks/FlowBlocks.js:492
 msgid "switch"
 msgstr "スイッチ"
 
+
 #: js/blocks/FlowBlocks.js:638
 msgid "The Stop block will stop a loop"
 msgstr "Stopブロックはループを停止します。"
+
 
 #: js/blocks/FlowBlocks.js:640
 msgid "Forever, Repeat, While, or Until."
 msgstr "Forever、Repeat、While、またはUntil。"
 
+
 #: js/blocks/FlowBlocks.js:697
 msgid "The Waitfor block will wait until the condition is true."
 msgstr "Waitforブロックは条件が真になるまで待ちます。"
+
 
 #: js/blocks/FlowBlocks.js:705
 msgid "wait for"
 msgstr "を待つ"
 
+
 #: js/blocks/FlowBlocks.js:780
 msgid "The Until block will repeat until the condition is true."
 msgstr "Untilブロックは条件が真になるまで繰り返します。"
+
 
 #: js/blocks/FlowBlocks.js:788
 msgid "until"
 msgstr "までに"
 
+
 #: js/blocks/FlowBlocks.js:790
 #: js/blocks/FlowBlocks.js:873
 msgid "do2"
 msgstr "～する"
+
 
 #: js/blocks/FlowBlocks.js:790
 #: js/blocks/FlowBlocks.js:873
@@ -8239,13 +9736,16 @@ msgstr "～する"
 msgid "do"
 msgstr "アクション"
 
+
 #: js/blocks/FlowBlocks.js:863
 msgid "The While block will repeat while the condition is true."
 msgstr "Whileブロックは条件が真である間繰り返します。"
 
+
 #: js/blocks/FlowBlocks.js:871
 msgid "while"
 msgstr "の間に"
+
 
 #: js/blocks/FlowBlocks.js:953
 #: js/blocks/FlowBlocks.js:964
@@ -8254,116 +9754,141 @@ msgstr "の間に"
 msgid "Conditionals lets your program take different actions depending on the condition."
 msgstr "条件付きを使用すると、プログラムは条件に応じてさまざまなアクションを実行できます。"
 
+
 #: js/blocks/FlowBlocks.js:957
 #: js/blocks/FlowBlocks.js:1022
 #: js/blocks/FlowBlocks.js:1033
 msgid "In this example if the mouse button is pressed a snare drum will play."
 msgstr "<br><br>図の例では、もし、パソコンのマウスを長おししていれば「キックドラム」ブロックをえんそうする。"
 
+
 #: js/blocks/FlowBlocks.js:968
 msgid "In this example if the mouse button is pressed a snare drum will play, else a kick drum will play."
 msgstr "この例では、マウス ボタンが押されるとスネア ドラムが再生され、そうではない場合はキック ドラムが再生されます。"
+
 
 #: js/blocks/FlowBlocks.js:979
 #: js/blocks/FlowBlocks.js:1042
 msgid "if"
 msgstr "もし"
 
+
 #: js/blocks/FlowBlocks.js:981
 #: js/blocks/FlowBlocks.js:1044
 msgid "then"
 msgstr "ならば"
 
+
 #: js/blocks/FlowBlocks.js:981
 msgid "else"
 msgstr "でなければ"
+
 
 #: js/blocks/FlowBlocks.js:1079
 msgid "The Forever block will repeat the contained blocks forever."
 msgstr "<h2>実行ブロック（くり返し）</h2><br>「ずっとくり返す」のブロックは、実行を停止しないかぎり、はさまれているブロックをくり返し実行する。"
 
+
 #: js/blocks/FlowBlocks.js:1081
 msgid "In this example of a simple drum machine a kick drum will play 1/4 notes forever."
 msgstr "この単純なドラムマシンの例では、キックドラムは 四分音符を永遠に演奏します。"
+
 
 #: js/blocks/FlowBlocks.js:1091
 msgid "forever"
 msgstr "ずっとくり返す"
 
+
 #: js/blocks/FlowBlocks.js:1127
 msgid "The Repeat block will repeat the contained blocks."
 msgstr "<h2>実行ブロック（くり返し）</h2><br>はさまれているブロックのプログラムを、入力した回数だけくり返す。"
+
 
 #: js/blocks/FlowBlocks.js:1129
 msgid "In this example the note will be played 4 times."
 msgstr "<br><br>図の例では、「ソ」の音が４回えんそうされる。"
 
+
 #: js/blocks/FlowBlocks.js:1137
 msgid "repeat"
 msgstr "～回くり返す"
+
 
 #: js/blocks/FlowBlocks.js:1177
 msgid "duplicate factor"
 msgstr "複製ファクター"
 
+
 #: js/blocks/MeterBlocks.js:34
-#.TRANS: musical meter (time signature), e.g., 4:4
+#. TRANS: musical meter (time signature), e.g., 4:4
 msgid "current meter"
 msgstr "現代の拍子"
 
+
 #: js/blocks/MeterBlocks.js:88
-#.TRANS: number of beats per minute
+#. TRANS: number of beats per minute
 msgid "beat factor"
 msgstr "拍を～倍にするファクター"
+
 
 #: js/blocks/MeterBlocks.js:96
 msgid "The Beat factor block returns the ratio of the note value to the meter note value."
 msgstr "「拍を～倍にするファクター」ブロックは、拍子音符値に対する音符値の比率を返します。"
 
+
 #: js/blocks/MeterBlocks.js:167
 msgid "The Beats per minute block returns the current beats per minute."
 msgstr "「スピードを決める」ブロックは現在の1分あたりのビート数を返します。"
 
+
 #: js/blocks/MeterBlocks.js:176
 #: js/widgets/status.js:155
-#.TRANS: number of beats played per minute
-#.TRANS: in Japanese: "１分当たりの拍の数"
+#. TRANS: number of beats played per minute
+#. TRANS: in Japanese: "１分当たりの拍の数"
 msgid "beats per minute2"
 msgstr "１分当たりの拍の数"
+
 
 #: js/blocks/MeterBlocks.js:176
 #: js/blocks/MeterBlocks.js:1101
 #: js/blocks/MeterBlocks.js:1183
 #: js/blocks/MeterBlocks.js:1260
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "beats per minute"
 msgstr "スピードを決める"
+
 
 #: js/blocks/MeterBlocks.js:204
 msgid "BPM must be a number, defaulting to 60."
 msgstr "BPM は数値である必要があり、デフォルトは 60 です。"
 
+
 #: js/blocks/MeterBlocks.js:207
 msgid "BPM must be at least 30, clamping to 30."
 msgstr "BPM は少なくとも 30 である必要があり、30 に固定されます。"
+
 
 #: js/blocks/MeterBlocks.js:210
 msgid "BPM must be at most 1000, clamping to 1000."
 msgstr "BPM は最大 1000 にする必要があり、1000 に固定されます。"
 
+
 #: js/blocks/MeterBlocks.js:256
-#.TRANS: count of current musical measure in meter
+#. TRANS: count of current musical measure in meter
 msgid "measure count"
 msgstr "小節の数"
+
 
 #: js/blocks/MeterBlocks.js:264
 msgid "The Measure count block returns the current measure."
 msgstr "Measure countブロックは現在の小節数を返します。"
 
+
 #: js/blocks/MeterBlocks.js:316
-#.TRANS: count of current beat in the meter
+#. TRANS: count of current beat in the meter
 msgid "beat count"
 msgstr "拍の位置"
+
 
 #: js/blocks/MeterBlocks.js:326
 #: js/blocks/MeterBlocks.js:337
@@ -8372,6 +9897,7 @@ msgstr "拍の位置"
 msgid "The Beat count block is the number of the current beat,"
 msgstr "<h2>拍（はく）の位置ブロック</h2><br>小節の中で何拍（はく）目かをあらわす数。たとえば、各小節の３拍（はく）めに何かアクション・イベントを起こしたいときなどに使う。"
 
+
 #: js/blocks/MeterBlocks.js:328
 #: js/blocks/MeterBlocks.js:341
 #: js/blocks/MeterBlocks.js:599
@@ -8379,69 +9905,84 @@ msgstr "<h2>拍（はく）の位置ブロック</h2><br>小節の中で何拍�
 msgid "In the figure, it is used to take an action on the first beat of each measure."
 msgstr "図では、各小節の最初の拍でアクションを実行するために使用されます。"
 
+
 #: js/blocks/MeterBlocks.js:339
 #: js/blocks/MeterBlocks.js:610
 msgid "eg 1, 2, 3, or 4."
 msgstr "<br>図の例では、それぞれの小節の１拍（ぱく）目に、特定のアクション・イベントを起こしている。"
 
+
 #: js/blocks/MeterBlocks.js:397
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "sum note values"
 msgstr "音の長さを足す"
+
 
 #: js/blocks/MeterBlocks.js:405
 #: js/blocks/MeterBlocks.js:469
 msgid "The Note counter block can be used to count the number of contained notes."
 msgstr "Note counterブロックは含まれる音符の数を数えるために使用できます。"
 
+
 #: js/blocks/MeterBlocks.js:461
-#.TRANS: count the number of notes
+#. TRANS: count the number of notes
 msgid "note counter"
 msgstr "音符の合計数"
 
+
 #: js/blocks/MeterBlocks.js:525
-#.TRANS: number of whole notes that have been played
+#. TRANS: number of whole notes that have been played
 msgid "whole notes played"
 msgstr "さいせいされた全音符の数"
+
 
 #: js/blocks/MeterBlocks.js:534
 msgid "The Whole notes played block returns the total number of whole notes played."
 msgstr "Whole notes playedブロックは演奏された全音符の総数を返します。"
 
+
 #: js/blocks/MeterBlocks.js:587
 #: js/turtleactions/DictActions.js:83
-#.TRANS: number of notes that have been played
+#. TRANS: number of notes that have been played
 msgid "notes played"
 msgstr "全体の拍の数"
+
 
 #: js/blocks/MeterBlocks.js:688
 msgid "The No clock block decouples the notes from the master clock."
 msgstr "<em>クロックなし</em>ブロックはそれぞれの動作の順番をリズムより優先します。"
 
+
 #: js/blocks/MeterBlocks.js:696
-#.TRANS: don't lock notes to master clock
+#. TRANS: don't lock notes to master clock
 msgid "no clock"
 msgstr "クロックなし"
+
 
 #: js/blocks/MeterBlocks.js:735
 msgid "on weak beat do"
 msgstr "弱拍に～する"
 
+
 #: js/blocks/MeterBlocks.js:740
 msgid "The On-weak-beat block lets you specify actions to take on weak (off) beats."
 msgstr "On-weak-beatブロックは弱拍（裏拍）で実行するアクションを指定できます。"
+
 
 #: js/blocks/MeterBlocks.js:785
 msgid "on strong beat"
 msgstr "強拍に"
 
+
 #: js/blocks/MeterBlocks.js:793
 msgid "The On-strong-beat block lets you specify actions to take on specified beats."
 msgstr "On-strong-beatブロックは指定された強拍で実行するアクションを指定できます。"
 
+
 #: js/blocks/MeterBlocks.js:804
 msgid "beat"
 msgstr "拍子"
+
 
 #: js/blocks/MeterBlocks.js:804
 #: js/blocks/ActionBlocks.js:411
@@ -8451,31 +9992,38 @@ msgstr "拍子"
 msgid "do1"
 msgstr "アクション実行"
 
+
 #: js/blocks/MeterBlocks.js:848
 msgid "on every beat do"
 msgstr "全ての拍子にアクション実行"
+
 
 #: js/blocks/MeterBlocks.js:856
 msgid "The On-every-beat block lets you specify actions to take on every beat."
 msgstr "On-every-beatブロックはすべての拍で実行するアクションを指定できます。"
 
+
 #: js/blocks/MeterBlocks.js:909
 msgid "on every note do"
 msgstr "全ての音符にアクション実行"
+
 
 #: js/blocks/MeterBlocks.js:917
 msgid "The On-every-note block lets you specify actions to take on every note."
 msgstr "On-every-noteブロックはすべての音符で実行するアクションを指定できます。"
 
+
 #: js/blocks/MeterBlocks.js:963
 #: js/blocks/MeterBlocks.js:1039
-#.TRANS: sets tempo by defining a beat and beats per minute
+#. TRANS: sets tempo by defining a beat and beats per minute
 msgid "master beats per minute"
 msgstr "全体のスピードを決める"
+
 
 #: js/blocks/MeterBlocks.js:975
 msgid "The Master beats per minute block sets the number of 1/4 notes per minute for every voice."
 msgstr "「全体のスピードを決める」ブロックは、各ボイスの 1 分あたりの 1/4 音符の数を設定します。"
+
 
 #: js/blocks/MeterBlocks.js:987
 #: js/blocks/MeterBlocks.js:1123
@@ -8483,11 +10031,13 @@ msgstr "「全体のスピードを決める」ブロックは、各ボイスの
 msgid "bpm"
 msgstr "１分あたりの拍の数"
 
+
 #: js/blocks/MeterBlocks.js:987
 #: js/blocks/MeterBlocks.js:1123
 #: js/blocks/MeterBlocks.js:1185
 msgid "beat value"
 msgstr "１拍"
+
 
 #: js/blocks/MeterBlocks.js:1070
 #: js/blocks/MeterBlocks.js:1217
@@ -8495,86 +10045,104 @@ msgstr "１拍"
 msgid "Beats per minute must be > 30."
 msgstr "１分あたりの拍の数には、３０より大きいあたいをせっていしてください。"
 
+
 #: js/blocks/MeterBlocks.js:1073
 #: js/blocks/MeterBlocks.js:1220
 #: js/blocks/MeterBlocks.js:1293
 msgid "Maximum beats per minute is 1000."
 msgstr "1分あたりの拍の数は、最大1000です。"
 
+
 #: js/blocks/MeterBlocks.js:1113
 msgid "The Beats per minute block sets the number of 1/4 notes per minute."
 msgstr "<h2>スピードを決めるブロック</h2><br>１分あたりの拍（はく）の数をせっていすることで、曲のスピードを決める。ひょうじゅんは４分音符（おんぷ）９０こ。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
+
 #: js/blocks/MeterBlocks.js:1327
-#.TRANS: anacrusis
+#. TRANS: anacrusis
 msgid "pickup"
 msgstr "ピックアップ"
+
 
 #: js/blocks/MeterBlocks.js:1334
 msgid "The Pickup block is used to accommodate any notes that come in before the beat."
 msgstr "「ピックアップ」ブロックは、ビートの前に入力されるノートを収容するために使用されます。"
 
+
 #: js/blocks/MeterBlocks.js:1400
 msgid "The beat of the music is determined by the Meter block (by default, 4 1/4 notes per measure)."
 msgstr "音楽のビートは「拍子」ブロックによって決定されます (デフォルトでは、1 小節あたり ４つの1/4音符)。"
+
 
 #: js/blocks/MeterBlocks.js:1415
 msgid "number of beats"
 msgstr "拍の数"
 
+
 #: js/blocks/OrnamentBlocks.js:32
 msgid "staccato factor"
 msgstr "スタッカートの長さファクター"
+
 
 #: js/blocks/OrnamentBlocks.js:108
 msgid "slur factor"
 msgstr "スラーの長さファクター"
 
+
 #: js/blocks/OrnamentBlocks.js:217
 #: js/blocks/OrnamentBlocks.js:309
-#.TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
+#. TRANS: the neighbor refers to a neighboring note, e.g., D is a neighbor of C
 msgid "neighbor"
 msgstr "音を加える"
 
+
 #: js/blocks/OrnamentBlocks.js:220
 #: js/blocks/IntervalsBlocks.js:708
-#.TRANS: calculate a relative step between notes based on semi-tones
+#. TRANS: calculate a relative step between notes based on semi-tones
 msgid "semi-tone interval"
 msgstr "半音階的音程"
+
 
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr "<h2>音を加えるブロック</h2><br>２つの同じ高さの音のあいだに、音を１つ入れることができる。<br>図の例では、ソとソのあいだにラが入り、「ソラソ」とすばやくえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
+
 #: js/blocks/OrnamentBlocks.js:364
 msgid "glide"
 msgstr "グリッサンド"
+
 
 #: js/blocks/OrnamentBlocks.js:472
 #: js/blocks/OrnamentBlocks.js:636
 msgid "slur"
 msgstr "スラー"
 
+
 #: js/blocks/OrnamentBlocks.js:551
 #: js/blocks/OrnamentBlocks.js:703
-#.TRANS: play each note sharply detached from the others
+#. TRANS: play each note sharply detached from the others
 msgid "staccato"
 msgstr "スタッカート"
+
 
 #: js/blocks/OrnamentBlocks.js:619
 msgid "The Slur block lengthens the sustain of notes while maintaining the specified rhythmic value of the notes."
 msgstr "「スラー」ブロックは、指定された音符の長さを全部組み合わせて長くします。"
 
+
 #: js/blocks/OrnamentBlocks.js:685
 msgid "The Staccato block shortens the length of the actual note while maintaining the specified rhythmic value of the notes."
 msgstr "「スタッカート」ブロックは、指定された音符の長さを維持しながら、実際の音符の長さを短縮します。"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:69
 #: js/blocks/RhythmBlockPaletteBlocks.js:248
-#.TRANS: rhythm block
-#.TRANS: translate "rhythm1" as rhythm
+#. TRANS: rhythm block
+#. TRANS: translate "rhythm1" as rhythm
 msgid "rhythm1"
 msgstr "連符（かけ算）"
+
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:89
 #: js/blocks/RhythmBlockPaletteBlocks.js:267
@@ -8584,186 +10152,226 @@ msgstr "連符（かけ算）"
 msgid "number of notes"
 msgstr "音符の数"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:150
 msgid "polyphonic rhythm"
 msgstr "ポリリズム"
+
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:234
 msgid "The Rhythm block is used to generate rhythm patterns."
 msgstr "<h2>連符（れんぷ）ブロック（かけ算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つなどくり返して使う。３連符（れんぷ）や５連符（れんぷ）など、２の倍数ではない音符（おんぷ）の数でグループを作りやすくなる。"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:296
 #: js/blocks/RhythmBlockPaletteBlocks.js:301
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "1/64 note"
 msgstr "６４分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:327
 #: js/blocks/RhythmBlockPaletteBlocks.js:332
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "1/32 note"
 msgstr "３２分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:361
 #: js/blocks/RhythmBlockPaletteBlocks.js:366
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "1/16 note"
 msgstr "１６分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:395
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "eighth note"
 msgstr "８分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:423
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "quarter note"
 msgstr "４分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:451
 #: js/blocks/RhythmBlockPaletteBlocks.js:456
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "half note"
 msgstr "２分音符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:485
 #: js/blocks/RhythmBlockPaletteBlocks.js:490
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "whole note"
 msgstr "全音符"
+
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:529
 #: js/blocks/RhythmBlockPaletteBlocks.js:597
 #: js/blocks/RhythmBlockPaletteBlocks.js:648
-#.TRANS: Do not modify the following line
-#.TRANS: A tuplet is a note value divided into irregular time values.
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
+#. TRANS: A tuplet is a note value divided into irregular time values.
+#. TRANS: Do not modify the following line
 msgid "tuplet"
 msgstr "～連符（タプル）"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:637
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "The Tuplet block is used to generate a group of notes played in a condensed amount of time."
 msgstr "「～連符」連符ブロックは、凝縮された時間で演奏される音符のグループを生成するために使用されます。"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:795
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "septuplet"
 msgstr "７連符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:823
-#.TRANS: Do not modify the following line
+#. TRANS: Do not modify the following line
 msgid "quintuplet"
 msgstr "５連符"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:851
-#.TRANS: A tuplet divided into 3 time values.
+#. TRANS: A tuplet divided into 3 time values.
 msgid "triplet"
 msgstr "３連符"
+
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:878
 msgid "simple tuplet"
 msgstr "連符（わり算）"
 
+
 #: js/blocks/RhythmBlockPaletteBlocks.js:888
 msgid "Tuplets are a collection of notes that get scaled to a specific duration."
 msgstr "<h2>連符（れんぷ）ブロック（わり算）</h2><br>まとまったいくつかの音符（おんぷ）。一定の長さの音を３つや５つに等分して使う。"
+
 
 #: js/blocks/RhythmBlockPaletteBlocks.js:890
 msgid "Using tuplets makes it easy to create groups of notes that are not based on a power of 2."
 msgstr "連符を使用すると、2 の累乗に基づいていない音符のグループを簡単に作成できます。"
 
+
 #: js/blocks/SensorsBlocks.js:36
 msgid "The Input block prompts for keyboard input."
 msgstr "インプットブロックはキーボード入力を促します。"
+
 
 #: js/blocks/SensorsBlocks.js:46
 msgid "input"
 msgstr "インプット"
 
+
 #: js/blocks/SensorsBlocks.js:64
 msgid "Input a value"
 msgstr "価値をインプット"
+
 
 #: js/blocks/SensorsBlocks.js:134
 msgid "input value"
 msgstr "インプットの価値"
 
+
 #: js/blocks/SensorsBlocks.js:139
 msgid "The Input-value block stores the input."
 msgstr "インプット値ブロックは入力を保存します。"
+
 
 #: js/blocks/SensorsBlocks.js:246
 msgid "loudness"
 msgstr "音量"
 
+
 #: js/blocks/SensorsBlocks.js:253
 msgid "The Loudness block returns the volume detected by the microphone."
 msgstr "ラウドネスブロックはマイクで検出された音量を返します。"
+
 
 #: js/blocks/SensorsBlocks.js:308
 msgid "click"
 msgstr "クリック"
 
+
 #: js/blocks/SensorsBlocks.js:314
 msgid "The Click block triggers an event if a mouse has been clicked."
 msgstr "クリックブロックはマウスがクリックされた場合にイベントをトリガーします。"
+
 
 #: js/blocks/SensorsBlocks.js:321
 msgid "The Click block triggers an event if a turtle has been clicked."
 msgstr "クリックブロックはカメがクリックされた場合にイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:350
-#.TRANS: The mouse cursor is over the mouse icon
+#. TRANS: The mouse cursor is over the mouse icon
 msgid "cursor over"
 msgstr "カーソル（上）"
+
 
 #: js/blocks/SensorsBlocks.js:355
 msgid "The Cursor over block triggers an event when the cursor is moved over a mouse."
 msgstr "「カーソル（上）」ブロックは、カーソルがマウス上に移動するとイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:364
 msgid "The Cursor over block triggers an event when the cursor is moved over a turtle."
 msgstr "「カーソル（上）」ブロックは、カーソルがタートル上に移動するとイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:395
-#.TRANS: The cursor is "out" -- it is no longer over the mouse.
+#. TRANS: The cursor is "out" -- it is no longer over the mouse.
 msgid "cursor out"
 msgstr "カーソル（外）"
 
+
 #: js/blocks/SensorsBlocks.js:401
-#.TRANS: hover
+#. TRANS: hover
 msgid "The Cursor out block triggers an event when the cursor is moved off of a mouse."
 msgstr "「カーソル（外）」ブロックは、カーソルがマウスから離れるとイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:411
-#.TRANS: hover
+#. TRANS: hover
 msgid "The Cursor out block triggers an event when the cursor is moved off of a turtle."
 msgstr "「カーソル（外）」ブロックは、カーソルがタートルから離れるとイベントをトリガーします。"
+
 
 #: js/blocks/SensorsBlocks.js:441
 msgid "cursor button down"
 msgstr "カーソルクリック（下）"
 
+
 #: js/blocks/SensorsBlocks.js:446
 msgid "The Cursor button down block triggers an event when the cursor button is pressed on a mouse."
 msgstr "「カーソルクリック（下）」ブロックは、マウスのカーソル ボタンが押されたときにイベントをトリガーします。"
+
 
 #: js/blocks/SensorsBlocks.js:455
 msgid "The Cursor button down block triggers an event when the cursor button is pressed on a turtle."
 msgstr "「カーソルクリック（下）」ブロックは、タートル上でカーソル ボタンが押されたときにイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:485
 msgid "cursor button up"
 msgstr "カーソルクリック（上）"
+
 
 #: js/blocks/SensorsBlocks.js:490
 msgid "The Cursor button up block triggers an event when the cursor button is released while over a mouse."
 msgstr "「カーソルクリック（上）」ブロックは、マウスの上でカーソル ボタンが放されるとイベントをトリガーします。"
 
+
 #: js/blocks/SensorsBlocks.js:499
 msgid "The Cursor button up block triggers an event when the cursor button is released while over a turtle."
 msgstr "「カーソルクリック（上）」ブロックは、タートルの上でカーソル ボタンが放されるとイベントをトリガーします。"
+
 
 #: js/blocks/SensorsBlocks.js:529
 #: js/blocks/SensorsBlocks.js:1004
@@ -8772,70 +10380,87 @@ msgstr "「カーソルクリック（上）」ブロックは、タートルの
 msgid "red"
 msgstr "赤"
 
+
 #: js/blocks/SensorsBlocks.js:574
 #: plugins/rodi.rtp:216
 msgid "pixel color"
 msgstr "ピクセルの色"
 
+
 #: js/blocks/SensorsBlocks.js:579
 msgid "The Get pixel block returns the color of the pixel under the mouse."
 msgstr "Get pixelブロックはマウス下のピクセルの色を返します。"
+
 
 #: js/blocks/SensorsBlocks.js:585
 msgid "The Get pixel block returns the color of the pixel under the turtle."
 msgstr "Get pixelブロックはカメの下のピクセルの色を返します。"
 
+
 #: js/blocks/SensorsBlocks.js:720
 msgid "time"
 msgstr "時間"
+
 
 #: js/blocks/SensorsBlocks.js:727
 msgid "The Time block returns the number of seconds that the program has been running."
 msgstr "「時間」ブロックは、プログラムが実行されている秒数を返します。"
 
+
 #: js/blocks/SensorsBlocks.js:766
 msgid "cursor y"
 msgstr "yざひょうち（カーソル）"
+
 
 #: js/blocks/SensorsBlocks.js:771
 msgid "The Cursor Y block returns the vertical position of the mouse."
 msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルのたて位置を表すｙざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。"
 
+
 #: js/blocks/SensorsBlocks.js:807
 msgid "cursor x"
 msgstr "xざひょうち（カーソル）"
+
 
 #: js/blocks/SensorsBlocks.js:812
 msgid "The Cursor X block returns the horizontal position of the mouse."
 msgstr "<h2>すうちブロック（カーソル）</h2><br>マウスカーソルの横位置を表すｘざひょうち。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。"
 
+
 #: js/blocks/SensorsBlocks.js:848
 msgid "mouse button"
 msgstr "マウスボタン"
+
 
 #: js/blocks/SensorsBlocks.js:850
 msgid "The Mouse-button block returns True if the mouse button is pressed."
 msgstr "<h2>真偽ブロック（マウスボタン）</h2><br>マウスのボタンがおされているかどうかはんていする。マウスボタンがおされていれば「真（しん）」、おされていなければ「偽（ぎ）」という値になる。<br>図の例は、ネズミを使って画面上に自由に線をえがけるプログラム。ネズミがパソコンのマウスカーソルの位置にいどうし続けつつ、マウスをおしているときだけペンをおろし、線をえがく。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
+
 #: js/blocks/SensorsBlocks.js:896
 msgid "to ASCII"
 msgstr "ASCIIに"
+
 
 #: js/blocks/SensorsBlocks.js:900
 msgid "The To ASCII block converts numbers to letters."
 msgstr "「ASCIIに」ブロックは数字を文字に変換します。"
 
+
 #: js/blocks/SensorsBlocks.js:967
 msgid "The Keyboard block returns computer keyboard input."
 msgstr "「キーボード」ブロックはコンピュータのキーボード入力を返します。"
+
 
 #: js/blocks/SensorsBlocks.js:1006
 msgid "The Get red block returns the red component of the pixel under the mouse."
 msgstr "Get redブロックはマウス下のピクセルの赤成分を返します。"
 
+
 #: js/blocks/SensorsBlocks.js:1009
 msgid "The Get red block returns the red component of the pixel under the turtle."
 msgstr "Get redブロックはカメの下のピクセルの赤成分を返します。"
+
 
 #: js/blocks/SensorsBlocks.js:1015
 #: js/blocks/PenBlocks.js:64
@@ -8843,13 +10468,16 @@ msgstr "Get redブロックはカメの下のピクセルの赤成分を返し�
 msgid "green"
 msgstr "緑"
 
+
 #: js/blocks/SensorsBlocks.js:1017
 msgid "The Get green block returns the green component of the pixel under the mouse."
 msgstr "Get green ブロックは、マウスの下にあるピクセルの緑色コンポーネントを返します。"
 
+
 #: js/blocks/SensorsBlocks.js:1020
 msgid "The Get green block returns the green component of the pixel under the turtle."
 msgstr "Get green ブロックは、タートルの下のピクセルの緑色コンポーネントを返します。"
+
 
 #: js/blocks/SensorsBlocks.js:1026
 #: js/blocks/PenBlocks.js:48
@@ -8857,39 +10485,48 @@ msgstr "Get green ブロックは、タートルの下のピクセルの緑色�
 msgid "blue"
 msgstr "青"
 
+
 #: js/blocks/SensorsBlocks.js:1028
 msgid "The Get blue block returns the blue component of the pixel under the mouse."
 msgstr "Get blue ブロックは、マウスの下にあるピクセルの青色のコンポーネントを返します。"
+
 
 #: js/blocks/SensorsBlocks.js:1031
 msgid "The Get blue block returns the blue component of the pixel under the turtle."
 msgstr "Get blue ブロックは、タートルの下のピクセルの青コンポーネントを返します。"
 
+
 #: js/blocks/VolumeBlocks.js:35
 msgid "synth volume"
 msgstr "シンセノ音量"
+
 
 #: js/blocks/VolumeBlocks.js:39
 msgid "The Synth volume block returns the current volume of the current synthesizer."
 msgstr "Synth volumeブロックは現在のシンセサイザーの音量を返します。"
 
+
 #: js/blocks/VolumeBlocks.js:105
 msgid "master volume"
 msgstr "マスター音量"
 
+
 #: js/blocks/VolumeBlocks.js:109
 msgid "The Master volume block returns the master volume."
 msgstr "Master volumeブロックはマスターボリュームを返します。"
+
 
 #: js/blocks/VolumeBlocks.js:355
 #: js/blocks/VolumeBlocks.js:525
 msgid "set synth volume"
 msgstr "楽器の音量をせってい"
 
+
 #: js/blocks/VolumeBlocks.js:362
 #: js/blocks/VolumeBlocks.js:546
 msgid "synth"
 msgstr "楽器"
+
 
 #: js/blocks/VolumeBlocks.js:403
 #: js/blocks/VolumeBlocks.js:578
@@ -8898,100 +10535,124 @@ msgstr "楽器"
 msgid "Setting volume to 0."
 msgstr "音量を「0」にせっていします。"
 
+
 #: js/blocks/VolumeBlocks.js:440
 msgid "Synth not found"
 msgstr "シンセが見つかりません"
+
 
 #: js/blocks/VolumeBlocks.js:495
 msgid "set drum volume"
 msgstr "ドラムの音量をせってい"
 
+
 #: js/blocks/VolumeBlocks.js:531
 msgid "The Set synth volume block will change the volume of a particular synth, eg guitar violin snare drum etc."
 msgstr "「楽器の音量をせってい」ブロックは、ギター、バイオリン、スネアドラムなどの特定のシンセサイザーの音量を変更します。"
+
 
 #: js/blocks/VolumeBlocks.js:535
 msgid "The default volume is 50."
 msgstr "デフォルトは音量５０。"
 
+
 #: js/blocks/VolumeBlocks.js:537
 msgid "The range is 0 for silence to 100 for full volume."
 msgstr "０から１００までのすうちをせっていできる。<br><br> "
+
 
 #: js/blocks/VolumeBlocks.js:598
 msgid "set panning"
 msgstr "ステレオを設定"
 
+
 #: js/blocks/VolumeBlocks.js:604
 msgid "The Set Panning block sets the panning for all synthesizers."
 msgstr "Set Panningブロックはすべてのシンセのパンを設定します。"
 
+
 #: js/blocks/VolumeBlocks.js:626
 msgid "Warning: Sound is coming out from only the left or right side."
 msgstr "ワーニング：音は右か左だけのスピーカーから出ている"
+
 
 #: js/blocks/VolumeBlocks.js:648
 #: js/blocks/VolumeBlocks.js:696
 msgid "set master volume"
 msgstr "全体の音量をせってい"
 
+
 #: js/blocks/VolumeBlocks.js:654
 msgid "The Set master volume block sets the volume for all synthesizers."
 msgstr "<h2>全体の音量をせっていブロック</h2><br>全体の音量をせっていする。"
+
 
 #: js/blocks/VolumeBlocks.js:784
 msgid "The Set relative volume block changes the volume of the contained notes."
 msgstr "Set relative volumeブロックは含まれる音符の音量を変更します。"
 
+
 #: js/blocks/VolumeBlocks.js:791
 msgid "set relative volume"
 msgstr "相対音量を設定"
+
 
 #: js/blocks/VolumeBlocks.js:843
 msgid "The Decrescendo block will decrease the volume of the contained notes by a specified amount for every note played."
 msgstr "「デクレッシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ減少させます。"
 
+
 #: js/blocks/VolumeBlocks.js:847
 msgid "For example if you have 7 notes in sequence contained in a Decrescendo block with a value of 5 the final note will be at 35% less than the starting volume."
 msgstr "たとえば、値が「5」の「デクレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 低くなります。"
+
 
 #: js/blocks/VolumeBlocks.js:857
 msgid "decrescendo"
 msgstr "デクレシェンド"
 
+
 #: js/blocks/VolumeBlocks.js:907
 msgid "The Crescendo block will increase the volume of the contained notes by a specified amount for every note played."
 msgstr "「クレシェンド」ブロックは、再生される音符ごとに、含まれる音符の音量を指定された量だけ増加させます。"
+
 
 #: js/blocks/VolumeBlocks.js:911
 msgid "For example if you have 7 notes in sequence contained in a Crescendo block with a value of 5 the final note will be at 35% more than the starting volume."
 msgstr "たとえば、値が「5」の「クレシェンド」ブロックに 7つの音符が連続して含まれている場合、最後の音符は開始音量より 35% 大きくなります。"
 
+
 #: js/blocks/VolumeBlocks.js:921
 msgid "crescendo"
 msgstr "クレシェンド"
+
 
 #: js/blocks/ActionBlocks.js:58
 msgid "The Return block will return a value from an action."
 msgstr "Returnブロックはアクションから値を返します。"
 
+
 #: js/blocks/ActionBlocks.js:75
 msgid "return"
 msgstr "リターン"
+
 
 #: js/blocks/ActionBlocks.js:128
 msgid "The Return to URL block will return a value to a webpage."
 msgstr "Return to URLブロックは値をウェブページに返します。"
 
+
 #: js/blocks/ActionBlocks.js:145
 msgid "return to URL"
 msgstr "URLに戻ります"
+
 
 #: js/blocks/ActionBlocks.js:178
 #: js/blocks/ProgramBlocks.js:86
 #: js/blocks/ProgramBlocks.js:181
 msgid "Invalid URL"
 msgstr "無効な URL"
+
 
 #: js/blocks/ActionBlocks.js:230
 #: js/blocks/ActionBlocks.js:311
@@ -9000,29 +10661,34 @@ msgstr "無効な URL"
 msgid "The Calculate block returns a value calculated by an action."
 msgstr "Calculateブロックはアクションで計算された値を返します。"
 
+
 #: js/blocks/ActionBlocks.js:248
 #: js/blocks/ActionBlocks.js:538
 #: js/blocks/ActionBlocks.js:730
 msgid "calculate"
 msgstr "計算する"
 
+
 #: js/blocks/ActionBlocks.js:397
 #: js/blocks/ActionBlocks.js:615
 #: js/blocks/ActionBlocks.js:965
 #: js/blocks/ActionBlocks.js:1417
-#.TRANS: do is the do something or take an action.
+#. TRANS: do is the do something or take an action.
 msgid "The Do block is used to initiate an action."
 msgstr "<h2>アクションブロック（指定）</h2><br>指定したアクションブロックを実行する。"
+
 
 #: js/blocks/ActionBlocks.js:814
 #: js/blocks/ActionBlocks.js:888
 msgid "The Arg block contains the value of an argument passed to an action."
 msgstr "Argブロックはアクションに渡された引数の値を含みます。"
 
+
 #: js/blocks/ActionBlocks.js:829
 #: js/blocks/ActionBlocks.js:901
 msgid "arg"
 msgstr "引数"
+
 
 #: js/blocks/ActionBlocks.js:859
 #: js/blocks/ActionBlocks.js:923
@@ -9030,26 +10696,32 @@ msgstr "引数"
 msgid "Invalid argument"
 msgstr "無効な議論"
 
+
 #: js/blocks/OrnamentBlocks.js:293
 msgid "The Neighbor block rapidly switches between neighboring pitches."
 msgstr "<h2>音を加えるブロック</h2><br>２つの同じ高さの音のあいだに、音を１つ入れることができる。<br>図の例では、ソとソのあいだにラが入り、「ソ、ラ、ソ」とすばやくえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ド、レ、ミ、ファ、ソ、ラ、シ、ド」、「ソ」を始まりの音にしたときの「ソ、ラ、シ、ド、レ、ミ、（♯ファ）、ソ」のこと。"
 
+
 #: js/blocks/ActionBlocks.js:967
 msgid "In the example, it is used with the One of block to choose a random phase."
 msgstr "<br><br>図の例は、決まったアクションではなく、２つのうちどちらか１つのアクションをランダムに実行させる。"
+
 
 #: js/blocks/ActionBlocks.js:1041
 #: js/blocks/ActionBlocks.js:1048
 msgid "The Listen block is used to listen for an event such as a mouse click."
 msgstr "<h2>イベントブロック（受け取り）</h2><br>特定のイベントに対して、その発生を受け取るたびに実行するアクションを１つ決めておくことができる。"
 
+
 #: js/blocks/ActionBlocks.js:1050
 msgid "When the event happens, an action is taken."
 msgstr "<br><br>イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
 
+
 #: js/blocks/ActionBlocks.js:1067
 msgid "on"
 msgstr "のとき"
+
 
 #: js/blocks/ActionBlocks.js:1070
 #: js/blocks/ActionBlocks.js:1071
@@ -9057,177 +10729,220 @@ msgstr "のとき"
 msgid "event"
 msgstr "イベント"
 
+
 #: js/blocks/ActionBlocks.js:1160
 msgid "The Broadcast block is used to trigger an event."
 msgstr "<h2>イベントブロック（発生）</h2><br>指定した名前のイベントをすべてのネズミに送る。イベントの発生は、各スクリプトが【イベントのたびにアクション】で指定したアクションの引きがねとしてはたらく。"
+
 
 #: js/blocks/ActionBlocks.js:1178
 msgid "broadcast"
 msgstr "イベント発生"
 
+
 #: js/blocks/ActionBlocks.js:1236
 msgid "Each Start block is a separate voice."
 msgstr "<h2>スタートブロック</h2><br>実行ボタンがおされると、スタートブロックが実行される。"
+
 
 #: js/blocks/ActionBlocks.js:1238
 msgid "All of the Start blocks run at the same time when the Play button is pressed."
 msgstr "[再生] ボタンを押すと、すべての Start ブロックが同時に実行されます。"
 
+
 #: js/blocks/ActionBlocks.js:1329
 msgid "The Action block is used to group together blocks so that they can be used more than once."
 msgstr "アクション ブロックは、複数のブロックをグループ化して複数回使用できるようにするために使用されます。"
+
 
 #: js/blocks/ActionBlocks.js:1333
 msgid "It is often used for storing a phrase of music that is repeated."
 msgstr "<br><br>何度も実行する音楽のフレーズなどにアクションを作っておくと便利。"
 
+
 #: js/blocks/ActionBlocks.js:1523
 msgid "define temperament"
 msgstr "音律を明確にする"
+
 
 #: js/blocks/BooleanBlocks.js:44
 msgid "The Not block is the logical not operator."
 msgstr "Notブロックは論理的なNOT演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:62
 msgid "not"
 msgstr "ではない"
+
 
 #: js/blocks/BooleanBlocks.js:133
 msgid "The And block is the logical and operator."
 msgstr "Andブロックは論理積（AND）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:151
 msgid "and"
 msgstr "かつ"
+
 
 #: js/blocks/BooleanBlocks.js:217
 msgid "The Or block is the logical or operator."
 msgstr "Orブロックは論理和（OR）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:235
 msgid "or"
 msgstr "または"
+
 
 #: js/blocks/BooleanBlocks.js:301
 msgid "The XOR block is the logical XOR operator."
 msgstr "XORブロックは排他的論理和（XOR）演算子です。"
 
+
 #: js/blocks/BooleanBlocks.js:319
 msgid "xor"
 msgstr "XOR（エクスクルーシブ・オア）"
+
 
 #: js/blocks/BooleanBlocks.js:391
 msgid "The Greater-than block returns True if the top number is greater than the bottom number."
 msgstr "「＞」ブロックは、上の数値が下の数値より大きい場合に True を返します。"
 
+
 #: js/blocks/BooleanBlocks.js:496
 msgid "The Less-than block returns True if the top number is less than the bottom number."
 msgstr "「＜」ブロックは、上の数値が下の数値より小さい場合に True を返します。"
+
 
 #: js/blocks/BooleanBlocks.js:596
 msgid "The Less-than-or-equal-to block returns True if the top number is less than or equal to the bottom number."
 msgstr "「≦」ブロックは、上の数値が下の数値以下の場合に True を返します。"
 
+
 #: js/blocks/BooleanBlocks.js:696
 msgid "The Greater-than-or-equal-to block returns True if the top number is greater than or equal to the bottom number."
 msgstr "「≥」ブロックは、上の数値が下の数値以上である場合に True を返します。"
+
 
 #: js/blocks/BooleanBlocks.js:802
 msgid "The Equal block returns True if the two numbers are equal."
 msgstr "<h2>しんぎブロック（等しい）</h2><br>２つのすうちをくらべて、同じすうちであるかどうかはんていする。「＝」は、２つのすうちが同じであれば「真（しん）」、同じでなければ「偽（ぎ）」という結果になる。<br><br>★しんぎブロックとは<br>「もし～ならば」などのじょうけんブロックを動かすために必要なブロック。<br>「もし～ならば」は、せいかくに表現すると、「もし～というじょうけんが正しいならば、次のブロックを実行する」という意味である。しんぎブロックは不等式などによるひかくが「正しい（真）」か、「正しくない（偽）」かの結果を表し、「もし～ならば」に続くブロックを実行するかどうか決める。"
 
+
 #: js/blocks/BooleanBlocks.js:901
 msgid "The Not-equal-to block returns True if the two numbers are not equal to each other."
 msgstr "「≠」ブロックは2つの数字が等しくない場合にTrueを返します。"
 
+
 #: js/blocks/BooleanBlocks.js:1003
 msgid "The Boolean block is used to specify true or false."
 msgstr "Booleanブロックはtrueまたはfalseを指定するために使われます。"
+
 
 #: js/blocks/BoxesBlocks.js:53
 #: js/blocks/BoxesBlocks.js:59
 msgid "The Add-to block is used to add to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、好きなすうちを足す。マイナスのすうちを使うと引き算になる。"
 
+
 #: js/blocks/BoxesBlocks.js:61
 msgid "It can also be used with other blocks such as Color and Pen size."
 msgstr "<br><br>マイナスの数値を使うと引き算になる。"
 
+
 #: js/blocks/BoxesBlocks.js:73
 msgid "add"
 msgstr "足す"
+
 
 #: js/blocks/BoxesBlocks.js:75
 #: js/widgets/temperament.js:1081
 msgid "to"
 msgstr "箱へ"
 
+
 #: js/blocks/BoxesBlocks.js:118
 msgid "Block does not support incrementing."
 msgstr "ブロックは、増殖をサポートできません"
+
 
 #: js/blocks/BoxesBlocks.js:152
 msgid "The Add-1-to block adds one to the value stored in a box."
 msgstr "<h2>数の箱（あたいを変える）</h2><br>指定した箱に、１を足す。"
 
+
 #: js/blocks/BoxesBlocks.js:163
 msgid "add 1 to"
 msgstr "箱に１を足す"
+
 
 #: js/blocks/BoxesBlocks.js:211
 msgid "The Subtract-1-from block subtracts one from the value stored in a box."
 msgstr "Subtract-1-fromブロックはボックスに保存された値から1を引きます。"
 
+
 #: js/blocks/BoxesBlocks.js:222
 msgid "subtract 1 from"
 msgstr "〜から１引く"
+
 
 #: js/blocks/BoxesBlocks.js:270
 #: js/blocks/BoxesBlocks.js:387
 msgid "The Box block returns the value stored in a box."
 msgstr "<h2>すうちブロック</h2><br>すうちブロックとして、箱のすうちを使う。"
 
+
 #: js/blocks/BoxesBlocks.js:504
 #: js/blocks/BoxesBlocks.js:580
 msgid "The Store in block will store a value in a box."
 msgstr "<h2>数の箱（あたいを入れる）</h2><br>指定した箱に、指定したすうちを入れる。"
 
+
 #: js/blocks/BoxesBlocks.js:656
 msgid "The Box2 block returns the value stored in Box2."
 msgstr "Box2ブロックはBox2に保存された値を返します。"
+
 
 #: js/blocks/BoxesBlocks.js:707
 msgid "The Store in Box2 block is used to store a value in Box2."
 msgstr "Store in Box2ブロックは値をBox2に保存するために使われます。"
 
+
 #: js/blocks/BoxesBlocks.js:719
 msgid "store in box2"
 msgstr "箱２にすうちを入れる"
+
 
 #: js/blocks/BoxesBlocks.js:765
 msgid "The Box1 block returns the value stored in Box1."
 msgstr "Box1ブロックはBox1に保存された値を返します。"
 
+
 #: js/blocks/BoxesBlocks.js:816
 msgid "The Store in Box1 block is used to store a value in Box1."
 msgstr "Store in Box1ブロックは値をBox1に保存するために使われます。"
+
 
 #: js/blocks/BoxesBlocks.js:830
 msgid "store in box1"
 msgstr "箱１にすうちを入れる"
 
+
 #: js/blocks/ExtrasBlocks.js:33
 msgid "fraction"
 msgstr "分数"
+
 
 #: js/blocks/ExtrasBlocks.js:36
 msgid "Convert a float to a fraction"
 msgstr "小数から分数"
 
+
 #: js/blocks/ExtrasBlocks.js:93
 msgid "save as ABC"
 msgstr "ABCでほぞん"
+
 
 #: js/blocks/ExtrasBlocks.js:96
 #: js/blocks/ExtrasBlocks.js:132
@@ -9235,71 +10950,88 @@ msgstr "ABCでほぞん"
 msgid "title"
 msgstr "名"
 
+
 #: js/blocks/ExtrasBlocks.js:129
 msgid "save as Lilypond"
 msgstr "Lilypondのフォーマットでほぞん"
+
 
 #: js/blocks/ExtrasBlocks.js:165
 msgid "save as SVG"
 msgstr "SVGでほぞん"
 
+
 #: js/blocks/ExtrasBlocks.js:217
 msgid "no background"
 msgstr "バックグラウンドなし"
+
 
 #: js/blocks/ExtrasBlocks.js:220
 msgid "The No background block eliminates the background from the saved SVG output."
 msgstr "ノー・バックグラウンドブロックは保存されたSVG出力の背景を削除します。"
 
+
 #: js/blocks/ExtrasBlocks.js:248
 msgid "show blocks"
 msgstr "ブロックを表示"
+
 
 #: js/blocks/ExtrasBlocks.js:250
 msgid "The Show blocks block shows the blocks."
 msgstr "ショウ・ブロックスブロックはブロックを表示します。"
 
+
 #: js/blocks/ExtrasBlocks.js:278
 msgid "The Hide blocks block hides the blocks."
 msgstr "ハイド・ブロックスブロックはブロックを非表示にします。"
+
 
 #: js/blocks/ExtrasBlocks.js:307
 #: js/blocks/ExtrasBlocks.js:340
 msgid "The Space block is used to add space between blocks."
 msgstr "<h2>スペースブロック</h2><br>ブロックとブロックの間にスペースを入れたいときに使う。"
 
+
 #: js/blocks/ExtrasBlocks.js:378
 msgid "wait"
 msgstr "待つ"
+
 
 #: js/blocks/ExtrasBlocks.js:381
 msgid "The Wait block pauses the program for a specified number of seconds."
 msgstr "ウェイトブロックは指定された秒数だけプログラムを一時停止します。"
 
+
 #: js/blocks/ExtrasBlocks.js:427
 msgid "The Comment block prints a comment at the top of the screen when the program is running in slow mode."
 msgstr "「コメント」ブロックは、プログラムが低速モードで実行されているときに、画面の上部にコメントを出力します。"
+
 
 #: js/blocks/ExtrasBlocks.js:435
 #: plugins/facebook.rtp:30
 msgid "comment"
 msgstr "コメント"
 
+
 #: js/blocks/ExtrasBlocks.js:471
 msgid "print"
 msgstr "結果を表示"
+
 
 #: js/blocks/ExtrasBlocks.js:478
 msgid "The Print block displays text at the top of the screen."
 msgstr "<h2>表示ブロック（結果）</h2><br>画面の上部に、指定した実行結果のすうちや文字を表示する。表示したテキストはクリックすると消すことができる。どこでプログラムがまちがっているかをかくにんする際（デバグ）などによく用いられる。"
 
+
 #: js/blocks/ExtrasBlocks.js:587
 msgid "display grid"
 msgstr "グリッドを表示"
 
+
 #: js/blocks/ExtrasBlocks.js:592
 msgid "The Display Grid Block changes the grid type"
 msgstr "表示グリッド ブロックのグリッド タイプの変更"
+
 
 #: js/blocks/ExtrasBlocks.js:858
 #: js/blocks/ExtrasBlocks.js:870
@@ -9307,128 +11039,156 @@ msgstr "表示グリッド ブロックのグリッド タイプの変更"
 msgid "debugger"
 msgstr "デバッガ"
 
+
 #: js/blocks/ExtrasBlocks.js:861
 msgid "The Debug block adds a debug point in your code. When reached, execution will pause and you can inspect variables."
 msgstr "「デバッガ」ブロックは、コードにデバッグ ポイントを追加します。到達すると、実行が一時停止され、変数を検査できるようになります。"
 
+
 #: js/blocks/PitchBlocks.js:677
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr "ピッチ番号をピッチとオクターヴにマッピングするためのオフセットを設定するために使われるブロックです。"
+
 
 #: js/blocks/MediaBlocks.js:45
 #: js/blocks/MediaBlocks.js:56
 msgid "The Right block returns the position of the right of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの右のｘざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
+
 #: js/blocks/MediaBlocks.js:47
 #: js/blocks/MediaBlocks.js:123
 msgid "In this example, the mouse moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
 msgstr "この例では、マウスはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。"
+
 
 #: js/blocks/MediaBlocks.js:58
 #: js/blocks/MediaBlocks.js:134
 msgid "In this example, the turtle moves right until it reaches the right edge of the canvas; then it reappears at the left of the canvas."
 msgstr "この例では、タートルはキャンバスの右端に到達するまで右に移動します。その後、キャンバスの左側に再び表示されます。"
 
+
 #: js/blocks/MediaBlocks.js:121
 #: js/blocks/MediaBlocks.js:132
 msgid "The Left block returns the position of the left of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの左のｘざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上））、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
+
 
 #: js/blocks/MediaBlocks.js:196
 #: js/blocks/MediaBlocks.js:207
 msgid "The Top block returns the position of the top of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの上のｙざひょうち。プラスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、上（y座標）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
+
 #: js/blocks/MediaBlocks.js:198
 #: js/blocks/MediaBlocks.js:273
 msgid "In this example, the mouse moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
 msgstr "この例では、マウスはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。"
+
 
 #: js/blocks/MediaBlocks.js:209
 #: js/blocks/MediaBlocks.js:284
 msgid "In this example, the turtle moves upward until it reaches the top edge of the canvas; then it reappears at the bottom of the canvas."
 msgstr "この例では、タートルはキャンバスの上端に到達するまで上向きに移動します。その後、キャンバスの下部に再び表示されます。"
 
+
 #: js/blocks/MediaBlocks.js:271
 #: js/blocks/MediaBlocks.js:282
 msgid "The Bottom block returns the position of the bottom of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスの下のｙざひょうち。マイナスのすうち。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
+
 #: js/blocks/PitchBlocks.js:753
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr "Number to octaveブロックはピッチ番号をオクターヴに変換します。"
+
 
 #: js/blocks/MediaBlocks.js:347
 msgid "The Width block returns the width of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
+
 #: js/blocks/MediaBlocks.js:404
 msgid "The Height block returns the height of the canvas."
 msgstr "<h2>すうちブロック（カンバス）</h2><br>カンバスのたてはばのすうちを表す。カンバスのじょうほうを持つすうちブロックは、カンバスのたてはば、よこはば、ざひょうち（上）、ざひょうち（下）、ざひょうち（左）、ざひょうち（右）などの６種類がある。"
 
+
 #: js/blocks/MediaBlocks.js:453
-#.TRANS: stops playback of an audio recording
+#. TRANS: stops playback of an audio recording
 msgid "stop play"
 msgstr "再生を停止"
 
+
 #: js/blocks/MediaBlocks.js:488
-#.TRANS: Erases the images and text
+#. TRANS: Erases the images and text
 msgid "erase media"
 msgstr "メディアを消す"
+
 
 #: js/blocks/MediaBlocks.js:493
 msgid "The Erase Media block erases text and images."
 msgstr "「メディアを消す」のブロックは文字と画像を消します。"
 
+
 #: js/blocks/MediaBlocks.js:523
-#.TRANS: play an audio recording
+#. TRANS: play an audio recording
 msgid "play back"
 msgstr "プレーバック"
+
 
 #: js/blocks/MediaBlocks.js:571
 msgid "speak"
 msgstr "しゃべる"
 
+
 #: js/blocks/MediaBlocks.js:579
 msgid "The Speak block outputs to the text-to-speech synthesizer"
 msgstr "<h2>音声ブロック</h2><br>打ち込んだ文字を、機械音声で読み上げる。"
+
 
 #: js/blocks/MediaBlocks.js:630
 msgid "camera"
 msgstr "カメラ"
 
+
 #: js/blocks/MediaBlocks.js:635
 msgid "The Camera block connects a webcam to the Show block."
 msgstr "カメラブロックはウェブカメラをショウブロックに接続します。"
+
 
 #: js/blocks/MediaBlocks.js:658
 msgid "video"
 msgstr "ビデオ"
 
+
 #: js/blocks/MediaBlocks.js:663
 msgid "The Video block selects video for use with the Show block."
 msgstr "ビデオブロックはショウブロックで使用するビデオを選択します。"
+
 
 #: js/blocks/MediaBlocks.js:691
 msgid "The Open file block opens a file for use with the Show block."
 msgstr "オープンファイルブロックはショウブロックで使用するファイルを開きます。"
 
+
 #: js/blocks/MediaBlocks.js:728
 msgid "stop media"
 msgstr "メデイアを停止"
+
 
 #: js/blocks/MediaBlocks.js:733
 msgid "The Stop media block stops audio or video playback."
 msgstr "ストップメディアブロックは音声または動画の再生を停止します。"
 
+
 #: js/blocks/MediaBlocks.js:762
 #: js/blocks/PitchBlocks.js:1633
 #: js/widgets/phrasemaker.js:1287
 #: js/widgets/musickeyboard.js:2219
-#.TRANS: a measure of frequency: one cycle per second
+#. TRANS: a measure of frequency: one cycle per second
 msgid "hertz"
 msgstr "ヘルツ"
+
 
 #: js/blocks/MediaBlocks.js:775
 #: js/blocks/WidgetBlocks.js:250
@@ -9441,27 +11201,32 @@ msgstr "ヘルツ"
 msgid "frequency"
 msgstr "周波数"
 
+
 #: js/blocks/MediaBlocks.js:775
 #: plugins/rodi.rtp:193
 msgid "duration (MS)"
 msgstr "継続時間（ミリ秒）"
 
+
 #: js/blocks/MediaBlocks.js:811
-#.TRANS: translate a note into hertz, e.g., A4 -> 440HZ
+#. TRANS: translate a note into hertz, e.g., A4 -> 440HZ
 msgid "note to frequency"
 msgstr "音符の高さを周波数表示へ"
+
 
 #: js/blocks/MediaBlocks.js:819
 msgid "The To frequency block converts a pitch name and octave to Hertz."
 msgstr "トゥーフリクエンシーブロックは音名とオクターブをヘルツに変換します。"
 
+
 #: js/blocks/MediaBlocks.js:829
 #: js/blocks/PitchBlocks.js:695
 #: js/blocks/PitchBlocks.js:1001
 #: js/blocks/PitchBlocks.js:1960
-#.TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
+#. TRANS: name2 is name as in name of pitch (JAPANESE ONLY)
 msgid "name2"
 msgstr "名前"
+
 
 #: js/blocks/MediaBlocks.js:829
 #: js/blocks/IntervalsBlocks.js:63
@@ -9475,185 +11240,228 @@ msgstr "名前"
 #: js/blocks/PitchBlocks.js:1960
 #: js/blocks/ToneBlocks.js:1058
 #: js/turtleactions/IntervalsActions.js:157
-#.TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
+#. TRANS: adjusts the shift up or down by one octave (twelve half-steps in the interval between two notes, one having twice or half the frequency in Hz of the other.)
 msgid "octave"
 msgstr "オクターヴの高さ"
+
 
 #: js/blocks/MediaBlocks.js:895
 msgid "The Avatar block is used to change the appearance of the mouse."
 msgstr "アバターブロックはマウスの外見を変更するために使われます。"
 
+
 #: js/blocks/MediaBlocks.js:902
 msgid "The Avatar block is used to change the appearance of the turtle."
 msgstr "アバターブロックはタートルの外見を変更するために使われます。"
 
+
 #: js/blocks/MediaBlocks.js:914
 #: js/blocks/MediaBlocks.js:974
-#.TRANS: a media object
+#. TRANS: a media object
 msgid "size"
 msgstr "大きさ"
+
 
 #: js/blocks/MediaBlocks.js:914
 msgid "image"
 msgstr "がぞうそざい"
 
+
 #: js/blocks/MediaBlocks.js:963
 msgid "The Show block is used to display text or images on the canvas."
 msgstr "<h2>表示ブロック（スタンプ）</h2><br>スタンプは、実行するとネズミの位置に指定した文字またはがぞうを表示する。ネズミの体の下に表れるので、小さい文字やがぞうだとネズミが移動しないと見えない場合がある。"
 
+
 #: js/blocks/MediaBlocks.js:971
-#.TRANS: show1 is show as in display an image or text on the screen.
+#. TRANS: show1 is show as in display an image or text on the screen.
 msgid "show1"
 msgstr "スタンプ"
+
 
 #: js/blocks/PitchBlocks.js:1065
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr "Registerブロックは後に続く音符のオクターヴ（レジスター）を簡単に変更する方法を提供します。"
 
+
 #: js/blocks/MediaBlocks.js:974
 msgid "obj"
 msgstr "そざい"
+
 
 #: js/blocks/MediaBlocks.js:1021
 msgid "The Media block is used to import an image."
 msgstr "<h2>がぞうブロック</h2><br>がぞうのブロック。ブロックのマークをおすと、コンピューター上からがぞうファイルを読み込むことができる。"
 
+
 #: js/blocks/MediaBlocks.js:1057
 msgid "The Text block holds a text string."
 msgstr "<h2>文字ブロック</h2><br>文字を指定するブロック。"
+
 
 #: js/blocks/NumberBlocks.js:164
 msgid "The Int block returns an integer."
 msgstr "Intブロックは整数を返します。"
 
+
 #: js/blocks/NumberBlocks.js:167
 msgid "int"
 msgstr "整数に"
+
 
 #: js/blocks/NumberBlocks.js:196
 msgid "The Mod block returns the remainder from a division."
 msgstr "Modブロックは割り算の余りを返します。"
 
+
 #: js/blocks/NumberBlocks.js:202
 msgid "mod"
 msgstr "～で割った余り（mod）"
+
 
 #: js/blocks/NumberBlocks.js:242
 msgid "The Power block calculates a power function."
 msgstr "Powerブロックはべき乗を計算します。"
 
+
 #: js/blocks/NumberBlocks.js:289
 msgid "The Sqrt block returns the square root."
 msgstr "Sqrtブロックは平方根を返します。"
+
 
 #: js/blocks/NumberBlocks.js:292
 msgid "sqrt"
 msgstr "平方根"
 
+
 #: js/blocks/NumberBlocks.js:330
 msgid "The Abs block returns the absolute value."
 msgstr "Absブロックは絶対値を返します。"
+
 
 #: js/blocks/NumberBlocks.js:336
 msgid "abs"
 msgstr "絶対値"
 
+
 #: js/blocks/NumberBlocks.js:367
 msgid "The Distance block returns the distance between two points. For example, between the mouse and the center of the screen."
 msgstr "Distanceブロックは2点間の距離を返します。例えば、マウスと画面中央の距離です。"
+
 
 #: js/blocks/NumberBlocks.js:375
 #: plugins/rodi.rtp:310
 msgid "distance"
 msgstr "距離"
 
+
 #: js/blocks/NumberBlocks.js:427
 msgid "The Divide block is used to divide."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちの割り算した計算結果を表すすうちブロック。上につないだすうちを、下につないだすうちで割る。"
+
 
 #: js/blocks/NumberBlocks.js:487
 msgid "The Multiply block is used to multiply."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちを掛け合わせた計算結果を表すすうちブロック。"
 
+
 #: js/blocks/NumberBlocks.js:613
 msgid "The Minus block is used to subtract."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちの引き算した計算結果を表すすうちブロック。上につないだすうちから、下につないだすうちを引く。"
+
 
 #: js/blocks/NumberBlocks.js:699
 msgid "The Plus block is used to add."
 msgstr "<h2>すうちブロック（計算）</h2><br>２つのすうちを足し合わせた計算結果を表すすうちブロック。"
 
+
 #: js/blocks/NumberBlocks.js:814
 msgid "The One-of block returns one of two choices."
 msgstr "<h2>特殊ブロック（ランダム）</h2><br>つないだ２つのブロックのうち、1つだけをランダムに選ぶ。「すうち」「アクション名」など、さまざまなブロックをつなぐことができる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。"
+
 
 #: js/blocks/NumberBlocks.js:821
 #: js/blocks/PitchBlocks.js:653
 msgid "one of"
 msgstr "どちらかランダム"
 
+
 #: js/blocks/NumberBlocks.js:823
 msgid "this"
 msgstr "これか"
+
 
 #: js/blocks/NumberBlocks.js:823
 msgid "that"
 msgstr "それか"
 
+
 #: js/blocks/NumberBlocks.js:878
 msgid "The Random block returns a random number."
 msgstr "<h2>すうちブロック（ランダム）</h2><br>指定したさいしょうちからさいだいちまでのはんいで、ランダムなすうちになる。<br><br>★ランダムとは<br>サイコロの目のように、何が出るか分からないすうちのこと。ランダム（random）は日本語で「らんすう」「でたらめな」という意味。ランダムを使うと、実行のたびにえんそう順じょが変わる曲などを作ることができる。"
+
 
 #: js/blocks/NumberBlocks.js:885
 msgid "random"
 msgstr "ランダム"
 
+
 #: js/blocks/NumberBlocks.js:887
 msgid "min"
 msgstr "さいしょうち"
+
 
 #: js/blocks/NumberBlocks.js:887
 msgid "max"
 msgstr "さいだいち"
 
+
 #: js/blocks/NumberBlocks.js:933
 msgid "The Number block holds a number."
 msgstr "<h2>すうちブロック</h2><br>すうちを指定するブロック。"
+
 
 #: js/blocks/PenBlocks.js:30
 msgid "purple"
 msgstr "紫"
 
+
 #: js/blocks/PenBlocks.js:80
 msgid "yellow"
 msgstr "黄色"
+
 
 #: js/blocks/PenBlocks.js:96
 #: plugins/nutrition.rtp:164
 msgid "orange"
 msgstr "オレンジ"
 
+
 #: js/blocks/PenBlocks.js:128
 msgid "white"
 msgstr "白"
+
 
 #: js/blocks/PenBlocks.js:144
 msgid "black"
 msgstr "黒"
 
+
 #: js/blocks/PenBlocks.js:163
 msgid "begin fill"
 msgstr "記入を始める"
+
 
 #: js/blocks/PenBlocks.js:190
 msgid "end fill"
 msgstr "記入を終わらせる"
 
+
 #: js/blocks/PenBlocks.js:212
 #: js/blocks/PenBlocks.js:561
-#.TRANS: set the background color
+#. TRANS: set the background color
 msgid "background"
 msgstr "背景"
+
 
 #: js/blocks/PenBlocks.js:259
 #: js/turtleactions/DictActions.js:71
@@ -9662,9 +11470,11 @@ msgstr "背景"
 msgid "grey"
 msgstr "灰色"
 
+
 #: js/blocks/PenBlocks.js:267
 msgid "The Grey block returns the current pen grey value."
 msgstr "グレーブロックは現在のペンのグレー値を返します。"
+
 
 #: js/blocks/PenBlocks.js:329
 #: js/turtleactions/DictActions.js:69
@@ -9673,9 +11483,11 @@ msgstr "グレーブロックは現在のペンのグレー値を返します。
 msgid "shade"
 msgstr "シェード"
 
+
 #: js/blocks/PenBlocks.js:336
 msgid "The Shade block returns the current pen shade value."
 msgstr "シェードブロックは現在のペンのシェード値を返します。"
+
 
 #: js/blocks/PenBlocks.js:398
 #: js/turtleactions/DictActions.js:67
@@ -9684,9 +11496,11 @@ msgstr "シェードブロックは現在のペンのシェード値を返しま
 msgid "color"
 msgstr "いろ"
 
+
 #: js/blocks/PenBlocks.js:408
 msgid "The Color block returns the current pen color."
 msgstr "<h2>ペンブロック</h2><br>げんざいのペンの色を、すうちでひょうじする。"
+
 
 #: js/blocks/PenBlocks.js:467
 #: js/turtleactions/DictActions.js:73
@@ -9695,184 +11509,227 @@ msgstr "<h2>ペンブロック</h2><br>げんざいのペンの色を、すう�
 msgid "pen size"
 msgstr "ペンの大きさ"
 
+
 #: js/blocks/PenBlocks.js:471
 msgid "The Pen size block returns the current pen size value."
 msgstr "ペンサイズブロックは現在のペンのサイズ値を返します。"
+
 
 #: js/blocks/PenBlocks.js:514
 msgid "set font"
 msgstr "フォントの設定"
 
+
 #: js/blocks/PenBlocks.js:519
 msgid "The Set font block sets the font used by the Show block."
 msgstr "フォント設定ブロックはショウブロックで使われるフォントを設定します。"
+
 
 #: js/blocks/PenBlocks.js:568
 msgid "The Background block sets the window background color."
 msgstr "背景ブロックは、カンバスの色をせっていする。"
 
+
 #: js/blocks/PenBlocks.js:599
 msgid "The Hollow line block creates a line with a hollow center."
 msgstr "ホローラインブロックは中空の線を作成します。"
 
+
 #: js/blocks/PenBlocks.js:607
-#.TRANS: draw a line logo has a hollow space down its center
+#. TRANS: draw a line logo has a hollow space down its center
 msgid "hollow line"
 msgstr "（中空の）線"
+
 
 #: js/blocks/PitchBlocks.js:1747
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr "1から始まり、音階の枠組みに関係なく（つまりオクターヴが常に8音とは限らない）"
 
+
 #: js/blocks/PenBlocks.js:676
 msgid "The Fill block fills in a shape with a color."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがいた図形の内がわをぬりつぶす。"
 
+
 #: js/blocks/PenBlocks.js:685
-#.TRANS: fill in as a solid color
+#. TRANS: fill in as a solid color
 msgid "fill"
 msgstr "ぬりつぶす"
 
+
 #: js/blocks/PenBlocks.js:762
-#.TRANS: raise up the pen so logo it does not draw when it is moved
+#. TRANS: raise up the pen so logo it does not draw when it is moved
 msgid "pen up"
 msgstr "ペンを上げる"
+
 
 #: js/blocks/PenBlocks.js:769
 msgid "The Pen-up block raises the pen so that it does not draw."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがくことをやめる。"
 
+
 #: js/blocks/PenBlocks.js:803
-#.TRANS: put down the pen so logo it draws when it is moved
+#. TRANS: put down the pen so logo it draws when it is moved
 msgid "pen down"
 msgstr "ペンを下ろす"
+
 
 #: js/blocks/PenBlocks.js:811
 msgid "The Pen-down block lowers the pen so that it draws."
 msgstr "<h2>ペンブロック</h2><br>ネズミの動きに合わせて線をえがく。"
 
+
 #: js/blocks/PenBlocks.js:845
-#.TRANS: set the width of the line drawn by the pen
+#. TRANS: set the width of the line drawn by the pen
 msgid "set pen size"
 msgstr "太さをせってい"
+
 
 #: js/blocks/PenBlocks.js:855
 msgid "The Set-pen-size block changes the size of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の太さをせっていする。太さには、0より大きいあたいを使う。"
 
+
 #: js/blocks/PitchBlocks.js:1839
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr "スケールディグリー1は、オクターヴに関係なく常に与えられたスケールの最初の音です。"
 
+
 #: js/blocks/PenBlocks.js:914
-#.TRANS: set degree of translucence of the pen color
+#. TRANS: set degree of translucence of the pen color
 msgid "set translucency"
 msgstr "透明度を設定"
+
 
 #: js/blocks/PenBlocks.js:922
 msgid "The Set translucency block changes the opacity of the pen."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線がどのくらいすきとおるかをせっていする。すうちが大きいほど、線がすきとおる。"
 
+
 #: js/blocks/PenBlocks.js:982
 msgid "set hue"
 msgstr "色相を設定"
+
 
 #: js/blocks/PenBlocks.js:990
 msgid "The Set hue block changes the color of the pen."
 msgstr "色相設定ブロックはペンの色を変更します。"
 
+
 #: js/blocks/PenBlocks.js:1048
 msgid "set shade"
 msgstr "色のこさをせってい"
+
 
 #: js/blocks/PenBlocks.js:1058
 msgid "The Set-shade block changes the pen color from dark to light."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の色のこさをせっていする。"
 
+
 #: js/blocks/PenBlocks.js:1112
-#.TRANS: set the level of vividness of the pen color
+#. TRANS: set the level of vividness of the pen color
 msgid "set grey"
 msgstr "灰色を設定"
+
 
 #: js/blocks/PenBlocks.js:1120
 msgid "The Set grey block changes the vividness of the pen color."
 msgstr "グレー設定ブロックはペンの色の鮮やかさを変更します。"
 
+
 #: js/blocks/PenBlocks.js:1173
 msgid "set color"
 msgstr "色をせってい"
+
 
 #: js/blocks/PenBlocks.js:1183
 msgid "The Set-color block changes the pen color."
 msgstr "<h2>ペンブロック</h2><br>ネズミがえがく線の色をせっていする。色は画面上で選ぶほか、それぞれすうちで決めることもできる。色は、0以上で、100より小さいあたいになる。"
 
+
 #: js/blocks/ProgramBlocks.js:33
 msgid "The Load-heap-from-app block loads the heap from a web page."
 msgstr "Load-heap-from-appブロックはウェブページからヒープを読み込みます。"
 
+
 #: js/blocks/ProgramBlocks.js:44
-#.TRANS: load the heap contents from a URL
+#. TRANS: load the heap contents from a URL
 msgid "load heap from App"
 msgstr "アプリからヒープをロード"
+
 
 #: js/blocks/ProgramBlocks.js:94
 msgid "404: Page not found"
 msgstr "４０４エラー：ページが見つかりません。"
 
+
 #: js/blocks/ProgramBlocks.js:106
 msgid "Error parsing JSON data:"
 msgstr "JSON データの構文エラーです。"
+
 
 #: js/blocks/ProgramBlocks.js:129
 msgid "The Save-heap-to-app block saves the heap to a web page."
 msgstr "Save-heap-to-appブロックはヒープをウェブページに保存します。"
 
+
 #: js/blocks/ProgramBlocks.js:140
-#.TRANS: save the heap contents to a URL
+#. TRANS: save the heap contents to a URL
 msgid "save heap to App"
 msgstr "アプリにヒープを保存"
+
 
 #: js/blocks/ProgramBlocks.js:190
 msgid "Cannot find a valid heap for"
 msgstr "正しいヒープが見つかりません。"
 
+
 #: js/blocks/ProgramBlocks.js:207
 msgid "The Load-heap block loads the heap from a file."
 msgstr "Load-heapブロックはファイルからヒープを読み込みます。"
 
+
 #: js/blocks/ProgramBlocks.js:218
-#.TRANS: load the heap from a file
+#. TRANS: load the heap from a file
 msgid "load heap"
 msgstr "ヒープをロードする"
+
 
 #: js/blocks/ProgramBlocks.js:271
 msgid "The file you selected does not contain a valid heap."
 msgstr "選んだファイルには、正しいヒープが含まれません。"
 
+
 #: js/blocks/ProgramBlocks.js:277
 msgid "The loadHeap block needs a loadFile block."
 msgstr "ロードヒープのブロックには、ロードファイルブロックが必要です。"
+
 
 #: js/blocks/ProgramBlocks.js:293
 msgid "The Set-heap block loads the heap."
 msgstr "Set-heapブロックはヒープを読み込みます。"
 
+
 #: js/blocks/ProgramBlocks.js:343
 msgid "The block you selected does not contain a valid heap."
 msgstr "選択したブロックには有効なヒープが含まれていません。"
+
 
 #: js/blocks/ProgramBlocks.js:348
 msgid "The Set heap block needs a heap."
 msgstr "Set heapブロックにはヒープが必要です。"
 
+
 #: js/blocks/ProgramBlocks.js:365
 msgid "The Load-dictionary block loads a dictionary from a file."
 msgstr "Load-dictionaryブロックはファイルから辞書を読み込みます。"
 
+
 #: js/blocks/ProgramBlocks.js:376
-#.TRANS: load a dictionary from a file
+#. TRANS: load a dictionary from a file
 msgid "load dictionary"
 msgstr "辞書をロード"
+
 
 #: js/blocks/ProgramBlocks.js:394
 #: js/blocks/ProgramBlocks.js:664
@@ -9880,114 +11737,140 @@ msgstr "辞書をロード"
 msgid "file"
 msgstr "ファイル"
 
+
 #: js/blocks/ProgramBlocks.js:448
 msgid "The file you selected does not contain a valid dictionary."
 msgstr "選択したファイルには有効な辞書が含まれていません。"
+
 
 #: js/blocks/ProgramBlocks.js:454
 msgid "The load dictionary block needs a load file block."
 msgstr "load dictionaryブロックにはload fileブロックが必要です。"
 
+
 #: js/blocks/ProgramBlocks.js:471
 msgid "The Set-dictionary block loads a dictionary."
 msgstr "Set-dictionaryブロックは辞書を読み込みます。"
 
+
 #: js/blocks/ProgramBlocks.js:482
-#.TRANS: load a dictionary from a JSON
+#. TRANS: load a dictionary from a JSON
 msgid "set dictionary"
 msgstr "辞書を設定"
+
 
 #: js/blocks/ProgramBlocks.js:551
 msgid "The block you selected does not contain a valid dictionary."
 msgstr "選択したブロックには有効な辞書が含まれていません。"
 
+
 #: js/blocks/ProgramBlocks.js:556
 msgid "The set dictionary block needs a dictionary."
 msgstr "set dictionaryブロックには辞書が必要です。"
+
 
 #: js/blocks/ProgramBlocks.js:573
 msgid "The Save-heap block saves the heap to a file."
 msgstr "Save-heapブロックはヒープをファイルに保存します。"
 
+
 #: js/blocks/ProgramBlocks.js:584
-#.TRANS: save the heap to a file
+#. TRANS: save the heap to a file
 msgid "save heap"
 msgstr "ヒープを保存する"
+
 
 #: js/blocks/ProgramBlocks.js:635
 msgid "The Save-dictionary block saves a dictionary to a file."
 msgstr "Save-dictionaryブロックは辞書をファイルに保存します。"
 
+
 #: js/blocks/ProgramBlocks.js:646
-#.TRANS: save a dictionary to a file
+#. TRANS: save a dictionary to a file
 msgid "save dictionary"
 msgstr "辞書を保存"
+
 
 #: js/blocks/ProgramBlocks.js:734
 msgid "The Open palette block opens a palette."
 msgstr "Open paletteブロックはパレットを開きます。"
 
+
 #: js/blocks/ProgramBlocks.js:741
 msgid "open palette"
 msgstr "パレットを開きます"
+
 
 #: js/blocks/ProgramBlocks.js:799
 msgid "The Delete block block removes a block."
 msgstr "Delete blockブロックはブロックを削除します。"
 
+
 #: js/blocks/ProgramBlocks.js:811
-#.TRANS: Move this block to the trash.
+#. TRANS: Move this block to the trash.
 msgid "delete block"
 msgstr "ブロックを消す"
+
 
 #: js/blocks/ProgramBlocks.js:875
 msgid "The Move block block moves a block."
 msgstr "Move blockブロックはブロックを移動します。"
 
+
 #: js/blocks/ProgramBlocks.js:883
-#.TRANS: Move the position of a block on the screen.
+#. TRANS: Move the position of a block on the screen.
 msgid "move block"
 msgstr "ブロックを動かす"
+
 
 #: js/blocks/ProgramBlocks.js:895
 #: js/blocks/ProgramBlocks.js:1058
 msgid "block number"
 msgstr "ブロックの番号"
 
+
 #: js/blocks/ProgramBlocks.js:936
 msgid "The Run block block runs a block. It accepts two types of arguments: block number or block name."
 msgstr "「ブロックを再生」ブロックはブロックを実行します。ブロック番号またはブロック名の 2 種類の引数を受け入れます。"
 
+
 #: js/blocks/ProgramBlocks.js:949
-#.TRANS: Run program beginning at this block.
+#. TRANS: Run program beginning at this block.
 msgid "run block"
 msgstr "ブロックを再生"
+
 
 #: js/blocks/ProgramBlocks.js:1038
 msgid "The Dock block connects two blocks."
 msgstr "Dock blockブロックは2つのブロックを接続します。"
 
+
 #: js/blocks/ProgramBlocks.js:1046
-#.TRANS: We can connect a block to another block.
+#. TRANS: We can connect a block to another block.
 msgid "connect blocks"
 msgstr "ブロックを繋ぐ"
+
 
 #: js/blocks/ProgramBlocks.js:1058
 msgid "target block"
 msgstr "目標のブロック"
 
+
 #: js/blocks/ProgramBlocks.js:1058
 msgid "connection number"
 msgstr "接続の番号"
+
 
 #: js/blocks/ProgramBlocks.js:1146
 msgid "The Make block block creates a new block."
 msgstr "Make blockブロックは新しいブロックを作成します。"
 
+
 #: js/blocks/ProgramBlocks.js:1158
-#.TRANS: Create a new block
+#. TRANS: Create a new block
 msgid "make block"
 msgstr "ブロックを作る"
+
 
 #: js/blocks/ProgramBlocks.js:1192
 #: js/blocks/ProgramBlocks.js:1233
@@ -10000,17 +11883,20 @@ msgstr "ブロックを作る"
 #: js/widgets/temperament.js:586
 #: js/widgets/temperament.js:800
 #: plugins/rodi.rtp:192
-#.TRANS: a musical note consisting of pitch and duration
+#. TRANS: a musical note consisting of pitch and duration
 msgid "note"
 msgstr "音符"
+
 
 #: js/blocks/ProgramBlocks.js:1328
 msgid "instrument"
 msgstr "楽器"
 
+
 #: js/blocks/ProgramBlocks.js:1342
 msgid "Cannot find block"
 msgstr "ブロックが見つかりません"
+
 
 #: js/blocks/ProgramBlocks.js:1361
 #: js/blocks/ProgramBlocks.js:1370
@@ -10018,17 +11904,21 @@ msgstr "ブロックが見つかりません"
 msgid "Warning: block argument type mismatch"
 msgstr "注意：ブロックとタイプが合っていません。"
 
+
 #: js/blocks/ProgramBlocks.js:1387
 msgid "Warning: block argument type unhandled:"
 msgstr "警告: ブロック引数の型が処理されません:"
+
 
 #: js/blocks/ProgramBlocks.js:1420
 msgid "The Open project block is used to open a project from a web page."
 msgstr "Open projectブロックはウェブページからプロジェクトを開くために使われます。"
 
+
 #: js/blocks/ProgramBlocks.js:1430
 msgid "open project"
 msgstr "プロジェクトを開く"
+
 
 #: js/blocks/ProgramBlocks.js:1482
 #: js/blocks/ProgramBlocks.js:1495
@@ -10036,89 +11926,107 @@ msgstr "プロジェクトを開く"
 msgid "Please enter a valid project URL (for example: /index.html?id=123&run=true)."
 msgstr "有効なプロジェクト URL (例: /index.html?id=123&run=true) を入力してください。"
 
+
 #: js/blocks/ProgramBlocks.js:1522
 msgid "Only Music Blocks project links are allowed (same site, musicblocks.sugarlabs.org, musicblocks.net)."
 msgstr "ミュージック・ブロックス プロジェクトのリンクのみが許可されます (同じサイト、musicblocks.sugarlabs.org、musicblocks.net)。"
+
 
 #: js/blocks/ProgramBlocks.js:1532
 msgid "Please allow popups for this site"
 msgstr "このサイトのポップアップを許可してください"
 
+
 #: js/blocks/WidgetBlocks.js:149
 #: js/widgets/timbre.js:905
-#.TRANS: sound envelope (ADSR)
+#. TRANS: sound envelope (ADSR)
 msgid "Envelope"
 msgstr "エンベロープ"
 
+
 #: js/blocks/WidgetBlocks.js:157
-#.TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
+#. TRANS: Attack time is the time taken for initial run-up of level from nil to peak, beginning when the key is first pressed.
 msgid "attack"
 msgstr "アタック"
 
+
 #: js/blocks/WidgetBlocks.js:159
-#.TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
+#. TRANS: Decay time is the time taken for the subsequent run down from the attack level to the designated sustain level.
 msgid "decay"
 msgstr "ディケイ"
 
+
 #: js/blocks/WidgetBlocks.js:161
-#.TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
+#. TRANS: Sustain level is the level during the main sequence of the sound's duration, until the key is released.
 msgid "sustain"
 msgstr "サステイン"
 
+
 #: js/blocks/WidgetBlocks.js:163
-#.TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
+#. TRANS: Release time is the time taken for the level to decay from the sustain level to zero after the key is released.
 msgid "release"
 msgstr "リリース"
+
 
 #: js/blocks/WidgetBlocks.js:181
 msgid "Attack value should be from 0 to 100."
 msgstr "アタック値には 0 以上100以下の数字をいれて下さい。"
 
+
 #: js/blocks/WidgetBlocks.js:184
 msgid "Decay value should be from 0 to 100."
 msgstr "減衰値には 0 以上100以下の数字をいれて下さい。"
+
 
 #: js/blocks/WidgetBlocks.js:187
 msgid "Sustain value should be from 0 to 100."
 msgstr "サステイン値には 0 以上100以下の数字をいれて下さい。"
 
+
 #: js/blocks/WidgetBlocks.js:190
 msgid "Release value should be from 0-100."
 msgstr "リリース値には 0 以上100以下の数字をいれて下さい。"
+
 
 #: js/blocks/WidgetBlocks.js:208
 msgid "You are adding multiple envelope blocks."
 msgstr "封筒ブロックを複数追加しています。"
 
+
 #: js/blocks/WidgetBlocks.js:239
 #: js/widgets/timbre.js:961
-#.TRANS: a filter removes some unwanted components from a signal
+#. TRANS: a filter removes some unwanted components from a signal
 msgid "Filter"
 msgstr "フィルター"
+
 
 #: js/blocks/WidgetBlocks.js:247
 #: js/blocks/ToneBlocks.js:42
 #: js/widgets/timbre.js:1656
 #: js/widgets/timbre.js:1908
-#.TRANS: type of filter, e.g., lowpass, highpass, etc.
-#.TRANS: there are different types (sine, triangle, square...) of oscillators.
+#. TRANS: type of filter, e.g., lowpass, highpass, etc.
+#. TRANS: there are different types (sine, triangle, square...) of oscillators.
 msgid "type"
 msgstr "種類"
 
+
 #: js/blocks/WidgetBlocks.js:249
 #: js/widgets/timbre.js:1932
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "rolloff"
 msgstr "ロールオフ"
 
+
 #: js/blocks/WidgetBlocks.js:281
-#.TRANS: rolloff is the steepness of a change in frequency.
+#. TRANS: rolloff is the steepness of a change in frequency.
 msgid "Rolloff value should be either -12, -24, -48, or -96 decibels/octave."
 msgstr "ロールオフ値は -12, -24, -48, -98 デシベル / オクターヴである必要があります。"
+
 
 #: js/blocks/WidgetBlocks.js:321
 msgid "The Temperament tool is used to define custom tuning."
 msgstr "Temperamentツールはカスタムチューニングを定義するために使用されます。"
+
 
 #: js/blocks/WidgetBlocks.js:411
 #: js/blocks/WidgetBlocks.js:1936
@@ -10126,424 +12034,522 @@ msgstr "Temperamentツールはカスタムチューニングを定義するた�
 msgid "Upload a sample and adjust its pitch center."
 msgstr "サンプルをアップロードしてピッチセンターを調整します。"
 
+
 #: js/blocks/WidgetBlocks.js:418
-#.TRANS: the speed at music is should be played.
+#. TRANS: the speed at music is should be played.
 msgid "sampler"
 msgstr "サンプラー"
+
 
 #: js/blocks/WidgetBlocks.js:611
 msgid "The Meter block opens a tool to select strong beats for the meter."
 msgstr "<h2>拍子ブロック</h2><br>テーブルの数字をクリックして、強い拍（はく）の位置を決める。<br>★拍子（ひょうし）とは<br>拍（はく）がいくつかまとまったもの。<br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
+
 #: js/blocks/WidgetBlocks.js:673
 msgid "The oscilloscope block opens a tool to visualize waveforms."
 msgstr "Oscilloscopeブロックは波形を可視化するツールを開きます。"
+
 
 #: js/blocks/WidgetBlocks.js:678
 msgid "oscilloscope"
 msgstr "オシロスコープ"
 
+
 #: js/blocks/WidgetBlocks.js:753
 msgid "The Custom mode block opens a tool to explore musical mode (the spacing of the notes in a scale)."
 msgstr "<h2>モード（音階）ブロック</h2><br>いろいろな音階をさがすツールを表示する。音階は、音と音のかんかくを決めながらさがすことができる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
+
 #: js/blocks/WidgetBlocks.js:761
-#.TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
+#. TRANS: musical mode is the pattern of half-steps in an octave, e.g., Major or Minor modes
 msgid "custom mode"
 msgstr "音階"
+
 
 #: js/blocks/WidgetBlocks.js:818
 msgid "The Tempo block opens a metronome to visualize the beat."
 msgstr "<h2>メトロノームブロック</h2><br>メトロノームを表示する。ボタンをおすと、メトロノームのはやさを変えられる。テーブルには、１分あたりの拍（はく）の数が表示される。<br><br>★拍（はく）とは<br>くり返されるリズムのこと。"
 
+
 #: js/blocks/WidgetBlocks.js:888
 msgid "The Arpeggio Widget is used to compose chord sequences."
 msgstr "「アルペジオ」ウィジェットは コード進行 を作るためです。"
+
 
 #: js/blocks/WidgetBlocks.js:894
 #: js/blocks/IntervalsBlocks.js:764
 msgid "arpeggio"
 msgstr "アルペジオ"
 
+
 #: js/blocks/WidgetBlocks.js:972
 msgid "The Pitch drum matrix is used to map pitches to drum sounds."
 msgstr "Pitch drumマトリックスはピッチをドラム音にマッピングするために使われます。"
 
+
 #: js/blocks/WidgetBlocks.js:977
-#.TRANS: makes a mapping between pitches and drum sounds
+#. TRANS: makes a mapping between pitches and drum sounds
 msgid "pitch-drum mapper"
 msgstr "音高-ドラム・マッパー"
+
 
 #: js/blocks/WidgetBlocks.js:1034
 msgid "You must have at least one pitch block and one drum block in the matrix."
 msgstr "フレーズメーカーブロックには、音の高さブロックとドラムブロックを最低1つずつ入れてください。"
 
+
 #: js/blocks/WidgetBlocks.js:1066
 msgid "The Pitch slider tool to is used to generate pitches at selected frequencies."
 msgstr "<h2>ヘルツスライダーブロック</h2><br>スライダーを上下にうごかすことで、違う周波数（ヘルツのすうち）の音を聞くことができる。作った音をデータ化することができる。また、ヘルツの初期せっていちは、自由に変えられる。<br><br>★ヘルツとは音の高さを表す周波数。<br>★周波数とは音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。"
 
+
 #: js/blocks/WidgetBlocks.js:1071
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "pitch slider"
 msgstr "ヘルツスライダー"
+
 
 #: js/blocks/WidgetBlocks.js:1131
 msgid "chromatic keyboard"
 msgstr "クロマティック・キーボード"
 
+
 #: js/blocks/WidgetBlocks.js:1165
 #: js/blocks/WidgetBlocks.js:1236
-#.TRANS: widget to generate pitches using a slider
+#. TRANS: widget to generate pitches using a slider
 msgid "music keyboard"
 msgstr "キーボード"
+
 
 #: js/blocks/WidgetBlocks.js:1217
 #: js/blocks/WidgetBlocks.js:1226
 msgid "The Music keyboard block opens a piano keyboard that can be used to create notes."
 msgstr "<h2>キーボードブロック</h2><br>ピアノのキーボードを表示する。作った音をデータ化することができる。<br><br> "
 
+
 #: js/blocks/WidgetBlocks.js:1296
 msgid "The Pitch staircase tool to is used to generate pitches from a given ratio."
 msgstr "Pitch staircaseツールは指定された比率からピッチを生成するために使用されます。"
 
+
 #: js/blocks/WidgetBlocks.js:1303
-#.TRANS: generate a progressive sequence of pitches
+#. TRANS: generate a progressive sequence of pitches
 msgid "pitch staircase"
 msgstr "音高の数列を作る"
+
 
 #: js/blocks/WidgetBlocks.js:1399
 msgid "The Rhythm Maker block opens a tool to create drum machines."
 msgstr "<h2>リズムメーカーブロック</h2><br>音の長さでぶんかつしてリズムを作るテーブルを表示する。作ったリズムをデータ化することができる。<br><br>"
 
+
 #: js/blocks/WidgetBlocks.js:1476
 msgid "G major scale"
 msgstr "Gメジャー"
+
 
 #: js/blocks/WidgetBlocks.js:1511
 msgid "C major scale"
 msgstr "Cメジャー"
 
+
 #: js/blocks/WidgetBlocks.js:1552
 msgid "The Phrase Maker block opens a tool to create musical phrases."
 msgstr "<h2>フレーズメーカーブロック</h2><br>フレーズを作るためのテーブルを表示する。作ったフレーズをデータ化することができる。<br><br>★フレーズとは<br>ひとまとまりの音楽。<br><br>"
 
+
 #: js/blocks/WidgetBlocks.js:1559
-#.TRANS: assigns pitch to a sequence of beats to generate a melody
+#. TRANS: assigns pitch to a sequence of beats to generate a melody
 msgid "phrase maker"
 msgstr "フレーズメーカー"
+
 
 #: js/blocks/WidgetBlocks.js:1621
 msgid "lyrics"
 msgstr "歌詞"
 
+
 #: js/blocks/WidgetBlocks.js:1717
 msgid "You must have at least one pitch block and one rhythm block in the matrix."
 msgstr "フレーズメーカーには、音の高さブロックと音符ブロックを組み合わせてください。"
+
 
 #: js/blocks/WidgetBlocks.js:1779
 msgid "The Status block opens a tool for inspecting the status of Music Blocks as it is running."
 msgstr "<h2>実行じょうきょうブロック</h2><br>ブロックの実行じょうきょうをけんさくするテーブルを表示する。<br>"
 
+
 #: js/blocks/WidgetBlocks.js:1943
 #: js/widgets/aiwidget.js:822
-#.TRANS: AI-generated music
+#. TRANS: AI-generated music
 msgid "AI Music"
 msgstr "AI音楽"
+
 
 #: js/blocks/WidgetBlocks.js:1996
 msgid "The Reflection block opens a space for you to think about your learning."
 msgstr "「振り返り」ブロックは、学習について考えるためのスペースを開きます。"
 
+
 #: js/blocks/WidgetBlocks.js:2001
 msgid "reflection"
 msgstr "「振り返り」"
+
 
 #: js/blocks/WidgetBlocks.js:2059
 msgid "The LEGO Bricks block opens a widget for designing virtual LEGO creations."
 msgstr "「レゴブロック」ブロックは、仮想 LEGO 作品をデザインするためのウィジェットを開きます。"
 
+
 #: js/blocks/WidgetBlocks.js:2066
-#.TRANS: LEGO bricks designer
+#. TRANS: LEGO bricks designer
 msgid "LEGO Bricks"
 msgstr "レゴブロック"
+
 
 #: js/blocks/WidgetBlocks.js:2125
 msgid "You must have at least one pitch block in the LEGO bricks widget."
 msgstr "「レゴブロック」ウィジェットには少なくとも 1つの「ピッチ」ブロックが必要です。"
 
+
 #: js/blocks/WidgetBlocks.js:2149
 msgid "Debug your music blocks project with new possibilities and more understanding."
 msgstr "新たな可能性と理解を深めて、ミュージック・ブロックス プロジェクトをデバッグします。"
+
 
 #: js/blocks/DrumBlocks.js:32
 msgid "noise name"
 msgstr "ノイズ名"
 
+
 #: js/blocks/DrumBlocks.js:62
 msgid "The Noise name block is used to select a noise synthesizer."
 msgstr "Noise nameブロックはノイズシンセサイザーを選択するために使われます。"
+
 
 #: js/blocks/DrumBlocks.js:78
 msgid "drum name"
 msgstr "ドラム名"
 
+
 #: js/blocks/DrumBlocks.js:108
 msgid "The Drum name block is used to select a drum."
 msgstr "<h2>ドラムブロック</h2><br>ドラムの種類を変えるときに使う。クリックで、いろいろなドラムの音を選ぶことができる。"
+
 
 #: js/blocks/DrumBlocks.js:125
 msgid "effects name"
 msgstr "エフェクト名"
 
+
 #: js/blocks/DrumBlocks.js:155
 msgid "The Effects name block is used to select a sound effect."
 msgstr "<h2>こうかおんブロック</h2><br>こうかおんの種類を変えるときに使う。クリックで、いろいろなおもしろい音を選ぶことができる。"
+
 
 #: js/blocks/DrumBlocks.js:172
 msgid "noise"
 msgstr "ノイズ"
 
+
 #: js/blocks/DrumBlocks.js:186
 msgid "The Play noise block will generate white, pink, or brown noise."
 msgstr "Play noiseブロックはホワイトノイズ、ピンクノイズ、またはブラウンノイズを生成します。"
+
 
 #: js/blocks/DrumBlocks.js:341
 msgid "Replace every instance of a pitch with a drum sound."
 msgstr "すべてのピッチをドラム音に置き換えます。"
 
+
 #: js/blocks/DrumBlocks.js:352
-#.TRANS: map a pitch to a drum sound
+#. TRANS: map a pitch to a drum sound
 msgid "map pitch to drum"
 msgstr "音符をドラムに変える"
+
 
 #: js/blocks/DrumBlocks.js:406
 #: js/blocks/DrumBlocks.js:415
 msgid "The Set drum block will select a drum sound to replace the pitch of any contained notes."
 msgstr "「ドラムをせってい」ブロックは、含まれているノートのピッチを置き換えるドラム サウンドを選択します。"
 
+
 #: js/blocks/DrumBlocks.js:419
 msgid "In the example above, a kick drum sound will be played instead of sol."
 msgstr "例の画像に<em>ソル</em>の代わりに<em>キックドラム</em>が鳴らします。"
 
+
 #: js/blocks/DrumBlocks.js:431
-#.TRANS: set the current drum sound for playback
+#. TRANS: set the current drum sound for playback
 msgid "set drum"
 msgstr "ドラムをせってい"
+
 
 #: js/blocks/DrumBlocks.js:475
 msgid "sound effect"
 msgstr "こうかおん"
 
+
 #: js/blocks/DrumBlocks.js:514
 msgid "You can use multiple Drum blocks within a Note block."
 msgstr "<h2>ドラムブロック</h2><br>「音符（おんぷ）ブロック」のなかに入れて使う。色々なドラムの音色を選ぶことができる。１つの「音符（おんぷ）ブロック」の中でふくすうの音色のドラムを組み合わせて使うことができる。"
+
 
 #: js/blocks/IntervalsBlocks.js:45
 msgid "set temperament"
 msgstr "音律をせってい"
 
+
 #: js/blocks/IntervalsBlocks.js:53
 msgid "The Set temperament block is used to choose the tuning system used by Music Blocks."
 msgstr "「音律をせってい」ブロックは、ミュージック・ブロックスで使用されるチューニング システムを選択するために使用されます。"
+
 
 #: js/blocks/IntervalsBlocks.js:94
 msgid "temperament name"
 msgstr "気質名"
 
+
 #: js/blocks/IntervalsBlocks.js:102
 msgid "The Temperament name block is used to select a tuning method."
 msgstr "<h2>音律（おんりつ）ブロック</h2><br>調律（ちょうりつ）のしかたをせっていする。<br>★音律（おんりつ）とは<br>音程（おんてい）（音どうしのへだたり）の決め方。同じ音階でも、音律（おんりつ）によって音の高さが変わる。<br>★調律（ちょうりつ）とは<br>楽器の音の高さを、音律（おんりつ）にしたがって整えること。"
+
 
 #: js/blocks/IntervalsBlocks.js:170
 msgid "doubly"
 msgstr "重"
 
+
 #: js/blocks/IntervalsBlocks.js:175
 msgid "The Doubly block will double the size of an interval."
 msgstr "Doublyブロックはインターバルのサイズを2倍にします。"
+
 
 #: js/blocks/IntervalsBlocks.js:274
 msgid "interval number"
 msgstr "音程を数で表示"
 
+
 #: js/blocks/IntervalsBlocks.js:279
 msgid "The Interval number block returns the number of scalar steps in the current interval."
 msgstr "「音程を数で表示」ブロックは、現在の音階の数値を返します。"
+
 
 #: js/blocks/IntervalsBlocks.js:332
 msgid "current interval"
 msgstr "現在の音階"
 
+
 #: js/blocks/IntervalsBlocks.js:337
 msgid "The Current interval block returns the name of scalar steps in the current interval."
 msgstr "「現在の音階」ブロックは、現在の音階の名前を返します。"
+
 
 #: js/blocks/IntervalsBlocks.js:395
 msgid "The Semi-tone interval block measures the distance between two notes in semi-tones."
 msgstr "「半音階的音程」ブロックは、2つの音符間の距離を半音単位で測定します。"
 
+
 #: js/blocks/IntervalsBlocks.js:403
-#.TRANS: measure the distance between two pitches in semi-tones
+#. TRANS: measure the distance between two pitches in semi-tones
 msgid "semi-tone interval measure"
 msgstr "半音階的音程で計る"
+
 
 #: js/blocks/IntervalsBlocks.js:474
 #: js/blocks/IntervalsBlocks.js:595
 msgid "You must use two pitch blocks when measuring an interval."
 msgstr "音程を計る際は、２つの音符を使う必要があります。"
 
+
 #: js/blocks/IntervalsBlocks.js:515
 msgid "The Scalar interval block measures the distance between two notes in the current key and mode."
 msgstr "「音階的な音程」ブロックは現在の調とモードで2つの音の距離を測定します。"
 
+
 #: js/blocks/IntervalsBlocks.js:523
-#.TRANS: measure the distance between two pitches in steps of musical scale
+#. TRANS: measure the distance between two pitches in steps of musical scale
 msgid "scalar interval measure"
 msgstr "全音階的音程で計る"
+
 
 #: js/blocks/IntervalsBlocks.js:698
 msgid "The Semi-tone interval block calculates a relative interval based on half steps."
 msgstr "「半音階的音程」ブロックは、半音に基づいて相対間隔を計算します。"
 
+
 #: js/blocks/IntervalsBlocks.js:702
 msgid "In the figure, we add sol# to sol."
 msgstr "例の画像には<em>ソ</em>が<em>ソ#</em>になります。"
+
 
 #: js/blocks/IntervalsBlocks.js:753
 msgid "The Arpeggio block will run each note block multiple times, adding a transposition based on the specified chord."
 msgstr "「アルペジオ」ブロックは各「音符」ブロックを複数回実行し、指定されたコードに基づいて移調を追加します。"
 
+
 #: js/blocks/IntervalsBlocks.js:757
 msgid "The output of the example is: do, mi, sol, sol, ti, mi"
 msgstr "例の解決は「ド、ミ、ソ、ソ、シ、ミ」"
+
 
 #: js/blocks/IntervalsBlocks.js:981
 msgid "The Chord block calculates common chords."
 msgstr "Chordブロックは一般的なコードを計算します。"
 
+
 #: js/blocks/IntervalsBlocks.js:983
 msgid "In the figure, we generate a C-major chord."
 msgstr "図では、Cメジャーコードを生成します。"
+
 
 #: js/blocks/IntervalsBlocks.js:988
 msgid "chord"
 msgstr "の和音"
 
+
 #: js/blocks/IntervalsBlocks.js:1040
 msgid "The Ratio Interval block calculates an interval based on a ratio."
 msgstr "「比で音程」ブロックは比の音程のピッチを経産する。"
+
 
 #: js/blocks/IntervalsBlocks.js:1045
 msgid "ratio interval"
 msgstr "比で音程"
 
+
 #: js/blocks/IntervalsBlocks.js:1116
 msgid "The Scalar interval block calculates a relative interval based on the current mode, skipping all notes outside of the mode."
 msgstr "「音階的な音程」ブロックは、現在のモードに基づいて相対的な音程を計算し、モード外のピッチをすべてスキップします。"
+
 
 #: js/blocks/IntervalsBlocks.js:1120
 msgid "In the figure, we add la to sol."
 msgstr "<br><br>上の図では、ソの「音符（おんぷ）ブロック」をきじゅんにして、「音階の上下ブロック」のすうちを２にせっていしているので、ソと、ソから２音あがったシの音が同時にえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
+
 #: js/blocks/IntervalsBlocks.js:1169
 msgid "The Define mode block allows you to define a custom mode by specifying pitch numbers."
 msgstr "「モードを定義する」ブロックを使用すると、ピッチ番号を指定してカスタム モードを定義できます。"
 
+
 #: js/blocks/IntervalsBlocks.js:1178
-#.TRANS: define a custom mode
+#. TRANS: define a custom mode
 msgid "define mode"
 msgstr "モードを定義する"
+
 
 #: js/blocks/IntervalsBlocks.js:1231
 msgid "movable Do"
 msgstr "移動ド"
 
+
 #: js/blocks/IntervalsBlocks.js:1235
 msgid "When Movable do is false, the solfege note names are always tied to specific pitches, eg \"do\" is always \"C-natural\" when Movable do is true, the solfege note names are assigned to scale degrees \"do\" is always the first degree of the major scale."
 msgstr "「移動ド」が「偽」の場合、ソルフェージュ音名は常に特定のピッチに関連付けられます。たとえば、「移動ド」が「真」の場合、「ド」は常に「ド・メジャー」となり、ソルフェージュ音名はスケール度に割り当てられます。「ド」は常に長音階の 1 度です。"
 
+
 #: js/blocks/IntervalsBlocks.js:1278
-#.TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
+#. TRANS: mode length is the number of notes in the mode, e.g., 7 for major and minor scales; 12 for chromatic scales
 msgid "mode length"
 msgstr "音階の音数"
+
 
 #: js/blocks/IntervalsBlocks.js:1287
 msgid "The Mode length block is the number of notes in the current scale."
 msgstr "<h2>音階の音数ブロック</h2><br>えんそうされている音階の、音の数を表示する。"
 
+
 #: js/blocks/IntervalsBlocks.js:1289
 msgid "Most Western scales have 7 notes."
 msgstr "西洋のほとんどの音階は、7つの音をもつ。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。"
 
+
 #: js/blocks/IntervalsBlocks.js:1341
-#.TRANS: the mode in music is 'major', 'minor', etc.
+#. TRANS: the mode in music is 'major', 'minor', etc.
 msgid "current mode"
 msgstr "現代の音階"
 
+
 #: js/blocks/IntervalsBlocks.js:1397
-#.TRANS: the key is a group of pitches with which a music composition is created
+#. TRANS: the key is a group of pitches with which a music composition is created
 msgid "current key"
 msgstr "現代の調"
 
+
 #: js/blocks/IntervalsBlocks.js:1452
 #: js/blocks/IntervalsBlocks.js:1497
-#.TRANS: set the key and mode, e.g. C Major
+#. TRANS: set the key and mode, e.g. C Major
 msgid "set key"
 msgstr "調をせってい"
+
 
 #: js/blocks/IntervalsBlocks.js:1506
 msgid "The Set key block is used to set the key and mode,"
 msgstr "<h2>調をせっていブロック</h2><br>調の部分に音の高さ、音階の部分に音階の種類を選び、調をせっていする。<br><br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。<br>★音階とは<br>順番に並んだ音のまとまり。"
 
+
 #: js/blocks/IntervalsBlocks.js:1512
 msgid "The Set key block is used to set the key and mode, eg C Major"
 msgstr "「調をせってい」ブロックは、調と音階(どメジャーなど) を設定するために使用されます。"
 
+
 #: js/blocks/IntervalsBlocks.js:1572
-#.TRANS: the number of pitches in the current temperament system
+#. TRANS: the number of pitches in the current temperament system
 msgid "temperament length"
 msgstr "音律の長さ"
+
 
 #: js/blocks/IntervalsBlocks.js:1577
 msgid "The Temperament length block returns the number of pitches in the current temperament system. For example, 12 for standard equal temperament or 31 for a 31-tone temperament."
 msgstr "「音律の長さ」ブロックは、現在の音律システムにおけるピッチの数を返します。たとえば、標準平均律の場合は「12」、31音律の場合は「31」です。"
 
+
 #: js/blocks/PitchBlocks.js:143
-#.TRANS: musical transposition (adjustment of pitch up or down)
+#. TRANS: musical transposition (adjustment of pitch up or down)
 msgid "transposition"
 msgstr "移調"
 
+
 #: js/blocks/PitchBlocks.js:170
-#.TRANS: step down one note in current musical scale
+#. TRANS: step down one note in current musical scale
 msgid "scalar step down"
 msgstr "音階内で~度下がる:"
+
 
 #: js/blocks/PitchBlocks.js:174
 msgid "The Scalar step down block returns the number of semi-tones down to the previous note in the current key and mode."
 msgstr "Scalar step downブロックは現在の調とモードにおける前の音までの半音数を返します。"
 
+
 #: js/blocks/PitchBlocks.js:194
-#.TRANS: step up one note in current musical scale
+#. TRANS: step up one note in current musical scale
 msgid "scalar step up"
 msgstr "音階内で~度上がる:"
+
 
 #: js/blocks/PitchBlocks.js:198
 msgid "The Scalar step up block returns the number of semi-tones up to the next note in the current key and mode."
 msgstr "Scalar step upブロックは現在の調とモードにおける次の音までの半音数を返します。"
 
+
 #: js/blocks/PitchBlocks.js:218
-#.TRANS: the change measured in half-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in half-steps between the current pitch and the previous pitch
 msgid "change in pitch"
 msgstr "音程の違い"
+
 
 #: js/blocks/PitchBlocks.js:222
 msgid "The Change in pitch block is the difference (in half steps) between the current pitch being played and the previous pitch played."
 msgstr "<em>音程の違い</em>ブロックは現在に鳴らされている音高と現在のちょうど前に鳴らされている音高（半音の値で）の違いです。"
 
+
 #: js/blocks/PitchBlocks.js:251
-#.TRANS: the change measured in scale-steps between the current pitch and the previous pitch
+#. TRANS: the change measured in scale-steps between the current pitch and the previous pitch
 msgid "scalar change in pitch"
 msgstr "音階のよって音程の違い"
+
 
 #: js/blocks/PitchBlocks.js:258
 #: js/blocks/PitchBlocks.js:457
@@ -10552,445 +12558,544 @@ msgstr "音階のよって音程の違い"
 #: js/widgets/temperament.js:793
 #: js/widgets/temperament.js:797
 #: js/widgets/temperament.js:1073
-#.TRANS: convert current note to piano key (1-88)
-#.TRANS: a mapping of pitch to the 88 piano keys
+#. TRANS: convert current note to piano key (1-88)
+#. TRANS: a mapping of pitch to the 88 piano keys
 msgid "pitch number"
 msgstr "音の高さを数で表示"
+
 
 #: js/blocks/PitchBlocks.js:264
 msgid "The Pitch number block is the value of the pitch of the note currently being played."
 msgstr "<h2>音の高さを数で表示ブロック</h2><br>音の高さを数で表示する。<br>"
 
+
 #: js/blocks/PitchBlocks.js:345
 #: js/blocks/PitchBlocks.js:458
-#.TRANS: the current pitch expressed in Hertz
+#. TRANS: the current pitch expressed in Hertz
 msgid "pitch in hertz"
 msgstr "音の高さをヘルツで表示"
+
 
 #: js/blocks/PitchBlocks.js:350
 msgid "The Pitch in Hertz block is the value in Hertz of the pitch of the note currently being played."
 msgstr "<h2>音の高さをヘルツで表示ブロック</h2><br>音の高さをヘルツで表示する。<br>たとえば、オクターヴが４のラの音は、４４０ヘルツというすうちで表すことができる。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>"
+
 
 #: js/blocks/PitchBlocks.js:385
 #: js/turtleactions/DictActions.js:87
 msgid "current pitch"
 msgstr "現代の音の高さ"
 
+
 #: js/blocks/PitchBlocks.js:391
 msgid "The Current Pitch block is used with the Pitch Converter block. In the example above, current pitch, sol 4, is displayed as 392 hertz."
 msgstr "Current PitchブロックはPitch Converterブロックと共に使用されます。上記の例では、現在のピッチsol 4が392ヘルツとして表示されます。"
+
 
 #: js/blocks/PitchBlocks.js:433
 msgid "This block converts the pitch value of the last note played into different formats such as hertz, letter name, pitch number, et al."
 msgstr "このブロックは最後に演奏された音のピッチ値をヘルツ、音名、ピッチ番号などの異なる形式に変換します。"
 
+
 #: js/blocks/PitchBlocks.js:459
 msgid "alphabet"
 msgstr "アルファベット"
 
+
 #: js/blocks/PitchBlocks.js:461
-#.TRANS: Translate as "alphabet class"
+#. TRANS: Translate as "alphabet class"
 msgid "letter class"
 msgstr "アルファベット・クラス"
+
 
 #: js/blocks/PitchBlocks.js:462
 msgid "solfege class"
 msgstr "階名"
 
+
 #: js/blocks/PitchBlocks.js:463
 msgid "staff y"
 msgstr "音部記号のｙ座標"
+
 
 #: js/blocks/PitchBlocks.js:464
 msgid "solfege syllable"
 msgstr "階名（ド、レ、ミ）"
 
+
 #: js/blocks/PitchBlocks.js:465
 msgid "pitch class"
 msgstr "ピッチ・クラス"
+
 
 #: js/blocks/PitchBlocks.js:466
 msgid "scalar class"
 msgstr "音階クラス"
 
+
 #: js/blocks/PitchBlocks.js:468
 msgid "nth degree"
 msgstr "ピッチ度"
+
 
 #: js/blocks/PitchBlocks.js:469
 msgid "pitch to shade"
 msgstr "音の高さををシェードに"
 
+
 #: js/blocks/PitchBlocks.js:470
 msgid "pitch to color"
 msgstr "音の高さを色に"
 
+
 #: js/blocks/PitchBlocks.js:666
 #: js/widgets/musickeyboard.js:856
-#.TRANS: MIDI is a technical standard for electronic music
+#. TRANS: MIDI is a technical standard for electronic music
 msgid "MIDI"
 msgstr "MIDI"
 
+
 #: js/blocks/PitchBlocks.js:679
-#.TRANS: set an offset associated with the numeric piano keyboard mapping
+#. TRANS: set an offset associated with the numeric piano keyboard mapping
 msgid "set pitch number offset"
 msgstr "音高の数字を初期化"
+
 
 #: js/blocks/PitchBlocks.js:682
 msgid "The Set pitch number offset block is used to set the offset for mapping pitch numbers to pitch and octave."
 msgstr "ピッチ番号をピッチとオクターブにマッピングするためのオフセットを設定するために使われるブロックです。"
 
+
 #: js/blocks/PitchBlocks.js:721
-#.TRANS: convert piano key number (1-88) to pitch
+#. TRANS: convert piano key number (1-88) to pitch
 msgid "number to pitch"
 msgstr "数字をピッチに"
+
 
 #: js/blocks/PitchBlocks.js:724
 msgid "The Number to pitch block will convert a pitch number to a pitch name."
 msgstr "「数字をピッチに」ブロックは、数字をピッチ名に変換します。"
 
+
 #: js/blocks/PitchBlocks.js:756
-#.TRANS: convert piano key number (1-88) to octave
+#. TRANS: convert piano key number (1-88) to octave
 msgid "number to octave"
 msgstr "数値をオクターヴ表記へ"
+
 
 #: js/blocks/PitchBlocks.js:758
 msgid "The Number to octave block will convert a pitch number to an octave."
 msgstr "Number to octaveブロックはピッチ番号をオクターブに変換します。"
 
+
 #: js/blocks/PitchBlocks.js:767
 msgid "y to pitch"
 msgstr "音の高さをy座に"
+
 
 #: js/blocks/PitchBlocks.js:770
 msgid "Y to pitch block will convert a staff y position to corresponding pitch notation."
 msgstr "五線譜のy位置を対応する音高表記に変換するブロック"
 
+
 #: js/blocks/PitchBlocks.js:884
 msgid "accidental selector"
 msgstr "臨時記号セレクター"
+
 
 #: js/blocks/PitchBlocks.js:890
 msgid "The Accidental selector block is used to choose between double-sharp, sharp, natural, flat, and double-flat."
 msgstr "<em>変化記号セレクター</em>ブロックはダブルシャープ（重嬰）、シャープ(嬰)、ナチュラル(本位)、フラット(変)、ダブルフラット（重変）から選ぶことができます。"
 
+
 #: js/blocks/PitchBlocks.js:903
 msgid "east indian solfege"
 msgstr "東インドのソルフェージュ"
+
 
 #: js/blocks/PitchBlocks.js:908
 msgid "Pitch can be specified in terms of ni dha pa ma ga re sa."
 msgstr "音の高さを、「sa、re、ga、ma、pa、dha、ni」の７つのインドのソルフェージュでせっていする。"
 
+
 #: js/blocks/PitchBlocks.js:919
 msgid "note name"
 msgstr "音名"
+
 
 #: js/blocks/PitchBlocks.js:924
 msgid "Pitch can be specified in terms of C D E F G A B."
 msgstr "<h2>音の高さブロック</h2><br>音の高さを、CDEFGABの７つのアルファベットでせっていする。たとえば、ドならばＣ、レならばＤであらわされる。"
 
+
 #: js/blocks/PitchBlocks.js:936
 msgid "solfege"
 msgstr "ソルファ"
+
 
 #: js/blocks/PitchBlocks.js:941
 msgid "Pitch can be specified in terms of do re mi fa sol la ti."
 msgstr "<h2>音の高さブロック</h2><br>音の高さを、ド、レ、ミ、ファ、ソ、ラ、シの７つのソルフェージュでせっていする。"
 
+
 #: js/blocks/PitchBlocks.js:989
 msgid "The Invert block rotates any contained notes around a target note."
 msgstr "Invertブロックは含まれる音符を対象の音符の周りで反転させます。"
 
+
 #: js/blocks/PitchBlocks.js:996
 #: js/widgets/modewidget.js:179
-#.TRANS: pitch inversion rotates a pitch around another pitch
+#. TRANS: pitch inversion rotates a pitch around another pitch
 msgid "Invert"
 msgstr "転回を"
 
+
 #: js/blocks/PitchBlocks.js:1035
-#.TRANS: pitch inversion rotates a pitch around another pitch (odd number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (odd number)
 msgid "invert (odd)"
 msgstr "転回を （奇数）"
 
+
 #: js/blocks/PitchBlocks.js:1067
-#.TRANS: pitch inversion rotates a pitch around another pitch (even number)
+#. TRANS: pitch inversion rotates a pitch around another pitch (even number)
 msgid "invert (even)"
 msgstr "転回を （偶数）"
 
+
 #: js/blocks/PitchBlocks.js:1088
-#.TRANS: register is the octave of the current pitch
+#. TRANS: register is the octave of the current pitch
 msgid "register"
 msgstr "登録"
+
 
 #: js/blocks/PitchBlocks.js:1092
 msgid "The Register block provides an easy way to modify the register (octave) of the notes that follow it."
 msgstr "Registerブロックは後に続く音符のオクターブ（レジスター）を簡単に変更する方法を提供します。"
 
+
 #: js/blocks/PitchBlocks.js:1115
-#.TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
+#. TRANS: cents are units used to specify the ratio between pitches. There are 100 cents between successive notes.
 msgid "50 cents"
 msgstr "50セント"
+
 
 #: js/blocks/PitchBlocks.js:1146
 msgid "The Semi-tone transposition block will shift the pitches contained inside Note blocks up (or down) by half steps."
 msgstr "<em>半音で移調</em>ブロックは<em>音符</em>の中に入っている音高を上（または下）に、特定されている<em>数字</em>の値によって、半音ずつ移動します。"
 
+
 #: js/blocks/PitchBlocks.js:1150
-msgid "In the example shown above, sol is shifted up to sol#."
-msgstr ""
+#.  AUTOTRANSLATED: Google Translate
+msgid "In the example shown above, sol is shifted up to sol#. "
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/blocks/PitchBlocks.js:1156
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "semi-tone transpose"
 msgstr "半音で移調"
+
 
 #: js/blocks/PitchBlocks.js:1188
 msgid "The Transpose by Ratio block will shift the pitches contained inside Note blocks up (or down) by a ratio"
 msgstr "「比で移動」ブロックは 音符の中のピッチを比で移動させる。"
 
+
 #: js/blocks/PitchBlocks.js:1196
-#.TRANS: adjust the amount of shift (up or down) of a pitch
+#. TRANS: adjust the amount of shift (up or down) of a pitch
 msgid "transpose by ratio"
 msgstr "比で移動"
 
+
 #: js/blocks/PitchBlocks.js:1287
-#.TRANS: down sixth means the note is five scale degrees below current note
+#. TRANS: down sixth means the note is five scale degrees below current note
 msgid "down sixth"
 msgstr "音階で6度下"
 
+
 #: js/blocks/PitchBlocks.js:1306
-#.TRANS: down third means the note is two scale degrees below current note
+#. TRANS: down third means the note is two scale degrees below current note
 msgid "down third"
 msgstr "音階で3度下"
 
+
 #: js/blocks/PitchBlocks.js:1325
-#.TRANS: seventh means the note is the six scale degrees above current note
+#. TRANS: seventh means the note is the six scale degrees above current note
 msgid "seventh"
 msgstr "7度の音"
 
+
 #: js/blocks/PitchBlocks.js:1344
-#.TRANS: sixth means the note is the five scale degrees above current note
+#. TRANS: sixth means the note is the five scale degrees above current note
 msgid "sixth"
 msgstr "6度の音"
 
+
 #: js/blocks/PitchBlocks.js:1363
-#.TRANS: fifth means the note is the four scale degrees above current note
+#. TRANS: fifth means the note is the four scale degrees above current note
 msgid "fifth"
 msgstr "5度の音"
 
+
 #: js/blocks/PitchBlocks.js:1383
-#.TRANS: fourth means the note is three scale degrees above current note
+#. TRANS: fourth means the note is three scale degrees above current note
 msgid "fourth"
 msgstr "４度の音"
 
+
 #: js/blocks/PitchBlocks.js:1402
-#.TRANS: third means the note is two scale degrees above current note
+#. TRANS: third means the note is two scale degrees above current note
 msgid "third"
 msgstr "3度の音"
 
+
 #: js/blocks/PitchBlocks.js:1421
-#.TRANS: second means the note is one scale degree above current note
+#. TRANS: second means the note is one scale degree above current note
 msgid "second"
 msgstr "2度の音"
+
 
 #: js/blocks/PitchBlocks.js:1462
 msgid "The Scalar transposition block will shift the pitches contained inside Note blocks up (or down) the scale."
 msgstr "<h2>調を変えるブロック</h2><br>「音符ブロック」内の音の高さを、すべて（音階内で、せっていしたすうち分だけ）上げる、または下げる。"
 
+
 #: js/blocks/PitchBlocks.js:1466
 msgid "In the example shown above, sol is shifted up to la."
 msgstr "<br><br>図の例では、ソがラに、ラがシに、シがドに…と置きかえられている。<br><br>★音階とは<br>順番に並んだ音のまとまり。たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>★調とは<br>中心的な役わりをはたす音と、音階の種類によって決まる、曲の感じ。中心的な役わりをはたす音だけを指すこともある。"
 
+
 #: js/blocks/PitchBlocks.js:1473
-#.TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
+#. TRANS: adjust the amount of shift (up or down) of a pitch by musical scale (scalar) steps
 msgid "scalar transpose"
 msgstr "調を変える"
+
 
 #: js/blocks/PitchBlocks.js:1508
 msgid "The Accidental block is used to create sharps and flats"
 msgstr "<em>変化記号</em>ブロックは <em>シャープ(嬰)</em>と<em>フラット(変)</em>を決める機能です。"
 
+
 #: js/blocks/PitchBlocks.js:1515
-#.TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
+#. TRANS: An accidental is a modification to a pitch, e.g., sharp or flat.
 msgid "accidental override"
 msgstr "変化記号無視"
+
 
 #: js/blocks/PitchBlocks.js:1638
 msgid "The Hertz block (in combination with a Number block) will play a sound at the specified frequency."
 msgstr "<h2>ヘルツブロック</h2><br>音の高さをヘルツ（周波数の単位）でせっていする。「すうちブロック」を組み合わせて使う。<br><br>★ヘルツとは<br>音の高さを表す周波数。<br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br><br>"
 
+
 #: js/blocks/PitchBlocks.js:1742
 msgid "The Pitch Number block will play a pitch associated by its number, e.g. 0 for C and 7 for G."
 msgstr "Pitch Numberブロックは番号に対応した音高を再生します。例：0はC、7はG。"
 
+
 #: js/blocks/PitchBlocks.js:1776
 #: js/blocks/PitchBlocks.js:1822
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
-#.TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
+#. TRANS: a numeric mapping of the notes in an octave based on the musical mode
 msgid "nth modal pitch"
 msgstr "ピッチ度"
+
 
 #: js/blocks/PitchBlocks.js:1779
 msgid "nth Modal Pitch takes the pattern of pitches in semitones for a mode and makes each point a degree of the mode,"
 msgstr "nth Modal Pitchはモードの半音単位の音高パターンを取り、各点をモードの度数にします。"
 
+
 #: js/blocks/PitchBlocks.js:1783
 msgid "starting from 1 and regardless of tonal framework (i.e. not always 8 notes in the octave)"
 msgstr "1から始まり、音階の枠組みに関係なく（つまりオクターブが常に8音とは限らない）"
+
 
 #: js/blocks/PitchBlocks.js:1827
 msgid "Nth Modal Pitch takes a number as an input as the nth degree for the given mode. 0 is the first position, 1 is the second, -1 is the note before the first etc."
 msgstr "Nth Modal Pitchは番号を入力として受け取り、指定されたモードのnth度数を表します。0は最初の位置、1は2番目、-1は最初の前の音など。"
 
+
 #: js/blocks/PitchBlocks.js:1831
 msgid "The pitches change according to the mode specified without any need for respellings."
 msgstr "音高は指定されたモードに従って変化し、書き換えは不要です。"
+
 
 #: js/blocks/PitchBlocks.js:1874
 msgid "Scale Degree is a common convention in music. Scale Degree offers seven possible positions in the scale (1-7) and can be modified via accidentals."
 msgstr "スケールディグリーは音楽で一般的な表記法です。スケール内の7つの位置（1-7）を示し、臨時記号で変更可能です。"
 
+
 #: js/blocks/PitchBlocks.js:1878
 msgid "Scale Degree 1 is always the first pitch in a given scale, regardless of octave."
 msgstr "スケールディグリー1は、オクターブに関係なく常に与えられたスケールの最初の音です。"
 
+
 #: js/blocks/PitchBlocks.js:1902
-#.TRANS: step some number of notes in current musical scale
+#. TRANS: step some number of notes in current musical scale
 msgid "scalar step"
 msgstr "音階内を上る／下りる"
+
 
 #: js/blocks/PitchBlocks.js:1908
 msgid "The Scalar Step block (in combination with a Number block) will play the next pitch in a scale,"
 msgstr "<h2>音階内を上る／下りるブロック</h2><br>音階内を順番に（ある一定のかんかくで）上りながら、または下りながら音をえんそうする。すうちをせっていすることで、次の音は前の音といくつちがうかが決まる。<br>たとえば、すうちを１にせっていした場合、ソの次にはラ（ソの１音上）、ファの次にはソ（ファの１音上）がえんそうされる。<br><br>★音階とは<br>順番に並んだ音のまとまり。"
 
+
 #: js/blocks/PitchBlocks.js:1912
 msgid "eg if the last note played was sol, Scalar Step 1 will play la."
 msgstr "<br><br>たとえば、「ド」を始まりの音にしたときの「ドレミファソラシド」、「ソ」を始まりの音にしたときの「ソラシドレミ（♯ファ）ソ」のこと。<br>"
 
+
 #: js/blocks/PitchBlocks.js:1949
 msgid "The Pitch block specifies the pitch name and octave of a note that together determine the frequency of the note."
 msgstr "<h2>音の高さブロック</h2><br>音の高さをせっていする。名前とオクターヴの高さを決めて使う。音の周波数も同時に決まる。<br><br>★周波数とは<br>音が１秒間に何回しんどうするかを表すすうち。周波数が高い（すうちが大きい）ほど、音が高くなる。<br>★オクターヴの高さとは<br>同じ名前でも高さがちがう音を表すすうち。<br><br>"
+
 
 #: js/blocks/ToneBlocks.js:34
 #: js/widgets/timbre.js:858
 msgid "Oscillator"
 msgstr "オシレータ―"
 
+
 #: js/blocks/ToneBlocks.js:44
 #: js/widgets/timbre.js:1670
-#.TRANS: Partials refers to the number of sine waves combined into the sound.
+#. TRANS: Partials refers to the number of sine waves combined into the sound.
 msgid "partials"
 msgstr "倍音"
+
 
 #: js/blocks/ToneBlocks.js:76
 msgid "You are adding multiple oscillator blocks."
 msgstr "複数のオシレーターブロックを追加しています。"
 
+
 #: js/blocks/ToneBlocks.js:148
 #: js/widgets/timbre.js:1359
-#.TRANS: a duo synthesizer combines a synth with a sequencer
+#. TRANS: a duo synthesizer combines a synth with a sequencer
 msgid "duo synth"
 msgstr "シーケンサー込みシンセ"
+
 
 #: js/blocks/ToneBlocks.js:153
 msgid "The Duo synth block is a duo-frequency modulator used to define a timbre."
 msgstr "Duo synthブロックは音色を定義するための二重周波数モジュレータです。"
+
 
 #: js/blocks/ToneBlocks.js:161
 #: js/widgets/timbre.js:1585
 msgid "vibrato rate"
 msgstr "ビブラートエフェクタのレート"
 
+
 #: js/blocks/ToneBlocks.js:161
 msgid "vibrato intensity"
 msgstr "ビブラートエフェクタの強度"
 
+
 #: js/blocks/ToneBlocks.js:189
 #: js/widgets/timbre.js:1343
-#.TRANS: AM (amplitude modulation) synthesizer
+#. TRANS: AM (amplitude modulation) synthesizer
 msgid "AM synth"
 msgstr "AM シンセ"
+
 
 #: js/blocks/ToneBlocks.js:193
 msgid "The AM synth block is an amplitude modulator used to define a timbre."
 msgstr "AMシンセブロックは音色を定義するための振幅変調装置です。"
 
+
 #: js/blocks/ToneBlocks.js:228
 #: js/widgets/timbre.js:1351
-#.TRANS: FM (frequency modulation) synthesizer
+#. TRANS: FM (frequency modulation) synthesizer
 msgid "FM synth"
 msgstr "FM シンセ"
+
 
 #: js/blocks/ToneBlocks.js:232
 msgid "The FM synth block is a frequency modulator used to define a timbre."
 msgstr "FMシンセブロックは音色を定義するための周波数変調装置です。"
 
+
 #: js/blocks/ToneBlocks.js:266
 msgid "partial"
 msgstr "倍音"
+
 
 #: js/blocks/ToneBlocks.js:269
 msgid "The Partial block is used to specify a weight for a specific partial harmonic."
 msgstr "Partialブロックは特定の部分倍音の重みを指定するために使われます。"
 
+
 #: js/blocks/ToneBlocks.js:288
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial weight must be between 0 and 1."
 msgstr "倍音のウェートは０と１の間である必要があります。"
 
+
 #: js/blocks/ToneBlocks.js:301
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "Partial block should be used inside of a Weighted-partials block."
 msgstr "倍音ブロックが「倍音ウェートブロック」の中にある必要があります。"
+
 
 #: js/blocks/ToneBlocks.js:321
 msgid "The Weighted partials block is used to specify the partials associated with a timbre."
 msgstr "「ウェート倍音」ブロックは、ティンバーに関連付けられた部分音を指定するために使用されます。"
 
+
 #: js/blocks/ToneBlocks.js:329
-#.TRANS: partials are weighted components in a harmonic series
+#. TRANS: partials are weighted components in a harmonic series
 msgid "weighted partials"
 msgstr "ウェート倍音"
+
 
 #: js/blocks/ToneBlocks.js:386
 msgid "The Harmonic block will add harmonics to the contained notes."
 msgstr "Harmonicブロックは含まれる音符に倍音を追加します。"
 
+
 #: js/blocks/ToneBlocks.js:393
-#.TRANS: A harmonic is an overtone.
+#. TRANS: A harmonic is an overtone.
 msgid "harmonic"
 msgstr "ハーモニックス"
+
 
 #: js/blocks/ToneBlocks.js:434
 msgid "The Distortion block adds distortion to the pitch."
 msgstr "Distortionブロックは音程に歪みを加えます。"
 
+
 #: js/blocks/ToneBlocks.js:441
-#.TRANS: distortion is an alteration in the sound
+#. TRANS: distortion is an alteration in the sound
 msgid "distortion"
 msgstr "ディストーション"
+
 
 #: js/blocks/ToneBlocks.js:490
 msgid "The Tremolo block adds a wavering effect."
 msgstr "<h2>トレモロブロック</h2><br>ゆれるような音のひびきにする。はやさで、ゆれのはやさを調節できる。<br>"
 
+
 #: js/blocks/ToneBlocks.js:492
 msgid "Tremolo makes the sound pulse louder and quieter."
 msgstr "トレモロを使用すると、音がパルスのように大きくなったり、小さくなったりします。"
+
 
 #: js/blocks/ToneBlocks.js:494
 msgid "The rate (first argument) controls how fast the sound pulses (cycles per second)."
 msgstr "レート (最初の引数) は、サウンドのパルス速度 (1 秒あたりのサイクル数) を制御します。"
 
+
 #: js/blocks/ToneBlocks.js:498
 msgid "The depth (second argument) controls the strength of the pulsing effect (0-100%)."
 msgstr "深さ (2 番目の引数) は、パルス効果の強さを制御します (0 ～ 100%)。"
 
+
 #: js/blocks/ToneBlocks.js:508
-#.TRANS: a wavering effect in a musical tone
+#. TRANS: a wavering effect in a musical tone
 msgid "tremolo"
 msgstr "トレモロ"
+
 
 #: js/blocks/ToneBlocks.js:513
 #: js/blocks/ToneBlocks.js:582
@@ -11000,26 +13105,30 @@ msgstr "トレモロ"
 #: js/widgets/timbre.js:2410
 #: js/widgets/timbre.js:2491
 #: js/widgets/timbre.js:2583
-#.TRANS: rate at which tremolo wavers
+#. TRANS: rate at which tremolo wavers
 msgid "rate"
 msgstr "はやさ"
+
 
 #: js/blocks/ToneBlocks.js:515
 #: js/blocks/ToneBlocks.js:653
 #: js/widgets/timbre.js:2340
 #: js/widgets/timbre.js:2501
-#.TRANS: amplitude of tremolo waver
+#. TRANS: amplitude of tremolo waver
 msgid "depth"
 msgstr "大きさ"
+
 
 #: js/blocks/ToneBlocks.js:572
 msgid "The Phaser block adds a sweeping sound."
 msgstr "Phaserブロックはスウィープ音を加えます。"
 
+
 #: js/blocks/ToneBlocks.js:579
-#.TRANS: alter the phase of the sound
+#. TRANS: alter the phase of the sound
 msgid "phaser"
 msgstr "フェーザー"
+
 
 #: js/blocks/ToneBlocks.js:582
 #: js/turtleactions/IntervalsActions.js:157
@@ -11027,106 +13136,130 @@ msgstr "フェーザー"
 msgid "octaves"
 msgstr "オクターヴ"
 
+
 #: js/blocks/ToneBlocks.js:582
 #: js/widgets/timbre.js:2589
 msgid "base frequency"
 msgstr "基本周波数"
 
+
 #: js/blocks/ToneBlocks.js:632
 msgid "The Chorus block adds a chorus effect."
 msgstr "<h2>コーラスブロック</h2><br>広がりのある音のひびきにする。はやさとずれで、ひびきが残る感じを調節できる。<br>"
+
 
 #: js/blocks/ToneBlocks.js:634
 msgid "The rate (first argument) controls the speed of the chorus modulation (cycles per second)."
 msgstr "レート (最初の引数) は、コーラス変調の速度 (1 秒あたりのサイクル数) を制御します。"
 
+
 #: js/blocks/ToneBlocks.js:638
 msgid "The delay (second argument) sets the time delay between chorus voices (milliseconds)."
 msgstr "ディレイ(第 2 引数) は、コーラスボイス間の遅延時間 (ミリ秒) を設定します。"
+
 
 #: js/blocks/ToneBlocks.js:642
 msgid "The depth (third argument) controls the amount of chorus effect (0-100%)."
 msgstr "深さ (3 番目の引数) は、コーラス・エフェクターの量 (0 ～ 100%) を制御します。"
 
+
 #: js/blocks/ToneBlocks.js:650
-#.TRANS: musical effect to simulate a choral sound
+#. TRANS: musical effect to simulate a choral sound
 msgid "chorus"
 msgstr "コーラス"
+
 
 #: js/blocks/ToneBlocks.js:653
 #: js/widgets/timbre.js:2496
 msgid "delay (MS)"
 msgstr "ディレイ・エフェクター（ms）"
 
+
 #: js/blocks/ToneBlocks.js:701
 msgid "The Vibrato block adds a rapid, slight variation in pitch."
 msgstr "<h2>ビブラートブロック</h2><br>音の高さに小きざみな変化をつける。"
+
 
 #: js/blocks/ToneBlocks.js:703
 msgid "The intensity (first argument) controls how much the pitch varies (semitones)."
 msgstr "大きさ (最初の引数) は、ピッチの変化量 (半音) を制御します。"
 
+
 #: js/blocks/ToneBlocks.js:707
 msgid "The rate (second argument) controls the speed of the pitch variation (cycles per second)."
 msgstr "レート (2 番目の引数) は、ピッチ変化の速度 (1 秒あたりのサイクル数) を制御します。"
 
+
 #: js/blocks/ToneBlocks.js:717
-#.TRANS: a rapid, slight variation in pitch
+#. TRANS: a rapid, slight variation in pitch
 msgid "vibrato"
 msgstr "ビブラート"
+
 
 #: js/blocks/ToneBlocks.js:720
 #: js/widgets/timbre.js:2409
 msgid "intensity"
 msgstr "大きさ"
 
+
 #: js/blocks/ToneBlocks.js:764
-#.TRANS: select synthesizer
+#. TRANS: select synthesizer
 msgid "set synth"
 msgstr "シンセを設定"
+
 
 #: js/blocks/ToneBlocks.js:834
 msgid "synth name"
 msgstr "シンセの名前"
 
+
 #: js/blocks/ToneBlocks.js:872
 msgid "set default instrument"
 msgstr "音色標準を設定"
+
 
 #: js/blocks/ToneBlocks.js:875
 msgid "The set default instrument block changes the default instrument from electronic synth to the instrument of your choice."
 msgstr "音色標準を設定すると、デフォルトの音色が電子シンセから選択した音色に変更されます。"
 
+
 #: js/blocks/ToneBlocks.js:925
 #: js/blocks/ToneBlocks.js:976
-#.TRANS: set the characteristics of a custom instrument
+#. TRANS: set the characteristics of a custom instrument
 msgid "set instrument"
 msgstr "音色をせってい"
+
 
 #: js/blocks/ToneBlocks.js:931
 #: js/blocks/ToneBlocks.js:965
 msgid "The Set instrument block selects a voice for the synthesizer, eg guitar piano violin or cello."
 msgstr "「音色をせってい」ブロックは、シンセサイザーの音声 (ギター、ピアノ、バイオリン、チェロなど) を選択します。"
 
+
 #: js/blocks/ToneBlocks.js:959
 msgid "The Set instrument block selects a voice for the synthesizer,"
 msgstr "<h2>音色をせっていブロック</h2><br>中に入っている「音符（おんぷ）ブロック」の音色を設定する。音色は、ギターやピアノなどの中から選ぶことができる。<br><br> "
+
 
 #: js/blocks/ToneBlocks.js:1048
 msgid "Import a sound file to use as an instrument and set its pitch center."
 msgstr "音色サンプルをアップロードして、音の高さを合わせる"
 
+
 #: js/blocks/ToneBlocks.js:1143
 msgid "Upload a sound file to connect with the sample block."
 msgstr "音色サンプルをアップロードして、音の高さを合わせる"
+
 
 #: js/blocks/RhythmBlocks.js:38
 msgid "The Note value block is the value of the duration of the note currently being played."
 msgstr "「音の長さ」ブロックは、現在演奏されている音符の長さの値です。"
 
+
 #: js/blocks/RhythmBlocks.js:150
 msgid "The Milliseconds block is similar to a Note block except that it uses time (in MS) to specify the note duration."
 msgstr "「Milliseconds」ブロックは、音符の長さを指定するために時間 (MS 単位) を使用することを除いて、「音符」ブロックに似ています。"
+
 
 #: js/blocks/RhythmBlocks.js:193
 #: js/blocks/RhythmBlocks.js:1085
@@ -11134,102 +13267,124 @@ msgstr "「Milliseconds」ブロックは、音符の長さを指定するため
 msgid "Note value must be greater than 0."
 msgstr "音の長さは、0より大きいあたいをせっていしてください。"
 
+
 #: js/blocks/RhythmBlocks.js:218
 #: js/blocks/RhythmBlocks.js:280
 #: js/blocks/RhythmBlocks.js:351
-#.TRANS: swing is a rhythmic variation that emphasises the offbeat
+#. TRANS: swing is a rhythmic variation that emphasises the offbeat
 msgid "swing"
 msgstr "スイング"
+
 
 #: js/blocks/RhythmBlocks.js:342
 msgid "The Swing block works on pairs of notes (specified by note value), adding some duration (specified by swing value) to the first note and taking the same amount from the second note."
 msgstr "「スイング」ブロックは、音符のペア (音符の値で指定) に作用し、最初の音符に一定の長さ (スイング値で指定) を追加し、2 番目の音符から同じ量を取得します。"
 
+
 #: js/blocks/RhythmBlocks.js:356
-#.TRANS: the amount to shift to the offbeat note
+#. TRANS: the amount to shift to the offbeat note
 msgid "swing value"
 msgstr "スイングの数値"
+
 
 #: js/blocks/RhythmBlocks.js:420
 msgid "The Skip notes block will cause notes to be skipped."
 msgstr "Skip notesブロックは音符をスキップさせます。"
 
+
 #: js/blocks/RhythmBlocks.js:428
-#.TRANS: substitute rests on notes being skipped
+#. TRANS: substitute rests on notes being skipped
 msgid "skip notes"
 msgstr "音符の省略"
+
 
 #: js/blocks/RhythmBlocks.js:479
 msgid "The Multiply note value block changes the duration of notes by changing their note values."
 msgstr "[音価を～倍にするファクター] ブロックは、音価を変更することで音符の長さを変更します。"
 
+
 #: js/blocks/RhythmBlocks.js:489
-#.TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
+#. TRANS: speed up note duration by some factor, e.g. convert 1/4 to 1/8 notes by using a factor of 2
 msgid "multiply note value"
 msgstr "音価を～倍にするファクター"
+
 
 #: js/blocks/RhythmBlocks.js:542
 msgid "The Tie block works on pairs of notes, combining them into one note."
 msgstr "<h2>タイブロック</h2><br>２つの音をつなげて１つの音にする。「音の高さブロック」を入れて使う。同じ高さの音だけ、つなぐことができる。"
 
+
 #: js/blocks/RhythmBlocks.js:550
-#.TRANS: tie notes together into one longer note
+#. TRANS: tie notes together into one longer note
 msgid "tie"
 msgstr "タイ"
 
+
 #: js/blocks/RhythmBlocks.js:591
 #: js/blocks/RhythmBlocks.js:670
-#.TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
+#. TRANS: a dotted note is played for 1.5x its value, e.g., 1/8. --> 3/16
 msgid "dot"
 msgstr "付点音符"
+
 
 #: js/blocks/RhythmBlocks.js:619
 #: js/turtleactions/RhythmActions.js:237
 msgid "An argument of -1 results in a note value of 0."
 msgstr "ー１は０の音価にします"
 
+
 #: js/blocks/RhythmBlocks.js:660
 msgid "The Dot block extends the duration of a note by 50%."
 msgstr "Dotブロックは音符の長さを50%延長します。"
+
 
 #: js/blocks/RhythmBlocks.js:662
 msgid "Eg a dotted quarter note will play for 3/8 (1/4 + 1/8) of a beat."
 msgstr "例：付点四分音符は1拍の3/8（1/4 + 1/8）演奏されます。"
 
+
 #: js/blocks/RhythmBlocks.js:715
 msgid "A rest of the specified note value duration can be constructed using a Silence block."
 msgstr "指定した音符の長さの休符は、「休符」ブロックを使用して構築できます。"
 
+
 #: js/blocks/RhythmBlocks.js:764
-#.TRANS: Japanese only: note value block for drum
+#. TRANS: Japanese only: note value block for drum
 msgid "note value drum"
 msgstr "音符（ドラム）"
+
 
 #: js/blocks/RhythmBlocks.js:828
 msgid "392 hertz"
 msgstr "３９２ヘルツ"
 
+
 #: js/blocks/RhythmBlocks.js:1113
 msgid "The Note block is a container for one or more Pitch blocks."
 msgstr "<h2>音符（おんぷ）ブロック</h2><br>音の長さと高さをせっていする。長さを決め、「音の高さブロック」を入れて使う。"
+
 
 #: js/blocks/RhythmBlocks.js:1115
 msgid "The Note block specifies the duration (note value) of its contents."
 msgstr "<br><br>「音の高さブロック」を２つ以上入れると、音を同時に出すことができる。"
 
+
 #: js/blocks/RhythmBlocks.js:1124
 msgid "value2"
 msgstr "長さ"
 
+
 #: js/blocks/RhythmBlocks.js:1190
 msgid "define frequency"
 msgstr "周波数を明確にする"
+
 
 #: js/blocks/RhythmBlocks.js:1208
 #: js/widgets/temperament.js:996
 #: js/widgets/temperament.js:1790
 msgid "octave space"
 msgstr "オクターヴ・スペース"
+
 
 #: js/blocks/GraphicsBlocks.js:46
 #: js/turtleactions/DictActions.js:77
@@ -11238,61 +13393,76 @@ msgstr "オクターヴ・スペース"
 msgid "heading"
 msgstr "向き（ネズミ）"
 
+
 #: js/blocks/GraphicsBlocks.js:56
 msgid "The Heading block returns the orientation of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミの向いている角度を表すすうちブロック。向きの値は、０以上で、３６０より小さい値になり、プラスだと右回り、マイナスだと左回りに変化する。"
+
 
 #: js/blocks/GraphicsBlocks.js:62
 msgid "The Heading block returns the orientation of the turtle."
 msgstr "ヘディングブロックはタートルの向きを返します。"
 
+
 #: js/blocks/GraphicsBlocks.js:136
 msgid "The Y block returns the vertical position of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミのｙざひょう（たて方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
+
 
 #: js/blocks/GraphicsBlocks.js:143
 msgid "The Y block returns the vertical position of the turtle."
 msgstr "Yブロックはタートルの垂直位置を返します。"
 
+
 #: js/blocks/GraphicsBlocks.js:152
 msgid "y3"
 msgstr "yざひょうち（ネズミ）"
+
 
 #: js/blocks/GraphicsBlocks.js:222
 msgid "The X block returns the horizontal position of the mouse."
 msgstr "<h2>すうちブロック</h2><br>ネズミのｘざひょう（よこ方向の位置）を表すすうちブロック。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
 
+
 #: js/blocks/GraphicsBlocks.js:229
 msgid "The X block returns the horizontal position of the turtle."
 msgstr "Xブロックはタートルの水平方向の位置を返します。"
+
 
 #: js/blocks/GraphicsBlocks.js:238
 msgid "x3"
 msgstr "xざひょうち（ネズミ）"
 
+
 #: js/blocks/GraphicsBlocks.js:298
 msgid "scroll xy"
 msgstr "カンバスを動かす"
+
 
 #: js/blocks/GraphicsBlocks.js:306
 msgid "The Scroll XY block moves the canvas."
 msgstr "<h2>いどうブロック（カンバス）</h2><br>カンバスを上下左右にいどうさせる。カンバスだけがいどうするので結果的に、画面上のすべてのネズミが同時にいどうするように見える。カンバスを右（プラス）にいどうするとネズミは左へ、左（マイナス）にいどうするとネズミは右に動いて見える。同じく、カンバスを上（プラス）にいどうするとネズミは下へ、下（マイナス）にいどうするとネズミは上に動いて見える。"
 
+
 #: js/blocks/GraphicsBlocks.js:316
 msgid "x2"
 msgstr "よこいどう"
+
 
 #: js/blocks/GraphicsBlocks.js:316
 msgid "y2"
 msgstr "たていどう"
 
+
 #: js/blocks/GraphicsBlocks.js:422
 msgid "The Control-point 2 block sets the second control point for the Bezier curve."
 msgstr "コントロールポイント2ブロックはベジエ曲線の第2コントロールポイントを設定します。"
 
+
 #: js/blocks/GraphicsBlocks.js:429
 msgid "control point 2"
 msgstr "コントロール点２"
+
 
 #: js/blocks/GraphicsBlocks.js:432
 #: js/blocks/GraphicsBlocks.js:483
@@ -11301,6 +13471,7 @@ msgstr "コントロール点２"
 msgid "x1"
 msgstr "xざひょう（ネズミ）"
 
+
 #: js/blocks/GraphicsBlocks.js:432
 #: js/blocks/GraphicsBlocks.js:483
 #: js/blocks/GraphicsBlocks.js:530
@@ -11308,41 +13479,52 @@ msgstr "xざひょう（ネズミ）"
 msgid "y1"
 msgstr "yざひょう（ネズミ）"
 
+
 #: js/blocks/GraphicsBlocks.js:473
 msgid "The Control-point 1 block sets the first control point for the Bezier curve."
 msgstr "コントロールポイント1ブロックはベジエ曲線の第1コントロールポイントを設定します。"
+
 
 #: js/blocks/GraphicsBlocks.js:480
 msgid "control point 1"
 msgstr "コントロール点１"
 
+
 #: js/blocks/GraphicsBlocks.js:523
 msgid "The Bezier block draws a Bezier curve."
 msgstr "ベジエブロックはベジエ曲線を描きます。"
+
 
 #: js/blocks/GraphicsBlocks.js:527
 msgid "bezier"
 msgstr "ベジェ曲線"
 
+
 #: js/blocks/GraphicsBlocks.js:589
+#.  AUTOTRANSLATED: Google Translate
 msgid "The Arc block moves the mouse in an arc."
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/blocks/GraphicsBlocks.js:596
 msgid "The Arc block moves the turtle in an arc."
 msgstr "アークブロックはタートルを弧を描いて動かします。"
 
+
 #: js/blocks/GraphicsBlocks.js:605
 msgid "arc"
 msgstr "円をえがいていどう"
+
 
 #: js/blocks/GraphicsBlocks.js:608
 msgid "angle"
 msgstr "角度"
 
+
 #: js/blocks/GraphicsBlocks.js:608
 msgid "radius"
 msgstr "半径"
+
 
 #: js/blocks/GraphicsBlocks.js:626
 #: js/blocks/GraphicsBlocks.js:782
@@ -11351,6 +13533,7 @@ msgstr "半径"
 msgid "Value must be within -5000 to 5000 when Wrap Mode is off."
 msgstr "ラップモードがオフのとき、値は -5000 から 5000 の範囲でなければなりません。"
 
+
 #: js/blocks/GraphicsBlocks.js:631
 #: js/blocks/GraphicsBlocks.js:790
 #: js/blocks/GraphicsBlocks.js:1039
@@ -11358,37 +13541,46 @@ msgstr "ラップモードがオフのとき、値は -5000 から 5000 の範�
 msgid "Value must be within -20000 to 20000 when Wrap Mode is on."
 msgstr "ラップモードがオンのとき、値は -20000 から 20000 の範囲でなければなりません。"
 
+
 #: js/blocks/GraphicsBlocks.js:671
 msgid "set heading"
 msgstr "向きを変える"
+
 
 #: js/blocks/GraphicsBlocks.js:684
 msgid "The Set heading block sets the heading of the turtle."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度に変える。"
 
+
 #: js/blocks/GraphicsBlocks.js:744
 msgid "The Set XY block moves the mouse to a specific position on the screen."
 msgstr "<h2>いどうブロック</h2><br>ネズミの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のネズミの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
+
 
 #: js/blocks/GraphicsBlocks.js:750
 msgid "The Set XY block moves the turtle to a specific position on the screen."
 msgstr "<h2>いどうブロック</h2><br>タートルの位置を、指定したざひょうにいどうさせる。<br><br>★ざひょうとは<br>物の位置を表すためのすうちのこと。ミュージック・ブロックスでは、２つ１組みのすうち（ざひょう）を使う。画面上のタートルの位置は、ほうがん用紙のマス目のように、よこ方向の目もり（xざひょう）とたて方向の目もり（ｙざひょう）を使って表す。"
 
+
 #: js/blocks/GraphicsBlocks.js:758
 msgid "set xy"
 msgstr "指定ざひょうにいどう"
+
 
 #: js/blocks/GraphicsBlocks.js:842
 msgid "The Right block turns the mouse to the right."
 msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度で右回りに回転させる。"
 
+
 #: js/blocks/GraphicsBlocks.js:849
 msgid "The Right block turns the turtle to the right."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度で右回りに回転させる。"
 
+
 #: js/blocks/GraphicsBlocks.js:858
 msgid "right1"
 msgstr "右を向く"
+
 
 #: js/blocks/GraphicsBlocks.js:858
 #: plugins/rodi.rtp:77
@@ -11397,17 +13589,21 @@ msgstr "右を向く"
 msgid "right"
 msgstr "ざひょうち（右）"
 
+
 #: js/blocks/GraphicsBlocks.js:922
 msgid "The Left block turns the mouse to the left."
 msgstr "<h2>いどうブロック</h2><br>ネズミの向きを、指定したすうちの角度で左回りに回転させる。"
+
 
 #: js/blocks/GraphicsBlocks.js:929
 msgid "The Left block turns the turtle to the left."
 msgstr "<h2>いどうブロック</h2><br>タートルの向きを、指定したすうちの角度で左回りに回転させる。"
 
+
 #: js/blocks/GraphicsBlocks.js:938
 msgid "left1"
 msgstr "左を向く"
+
 
 #: js/blocks/GraphicsBlocks.js:938
 #: plugins/rodi.rtp:79
@@ -11416,6 +13612,7 @@ msgstr "左を向く"
 msgid "left"
 msgstr "ざひょうち（左）"
 
+
 #: js/blocks/GraphicsBlocks.js:990
 #: js/widgets/temperament.js:170
 #: plugins/rodi.rtp:69
@@ -11423,13 +13620,16 @@ msgstr "ざひょうち（左）"
 msgid "back"
 msgstr "後ろへ進む"
 
+
 #: js/blocks/GraphicsBlocks.js:999
 msgid "The Back block moves the mouse backward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、ネズミを後ろにもどす。体の向きは変えない。"
 
+
 #: js/blocks/GraphicsBlocks.js:1006
 msgid "The Back block moves the turtle backward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タートルを後ろにもどす。体の向きは変えない。"
+
 
 #: js/blocks/GraphicsBlocks.js:1079
 #: plugins/rodi.rtp:71
@@ -11437,22 +13637,27 @@ msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タート�
 msgid "forward"
 msgstr "前へ進む"
 
+
 #: js/blocks/GraphicsBlocks.js:1088
 msgid "The Forward block moves the mouse forward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、ネズミを前に進める。"
 
+
 #: js/blocks/GraphicsBlocks.js:1095
 msgid "The Forward block moves the turtle forward."
 msgstr "<h2>いどうブロック</h2><br>指定したすうち分、タートルを前に進める。"
+
 
 #: js/blocks/GraphicsBlocks.js:1203
 #: js/blocks/GraphicsBlocks.js:1221
 msgid "wrap"
 msgstr "巻きつける"
 
+
 #: js/blocks/GraphicsBlocks.js:1211
 msgid "The Wrap block enables or disables screen wrapping for the graphics actions within it."
 msgstr "「巻きつける」ブロックは、その中のグラフィックス アクションの画面ラッピングを有効または無効にします。"
+
 
 #: js/turtleactions/DictActions.js:75
 #: js/turtleactions/DictActions.js:142
@@ -11460,136 +13665,169 @@ msgstr "「巻きつける」ブロックは、その中のグラフィックス
 msgid "font"
 msgstr "フォント"
 
+
 #: js/turtleactions/DictActions.js:257
 msgid "Dictionary with this name does not exist"
 msgstr "この名前の辞書は存在しません。"
+
 
 #: js/turtleactions/DictActions.js:260
 msgid "Key with this name does not exist in %s"
 msgstr "この名前のキー（調）は %s に存在しません"
 
+
 #: js/turtleactions/DrumActions.js:227
 msgid "Noise Block: Did you mean to use a Note block?"
 msgstr "音符ブロックを使いますか？"
+
 
 #: js/turtleactions/MeterActions.js:116
 #: js/turtleactions/MeterActions.js:140
 msgid "beats per minute must be greater than %s"
 msgstr "1 分あたりの拍数は %s より大きくなければなりません"
 
+
 #: js/turtleactions/MeterActions.js:124
 #: js/turtleactions/MeterActions.js:148
 msgid "maximum"
 msgstr "最大限"
+
 
 #: js/turtleactions/MeterActions.js:124
 #: js/turtleactions/MeterActions.js:148
 msgid "beats per minute is %s"
 msgstr "1 分あたりの拍数は %s です"
 
+
 #: js/turtleactions/VolumeActions.js:260
 msgid "Synth not found: %s"
 msgstr "シンセが見つかりません: %s"
+
 
 #: js/turtleactions/IntervalsActions.js:147
 msgid "one"
 msgstr "１度"
 
+
 #: js/turtleactions/IntervalsActions.js:148
 msgid "two"
 msgstr "２度"
+
 
 #: js/turtleactions/IntervalsActions.js:149
 msgid "three"
 msgstr "３度"
 
+
 #: js/turtleactions/IntervalsActions.js:150
 msgid "four"
 msgstr "４度"
+
 
 #: js/turtleactions/IntervalsActions.js:151
 msgid "five"
 msgstr "５度"
 
+
 #: js/turtleactions/IntervalsActions.js:152
 msgid "six"
 msgstr "６度"
+
 
 #: js/turtleactions/IntervalsActions.js:153
 msgid "seven"
 msgstr "７度"
 
+
 #: js/turtleactions/IntervalsActions.js:154
 msgid "eight"
 msgstr "８度"
 
+
 #: js/turtleactions/IntervalsActions.js:155
 msgid "nine"
 msgstr "９度"
+
 
 #: js/turtleactions/IntervalsActions.js:163
 #: js/turtleactions/IntervalsActions.js:185
 msgid "below"
 msgstr "下"
 
+
 #: js/turtleactions/IntervalsActions.js:167
 msgid "above"
 msgstr "上"
+
 
 #: js/turtleactions/IntervalsActions.js:177
 msgid "plus"
 msgstr "と"
 
+
 #: js/turtleactions/IntervalsActions.js:192
+#.  AUTOTRANSLATED: Google Translate
 msgid "steps"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/turtleactions/IntervalsActions.js:311
 msgid "Adding missing pitch number 0."
 msgstr "ピッチ数値「0」を加える"
 
+
 #: js/turtleactions/IntervalsActions.js:339
 msgid "Ignoring duplicate pitch numbers."
 msgstr "重複しているピッチ数値は無視します"
+
 
 #: js/turtleactions/PitchActions.js:288
 msgid "Scalar transpositions are equal to Semitone transpositions for custom temperament."
 msgstr "音階的な移調は、カスタム音律の半音移調と同じです。"
 
+
 #: js/turtleactions/OrnamentActions.js:49
 msgid "Staccato value must be non-zero."
 msgstr "スタッカート値はゼロ以外でなければなりません。"
+
 
 #: js/turtleactions/OrnamentActions.js:79
 msgid "Slur value must be non-zero."
 msgstr "スラー値はゼロ以外でなければなりません。"
 
+
 #: js/turtleactions/ToneActions.js:136
 msgid "Vibrato intensity must be between 1 and 100."
 msgstr "ビブラートの大きさは、1から100までのはんいでせっていしてください。"
+
 
 #: js/turtleactions/ToneActions.js:142
 msgid "Vibrato rate must be greater than 0."
 msgstr "ビブラートのはやさは、0より大きいあたいをせっていしてください。"
 
+
 #: js/turtleactions/ToneActions.js:195
 #: js/turtleactions/ToneActions.js:268
-#.TRANS: Depth is the intesity of the tremolo or chorus effect.
+#. TRANS: Depth is the intesity of the tremolo or chorus effect.
 msgid "Depth is out of range."
 msgstr "（エフェクタの）深さの数字が変域外です。"
+
 
 #: js/turtleactions/ToneActions.js:304
 msgid "Distortion must be from 0 to 100."
 msgstr "ディストーションは、0から100までのはんいでせっていしてください。"
 
+
 #: js/widgets/temperament.js:1843
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr "オクターヴ比が変わりました。これにより調律が大きく変わります。"
 
+
 #: js/turtleactions/ToneActions.js:335
-#.TRANS: partials components in a harmonic series
+#. TRANS: partials components in a harmonic series
 msgid "Partial must be greater than or equal to 0."
 msgstr "倍音が０以上である必要があります。"
+
 
 #: js/turtleactions/ToneActions.js:381
 #: js/turtleactions/ToneActions.js:420
@@ -11598,143 +13836,180 @@ msgstr "倍音が０以上である必要があります。"
 msgid "Unable to use synth due to existing oscillator."
 msgstr "既存のオシレーターがあるためシンセは使用できません。"
 
+
 #: js/turtleactions/ToneActions.js:391
 #: js/turtleactions/ToneActions.js:430
 msgid "The input cannot be negative."
 msgstr "マイナスの数値をいれることはできません。"
 
+
 #: js/turtleactions/RhythmActions.js:151
+#.  AUTOTRANSLATED: Google Translate
 msgid "Neighbor note value is too large for the current note duration."
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/jseditor.js:393
 msgid "Reset Code"
 msgstr "コードをリセット"
 
+
 #: js/widgets/jseditor.js:421
 msgid "Convert JavaScript to Blocks"
 msgstr "JavaScript をブロックに変換する"
+
 
 #: js/widgets/jseditor.js:555
 msgid "Toggle Console"
 msgstr "コンソールの切り替え"
 
+
 #: js/widgets/jseditor.js:984
 msgid "JavaScript block conversion is unavailable because its configuration file failed to load."
 msgstr "JavaScript ブロック変換は、構成ファイルのロードに失敗したため使用できません。"
+
 
 #: js/widgets/jseditor.js:987
 msgid "JavaScript block conversion is still loading. Please try again."
 msgstr "JavaScript ブロック変換はまだ読み込み中です。もう一度試してください。"
 
+
 #: js/widgets/plugin-dialog.js:76
 msgid "Enter the name of a built-in plugin, or leave blank to upload a plugin file:"
 msgstr "組み込みプラグインの名前を入力するか、空白のままにしてプラグイン ファイルをアップロードします。"
+
 
 #: js/widgets/widgetWindows.js:221
 msgid "Close window"
 msgstr "ウィンドウを閉じる"
 
+
 #: js/widgets/widgetWindows.js:267
 msgid "Minimize"
 msgstr "最小化する"
+
 
 #: js/widgets/widgetWindows.js:269
 msgid "Roll up window"
 msgstr "ウィンドウをロールアップする"
 
+
 #: js/widgets/widgetWindows.js:289
 msgid "Maximize window"
 msgstr "ウィンドウを最大化する"
+
 
 #: js/widgets/aidebugger.js:165
 msgid "Reset conversation"
 msgstr "会話をリセット"
 
+
 #: js/widgets/aidebugger.js:170
 msgid "Export chat"
 msgstr "チャットをエクスポートする"
+
 
 #: js/widgets/aidebugger.js:178
 msgid "Debugger initialized"
 msgstr "デバッガが初期化されました"
 
+
 #: js/widgets/aidebugger.js:388
 msgid "AI Debugger backend is not configured for this host."
 msgstr "AI デバッガー バックエンドはこのホスト用に構成されていません。"
+
 
 #: js/widgets/aidebugger.js:403
 msgid "Debugger error: Could not prepare project data."
 msgstr "デバッガー エラー: プロジェクト データを準備できませんでした。"
 
+
 #: js/widgets/aidebugger.js:449
 msgid "Server error: Invalid response from AI backend."
 msgstr "サーバー エラー: AI バックエンドからの無効な応答。"
+
 
 #: js/widgets/aidebugger.js:458
 msgid "Server error: Unable to connect to AI backend."
 msgstr "サーバー エラー: AI バックエンドに接続できません。"
 
+
 #: js/widgets/aidebugger.js:466
 #: js/widgets/aidebugger.js:738
+#.  AUTOTRANSLATED: Google Translate
 msgid "Could not reach the AI assistant. Please check your connection and try again."
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/aidebugger.js:552
 msgid "Before we start"
 msgstr "始める前に"
 
+
 #: js/widgets/aidebugger.js:556
 msgid "The AI Debugger will send your current project data to an external server for analysis. Your project blocks and structure will be shared with:"
 msgstr "AI デバッガーは、分析のために現在のプロジェクト データを外部サーバーに送信します。プロジェクトのブロックと構造は以下と共有されます。"
+
 
 #: js/widgets/aidebugger.js:570
 msgid "Analyze my project"
 msgstr "私のプロジェクトを分析してください"
 
+
 #: js/widgets/aidebugger.js:599
 msgid "AI analysis was not started. You can type a question below, but project data will not be sent until you agree."
 msgstr "AI解析は開始されていません。以下に質問を入力できますが、同意するまでプロジェクト データは送信されません。"
+
 
 #: js/widgets/aidebugger.js:629
 msgid "Debugger error: Invalid project data format."
 msgstr "デバッガー エラー: 無効なプロジェクト データ形式です。"
 
+
 #: js/widgets/aidebugger.js:646
 msgid "Debugger error: Could not load project data."
 msgstr "デバッガ エラー: プロジェクト データをロードできませんでした。"
+
 
 #: js/widgets/aidebugger.js:670
 msgid "AI Debugger is not available on this host. The backend URL could not be determined."
 msgstr "AI デバッガーはこのホストでは使用できません。バックエンド URL を特定できませんでした。"
 
+
 #: js/widgets/aidebugger.js:723
 msgid "Server error: No initial response from AI backend."
 msgstr "サーバー エラー: AI バックエンドからの初期応答がありません。"
+
 
 #: js/widgets/aidebugger.js:730
 msgid "Server error: Failed to initialize AI debugger."
 msgstr "サーバー エラー: AI デバッガーの初期化に失敗しました。"
 
+
 #: js/widgets/aidebugger.js:762
 msgid "Conversation reset."
 msgstr "会話がリセットされました。"
+
 
 #: js/widgets/aidebugger.js:771
 msgid "No conversation to export."
 msgstr "エクスポートする会話はありません。"
 
+
 #: js/widgets/aidebugger.js:786
 msgid "Debugger error: Could not retrieve project data for export."
 msgstr "デバッガー エラー: エクスポートするプロジェクト データを取得できませんでした。"
+
 
 #: js/widgets/aidebugger.js:818
 msgid "Chat exported successfully."
 msgstr "チャットは正常にエクスポートされました。"
 
+
 #: js/widgets/aidebugger.js:867
 msgid "Chat cleared."
 msgstr "チャットがクリアされました。"
+
 
 #: js/widgets/aiwidget.js:136
 #: js/widgets/aiwidget.js:137
@@ -11750,116 +14025,145 @@ msgstr "チャットがクリアされました。"
 msgid "Pause"
 msgstr "止める"
 
+
 #: js/widgets/aiwidget.js:181
 #: js/widgets/sampler.js:298
 msgid "Warning: Sample is bigger than 1MB."
 msgstr "ワーニング：サンプルは１MBより大きいです。"
 
+
 #: js/widgets/aiwidget.js:649
 msgid "New start block generated."
 msgstr "新しい開始ブロックが生成されました。"
 
+
 #: js/widgets/aiwidget.js:651
 msgid "MIDI loading. This may take some time depending upon the number of notes in the track"
 msgstr "「MIDI]を読み込み中です。音符の数とトラックの数によって時間がかかるかもしれません。"
+
 
 #: js/widgets/aiwidget.js:660
 #: js/widgets/sampler.js:323
 msgid "Upload failed: Sample is not a .wav file."
 msgstr "アップロードできませんでした： サンプルは .wavファイルでは ありません。"
 
+
 #: js/widgets/aiwidget.js:792
 msgid "Generate blocks"
 msgstr "ブロックを生成する"
+
 
 #: js/widgets/aiwidget.js:804
 msgid "Set API Key"
 msgstr "APIキーの設定"
 
+
 #: js/widgets/aiwidget.js:807
 msgid "Enter your Groq API Key: %s"
 msgstr "Groq API キーを入力してください: %s"
+
 
 #: js/widgets/aiwidget.js:875
 msgid "Synth error: %s"
 msgstr "シンセのエラー: %s"
 
+
 #: js/widgets/aiwidget.js:878
 msgid "Audio not supported in this browser."
 msgstr "このブラウザでは音声がサポートされていません。"
 
+
 #: js/widgets/aiwidget.js:1108
 msgid "Please set your Groq API Key using the settings button (wrench icon) first."
 msgstr "まず設定ボタン (レンチアイコン) を使用して Groq API キーを設定してください。"
+
 
 #: js/widgets/legobricks.js:355
 #: js/widgets/phrasemaker.js:683
 msgid "Export"
 msgstr "テーブルをほぞん"
 
+
 #: js/widgets/legobricks.js:363
 msgid "Upload Image"
 msgstr "画像をアップロードする"
+
 
 #: js/widgets/legobricks.js:369
 msgid "Webcam"
 msgstr "ウェブカメラ"
 
+
 #: js/widgets/legobricks.js:409
 msgid "LEGO Bricks - Phrase Maker with %s pitch rows (sorted by frequency, Instrument)"
 msgstr "レゴブロック - %s ピッチ行を含むフレーズ・メーカー (周波数、音声順に並べ替え)"
+
 
 #: js/widgets/legobricks.js:856
 msgid "No color data to save. Please scan an image first."
 msgstr "保存するカラー データがありません。まず画像をスキャンしてください。"
 
+
 #: js/widgets/legobricks.js:864
 msgid "No notes detected from color scanning."
 msgstr "カラー スキャンではメモが検出されませんでした。"
+
 
 #: js/widgets/legobricks.js:877
 msgid "LEGO phrase"
 msgstr "レゴ のフレーズ"
 
+
 #: js/widgets/legobricks.js:989
 msgid "LEGO phrase saved as action blocks with %s notes."
 msgstr "レゴ フレーズは %s 音符を含む「アクション」ブロックとして保存されました。"
+
 
 #: js/widgets/legobricks.js:1212
 msgid "Exporting phrase data: %s"
 msgstr "フレーズ データをエクスポートしています: %s"
 
+
 #: js/widgets/legobricks.js:1229
 msgid "Phrase cleared"
 msgstr "フレーズをクリアしました"
+
 
 #: js/widgets/legobricks.js:1269
 msgid "Image uploaded successfully"
 msgstr "画像が正常にアップロードされました"
 
+
 #: js/widgets/legobricks.js:1323
+#.  AUTOTRANSLATED: Google Translate
 msgid "Photo captured"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/legobricks.js:1328
 msgid "Webcam started"
 msgstr "ウェブカメラが開始されました"
 
+
 #: js/widgets/legobricks.js:1331
 msgid "Webcam access denied: %s"
 msgstr "ウェブカメラへのアクセスが拒否されました: %s"
+
 
 #: js/widgets/legobricks.js:1388
 msgid "Eye dropper active - hover over image to preview colors, click to select background color."
 msgstr "スポイトがアクティブ - 画像の上にカーソルを置くと色がプレビューされ、クリックして背景色を選択できます。"
 
+
 #: js/widgets/legobricks.js:1449
 msgid "Background color selected: %s"
 msgstr "選択された背景色: %s"
 
+
 #: js/widgets/legobricks.js:1452
 msgid "Could not sample color - please try clicking on the image."
 msgstr "カラーのサンプルができませんでした - 画像をクリックしてみてください。"
+
 
 #: js/widgets/legobricks.js:1935
 #: js/widgets/legobricks.js:2078
@@ -11867,9 +14171,11 @@ msgstr "カラーのサンプルができませんでした - 画像をクリッ
 msgid "Instrument changed to: %s"
 msgstr "音声は次のように変更されました: %s"
 
+
 #: js/widgets/legobricks.js:2234
 msgid "Scanning image with vertical lines..."
 msgstr "画像をスキャンすると縦線が入ります..."
+
 
 #: js/widgets/meterwidget.js:198
 #: js/widgets/meterwidget.js:199
@@ -11883,22 +14189,27 @@ msgstr "画像をスキャンすると縦線が入ります..."
 msgid "Play all"
 msgstr "全てさいせい"
 
+
 #: js/widgets/meterwidget.js:286
 #: js/widgets/sampler.js:1287
 msgid "Reset"
 msgstr "リセット"
 
+
 #: js/widgets/meterwidget.js:312
 msgid "Click in the circle to select strong beats for the meter."
 msgstr "クリックで強い拍の位置を選べます。"
+
 
 #: js/widgets/modewidget.js:170
 msgid "Rotate counter clockwise"
 msgstr "左回りにずれる"
 
+
 #: js/widgets/modewidget.js:176
 msgid "Rotate clockwise"
 msgstr "右回りにずれる"
+
 
 #: js/widgets/modewidget.js:182
 #: js/widgets/pitchstaircase.js:795
@@ -11907,10 +14218,12 @@ msgstr "右回りにずれる"
 msgid "Undo"
 msgstr "１つもどす"
 
+
 #: js/widgets/modewidget.js:200
-#.TRANS: A circle of notes represents the musical mode.
+#. TRANS: A circle of notes represents the musical mode.
 msgid "Click in the circle to select notes for the mode."
 msgstr "クリックで音の高さを選んで音階を設定できます。"
+
 
 #: js/widgets/modewidget.js:1015
 #: js/widgets/phrasemaker.js:5131
@@ -11923,47 +14236,58 @@ msgstr "クリックで音の高さを選んで音階を設定できます。"
 msgid "New action block generated."
 msgstr "新しいアクションを作りました。"
 
+
 #: js/widgets/oscilloscope.js:81
 msgid "Zoom In"
 msgstr "ズームイン"
+
 
 #: js/widgets/oscilloscope.js:89
 msgid "Zoom Out"
 msgstr "ズームアウト"
 
+
 #: js/widgets/phrasemaker.js:687
 msgid "Sort"
 msgstr "ならべなおす"
+
 
 #: js/widgets/phrasemaker.js:690
 #: js/widgets/musickeyboard.js:846
 msgid "Add note"
 msgstr "音符を足す"
 
+
 #: js/widgets/phrasemaker.js:1195
 msgid "Click on the table to add notes."
 msgstr "ます目をクリックするとメロディやリズムを作れます。"
+
 
 #: js/widgets/phrasemaker.js:2954
 #: js/widgets/phrasemaker.js:3107
 msgid "tuplet value"
 msgstr "何連符価"
 
+
 #: js/widgets/pitchslider.js:162
 msgid "Move up"
 msgstr "上げる"
+
 
 #: js/widgets/pitchslider.js:173
 msgid "Move down"
 msgstr "下げる"
 
+
 #: js/widgets/pitchslider.js:195
 msgid "Use the up/down buttons or arrow keys to change pitch."
 msgstr "ピッチを変更するには、上下ボタンまたは矢印キーを使用します。"
 
+
 #: js/widgets/pitchslider.js:196
 msgid "Click on the slider to create a note block."
 msgstr "スライダーで音の高さを変えます。"
+
 
 #: js/widgets/pitchstaircase.js:402
 #: js/widgets/pitchstaircase.js:738
@@ -11971,73 +14295,90 @@ msgstr "スライダーで音の高さを変えます。"
 msgid "Play chord"
 msgstr "和音を再生する"
 
+
 #: js/widgets/pitchstaircase.js:445
 #: js/widgets/pitchstaircase.js:758
 #: js/widgets/pitchstaircase.js:768
 msgid "Play scale"
 msgstr "音階を再生する"
 
+
 #: js/widgets/pitchstaircase.js:810
 msgid "Click on a note to create a new step."
 msgstr "ピッチをクリックすると新しい段が作れますよ。"
+
 
 #: js/widgets/reflection.js:142
 msgid "Summary"
 msgstr "まとめ"
 
+
 #: js/widgets/reflection.js:160
 msgid "Talk with Rohan"
 msgstr "ロハンさんと話す"
+
 
 #: js/widgets/reflection.js:167
 msgid "Talk with Alan"
 msgstr "アランさんと話す"
 
+
 #: js/widgets/reflection.js:174
 msgid "Talk with Beethoven"
 msgstr "ベートーヴェンさんとの話す"
+
 
 #: js/widgets/reflection.js:181
 msgid "Refresh"
 msgstr "リフレッシュ"
 
+
 #: js/widgets/reflection.js:231
 msgid "Reflect on your project."
 msgstr "自分のプロジェクトを振り返ってください。"
+
 
 #: js/widgets/reflection.js:378
 #: js/widgets/reflection.js:626
 msgid "Failed to send message."
 msgstr "メッセージの送信に失敗しました。"
 
+
 #: js/widgets/reflection.js:455
 msgid "No changes were detected in your project."
 msgstr "プロジェクト内で変更は検出されませんでした。"
+
 
 #: js/widgets/reflection.js:716
 msgid "No conversation to save."
 msgstr "保存できる会話はありません。"
 
+
 #: js/widgets/rhythmruler.js:664
 msgid "Save rhythms"
 msgstr "リズムだけをほぞん"
+
 
 #: js/widgets/rhythmruler.js:687
 msgid "Save drum machine"
 msgstr "ドラムとしてほぞん"
 
+
 #: js/widgets/rhythmruler.js:748
-#.TRANS: user can tap out a rhythm by clicking on a ruler.
+#. TRANS: user can tap out a rhythm by clicking on a ruler.
 msgid "Tap a rhythm"
 msgstr "リズムをタップする"
+
 
 #: js/widgets/rhythmruler.js:764
 msgid "Circular view"
 msgstr "円形ビュー"
 
+
 #: js/widgets/rhythmruler.js:999
 msgid "Click on the ruler to divide it."
 msgstr "クリックするとリズムをわけることができます。"
+
 
 #: js/widgets/rhythmruler.js:1167
 #: js/widgets/rhythmruler.js:1367
@@ -12045,50 +14386,62 @@ msgstr "クリックするとリズムをわけることができます。"
 msgid "tap a rhythm"
 msgstr "リズムをタップする"
 
+
 #: js/widgets/rhythmruler.js:1680
 msgid "Maximum value of 256 has been exceeded."
 msgstr "リズムメーカーの音の長さは、最大２５６です。"
+
 
 #: js/widgets/tempo.js:125
 msgid "Save tempo"
 msgstr "テンポを保存"
 
+
 #: js/widgets/tempo.js:162
 msgid "speed up"
 msgstr "速くする"
+
 
 #: js/widgets/tempo.js:171
 msgid "slow down"
 msgstr "遅くする"
 
+
 #: js/widgets/tempo.js:218
 msgid "Adjust the tempo with the buttons."
 msgstr "１分あたりの拍数でテンポを決められます。"
 
+
 #: js/widgets/tempo.js:311
 msgid "Please enter a number between 30 and 1000"
 msgstr "３０から１０００までの数字を入力してください。"
+
 
 #: js/widgets/tempo.js:318
 #: js/widgets/tempo.js:321
 msgid "The beats per minute must be between 30 and 1000."
 msgstr "1分あたりの拍の数は、30から1000までのはんいでせっていしてください。"
 
+
 #: js/widgets/tempo.js:337
 msgid "The beats per minute must be below 1000."
 msgstr "1分あたりの拍の数は、最大1000です。"
+
 
 #: js/widgets/tempo.js:353
 msgid "The beats per minute must be above 30"
 msgstr "１分あたりの拍の数には、３０より大きいあたいをせっていしてください。"
 
+
 #: js/widgets/arpeggio.js:251
 msgid "Click in the grid to add steps to the arpeggio."
 msgstr "テーブルを クリックでアルペジオのピッチを加える。"
 
+
 #: js/widgets/help.js:65
 msgid "Start by dragging a block from the left panel and connect it to the Start block."
 msgstr "はじめに左側のパネルからブロックをドラッグして、それを「スタート」ブロックに接続します。"
+
 
 #: js/widgets/help.js:104
 #: js/widgets/help.js:142
@@ -12099,6 +14452,7 @@ msgstr "はじめに左側のパネルからブロックをドラッグして、
 msgid "Next"
 msgstr "次"
 
+
 #: js/widgets/help.js:111
 #: js/widgets/help.js:148
 #: js/widgets/help.js:149
@@ -12108,6 +14462,7 @@ msgstr "次"
 msgid "Previous"
 msgstr "前の"
 
+
 #: js/widgets/help.js:135
 #: js/widgets/help.js:172
 #: js/widgets/help.js:202
@@ -12115,63 +14470,77 @@ msgstr "前の"
 msgid "Take a tour"
 msgstr "ツアーを始めよう"
 
+
 #: js/widgets/help.js:255
 #: js/widgets/help.js:801
 msgid "Show Palette containing the block"
 msgstr "ブロックを含むパレットを表示"
+
 
 #: js/widgets/help.js:337
 #: js/widgets/help.js:873
 msgid "Load this block"
 msgstr "このブロックをロードします"
 
+
 #: js/widgets/help.js:352
 msgid "This block is only available in advance mode"
 msgstr "このブロックはアドバンスモードでのみ利用可能です"
+
 
 #: js/widgets/help.js:881
 msgid "This block is only available in advance mode."
 msgstr "このブロックはアドバンスモードでのみ使用できます。"
 
+
 #: js/widgets/musickeyboard.js:865
 msgid "Metronome"
 msgstr "メトロノーム"
+
 
 #: js/widgets/musickeyboard.js:1793
 msgid "Note value"
 msgstr "ノートの値"
 
+
 #: js/widgets/musickeyboard.js:2296
 msgid "All 12 pitches are already in the keyboard. Adding duplicate."
 msgstr "12個のピッチ、すべてがすでにキーボードに組み込まれています。重複を追加します。"
 
+
 #: js/widgets/musickeyboard.js:3547
 msgid "New action blocks generated."
 msgstr "新しいアクションを作りました。"
+
 
 #: js/widgets/musickeyboard.js:3681
 #: js/widgets/musickeyboard.js:3689
 msgid "MIDI device present."
 msgstr "MIDIデバイスが見つかりました。"
 
+
 #: js/widgets/musickeyboard.js:3692
 msgid "No MIDI device found."
 msgstr "MIDIデバイスが見つかりません。"
 
+
 #: js/widgets/musickeyboard.js:3702
 msgid "Failed to get MIDI access in browser."
 msgstr "ブラウザはMIDIのアクセスができませんでした。"
+
 
 #: js/widgets/pitchdrummatrix.js:377
 #: js/widgets/pitchdrummatrix.js:722
 msgid "Click in the grid to map notes to drums."
 msgstr "グラフにクリックして音符をどちらのドラムに変えるか決めることができます。"
 
+
 #: js/widgets/temperament.js:170
 #: js/widgets/temperament.js:1193
 #: js/widgets/temperament.js:1357
 msgid "preview"
 msgstr "試す"
+
 
 #: js/widgets/temperament.js:174
 #: js/widgets/temperament.js:680
@@ -12183,17 +14552,21 @@ msgstr "試す"
 msgid "done"
 msgstr "終った"
 
+
 #: js/widgets/temperament.js:391
 msgid "back to 2:1 octave space"
 msgstr "2:1 オクターヴ・スペースに戻る"
+
 
 #: js/widgets/temperament.js:534
 msgid "edit"
 msgstr "編集する"
 
+
 #: js/widgets/temperament.js:657
 msgid "cents"
 msgstr "セント"
+
 
 #: js/widgets/temperament.js:793
 #: js/widgets/temperament.js:798
@@ -12201,346 +14574,432 @@ msgstr "セント"
 msgid "ratio"
 msgstr "比率"
 
+
 #: js/widgets/temperament.js:799
 msgid "interval"
 msgstr "音と音の間の間隔"
+
 
 #: js/widgets/temperament.js:946
 msgid "non scalar"
 msgstr "音階内ではない"
 
+
 #: js/widgets/temperament.js:996
 msgid "ratios"
 msgstr "比率"
+
 
 #: js/widgets/temperament.js:996
 msgid "arbitrary"
 msgstr "自由意思"
 
+
 #: js/widgets/temperament.js:1091
 msgid "number of divisions"
 msgstr "分配の数"
+
 
 #: js/widgets/temperament.js:1129
 msgid "The Number of divisions is too large."
 msgstr "分割数が大きすぎます。"
 
+
 #: js/widgets/temperament.js:1261
 msgid "recursion"
 msgstr "反復"
 
+
 #: js/widgets/temperament.js:1300
+#.  AUTOTRANSLATED: Google Translate
 msgid "Please enter a valid ratio (e.g. 3:2) within the octave space."
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/temperament.js:1832
 msgid "The octave ratio has changed. This changes temperament significantly."
 msgstr "オクターブ比が変わりました。これにより調律が大きく変わります。"
 
+
 #: js/widgets/temperament.js:1876
 msgid "Invalid temperament: %s. Skipping to next temperament."
 msgstr "無効な音律: %s。次の音律にスキップします。"
+
 
 #: js/widgets/temperament.js:2563
 msgid "Table"
 msgstr "グリッド"
 
+
 #: js/widgets/temperament.js:2623
 msgid "Invalid temperament interval data. Skipping note %s."
 msgstr "無効な音律間隔データです。%sのピッチ をスキップします。"
+
 
 #: js/widgets/temperament.js:2694
 msgid "Add pitches"
 msgstr "音高を足す"
 
+
 #: js/widgets/sampler.js:307
 msgid "Recording started"
 msgstr "録音開始"
+
 
 #: js/widgets/sampler.js:315
 msgid "Recording complete"
 msgstr "録音完了"
 
+
 #: js/widgets/sampler.js:366
 msgid "A new sample block was generated."
 msgstr "新しい「音色サンプル」ブロックが作りました"
 
+
 #: js/widgets/sampler.js:407
 msgid "Warning: Your sample cannot be loaded because it is >1MB."
 msgstr "ワーニング：音色サンプルは> 1MBであるため 読み込むことができません。"
+
 
 #: js/widgets/sampler.js:578
 #: js/widgets/sampler.js:1106
 msgid "Tuner stopped."
 msgstr "チューナーが停止しました。"
 
+
 #: js/widgets/sampler.js:602
 msgid "Upload sample"
 msgstr "音色サンプルをアップロード"
+
 
 #: js/widgets/sampler.js:657
 msgid "Save sample"
 msgstr "音色 サンプルを 保存"
 
+
 #: js/widgets/sampler.js:670
 msgid "Toggle Mic"
 msgstr "マイクの切り替え"
+
 
 #: js/widgets/sampler.js:672
 msgid "Playback"
 msgstr "再生"
 
+
 #: js/widgets/sampler.js:674
 msgid "Prompt"
 msgstr "プロンプト"
 
+
 #: js/widgets/sampler.js:732
+#.  AUTOTRANSLATED: Google Translate
 msgid "AI Sample Generation"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/sampler.js:798
 msgid "Generating audio... (It may take up to 1 minute)"
 msgstr "新しい音声を生成しています... (最大 1 分かかる場合があります)"
 
+
 #: js/widgets/sampler.js:801
 msgid "Generating audio..."
 msgstr "新しい音声を生成しています..."
+
 
 #: js/widgets/sampler.js:811
 msgid "Audio ready!"
 msgstr "新しい音声の準備完了！"
 
+
 #: js/widgets/sampler.js:816
 msgid "Failed to generate audio."
 msgstr "音声の生成に失敗しました。"
 
+
 #: js/widgets/sampler.js:822
 msgid "An error occurred."
 msgstr "エラーが発生しました。"
+
 
 #: js/widgets/sampler.js:920
 #: js/widgets/sampler.js:2232
 msgid "Tuner"
 msgstr "チューナー"
 
+
 #: js/widgets/sampler.js:1030
 msgid "Chromatic"
 msgstr "クロマチック"
+
 
 #: js/widgets/sampler.js:1042
 msgid "Target pitch"
 msgstr "目標ピッチ"
 
+
 #: js/widgets/sampler.js:1104
 msgid "Tuner started."
 msgstr "チューナーが起動しました。"
+
 
 #: js/widgets/sampler.js:1115
 msgid "Cents adjustment"
 msgstr "セント調整"
 
+
 #: js/widgets/sampler.js:2211
 msgid "Microphone access failed: %s"
 msgstr "マイクアクセスに失敗しました: %s"
 
+
 #: js/widgets/sampler.js:2239
 msgid "Start"
-msgstr ""
+msgstr "スタート"
+
 
 #: js/widgets/sampler.js:2251
+#.  AUTOTRANSLATED: Google Translate
 msgid "Detected Pitch:"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/sampler.js:2260
+#.  AUTOTRANSLATED: Google Translate
 msgid "Note:"
-msgstr ""
+msgstr "Error 500 (Server Error)!!1500.That’s an error.There was an error. Please try again later.That’s all we know."
+
 
 #: js/widgets/timbre.js:839
 msgid "Synthesizer"
 msgstr "シンセサイザー"
 
+
 #: js/widgets/timbre.js:947
 #: planet/js/GlobalTag.js:48
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Effects"
 msgstr "音響効果"
+
 
 #: js/widgets/timbre.js:999
 msgid "Add filter"
 msgstr "フィルターを加える"
 
+
 #: js/widgets/timbre.js:1036
 msgid "Click on buttons to open the timbre design tools."
 msgstr "ボタンをクリックするとカスタム音色ツールが開きます。"
 
+
 #: js/widgets/timbre.js:1410
 msgid "harmonicity"
 msgstr "倍音の音色"
+
 
 #: js/widgets/timbre.js:1474
 #: js/widgets/timbre.js:1540
 msgid "modulation index"
 msgstr "モジュレーションインデックス"
 
+
 #: js/widgets/timbre.js:1594
 msgid "vibrato amount"
 msgstr "ビブラートの速さ"
+
 
 #: js/widgets/timbre.js:2074
 msgid "Filter already present."
 msgstr "フィルターは もう 存在しています。"
 
+
 #: js/widgets/timbre.js:2664
 msgid "distortion amount"
 msgstr "ディストーションの大きさ"
 
+
 #: planet/js/GlobalCard.js:50
 msgid "More Details"
 msgstr "さらに詳しく"
+
 
 #: planet/js/GlobalCard.js:53
 #: planet/js/SaveInterface.js:34
 msgid "Open in Music Blocks"
 msgstr "ミュージック・ブロックスで開きます"
 
+
 #: planet/js/GlobalCard.js:64
 msgid "Share project"
 msgstr "プロジェクトをシェアする"
+
 
 #: planet/js/GlobalCard.js:70
 msgid "Share"
 msgstr "シェア"
 
+
 #: planet/js/GlobalCard.js:72
 msgid "Copy link to clipboard"
 msgstr "リンクをクリップボードにコピー"
+
 
 #: planet/js/GlobalCard.js:76
 msgid "Flags"
 msgstr "旗"
 
+
 #: planet/js/GlobalCard.js:77
 msgid "Run project on startup."
 msgstr "起動時にプロジェクトを実行します。"
+
 
 #: planet/js/GlobalCard.js:80
 msgid "Show code blocks on startup."
 msgstr "起動時にコード ブロックを表示します。"
 
+
 #: planet/js/GlobalCard.js:83
 msgid "Collapse code blocks on startup."
 msgstr "起動時にコード ブロックを折りたたむ。"
+
 
 #: planet/js/GlobalCard.js:90
 msgid "Advanced Options"
 msgstr "詳細オプション"
 
+
 #: planet/js/GlobalCard.js:238
 msgid "Link copied to clipboard!"
 msgstr "リンクがクリップボードにコピーされました!"
+
 
 #: planet/js/GlobalCard.js:245
 msgid "Failed to copy link to clipboard"
 msgstr "リンクをクリップボードにコピーできませんでした"
 
+
 #: planet/js/GlobalPlanet.js:36
 msgid "No results found."
 msgstr "検索の結果に何もはありません"
+
 
 #: planet/js/GlobalPlanet.js:52
 msgid "Remix of"
 msgstr "のリミックス"
 
+
 #: planet/js/GlobalPlanet.js:508
 msgid "Cannot connect to server"
 msgstr "サーバに接続できません"
 
+
 #: planet/js/GlobalTag.js:26
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "All Projects"
 msgstr "全てのプロジェクト"
 
+
 #: planet/js/GlobalTag.js:28
 #: planet/js/StringHelper.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "My Projects"
 msgstr "自分のプロジェクト"
 
+
 #: planet/js/GlobalTag.js:30
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Examples"
 msgstr "プロジェクトの見本"
 
+
 #: planet/js/GlobalTag.js:34
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Art"
 msgstr "アート"
 
+
 #: planet/js/GlobalTag.js:36
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Math"
 msgstr "算数"
 
+
 #: planet/js/GlobalTag.js:38
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Interactive"
 msgstr "インタラクティブ"
 
+
 #: planet/js/GlobalTag.js:40
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Design"
 msgstr "デザイン"
 
+
 #: planet/js/GlobalTag.js:42
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Game"
 msgstr "ゲーム"
 
+
 #: planet/js/GlobalTag.js:50
-#.TRANS: On the Planet, we use labels to tag projects.
+#. TRANS: On the Planet, we use labels to tag projects.
 msgid "Code Snippet"
 msgstr "短いコード"
+
 
 #: planet/js/LocalCard.js:36
 msgid "View published project"
 msgstr "公開されたプロジェクトを見る"
+
 
 #: planet/js/LocalCard.js:44
 #: planet/js/StringHelper.js:37
 msgid "Publish project"
 msgstr "プロジェクトを公開する"
 
+
 #: planet/js/LocalCard.js:55
 msgid "Edit project"
 msgstr "プロジェクトを編集する"
+
 
 #: planet/js/LocalCard.js:58
 msgid "Delete project"
 msgstr "プロジェクトを消す"
 
+
 #: planet/js/LocalCard.js:61
 msgid "Download project"
 msgstr "プロジェクトをダウンロードする"
+
 
 #: planet/js/LocalCard.js:67
 msgid "Duplicate project"
 msgstr "プロジェクトをコピーする"
 
+
 #: planet/js/Planet.js:139
 msgid "New Project"
 msgstr "新しいプロジェクト"
+
 
 #: planet/js/Planet.js:147
 msgid "Unsaved changes will be lost. Are you sure?"
 msgstr "保存されていない変更は失われます。本気ですか？"
 
+
 #: planet/js/ProjectViewer.js:29
 msgid "Error: Report could not be submitted. Try again later."
 msgstr "エラー：通報ができませんでした。後で再度試してください。"
 
+
 #: planet/js/ProjectViewer.js:30
 msgid "Thank you for reporting this project. A moderator will review the project shortly, to verify violation of the Sugar Labs Code of Conduct."
 msgstr "このプロジェクトを通報して下さってありがとうございます。モデレータが間もなく、プロジェクトを見ます。"
+
 
 #: planet/js/ProjectViewer.js:33
 #: planet/js/StringHelper.js:64
@@ -12549,363 +15008,452 @@ msgstr "このプロジェクトを通報して下さってありがとうござ
 msgid "Report Project"
 msgstr "プロジェクトを通報する"
 
+
 #: planet/js/ProjectViewer.js:34
 #: planet/js/StringHelper.js:65
 msgid "Project Reported"
 msgstr "プロジェクトは通報されました"
 
+
 #: planet/js/ProjectViewer.js:35
 msgid "Report description required"
 msgstr "レポート表記が必要です"
+
 
 #: planet/js/ProjectViewer.js:36
 msgid "Report description too long"
 msgstr "レポート表記が長すぎます"
 
+
 #: planet/js/Publisher.js:31
 msgid "Feature unavailable - cannot connect to server. Reload Music Blocks to try again."
 msgstr "エラー：サーバに接続できません。ミュージック・ブロックスをリロードし、再度試して下さい。"
+
 
 #: planet/js/Publisher.js:216
 #: planet/js/Publisher.js:233
 msgid "This field is required"
 msgstr "この項目は必須項目です"
 
+
 #: planet/js/Publisher.js:223
 msgid "Title too long"
 msgstr "タイトルが長すぎます"
+
 
 #: planet/js/Publisher.js:240
 msgid "Description too long"
 msgstr "表記が長すぎます"
 
+
 #: planet/js/Publisher.js:373
 msgid "Server Error"
 msgstr "サーバーエラー"
+
 
 #: planet/js/Publisher.js:373
 msgid "Try Again"
 msgstr "もう一度使い直してください。"
 
+
 #: planet/js/SaveInterface.js:37
 msgid "Open in Turtle Blocks"
 msgstr "タートル ブロックスで開きます"
+
 
 #: planet/js/StringHelper.js:29
 msgid "Planet"
 msgstr "プラネット"
 
+
 #: planet/js/StringHelper.js:30
 msgid "Close Planet"
 msgstr "プラネットを閉じる"
+
 
 #: planet/js/StringHelper.js:31
 msgid "Open project from file"
 msgstr "ファイルからプロジェクトを開く"
 
+
 #: planet/js/StringHelper.js:33
 msgid "Local"
 msgstr "ローカル"
+
 
 #: planet/js/StringHelper.js:34
 msgid "Global"
 msgstr "グローバル"
 
+
 #: planet/js/StringHelper.js:35
 msgid "Search for a project"
 msgstr "プロジェクト検索"
 
+
 #: planet/js/StringHelper.js:39
 msgid "Tags (max 5)"
 msgstr "タッグ（最大5個）"
+
 
 #: planet/js/StringHelper.js:40
 #: planet/js/StringHelper.js:63
 msgid "Description"
 msgstr "記入"
 
+
 #: planet/js/StringHelper.js:41
 #: planet/js/StringHelper.js:74
 msgid "Submit"
 msgstr "確認"
 
+
 #: planet/js/StringHelper.js:43
 msgid "Delete \"<span id=\"deleter-title\"></span>\"?"
 msgstr "「<span id=\"deleter-title\"></span>」を削除しますか?"
+
 
 #: planet/js/StringHelper.js:46
 msgid "Permanently delete project \"<span id=\"deleter-name\"></span>\"?"
 msgstr "プロジェクト「<span id=\"deleter-name\"></span>」を完全に削除しますか?"
 
+
 #: planet/js/StringHelper.js:50
 msgid "Explore Projects"
 msgstr "プロジェクトを探す"
+
 
 #: planet/js/StringHelper.js:51
 #: planet/js/helper.js:149
 msgid "Show more tags"
 msgstr "タッグをもっと見る"
 
+
 #: planet/js/StringHelper.js:52
 msgid "Most recent"
 msgstr "一番最近"
+
 
 #: planet/js/StringHelper.js:53
 msgid "Most liked"
 msgstr "「いいね」の一番ある"
 
+
 #: planet/js/StringHelper.js:54
 msgid "Most downloaded"
 msgstr "ダウンロードの一番ある"
+
 
 #: planet/js/StringHelper.js:55
 msgid "A-Z"
 msgstr "「A-Z」の順番"
 
+
 #: planet/js/StringHelper.js:56
 msgid "Sort by"
 msgstr "～で整理する"
+
 
 #: planet/js/StringHelper.js:57
 msgid "Load More Projects"
 msgstr "プロジェクトをもっとロードする"
 
+
 #: planet/js/StringHelper.js:58
 msgid "Last Updated"
 msgstr "最後の更新"
+
 
 #: planet/js/StringHelper.js:59
 msgid "Creation Date"
 msgstr "作成日"
 
+
 #: planet/js/StringHelper.js:60
 msgid "Number of Downloads:"
 msgstr "ダウンロード数"
+
 
 #: planet/js/StringHelper.js:61
 msgid "Number of Likes:"
 msgstr "「いいね」の数"
 
+
 #: planet/js/StringHelper.js:62
 msgid "Tags:"
 msgstr "タッグ"
+
 
 #: planet/js/StringHelper.js:69
 msgid "Report projects which violate the <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs Code of Conduct</a>."
 msgstr "<a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/CODE_OF_CONDUCT.md\" target=\"_blank\" rel=\"noopener noreferrer\">Sugar Labs 行動規範</a>に違反するプロジェクトを報告します。"
 
+
 #: planet/js/StringHelper.js:73
 msgid "Reason for reporting project"
 msgstr "プロジェクトを通報する理由"
+
 
 #: planet/js/StringHelper.js:77
 msgid "Download as File"
 msgstr "ファイルでダウンロードする"
 
+
 #: planet/js/helper.js:150
 msgid "Show fewer tags"
 msgstr "タッグを非表示"
+
 
 #: planet/js/ProjectStorage.js:270
 msgid "anonymous"
 msgstr "匿名"
 
+
 #: plugins/accelerometer.rtp:48
 msgid "motion x"
 msgstr "x座標の動き"
+
 
 #: plugins/accelerometer.rtp:56
 msgid "motion y"
 msgstr "y座標の動き"
 
+
 #: plugins/accelerometer.rtp:64
 msgid "motion z"
 msgstr "z座標の動き"
+
 
 #: plugins/facebook.rtp:27
 msgid "publish"
 msgstr "プロジェクトをフェースブックにアップロードする"
 
+
 #: plugins/maths.rtp:62
 msgid "power"
 msgstr "指数"
+
 
 #: plugins/maths.rtp:62
 msgid "base"
 msgstr "ベース"
 
+
 #: plugins/maths.rtp:62
 msgid "exp"
 msgstr "exp"
+
 
 #: plugins/maths.rtp:99
 msgid "floor"
 msgstr "床"
 
+
 #: plugins/maths.rtp:104
 msgid "ceiling"
 msgstr "天井"
+
 
 #: plugins/maths.rtp:109
 msgid "to degrees"
 msgstr "度数法へ変換"
 
+
 #: plugins/maths.rtp:114
 msgid "to radians"
 msgstr "ラジアンへ変換"
+
 
 #: plugins/nutrition.rtp:104
 msgid "get calories"
 msgstr "カロリーをとる"
 
+
 #: plugins/nutrition.rtp:107
 msgid "get protein"
 msgstr "たんぱく質をとる"
+
 
 #: plugins/nutrition.rtp:110
 msgid "get carbs"
 msgstr "炭水化物"
 
+
 #: plugins/nutrition.rtp:113
 msgid "get fiber"
 msgstr "食物繊維をとる"
+
 
 #: plugins/nutrition.rtp:116
 msgid "get fat"
 msgstr "太る"
 
+
 #: plugins/nutrition.rtp:119
 msgid "get name"
 msgstr "名前を獲得する"
+
 
 #: plugins/nutrition.rtp:122
 msgid "calories"
 msgstr "カロリー"
 
+
 #: plugins/nutrition.rtp:128
 msgid "protein"
 msgstr "たんぱく"
+
 
 #: plugins/nutrition.rtp:134
 msgid "carbs"
 msgstr "炭水化物"
 
+
 #: plugins/nutrition.rtp:140
 msgid "fiber"
 msgstr "食物繊維"
+
 
 #: plugins/nutrition.rtp:146
 msgid "fat"
 msgstr "脂肪"
 
+
 #: plugins/nutrition.rtp:152
 msgid "eat"
 msgstr "食べる"
+
 
 #: plugins/nutrition.rtp:155
 msgid "digest meal"
 msgstr "食事を熟す"
 
+
 #: plugins/nutrition.rtp:158
 msgid "apple"
 msgstr "りんご"
+
 
 #: plugins/nutrition.rtp:161
 msgid "banana"
 msgstr "バナナ"
 
+
 #: plugins/nutrition.rtp:167
 msgid "wheat bread"
 msgstr "麦パン"
+
 
 #: plugins/nutrition.rtp:170
 msgid "corn"
 msgstr "コーン"
 
+
 #: plugins/nutrition.rtp:173
 msgid "potato"
 msgstr "芋"
+
 
 #: plugins/nutrition.rtp:176
 msgid "sweet potato"
 msgstr "スイートポテト"
 
+
 #: plugins/nutrition.rtp:179
 msgid "tomato"
 msgstr "トマト"
+
 
 #: plugins/nutrition.rtp:182
 msgid "broccoli"
 msgstr "ブロッコリー"
 
+
 #: plugins/nutrition.rtp:185
 msgid "rice and beans"
 msgstr "ご飯と豆"
+
 
 #: plugins/nutrition.rtp:188
 msgid "tamale"
 msgstr "タマレ"
 
+
 #: plugins/nutrition.rtp:191
 msgid "cheese"
 msgstr "チーズ"
+
 
 #: plugins/nutrition.rtp:194
 msgid "chicken"
 msgstr "鶏肉"
 
+
 #: plugins/nutrition.rtp:197
 msgid "fish"
 msgstr "魚"
+
 
 #: plugins/nutrition.rtp:200
 msgid "beef"
 msgstr "牛肉"
 
+
 #: plugins/nutrition.rtp:203
 msgid "cake"
 msgstr "ケーキ"
+
 
 #: plugins/nutrition.rtp:206
 msgid "cookie"
 msgstr "クッキー"
 
+
 #: plugins/nutrition.rtp:209
 msgid "water"
 msgstr "水"
+
 
 #: plugins/rodi.rtp:172
 msgid "blink"
 msgstr "点滅する"
 
+
 #: plugins/rodi.rtp:246
 msgid "led"
 msgstr "発光ダイオード"
+
 
 #: plugins/rodi.rtp:265
 msgid "light intensity"
 msgstr "光の強さ"
 
+
 #: plugins/rodi.rtp:282
 msgid "infrared light (left)"
 msgstr "赤外光 （左）"
+
 
 #: plugins/rodi.rtp:296
 msgid "infrared light (right)"
 msgstr "赤外光 （右）"
 
+
 #: plugins/rodi.rtp:338
 msgid "move"
 msgstr "動き出し"
+
 
 #: plugins/weather.rtp:68
 #: plugins/weather.rtp:97
 msgid "Days ahead must be in the range of -1 to 5."
 msgstr "日にちは -１から５までの数でなくてはなりません"
 
+
 #: plugins/weather.rtp:122
 msgid "forecast"
 msgstr "天気予報"
+
 
 #: plugins/weather.rtp:123
 #: plugins/weather.rtp:137
@@ -12913,171 +15461,203 @@ msgstr "天気予報"
 msgid "city"
 msgstr "市"
 
+
 #: plugins/weather.rtp:124
 #: plugins/weather.rtp:138
 #: plugins/weather.rtp:151
 msgid "day"
 msgstr "曜日"
 
+
 #: plugins/weather.rtp:136
 msgid "high"
 msgstr "高"
+
 
 #: plugins/weather.rtp:149
 msgid "low"
 msgstr "低"
 
+
 #: js/utils/utils-logic.js:324
 
-#~msgid "Invalid input passed to rationalSum"
-#~msgstr ""
+#~ msgid "Invalid input passed to rationalSum"
+#~ msgstr ""
+
 
 #: js/activity.js:2014
 
 #: js/activity.js:2092
 
-#~msgid "Save recording"
-#~msgstr "録音を保存する"
+#~ msgid "Save recording"
+#~ msgstr "録音を保存する"
+
 
 #: js/activity.js:2021
 
 #: js/activity.js:2071
 
-#~msgid "File save canceled"
-#~msgstr "ファイルの保存がキャンセルされました"
+#~ msgid "File save canceled"
+#~ msgstr "ファイルの保存がキャンセルされました"
+
 
 #: js/activity.js:2042
 
 #: js/activity.js:2052
 
-#~msgid "Recorded file is empty. File not saved."
-#~msgstr "録音されたファイルは空です。ファイルが保存されていません。"
+#~ msgid "Recorded file is empty. File not saved."
+#~ msgstr "録音されたファイルは空です。ファイルが保存されていません。"
+
 
 #: js/activity.js:2069
 
 #: js/activity.js:2099
 
-#~msgid "Enter file name"
-#~msgstr "ファイル名を入力してください"
+#~ msgid "Enter file name"
+#~ msgstr "ファイル名を入力してください"
+
 
 #: js/activity.js:2082
 
-#~msgid "Saved! Check your Downloads folder."
-#~msgstr "保存しました！ダウンロードフォルダーを確認してください。"
+#~ msgid "Saved! Check your Downloads folder."
+#~ msgstr "保存しました！ダウンロードフォルダーを確認してください。"
+
 
 #: js/activity.js:2089
 
-#~msgid "Recording stopped. File saved."
-#~msgstr "録音が停止されました。ファイルが保存されました。"
+#~ msgid "Recording stopped. File saved."
+#~ msgstr "録音が停止されました。ファイルが保存されました。"
+
 
 #: js/activity.js:2094
 
-#~msgid "recording"
-#~msgstr "録音中"
+#~ msgid "recording"
+#~ msgstr "録音中"
+
 
 #: js/activity.js:2131
 
-#~msgid "Recording started. Click stop to finish."
-#~msgstr "録音が開始されました。終了するには「停止」をクリックします。"
+#~ msgid "Recording started. Click stop to finish."
+#~ msgstr "録音が開始されました。終了するには「停止」をクリックします。"
+
 
 #: js/activity.js:2211
 
-#~msgid "Recording failed: %s"
-#~msgstr "録音に失敗しました: %s"
+#~ msgid "Recording failed: %s"
+#~ msgstr "録音に失敗しました: %s"
+
 
 #: js/activity.js:2671
 
-#~msgid "show Cartesian"
-#~msgstr "ほうがん（ざひょう）を表示"
+#~ msgid "show Cartesian"
+#~ msgstr "ほうがん（ざひょう）を表示"
+
 
 #: js/activity.js:3340
 
-#~msgid "output tools"
-#~msgstr "出力ツール"
+#~ msgid "output tools"
+#~ msgstr "出力ツール"
+
 
 #: js/activity.js:3343
 
-#~msgid "custom note"
-#~msgstr "カスタムノート"
+#~ msgid "custom note"
+#~ msgstr "カスタムノート"
+
 
 #: js/activity.js:3346
 
-#~msgid "accidental name"
-#~msgstr "偶然の名前"
+#~ msgid "accidental name"
+#~ msgstr "偶然の名前"
+
 
 #: js/activity.js:3361
 
-#~msgid "chord name"
-#~msgstr "chord name"
+#~ msgid "chord name"
+#~ msgstr "chord name"
+
 
 #: js/activity.js:3367
 
-#~msgid "filter type"
-#~msgstr "フィルターの種類"
+#~ msgid "filter type"
+#~ msgstr "フィルターの種類"
+
 
 #: js/activity.js:3370
 
-#~msgid "oscillator type"
-#~msgstr "発振器の種類"
+#~ msgid "oscillator type"
+#~ msgstr "発振器の種類"
+
 
 #: js/activity.js:3385
 
-#~msgid "wrap mode"
-#~msgstr "ラップモード"
+#~ msgid "wrap mode"
+#~ msgstr "ラップモード"
+
 
 #: js/activity.js:3388
 
-#~msgid "load file"
-#~msgstr "ロード ファイル "
+#~ msgid "load file"
+#~ msgstr "ロード ファイル "
+
 
 #: js/activity.js:3717
 
 #: js/activity.js:7467
 
-#~msgid "This block is deprecated."
-#~msgstr "このブロックはもうありません。"
+#~ msgid "This block is deprecated."
+#~ msgstr "このブロックはもうありません。"
+
 
 #: js/activity.js:3719
 
 #: js/activity.js:7469
 
-#~msgid "Block cannot be found."
-#~msgstr "ブロックが見つかりません。"
+#~ msgid "Block cannot be found."
+#~ msgstr "ブロックが見つかりません。"
+
 
 #: js/activity.js:7080
 
-#~msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
-#~msgstr "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。"
+#~ msgid "Invalid plugin name. Only alphanumeric characters, hyphens, and underscores are allowed."
+#~ msgstr "プラグイン名が無効です。英数字、ハイフン、アンダースコアのみが使用できます。"
+
 
 #: js/activity.js:7586
 
-#~msgid "You can type d to create a do block and r to create a re block etc."
-#~msgstr "キーボードを使うと、パレットボタンからブロックをドラッグして配置するだけでなく、ボタンをおすだけでちょくせつブロックを置くことができる。★ショートカットキー d …… 「ド」（４分音符、４オクターヴ） r …… 「レ」（４分音符、４オクターヴ） m …… 「ミ」（４分音符、４オクターヴ） f</em> …… 「ファ」（４分音符、４オクターヴ s …… 「ソ」（４分音符、４オクターヴ） l …… 「ラ」（４分音符、４オクターヴ） t …… 「シ」（４分音符、４オクターヴ）"
+#~ msgid "You can type d to create a do block and r to create a re block etc."
+#~ msgstr "キーボードを使うと、パレットボタンからブロックをドラッグして配置するだけでなく、ボタンをおすだけでちょくせつブロックを置くことができる。★ショートカットキー d …… 「ド」（４分音符、４オクターヴ） r …… 「レ」（４分音符、４オクターヴ） m …… 「ミ」（４分音符、４オクターヴ） f</em> …… 「ファ」（４分音符、４オクターヴ s …… 「ソ」（４分音符、４オクターヴ） l …… 「ラ」（４分音符、４オクターヴ） t …… 「シ」（４分音符、４オクターヴ）"
+
 
 #: js/activity.js:8099
 
-#~msgid "Select is enabled."
-#~msgstr "選択モードが有効です。"
+#~ msgid "Select is enabled."
+#~ msgstr "選択モードが有効です。"
+
 
 #: js/activity.js:8100
 
-#~msgid "Select is disabled."
-#~msgstr "選択モードが無効です。"
+#~ msgid "Select is disabled."
+#~ msgstr "選択モードが無効です。"
+
 
 #: js/activity.js:9291
 
-#~msgid "Error regenerating palettes. Please refresh the page."
-#~msgstr "パレットの再生成に失敗しました。ページを更新してください。"
+#~ msgid "Error regenerating palettes. Please refresh the page."
+#~ msgstr "パレットの再生成に失敗しました。ページを更新してください。"
+
 
 #: js/blocks/PitchBlocks.js:1123
 
-#~msgid "In the example shown above, sol is shifted up to sol#. "
-#~msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
+#~ msgid "In the example shown above, sol is shifted up to sol#. "
+#~ msgstr "例の画像に<em>ソル</em>が<em>ソル#</em>に上に移動されています。"
+
 
 #: js/widgets/sampler.js:615
 
-#~msgid "Trim"
-#~msgstr "トリム"
+#~ msgid "Trim"
+#~ msgstr "トリム"
+
 
 #: js/turtleactions/MeterActions.js:148
 
@@ -13511,11 +16091,12 @@ msgstr "低"
 
 #: index.html (record dropdown)
 
-#~msgid "Record canvas and toolbars"
-#~msgstr "キャンバスとツールバーを録画"
+#~ msgid "Record canvas and toolbars"
+#~ msgstr "キャンバスとツールバーを録画"
+
 
 #: index.html (record dropdown)
 
-#~msgid "Record canvas only"
-#~msgstr "キャンバスのみ録画"
+#~ msgid "Record canvas only"
+#~ msgstr "キャンバスのみ録画"
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

To assist the i18n team, AI translations have been added to 24 strings in the `ja.po `file. These strings are tagged as such. They have also been migrated to` ja-kana.po` as hiragana.

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

AI translation run on the JA PO files.

