### PR TITLE
fix: prevent unsettled promises on plugin script loading errors

### DIFF
--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -128,12 +128,13 @@ describe("processPluginData script cleanup", () => {
         const originalAppendChild = document.head.appendChild.bind(document.head);
         appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
             originalAppendChild(script);
-            script.onerror(new Error("load failed"));
+            script.onerror({ type: "error" });
             return script;
         });
 
-        await expect(
-            processPluginData(
+        let err;
+        try {
+            await processPluginData(
                 createActivity(),
                 JSON.stringify({
                     BLOCKPLUGINS: {
@@ -141,8 +142,13 @@ describe("processPluginData script cleanup", () => {
                     }
                 }),
                 "plugins/test.json"
-            )
-        ).rejects.toThrow("load failed");
+            );
+        } catch (e) {
+            err = e;
+        }
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Failed to execute plugin script");
 
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
         expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");
@@ -153,12 +159,13 @@ describe("processPluginData script cleanup", () => {
         const originalAppendChild = document.head.appendChild.bind(document.head);
         appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
             originalAppendChild(script);
-            script.onerror(new Error("blob load failed"));
+            script.onerror({ type: "error" });
             return script;
         });
 
-        await expect(
-            processPluginData(
+        let err;
+        try {
+            await processPluginData(
                 createActivity(),
                 JSON.stringify({
                     FLOWPLUGINS: {
@@ -166,8 +173,13 @@ describe("processPluginData script cleanup", () => {
                     }
                 }),
                 "plugins/test.json"
-            )
-        ).rejects.toThrow("Failed to load plugin script: blob load failed");
+            );
+        } catch (e) {
+            err = e;
+        }
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Failed to load plugin script");
 
         errorSpy.mockRestore();
     });

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -142,7 +142,7 @@ describe("processPluginData script cleanup", () => {
                 }),
                 "plugins/test.json"
             )
-        ).rejects.toThrow("Failed to execute plugin script");
+        ).rejects.toThrow("load failed");
 
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
         expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -132,15 +132,17 @@ describe("processPluginData script cleanup", () => {
             return script;
         });
 
-        await processPluginData(
-            createActivity(),
-            JSON.stringify({
-                BLOCKPLUGINS: {
-                    testBlock: "globalThis.pluginSetupLoaded = true;"
-                }
-            }),
-            "plugins/test.json"
-        );
+        await expect(
+            processPluginData(
+                createActivity(),
+                JSON.stringify({
+                    BLOCKPLUGINS: {
+                        testBlock: "globalThis.pluginSetupLoaded = true;"
+                    }
+                }),
+                "plugins/test.json"
+            )
+        ).rejects.toThrow("Failed to execute plugin script");
 
         expect(document.head.querySelectorAll("script[src^='blob:plugin-setup']")).toHaveLength(0);
         expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");

--- a/js/utils/__tests__/utils-plugin-loader.test.js
+++ b/js/utils/__tests__/utils-plugin-loader.test.js
@@ -148,6 +148,30 @@ describe("processPluginData script cleanup", () => {
         expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:plugin-setup-0");
     });
 
+    it("rejects when main blob script fails to load", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const originalAppendChild = document.head.appendChild.bind(document.head);
+        appendChildSpy = jest.spyOn(document.head, "appendChild").mockImplementation(script => {
+            originalAppendChild(script);
+            script.onerror(new Error("blob load failed"));
+            return script;
+        });
+
+        await expect(
+            processPluginData(
+                createActivity(),
+                JSON.stringify({
+                    FLOWPLUGINS: {
+                        testFlow: "return true;"
+                    }
+                }),
+                "plugins/test.json"
+            )
+        ).rejects.toThrow("Failed to load plugin script: blob load failed");
+
+        errorSpy.mockRestore();
+    });
+
     it("returns null and logs error when plugin data is invalid JSON", async () => {
         const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -684,8 +684,11 @@ window.__mb_plugin_registry["${registryName}"] = function(logo) {
             script.onerror = e => {
                 URL.revokeObjectURL(url);
                 document.head.removeChild(script);
-                console.error("Failed to load CSP Blob script for plugins", e);
-                reject(e);
+                const err = new Error(
+                    "Failed to load plugin script" + (e && e.message ? ": " + e.message : "")
+                );
+                console.error("Failed to load CSP Blob script for plugins", err);
+                reject(err);
             };
             document.head.appendChild(script);
         });
@@ -742,12 +745,15 @@ window.__mb_plugin_registry["${registryName}"] = function(activity, globalActivi
                 }
                 resolve();
             };
