### PR TITLE
fix(block): prevent cache updates when bitmapCache is missing

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -489,6 +489,15 @@ describe("Block Foundation", () => {
                 expect(block.container.updateCache).toHaveBeenCalled();
             });
 
+            it("should not update a cache that has not been created yet", () => {
+                block.container.bitmapCache = null;
+
+                expect(() => block.highlight()).not.toThrow();
+                expect(block.highlightBitmap.visible).toBe(true);
+                expect(block.bitmap.visible).toBe(false);
+                expect(block.container.updateCache).not.toHaveBeenCalled();
+            });
+
             it("should do nothing if trashed", () => {
                 block.trash = true;
                 block.highlight();
@@ -503,6 +512,28 @@ describe("Block Foundation", () => {
                 block.unhighlight();
                 expect(block.bitmap.visible).toBe(true);
                 expect(block.highlightBitmap.visible).toBe(false);
+            });
+
+            it("should not update a cache that has not been created yet", () => {
+                block.container.bitmapCache = null;
+
+                expect(() => block.unhighlight()).not.toThrow();
+                expect(block.bitmap.visible).toBe(true);
+                expect(block.highlightBitmap.visible).toBe(false);
+                expect(block.container.updateCache).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("unhighlightSelectedBlocks()", () => {
+            it("should not update a cache that has not been created yet", () => {
+                mockBlocks.unhighlight = jest.fn();
+                block.disconnectedBitmap = { visible: false };
+                block.container.bitmapCache = null;
+
+                expect(() => block.unhighlightSelectedBlocks(0, true)).not.toThrow();
+                expect(mockBlocks.unhighlight).toHaveBeenCalledWith(0, true);
+                expect(block.disconnectedBitmap.visible).toBe(true);
+                expect(block.container.updateCache).not.toHaveBeenCalled();
             });
         });
 

--- a/js/block.js
+++ b/js/block.js
@@ -716,7 +716,7 @@ class Block {
         }
 
         if (this._viewportVisible !== false) {
-            this.container.updateCache();
+            this.updateCache();
         }
     }
 
@@ -800,7 +800,7 @@ class Block {
         }
 
         if (this._viewportVisible !== false) {
-            this.container.updateCache();
+            this.updateCache();
         }
     }
 
@@ -810,7 +810,7 @@ class Block {
             if (!this.collapsed) {
                 this.disconnectedBitmap.visible = true;
             }
-            this.container.updateCache();
+            this.updateCache();
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes a crash that can occur when using multiple-block selection after a block has been deleted.

When a block is deleted, `container.uncache()` releases its backing canvas cache. Selection may later attempt to update the deleted block's visual state by calling EaselJS `container.updateCache()` directly.

Since the container no longer has an active `bitmapCache`, EaselJS throws:

```text
Uncaught: cache() must be called before updateCache()
```

The affected highlight and unhighlight paths now use the existing `Block.updateCache()` wrapper instead of calling `container.updateCache()` directly. The wrapper safely skips the cache update when the container no longer has an active bitmap cache.

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Images

### Before

<img width="1917" height="973" alt="Screenshot 2026-08-29 113620" src="https://github.com/user-attachments/assets/de392c75-8178-4d9d-902d-01519e0e60e2" />

### After

<img width="1916" height="972" alt="Screenshot 2026-08-29 115357" src="https://github.com/user-attachments/assets/cda41e55-672d-4f6b-bd00-30e4d39a603f" />

## Changes Made

* Replaced direct `container.updateCache()` calls in the affected block highlight and unhighlight paths with `Block.updateCache()`.
* Prevented attempts to update blocks whose bitmap cache has already been removed.
* Added regression tests covering:

  * highlighting a block without an active bitmap cache;
  * unhighlighting a block without an active bitmap cache;
  * clearing the multiple-selection state when a selected block has no active bitmap cache.

## Bug Reproduction Steps

### Before this fix

1. Run Music Blocks and open `http://127.0.0.1:3000`.
2. Import a project containing multiple blocks.
3. Delete one of the blocks.
4. Enable selection mode.
5. Drag the selection rectangle across the remaining blocks.
6. Observe the following error in the browser console:

```text
Uncaught: cache() must be called before updateCache()
```

The application may stop responding correctly after the error.

### After this fix

Repeat the same steps.

The selection rectangle works normally after deleting a block, and no EaselJS cache error is thrown.

---

## Testing Performed

Added unit tests that set `container.bitmapCache` to `null` and verify that:

* `highlight()` updates the expected visual state without calling the raw `container.updateCache()`;
* `unhighlight()` updates the expected visual state without calling the raw `container.updateCache()`;
* `unhighlightSelectedBlocks()` updates the block state without attempting to update a missing cache.

### Manual browser verification

1. Import a project containing multiple blocks.
2. Delete one of the blocks.
3. Enable selection mode.
4. Drag the selection rectangle across the remaining blocks.
5. Confirm that Music Blocks remains responsive.
6. Confirm that the browser console does not report the EaselJS cache error.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).
