### PR TITLE
fix(project-manager): hoist finishLoading to fix import error paths

### DIFF
--- a/js/__tests__/project-manager.test.js
+++ b/js/__tests__/project-manager.test.js
@@ -1913,4 +1913,56 @@ describe("_setupFileHandlers inner callbacks", () => {
         activity.fileChooser.files = [];
         expect(() => handlers.change()).not.toThrow();
     });
+
+    it("change handler shows exactly one error when HTML has no project data", () => {
+        origFileReader = global.FileReader;
+        const readers = [];
+        class MockFR {
+            constructor() {
+                this.onload = null;
+                readers.push(this);
+            }
+            readAsText() {}
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        global.extractProjectDataFromHTML.mockReturnValue(null);
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        activity.fileChooser.files = [{ name: "song.html" }];
+        handlers.change();
+
+        const reader = readers[0];
+        reader.result = "<html><body>no project data here</body></html>";
+        reader.onload();
+        jest.advanceTimersByTime(200);
+
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(activity.errorMsg).toHaveBeenCalledWith(
+            "Cannot find project data in this HTML file."
+        );
+        expect(global.ErrorHandler.capture).not.toHaveBeenCalled();
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+    });
+});
+
+describe("_finishLoading", () => {
+    it("resets loading state, cursor, and update flag", () => {
+        const activity = makeActivity();
+        activity.loading = true;
+        activity.update = false;
+        document.body.style.cursor = "wait";
+        const pm = new ProjectManager(activity);
+
+        pm._finishLoading();
+
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.update).toBe(true);
+    });
 });

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -236,6 +236,18 @@ class ProjectManager {
         that.update = true;
     }
 
+    /**
+     * Clears the loading state after a project load attempt completes,
+     * successfully or not.
+     * @private
+     * @returns {void}
+     */
+    _finishLoading() {
+        this.activity.loading = false;
+        document.body.style.cursor = "default";
+        this.activity.update = true;
+    }
+
     _loadProject(projectID, flags) {
         const that = this.activity;
 
@@ -268,12 +280,6 @@ class ProjectManager {
 
         const pm = this;
         setTimeout(() => {
-            const finishLoading = () => {
-                that.loading = false;
-                document.body.style.cursor = "default";
-                that.update = true;
-            };
-
             try {
                 if (that.planet && typeof that.planet.openProjectFromPlanet === "function") {
                     that.planet.openProjectFromPlanet(projectID, () => {
@@ -299,7 +305,7 @@ class ProjectManager {
                 });
             }
 
-            finishLoading();
+            pm._finishLoading();
         }, 2500);
 
         const run = flags.run;
@@ -786,7 +792,7 @@ class ProjectManager {
                                         that.errorMsg(
                                             _("Cannot find project data in this HTML file.")
                                         );
-                                        finishLoading();
+                                        pm._finishLoading();
                                         return;
                                     }
                                     obj = JSON.parse(unescapeHTML(extracted));
@@ -900,7 +906,7 @@ class ProjectManager {
                                 extracted = extractProjectDataFromHTML(cleanData);
                                 if (!extracted) {
                                     that.errorMsg(_("Cannot find project data in this HTML file."));
-                                    finishLoading();
+                                    pm._finishLoading();
                                     return;
                                 }
                                 obj = JSON.parse(unescapeHTML(extracted));


### PR DESCRIPTION
## Description

`finishLoading` - the helper that clears the loading state after a project load attempt (`loading = false`, cursor back to default, `update = true`) - was defined as a `const` **inside the `setTimeout` closure of `_loadProject`** (`js/project-manager.js`). But `_setupFileHandlers` called it from two entirely different scopes:

-   the file-picker `change` handler, right after showing "Cannot find project data in this HTML file.", and
-   the drag-and-drop `_handleFileSelect` handler, at the same guard.

No `finishLoading` binding exists in either scope, so both calls are a guaranteed `ReferenceError`. Because each call sits inside the surrounding `try`, the generic `catch` swallowed the ReferenceError and reacted to it:

-   the user saw a **second, contradictory error** - "Cannot load project from the file. Please check the file type." - right after the accurate "Cannot find project data in this HTML file." message, and
-   `ErrorHandler.capture` recorded a bogus `ReferenceError` under `loadProjectFromFile`, polluting telemetry and masking the real (benign) cause.

**User-visible effect:** loading an HTML file that isn't a Music Blocks project - the exact case this branch was written for - produced two conflicting error messages, and the early-return semantics of the guard were broken in both import paths.

**Fix:** the helper is now a private method, `ProjectManager._finishLoading()`, and all three call sites (the original one in `_loadProject` plus the two broken ones) call `pm._finishLoading()`. The duplicate closure-local definition is gone.

## Related Issue

No existing issue - found through code inspection while auditing the project import pipeline for scope bugs.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Tests — Adds or updates test coverage
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/project-manager.js` - new private `_finishLoading()` method; the closure-local `const finishLoading` in `_loadProject` is removed and all three call sites now use `pm._finishLoading()`.
-   `js/__tests__/project-manager.test.js` - two new tests:
    -   a behavioral test that drives the real file-chooser `change` handler (via the suite's existing `captureHandlers` + mock `FileReader` scaffolding) with an HTML file containing no project data, asserting **exactly one** error message is shown, no `ReferenceError` reaches `ErrorHandler.capture`, and the loading state is properly cleared;
    -   a unit test for `_finishLoading()` itself.

## Testing Performed

-   Followed TDD: both tests were written first and failed on the old code for the expected reasons — the behavioral test received **two** `errorMsg` calls (the double-error bug reproduced exactly), and `_finishLoading` didn't exist.
-   Worth noting: this handler path carried an `istanbul ignore` comment claiming it was "inaccessible from Jest" — it turned out to be drivable with the suite's existing handler-capture and `FileReader` mocks, so the previously untested branch now has real coverage.
-   `npx jest js/__tests__/project-manager.test.js` - 108/108 pass.
-   Full Jest suite: 8,184 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit independently of this change.
-   `npx eslint` on both changed files - clean (pre-commit hooks ran eslint + prettier); commit is DCO signed-off.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   `_finishLoading()` reads state through `this.activity`, so it behaves identically from every call site; the `pm` reference the handlers already close over is used to call it.
-   The drag-and-drop path (`_handleFileSelect`) has the same shape as the file-picker path and gets the same fix; the behavioral test covers the file-picker route, which shares the guard logic verbatim.
-   The stale "inaccessible from Jest" istanbul comment on this branch could be dropped in a follow-up now that the path is exercised - left untouched here to keep the diff focused.
