### PR TITLE
fix(musicutils): return exactly edo names from generateNoteNames

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -3975,3 +3975,60 @@ describe("non-EDO temperament helpers", () => {
         });
     });
 });
+
+describe("generateNoteNames EDO length contract", () => {
+    // The table must have exactly one entry per division of the octave.
+    // Callers depend on this: transposition in getNote() derives octave
+    // arithmetic from the EDO but wraps note names on the table length, so a
+    // table longer than the EDO desynchronises the two and yields note names
+    // outside the temperament.
+    it.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 19, 22, 24, 31, 41, 53])(
+        "returns exactly %i names for %i-EDO",
+        edo => {
+            expect(generateNoteNames(edo)).toHaveLength(edo);
+        }
+    );
+
+    // EDO < 7 leaves at least one natural letter with no room. Before the fix
+    // the letter was emitted regardless, so every one of these returned all
+    // seven naturals.
+    it.each([1, 2, 3, 4, 6])("does not fall back to all seven naturals for %i-EDO", edo => {
+        const names = generateNoteNames(edo);
+        expect(names).toHaveLength(edo);
+        expect(names).not.toEqual(["C", "D", "E", "F", "G", "A", "B"]);
+    });
+
+    it("keeps 12-EDO exactly as the standard chromatic table", () => {
+        expect(generateNoteNames(12)).toEqual([
+            "C",
+            "C" + SHARP,
+            "D",
+            "D" + SHARP,
+            "E",
+            "F",
+            "F" + SHARP,
+            "G",
+            "G" + SHARP,
+            "A",
+            "A" + SHARP,
+            "B"
+        ]);
+    });
+
+    it("keeps the small special-cased tables unchanged", () => {
+        expect(generateNoteNames(5)).toEqual(["C", "D", "E", "G", "A"]);
+        expect(generateNoteNames(7)).toEqual(["C", "D", "E", "F", "G", "A", "B"]);
+    });
+
+    it.each([3, 6, 12, 19, 31])("produces no duplicate names for %i-EDO", edo => {
+        const names = generateNoteNames(edo);
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    it("starts every table at C and returns cached results consistently", () => {
+        for (const edo of [3, 6, 12, 19]) {
+            expect(generateNoteNames(edo)[0]).toBe("C");
+            expect(generateNoteNames(edo)).toEqual(generateNoteNames(edo));
+        }
+    });
+});

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1036,6 +1036,14 @@ function generateNoteNames(edo) {
         const nextNatural = naturals[(n + 1) % 7];
         const edoSteps = intervals[n].steps;
 
+        // An interval can be allotted zero steps when the octave has fewer
+        // divisions than there are natural letters (EDO < 7). Emitting the
+        // letter anyway would push the table past `edo` entries and break the
+        // length contract callers rely on, so skip letters with no room.
+        if (edoSteps === 0) {
+            continue;
+        }
+
         names.push(natural);
 
         const numAccidentals = edoSteps - 1;


### PR DESCRIPTION
## Description

`generateNoteNames(edo)` promises a table with one entry per division of the octave, but for any octave with fewer than 7 divisions it returned all seven natural letters instead.

When an octave has fewer divisions than there are natural letters, the step-distribution loop allots **zero** steps to one or more intervals. The name-building loop pushed the letter before consulting that count, so it was emitted regardless and the table always ran to seven entries. EDO 5 and 7 only appeared correct because they are special-cased above the general path and never reach that loop.

This desynchronised two quantities derived from the same temperament. In `getNote()`, octave arithmetic counts in `octaveLength` while note names wrap on `generateNoteNames(octaveLength).length`. When the table was longer than the EDO, transposing produced a note name outside the temperament and shifted the octave at the wrong point.

## Related Issue

**Fixes:** #8340

## Category

- [x] Bug Fix

## Changes Made

Skip natural letters that were allotted no room, so the table length always matches the requested EDO:

```js
const edoSteps = intervals[n].steps;

if (edoSteps === 0) {
    continue;
}

names.push(natural);
```

Added a `generateNoteNames EDO length contract` suite to `js/utils/__tests__/musicutils.test.js` covering the length contract from 1 to 53, the previously broken values, an exact-match check on the 12-EDO chromatic table, duplicate-name checks, and cache consistency.

## Testing Performed

Full suite passes: **223 suites, 8220 tests**. `npm run lint` and `npx prettier --check` are both clean.

Verified that values which were already correct are untouched. These produce byte-identical tables before and after:

| EDO | before | after |
|----:|-------:|------:|
| 5 | 5 | 5 |
| 7 | 7 | 7 |
| 12 | 12 | 12 |
| 17 | 17 | 17 |
| 19 | 19 | 19 |
| 22 | 22 | 22 |
| 31 | 31 | 31 |

And the previously broken values now hold the contract:

| EDO | before | after |
|----:|-------:|------:|
| 1 | 7 | 1 |
| 2 | 7 | 2 |
| 3 | 7 | 3 |
| 4 | 7 | 4 |
| 6 | 7 | 6 |

The 5 and 7 special cases still match exactly what the general path now computes, so they are consistent rather than divergent shortcuts.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

This restores the documented length contract. It does not attempt to make the names chosen for very small EDOs musically ideal. 6-EDO yields `C D E F G A` rather than a whole-tone spelling, which is a separate question about name selection that I kept out to keep this change focused.