-            sScript.onerror = err => {
+            sScript.onerror = e => {
                 URL.revokeObjectURL(sUrl);
                 if (sScript.parentNode) {
                     sScript.parentNode.removeChild(sScript);
                 }
-                reject(err || new Error("Failed to execute plugin script"));
+                const err = new Error(
+                    "Failed to execute plugin script" + (e && e.message ? ": " + e.message : "")
+                );
+                reject(err);
             };
             document.head.appendChild(sScript);
         });

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -726,7 +726,7 @@ window.__mb_plugin_registry["${registryName}"] = function(activity, globalActivi
         const sUrl = URL.createObjectURL(sBlob);
         const sScript = document.createElement("script");
         sScript.src = sUrl;
-        await new Promise(resolve => {
+        await new Promise((resolve, reject) => {
             sScript.onload = () => {
                 if (window.__mb_plugin_registry[registryName]) {
                     try {
@@ -742,12 +742,12 @@ window.__mb_plugin_registry["${registryName}"] = function(activity, globalActivi
                 }
                 resolve();
             };
-            sScript.onerror = () => {
+            sScript.onerror = err => {
                 URL.revokeObjectURL(sUrl);
                 if (sScript.parentNode) {
                     sScript.parentNode.removeChild(sScript);
                 }
-                resolve(); // Still resolve to let others run
+                reject(new Error("Failed to execute plugin script"));
             };
             document.head.appendChild(sScript);
         });

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -747,7 +747,7 @@ window.__mb_plugin_registry["${registryName}"] = function(activity, globalActivi
                 if (sScript.parentNode) {
                     sScript.parentNode.removeChild(sScript);
                 }
-                reject(new Error("Failed to execute plugin script"));
+                reject(err || new Error("Failed to execute plugin script"));
             };
             document.head.appendChild(sScript);
         });


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->
When a plugin setup script fails to load in processPluginData(), the error handler cleans up the script but does not reject the Promise. Due to this musicblocks can think the plugin loaded successfully and only show an error later when the plugin function is used. This PR makes the Promise reject when the plugin script fails to load so the error is handled properly.

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->

- utils.js: Reject the Promise when the plugin setup script fails to load. Wrap the raw browser Event received in onerror into a proper JavaScript Error before rejecting
- utils-plugin-loader.test.js: Added a test to make sure the Promise rejects with the expected error

## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->

Tested using the below script in browser console by simulating a script load error on document.head.appendChild

```js
(async () => {
    const originalAppend = document.head.appendChild.bind(document.head);

    document.head.appendChild = (el) => {
        if (el.src?.startsWith("blob:")) {
            setTimeout(() => el.onerror?.(new Event("error")), 0);
            return el;
        }
        return originalAppend(el);
    };

    try {
        const payload = JSON.stringify({ BLOCKPLUGINS: { testBlock: "1+1;" } });
        await processPluginData(globalActivity, payload, "plugins/test.json");
        console.log("Test failed: CSP error was not handled.");
    } catch (err) {
        console.log("Test passed: Caught CSP error:", err.message);
    } finally {
        document.head.appendChild = originalAppend;
    }
})(); 
```

The test fails on musicblocks and passes locally.

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading error handling with clearer error messages.
  * Plugin setup failures now correctly stop processing and report the loading or execution error.
  * Preserved cleanup behavior after plugin loading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->