### PR TITLE
fix: guard lastNotePlayed null in MyPitchBlock.setter

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -285,7 +285,8 @@ function setupPitchBlocks(activity) {
                 undefined,
                 activity
             );
-            tur.singer.lastNotePlayed = [obj[0] + obj[1], tur.singer.lastNotePlayed[1]];
+            const beatValue = tur.singer.lastNotePlayed !== null ? tur.singer.lastNotePlayed[1] : 4;
+            tur.singer.lastNotePlayed = [obj[0] + obj[1], beatValue];
         }
 
         arg(logo, turtle, blk) {

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -1373,6 +1373,16 @@ describe("setupPitchBlocks", () => {
                     expect(turtles.ithTurtle(0).singer.previousNotePlayed).toBeDefined();
                 }
             });
+
+            it("MyPitchBlock setter does not crash when lastNotePlayed is null", () => {
+                const block = createdBlocks["mypitch"];
+                if (block && block.setter) {
+                    turtles.ithTurtle(0).singer.lastNotePlayed = null;
+                    expect(() => block.setter(logo, 60, 0)).not.toThrow();
+                    expect(turtles.ithTurtle(0).singer.lastNotePlayed).toBeDefined();
+                    expect(turtles.ithTurtle(0).singer.lastNotePlayed[1]).toBe(4);
+                }
+            });
         });
 
         describe("Complex Flow Scenarios", () => {


### PR DESCRIPTION
Before the first note is played, tur.singer.lastNotePlayed is null. MyPitchBlock.setter() accessed lastNotePlayed[1] unconditionally, throwing TypeError: Cannot read properties of null (reading '1').
Preserve the previous beat value when lastNotePlayed exists; fall back to 4 (the default used throughout PitchActions.js and turtle-singer.js) when it is null.
Add a regression test covering the null case.
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description
Using "add 1 to" with the pitch number block before the turtle has played a note throws a `TypeError: Cannot read properties of null (reading '1')`. This occurs because `MyPitchBlock.setter()` unconditionally accesses `tur.singer.lastNotePlayed[1]`, which is initialized to `null` before the first note is played. 
This PR adds a null check to preserve the beat value of the last played note if it exists, and falls back to `4` (the standard default beat value used throughout `PitchActions.js` and `turtle-singer.js`) when `lastNotePlayed` is `null`.

## Related Issue
<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->
**Fixes:** #8326 
---

## Category
<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation
---

## Changes Made
- **`js/blocks/PitchBlocks.js`**: Refactored the assignment of `tur.singer.lastNotePlayed` inside `MyPitchBlock.setter()` to safely retrieve the previous beat value using a null guard.
- **`js/blocks/__tests__/PitchBlocks.test.js`**: Added a new test inside the `Setter Methods` suite to verify `MyPitchBlock.setter` does not throw when `lastNotePlayed` is null, initializing it correctly with a default beat value of `4`.
---

## Visual Changes
<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->
*Not applicable.*
---

## Testing Performed
- `jest --testPathPattern=PitchBlocks`: **95/95 passed** (including the new regression test case)
- `jest` (full suite): **8188/8188 passed** across 223 suites — no regressions
- `eslint` on changed files: clean
- `prettier --check` on changed files: clean
---

## Checklist
<!-- Please check the boxes that apply. Add or remove items as needed. -->
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).
---

## Additional Notes
*None.*
---
<details>
<summary><b>Contributor Resources</b></summary>
<br>
- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)
</details>