### PR TITLE
fix(pitch): initialize duration before first note

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -285,8 +285,7 @@ function setupPitchBlocks(activity) {
                 undefined,
                 activity
             );
-            const beatValue = tur.singer.lastNotePlayed !== null ? tur.singer.lastNotePlayed[1] : 4;
-            tur.singer.lastNotePlayed = [obj[0] + obj[1], beatValue];
+            tur.singer.lastNotePlayed = [obj[0] + obj[1], tur.singer.lastNotePlayed?.[1] ?? 4];
         }
 
         arg(logo, turtle, blk) {

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -534,6 +534,10 @@ describe("setupPitchBlocks", () => {
             turtles.ithTurtle(0).singer.lastNotePlayed = ["C4", 0.5];
             block.setter(logo, 60, 0);
             expect(turtles.ithTurtle(0).singer.lastNotePlayed).toBeDefined();
+
+            turtles.ithTurtle(0).singer.lastNotePlayed = null;
+            block.setter(logo, 60, 0);
+            expect(turtles.ithTurtle(0).singer.lastNotePlayed).toEqual(["C5", 4]);
         });
     });
 


### PR DESCRIPTION
## Description

  Fixes the pitch number setter when it runs before any note has been played. The setter now initializes the note duration to `4` instead of reading index `1` from a `null` `lastNotePlayed` value.

  ## Related Issue

  **Fixes:** #8326

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ---

  ## Changes Made

  - Preserve the existing note duration when `lastNotePlayed` exists.
  - Initialize the duration to `4` when no prior note has been played.
  - Add a regression test for the initial `null` state.

  ---

  ## Testing Performed

  - `npx jest js/blocks/__tests__/PitchBlocks.test.js --runInBand` — 81 tests passed.
  - `npm run lint` — passed.
  - `npx prettier --check js/blocks/PitchBlocks.js js/blocks/__tests__/PitchBlocks.test.js` — passed.
  - `npm test -- --runInBand` — 223 suites and 8,187 tests passed.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [ ] I have updated the documentation to reflect these changes, if applicable.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [ ] I have addressed the code review feedback from the previous submission, if applicable.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

  `npx prettier --check .` fails on existing repository files unrelated to this change, including `examples/5-Limit-Lattice.html`. The two modified files pass Prettier.