### PR TITLE
test(synth): cover recorder setup, download flow, and analyser lifecycle

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -2126,6 +2126,314 @@ describe("Utility Functions (logic-only)", () => {
             expect(() => stopSound(turtle, "electronic synth")).not.toThrow();
         });
     });
+
+    describe("microphone analyser and recording player lifecycle", () => {
+        let savedPlayer, savedTimeout, savedAnalyser, savedMic;
+
+        beforeEach(() => {
+            savedPlayer = Synth.player;
+            savedTimeout = Synth._recordingPlayTimeout;
+            savedAnalyser = Synth.analyser;
+            savedMic = Synth.mic;
+        });
+
+        afterEach(() => {
+            Synth.player = savedPlayer;
+            Synth._recordingPlayTimeout = savedTimeout;
+            Synth.analyser = savedAnalyser;
+            Synth.mic = savedMic;
+        });
+
+        it("cancels a pending playback timeout when recording playback is stopped", () => {
+            const clearSpy = jest.spyOn(global, "clearTimeout");
+            Synth._recordingPlayTimeout = 4242;
+            Synth.player = null;
+
+            Synth.stopPlayBackRecording();
+
+            expect(clearSpy).toHaveBeenCalledWith(4242);
+            expect(Synth._recordingPlayTimeout).toBeNull();
+            clearSpy.mockRestore();
+        });
+
+        it("stops, disposes, and releases the recording player", () => {
+            const stop = jest.fn();
+            const dispose = jest.fn();
+            Synth._recordingPlayTimeout = null;
+            Synth.player = { stop, dispose };
+
+            Synth.stopPlayBackRecording();
+
+            expect(stop).toHaveBeenCalled();
+            expect(dispose).toHaveBeenCalled();
+            expect(Synth.player).toBeNull();
+        });
+
+        it("still disposes the player when stopping it throws", () => {
+            const dispose = jest.fn();
+            Synth._recordingPlayTimeout = null;
+            Synth.player = {
+                stop: jest.fn(() => {
+                    throw new Error("already stopped");
+                }),
+                dispose
+            };
+
+            expect(() => Synth.stopPlayBackRecording()).not.toThrow();
+            expect(dispose).toHaveBeenCalled();
+            expect(Synth.player).toBeNull();
+        });
+
+        it("still releases the player when disposing it throws", () => {
+            Synth._recordingPlayTimeout = null;
+            Synth.player = {
+                stop: jest.fn(),
+                dispose: jest.fn(() => {
+                    throw new Error("already disposed");
+                })
+            };
+
+            expect(() => Synth.stopPlayBackRecording()).not.toThrow();
+            expect(Synth.player).toBeNull();
+        });
+
+        it("tolerates a player that exposes neither stop nor dispose", () => {
+            Synth._recordingPlayTimeout = null;
+            Synth.player = {};
+
+            expect(() => Synth.stopPlayBackRecording()).not.toThrow();
+            expect(Synth.player).toBeNull();
+        });
+
+        it("is a no-op when there is no recording player", () => {
+            Synth._recordingPlayTimeout = null;
+            Synth.player = null;
+
+            expect(() => Synth.stopPlayBackRecording()).not.toThrow();
+            expect(Synth.player).toBeNull();
+        });
+
+        it("connects a fresh waveform analyser to the microphone", () => {
+            const connect = jest.fn();
+            Synth.analyser = null;
+            Synth.mic = { connect, disconnect: jest.fn() };
+
+            Synth.LiveWaveForm();
+
+            expect(Synth.analyser).not.toBeNull();
+            expect(Synth.analyser.type).toBe("waveform");
+            expect(Synth.analyser.size).toBe(8192);
+            expect(connect).toHaveBeenCalledWith(Synth.analyser);
+        });
+
+        it("disconnects and disposes a previous analyser before replacing it", () => {
+            const previous = { dispose: jest.fn() };
+            const disconnect = jest.fn();
+            Synth.analyser = previous;
+            Synth.mic = { connect: jest.fn(), disconnect };
+
+            Synth.LiveWaveForm();
+
+            expect(disconnect).toHaveBeenCalledWith(previous);
+            expect(previous.dispose).toHaveBeenCalled();
+            expect(Synth.analyser).not.toBe(previous);
+        });
+
+        it("reads waveform values from the active analyser", () => {
+            const values = new Float32Array([0.1, -0.2, 0.3]);
+            Synth.analyser = { getValue: jest.fn(() => values) };
+
+            expect(Synth.getWaveFormValues()).toBe(values);
+            expect(Synth.analyser.getValue).toHaveBeenCalled();
+        });
+    });
+
+    describe("recorder setup and recording download flow", () => {
+        let savedFF, savedMBDialog, savedCreateObjectURL, savedAlert;
+
+        // setupRecorder connects every live instrument to the media-stream
+        // destination, and the Tone mocks do not implement connect(), so run
+        // it against an empty instrument table and restore afterwards.
+        const withNoInstruments = fn => {
+            const saved = {};
+            for (const key of Object.keys(instruments)) {
+                saved[key] = instruments[key];
+                delete instruments[key];
+            }
+            try {
+                return fn();
+            } finally {
+                Object.assign(instruments, saved);
+            }
+        };
+
+        beforeEach(() => {
+            savedFF = platform.FF;
+            savedMBDialog = window.MBDialog;
+            savedCreateObjectURL = global.URL.createObjectURL;
+            savedAlert = global.alert;
+            global.URL.createObjectURL = jest.fn(() => "blob:recording");
+            global.alert = jest.fn();
+            global.MediaRecorder = jest.fn(function () {
+                return this;
+            });
+        });
+
+        afterEach(() => {
+            platform.FF = savedFF;
+            window.MBDialog = savedMBDialog;
+            global.URL.createObjectURL = savedCreateObjectURL;
+            global.alert = savedAlert;
+            delete window.prompt;
+        });
+
+        const setup = () => withNoInstruments(() => Synth.setupRecorder());
+
+        it("requests a wav recorder on Firefox", () => {
+            platform.FF = true;
+            setup();
+            expect(global.MediaRecorder.mock.calls[0][1]).toEqual({ type: "audio/wav" });
+        });
+
+        it("requests a webm recorder on other browsers", () => {
+            platform.FF = false;
+            setup();
+            expect(global.MediaRecorder.mock.calls[0][1]).toEqual({ mimeType: "audio/webm" });
+        });
+
+        it("ignores data events with no payload", () => {
+            platform.FF = false;
+            setup();
+
+            expect(() => Synth.recorder.ondataavailable({})).not.toThrow();
+            Synth.recorder.onstop();
+
+            // No chunks were collected, so no object URL is ever minted.
+            expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+        });
+
+        it("ignores zero-length data chunks", () => {
+            platform.FF = false;
+            setup();
+
+            Synth.recorder.ondataavailable({ data: { size: 0 } });
+            Synth.recorder.onstop();
+
+            expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+        });
+
+        it("does nothing on stop when nothing was recorded", () => {
+            platform.FF = false;
+            setup();
+
+            expect(() => Synth.recorder.onstop()).not.toThrow();
+            expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+        });
+
+        it("prompts through MBDialog and downloads an ogg file off Firefox", async () => {
+            platform.FF = false;
+            window.MBDialog = {
+                prompt: jest.fn(() => Promise.resolve("my song")),
+                alert: jest.fn()
+            };
+            const clicked = [];
+            jest.spyOn(document.body, "appendChild").mockImplementation(node => {
+                if (node.tagName === "A") clicked.push(node);
+                return node;
+            });
+            jest.spyOn(document.body, "removeChild").mockImplementation(node => node);
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+            await Promise.resolve();
+
+            expect(window.MBDialog.prompt).toHaveBeenCalled();
+            expect(global.URL.createObjectURL).toHaveBeenCalled();
+            expect(clicked).toHaveLength(1);
+            expect(clicked[0].download).toBe("my song.ogg");
+            jest.restoreAllMocks();
+        });
+
+        it("uses a wav extension on Firefox", async () => {
+            platform.FF = true;
+            window.MBDialog = {
+                prompt: jest.fn(() => Promise.resolve("take one")),
+                alert: jest.fn()
+            };
+            const clicked = [];
+            jest.spyOn(document.body, "appendChild").mockImplementation(node => {
+                if (node.tagName === "A") clicked.push(node);
+                return node;
+            });
+            jest.spyOn(document.body, "removeChild").mockImplementation(node => node);
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+            await Promise.resolve();
+
+            expect(clicked[0].download).toBe("take one.wav");
+            jest.restoreAllMocks();
+        });
+
+        it("falls back to the browser prompt when MBDialog is unavailable", () => {
+            platform.FF = false;
+            delete window.MBDialog;
+            window.prompt = jest.fn(() => "fallback");
+            jest.spyOn(document.body, "appendChild").mockImplementation(node => node);
+            jest.spyOn(document.body, "removeChild").mockImplementation(node => node);
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+
+            expect(window.prompt).toHaveBeenCalled();
+            jest.restoreAllMocks();
+        });
+
+        it("reports a cancelled download when the name is null", async () => {
+            platform.FF = false;
+            window.MBDialog = {
+                prompt: jest.fn(() => Promise.resolve(null)),
+                alert: jest.fn()
+            };
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+            await Promise.resolve();
+
+            expect(window.MBDialog.alert).toHaveBeenCalled();
+        });
+
+        it("treats a whitespace-only name as a cancelled download", async () => {
+            platform.FF = false;
+            window.MBDialog = {
+                prompt: jest.fn(() => Promise.resolve("   ")),
+                alert: jest.fn()
+            };
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+            await Promise.resolve();
+
+            expect(window.MBDialog.alert).toHaveBeenCalled();
+        });
+
+        it("falls back to a plain alert when MBDialog cannot report the cancel", () => {
+            platform.FF = false;
+            delete window.MBDialog;
+            window.prompt = jest.fn(() => null);
+
+            setup();
+            Synth.recorder.ondataavailable({ data: { size: 12 } });
+            Synth.recorder.onstop();
+
+            expect(global.alert).toHaveBeenCalled();
+        });
+    });
 });
 
 describe("Tuner Utilities (Audio Test Functions)", () => {


### PR DESCRIPTION
## Description

Raises `synthutils.js` coverage from **45.62% to 48.47% statements**, **45.16% to 47.96% branches**, and **48.96% to 55.86% functions**, taking **ten previously never-called functions** under test.

`synthutils.js` had 74 of its 145 functions never called by the existing suite. Two coherent groups accounted for much of that: the recorder setup and download flow, and the microphone analyser path. The existing tuner tests exercise `tunerAnalyser`, but `this.analyser`, the recording player, and everything hanging off `setupRecorder` had no coverage at all.

## Related Issue

**Fixes:** #8342

## Category

- [x] Tests

## Changes Made

Added twenty tests in `js/utils/__tests__/synthutils.test.js`.

`setupRecorder` is driven against a temporarily emptied instrument table, since the Tone mocks do not implement `connect()`. That reaches the Firefox wav versus webm branch, the `ondataavailable` guards for absent and zero-length chunks, and the `onstop` path. The download flow is covered end to end: `MBDialog.prompt` when present and the `window.prompt` fallback when not, the wav and ogg extension split, and all three `finishDownload` outcomes.

`stopPlayBackRecording` routes through `_disposeRecordingPlayer`, whose `stop` and `dispose` calls sit in separate `try/catch` blocks, so each is made to throw in turn to prove the player reference is still released. The no-player, missing-method, and pending-timeout branches are covered too.

`LiveWaveForm` is exercised from a clean state and with a previous analyser present, so the disconnect-and-dispose branch runs rather than being skipped. `getWaveFormValues` is verified against a stubbed analyser.

No production code is touched.

## Testing Performed

Full suite passes: **223 suites, 8207 tests**. `npm run lint` and `npx prettier --check` are both clean.

Coverage of `js/utils/synthutils.js`, measured with and without this commit:

| metric | before | after |
|---|---:|---:|
| Statements | 45.62% (735/1611) | 48.47% (781/1611) |
| Branches | 45.16% (467/1034) | 47.96% (496/1034) |
| Functions | 48.96% (71/145) | 55.86% (81/145) |
| Lines | 46.2% (718/1554) | 48.97% (761/1554) |

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
