### PR TITLE
fix: handle save stack context menu index collision

### DIFF
--- a/js/piemenu-block-context.js
+++ b/js/piemenu-block-context.js
@@ -101,12 +101,10 @@ const piemenuBlockContext = block => {
     wheel.navItems[1].setTooltip(_("Extract"));
     wheel.navItems[2].setTooltip(_("Move to trash"));
     wheel.navItems[3].setTooltip(_("Close"));
-    if (
-        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
-            block.blocks.blockList[topBlock].name
-        )
-    ) {
-        wheel.navItems[4].setTooltip(_("Save stack"));
+    const saveStackIndex = labels.indexOf("imgsrc:header-icons/save-blocks-button.svg");
+
+    if (saveStackIndex !== -1) {
+        wheel.navItems[saveStackIndex].setTooltip(_("Save stack"));
     }
 
     if (helpButton !== null) {
@@ -183,12 +181,8 @@ const piemenuBlockContext = block => {
 
     document.body.addEventListener("click", window._contextWheelClickHandler);
 
-    if (
-        ["customsample", "temperament1", "definemode", "show", "turtleshell", "action"].includes(
-            block.name
-        )
-    ) {
-        wheel.navItems[4].navigateFunction = () => {
+    if (saveStackIndex !== -1) {
+        wheel.navItems[saveStackIndex].navigateFunction = () => {
             that.blocks.activeBlock = blockBlock;
             that.blocks.prepareStackForCopy();
             that.blocks.saveStack();


### PR DESCRIPTION
## Summary

Fixed a bug where the context menu assumed Save Stack was always at index `4`, which could target the Help button or cause a crash.

## Fix

* Dynamically find the Save Stack button using `labels.indexOf()`.
* Use the same index for its tooltip and click handler.
* Avoid accessing the button when it isn't present.

## Category
- [x] Bug Fix — Fixes a bug or incorrect behavior

## Tests

* Tested top-level `action` blocks.
* Tested nested `forward` inside `action`.
* Tested blocks with and without Help.
* Verified no context-menu errors after the fix.
* Confirmed the existing `prepareMacroExports()` Save Stack error is unrelated.