### PR TITLE
feat(widgets): add reset to default ratios button in pitch staircase

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -1045,5 +1045,23 @@ describe("PitchStaircase Widget", () => {
             ];
             expect(() => psc._makeStairs()).not.toThrow();
         });
+
+        test("resetDefaults should reset ratio inputs to 3 and 2 while preserving existing stairs", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc._musicRatio1 = { value: "7" };
+            psc._musicRatio2 = { value: "9" };
+            psc.Stairs = [
+                ["A", "4", 220.0],
+                ["B", "4", 240.0]
+            ];
+
+            psc.resetDefaults();
+
+            expect(psc._musicRatio1.value).toBe("3");
+            expect(psc._musicRatio2.value).toBe("2");
+            expect(psc.Stairs.length).toBe(2);
+            expect(mockTextMsg).toHaveBeenCalledWith("Reset to default ratios (3/2).", 2000);
+        });
     });
 });

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -872,6 +872,14 @@ class PitchStaircase {
                 while (this._undo());
             };
 
+        widgetWindow.addButton(
+            "reload.svg",
+            PitchStaircase.ICONSIZE,
+            _("Reset to default ratios")
+        ).onclick = () => {
+            this.resetDefaults();
+        };
+
         // The pitch-staircase (psc) table
         this._pscTable = document.createElement("table");
         widgetWindow.getWidgetBody().append(this._pscTable);
@@ -886,6 +894,22 @@ class PitchStaircase {
                 wfbWidget.style.maxHeight = 10 * PitchStaircase.BUTTONSIZE + "px";
             }
         };
+    }
+
+    /**
+     * @public
+     * @returns {void}
+     */
+    resetDefaults() {
+        if (this._musicRatio1) {
+            this._musicRatio1.value = "3";
+        }
+        if (this._musicRatio2) {
+            this._musicRatio2.value = "2";
+        }
+        if (this.activity && typeof this.activity.textMsg === "function") {
+            this.activity.textMsg(_("Reset to default ratios (3/2)."), 2000);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a **Reset to default ratios** (`reload.svg`) toolbar button to the Pitch Staircase widget (`pitchstaircase.js`).

- **Reset Ratios Action**: Allows students to quickly restore the ratio multiplier inputs back to the default Pythagorean pure fifth ratio (`3` and `2`) without deleting their constructed musical staircase.
- **User Feedback**: Displays an informative feedback toast notification (`_("Reset to default ratios (3/2).")`).
- **Unit Test Coverage**: Added unit tests in `pitchstaircase.test.js` verifying that `resetDefaults()` properly resets ratio inputs to `3` and `2` while keeping existing stairs intact.

## Related Issue

N/A

## Category

- [x] Feature — Adds new functionality
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/widgets/pitchstaircase.js`**:
  - Added `reload.svg` toolbar button to `PitchStaircase.prototype.init()`.
  - Added `resetDefaults()` method to reset ratio inputs back to `3` and `2`.
- **`js/widgets/__tests__/pitchstaircase.test.js`**:
  - Added unit test for `resetDefaults()` asserting input restoration and stair preservation.

## Testing Performed

- Tested live in the Pitch Staircase widget window.
- Ran Jest unit test suite for `pitchstaircase.test.js` (passed 100%).
- Ran `lint-staged` with ESLint and Prettier (0 errors, 0 warnings).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
