### PR TITLE
fix(project-manager): resolve ReferenceError on invalid HTML imports

### DIFF
--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -97,6 +97,13 @@ class ProjectManager {
         }
     }
 
+    finishLoading() {
+        const that = this.activity;
+        that.loading = false;
+        document.body.style.cursor = "default";
+        that.update = true;
+    }
+
     showContents() {
         clearInterval(window.intervalId);
         document.getElementById("loadingText").textContent = _("Loading Complete!");
@@ -268,12 +275,6 @@ class ProjectManager {
 
         const pm = this;
         setTimeout(() => {
-            const finishLoading = () => {
-                that.loading = false;
-                document.body.style.cursor = "default";
-                that.update = true;
-            };
-
             try {
                 if (that.planet && typeof that.planet.openProjectFromPlanet === "function") {
                     that.planet.openProjectFromPlanet(projectID, () => {
@@ -299,7 +300,7 @@ class ProjectManager {
                 });
             }
 
-            finishLoading();
+            pm.finishLoading();
         }, 2500);
 
         const run = flags.run;
@@ -786,7 +787,7 @@ class ProjectManager {
                                         that.errorMsg(
                                             _("Cannot find project data in this HTML file.")
                                         );
-                                        finishLoading();
+                                        pm.finishLoading();
                                         return;
                                     }
                                     obj = JSON.parse(unescapeHTML(extracted));
@@ -900,7 +901,7 @@ class ProjectManager {
                                 extracted = extractProjectDataFromHTML(cleanData);
                                 if (!extracted) {
                                     that.errorMsg(_("Cannot find project data in this HTML file."));
-                                    finishLoading();
+                                    pm.finishLoading();
                                     return;
                                 }
                                 obj = JSON.parse(unescapeHTML(extracted));


### PR DESCRIPTION
## Description
Fixes a high-impact bug where attempting to import an HTML file that lacks valid MusicBlocks project data causes an unhandled `ReferenceError`, permanently freezing the UI loading spinner.

**Root Cause:** 
The `finishLoading` function was incorrectly scoped locally inside `loadFromPlanet`, making it inaccessible to the `_setupFileHandlers` drag-and-drop listener. 

**Fix:** 
Extracted the scattered `finishLoading` logic into a formal, reusable `ProjectManager` class method and updated all broken references to call `this.finishLoading()`.

## Steps to Reproduce
1. Create a blank/empty file on your desktop named `test.html`.
2. Open MusicBlocks and drag-and-drop `test.html` directly onto the canvas.
3. Observe the behavior.

## Proof of Fix (Before/After)

### ❌ Before

The DevTools console throws a fatal error: `Uncaught ReferenceError: finishLoading is not defined`.


<img width="1537" height="527" alt="WhatsApp Image 2026-08-29 at 2 01 15 AM" src="https://github.com/user-attachments/assets/9ff233c0-2bc0-4995-8ab8-f197c7d7af32" />

<img width="768" height="102" alt="WhatsApp Image 2026-08-29 at 2 01 33 AM" src="https://github.com/user-attachments/assets/041e58e2-47ba-4bca-b124-f53789ae8f18" />


### ✅ After
The loading spinner is immediately dismissed. The UI gracefully continues to function and displays the correct warning toast: *"Cannot find project data in this HTML file."*


<img width="1530" height="836" alt="WhatsApp Image 2026-08-29 at 2 02 14 AM" src="https://github.com/user-attachments/assets/c91cfe46-5bdf-4d66-817a-853a9055c2ba" />

<img width="788" height="172" alt="WhatsApp Image 2026-08-29 at 2 02 40 AM" src="https://github.com/user-attachments/assets/82cf7a30-b034-4056-85c5-bfce47aa7ccf" />


## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] i18n


## Checklist
- [x] I have tested this change locally to ensure it resolves the issue.
- [x] This fix complies with the String Freeze constraint (no user-facing strings were modified).
- [x] I have run `npm run lint` and `npm run test` successfully.
