### PR TITLE
fix: remove leaked stylesheet links on JSEditor close

### DIFF
--- a/js/activity/__tests__/help-controller.test.js
+++ b/js/activity/__tests__/help-controller.test.js
@@ -376,6 +376,17 @@ describe("HelpController.toggleJSEditor", () => {
         );
         expect(JSEditorMock.instances).toEqual([activity]);
     });
+
+    test("does not recreate the JSEditor if already open", async () => {
+        const activity = makeActivity();
+        const controller = new HelpController(activity);
+        window.widgetWindows.isOpen.mockImplementation(name => name === "JavaScript Editor");
+
+        await controller.toggleJSEditor();
+
+        expect(global.lazyLoad).not.toHaveBeenCalled();
+        expect(JSEditorMock.instances).toEqual([]);
+    });
 });
 
 describe("HelpController.showStats", () => {

--- a/js/activity/help-controller.js
+++ b/js/activity/help-controller.js
@@ -46,6 +46,10 @@ class HelpController {
      * Toggles display of javaScript editor widget.
      */
     async toggleJSEditor() {
+        if (window.widgetWindows?.isOpen("JavaScript Editor")) {
+            return;
+        }
+
         await lazyLoad([
             "widgets/jseditor",
             "activity/js-export/samples/sample",

--- a/js/widgets/__tests__/jseditor.test.js
+++ b/js/widgets/__tests__/jseditor.test.js
@@ -128,6 +128,9 @@ document.body.appendChild(overlayCanvas);
 
 // Load JSEditor — it has a CommonJS export
 beforeEach(() => {
+    // Remove any codejar stylesheet links left from previous tests
+    document.head.querySelectorAll('link[href*="codejar/styles/"]').forEach(link => link.remove());
+
     document.body.innerHTML = "";
     // Re-create overlayCanvas
     const canvas = document.createElement("canvas");
@@ -766,6 +769,54 @@ describe("JSEditor", () => {
             }
 
             expect(editor._currentStyle).toBe(0);
+        });
+    });
+
+    describe("stylesheet cleanup on close", () => {
+        const countLinks = () =>
+            document.head.querySelectorAll('link[href*="codejar/styles/"]').length;
+
+        test("constructor adds exactly 4 stylesheet links", () => {
+            createEditor();
+
+            expect(countLinks()).toBe(4);
+        });
+
+        test("onclose removes all stylesheet links from document.head", () => {
+            const editor = createEditor();
+
+            expect(countLinks()).toBe(4);
+
+            editor.widgetWindow.onclose();
+
+            expect(countLinks()).toBe(0);
+        });
+
+        test("onclose empties the _styles array", () => {
+            const editor = createEditor();
+
+            expect(editor._styles).toHaveLength(4);
+
+            editor.widgetWindow.onclose();
+
+            expect(editor._styles).toHaveLength(0);
+        });
+
+        test("open-close-open cycle does not accumulate links", () => {
+            const editor1 = createEditor();
+            expect(countLinks()).toBe(4);
+
+            editor1.widgetWindow.onclose();
+            expect(countLinks()).toBe(0);
+
+            const editor2 = createEditor();
+            expect(countLinks()).toBe(4);
+
+            editor2.widgetWindow.onclose();
+            expect(countLinks()).toBe(0);
+
+            createEditor();
+            expect(countLinks()).toBe(4);
         });
     });
 });

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -289,6 +289,9 @@ class JSEditor {
                 document.removeEventListener("mouseup", this._resizeHandlers.stopResize);
                 this._resizeHandlers = null;
             }
+            // Remove stylesheet links added by this instance
+            this._styles.forEach(link => link.remove());
+            this._styles = [];
             this.isOpen = false;
             defaultOnClose();
         };


### PR DESCRIPTION
## Description

Opening the JavaScript Editor widget appends 4 `<link>` stylesheet tags to `document.head` for CodeJar themes. Closing the widget never removes them, and `toggleJSEditor()` in `HelpController` creates a brand-new `JSEditor` instance on every toolbar click without checking if one is already open. This means each open/close cycle leaks 4 more `<link>` tags into the DOM — a normal classroom usage pattern that quietly accumulates dead stylesheet nodes and unnecessary CSS fetch/cache lookups.

This PR fixes both root causes and adds regression tests.

## Related Issue

**Fixes:** #8325

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

---

## Changes Made

**1. Stylesheet cleanup on close (`js/widgets/jseditor.js`)**

Added two lines to the existing `onclose` handler to remove the 4 `<link>` elements from `document.head` and clear the `_styles` array. Follows the same teardown pattern already used for `_resizeHandlers` directly above in the same handler.

**2. Duplicate instance guard (`js/activity/help-controller.js`)**

Added an early return in `toggleJSEditor()` using `window.widgetWindows?.isOpen("JavaScript Editor")` to prevent creating a new `JSEditor` when one is already open. This uses the widget window system's own tracking (the key `"JavaScript Editor"` is what JSEditor passes to `windowFor` as `saveAs`). `widgetWindows.isOpen()` was chosen over `this.isOpen` because `_toggleConsole()` overloads `isOpen` for console panel visibility — collapsing the console sets `isOpen = false` even though the editor window is still open.

**3. Regression tests (`js/widgets/__tests__/jseditor.test.js`)**

Added a `describe("stylesheet cleanup on close")` block with 4 tests:
- Constructor adds exactly 4 stylesheet links
- `onclose` removes all links from `document.head`
- `onclose` empties the `_styles` array
- Open → close → open cycle does not accumulate links

Also added `document.head` cleanup of codejar link tags in `beforeEach` to prevent cross-test pollution.

---

## Visual Changes

*Not applicable (fixes a DOM element leak and duplicate window creation).*

---

## Testing Performed

- `jest --testPathPattern=jseditor`: **60/60 tests passed** (including 4 new regression tests)
- `jest` (full suite): **8191/8191 tests passed** across 223 suites — no regressions
- `eslint --max-warnings=0` on all 3 changed files: clean
- `prettier --check` on all 3 changed files: clean
- Pre-commit hook (lint-staged): passed

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

*None.*