### PR TITLE
fix: wire ast2blocklist_config_ready promise to script onload (Relate…

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,23 +198,18 @@
         />
         <noscript><link rel="stylesheet" href="css/themes.css?v=fixed" /></noscript>
         <script>
-            let ast2blocklist_config;
             window.ast2blocklist_config_failed = false;
-            window.ast2blocklist_config_ready = fetch("js/js-export/ast2blocks.min.json")
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`Failed to load AST block config: ${response.status}`);
-                    }
-                    return response.json();
-                })
-                .then(data => {
-                    ast2blocklist_config = data;
-                    return data;
-                })
-                .catch(() => {
+            window.ast2blocklist_config_ready = new Promise((resolve, reject) => {
+                const script = document.createElement("script");
+                script.src = "js/js-export/ast2blocks.config.js";
+                script.defer = true;
+                script.onload = resolve;
+                script.onerror = () => {
                     window.ast2blocklist_config_failed = true;
-                    return null;
-                });
+                    reject(new Error("ast2blocks.config.js failed to load"));
+                };
+                document.head.appendChild(script);
+            });
         </script>
     </head>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     collectCoverageFrom: [
         "js/**/*.js",
         "!js/__tests__/**",
+        "!js/js-export/ast2blocks.config.js",
         "planet/js/**/*.js",
         "!planet/js/__tests__/**"
     ],

--- a/js/js-export/__tests__/minify.test.js
+++ b/js/js-export/__tests__/minify.test.js
@@ -19,7 +19,7 @@ describe("minify.js", () => {
         jest.resetModules();
     });
 
-    it("reads ast2blocks.json and writes minified output to ast2blocks.min.json", () => {
+    it("reads ast2blocks.json and writes minified output to ast2blocks.min.json and ast2blocks.config.js", () => {
         const fs = require("fs");
         fs.readFileSync.mockReturnValue('{"key":"value","arr":[1,2,3]}');
         fs.writeFileSync.mockImplementation(() => {});
@@ -28,6 +28,10 @@ describe("minify.js", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             "ast2blocks.min.json",
             '{"key":"value","arr":[1,2,3]}'
+        );
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+            "ast2blocks.config.js",
+            'window.ast2blocklist_config = {"key":"value","arr":[1,2,3]};'
         );
     });
 

--- a/js/js-export/ast2blocks.config.js
+++ b/js/js-export/ast2blocks.config.js
@@ -1,0 +1,2115 @@
+window.ast2blocklist_config = {
+    default_connections: ["parent_or_previous_sibling", "argument", "first_child", "next_sibling"],
+    argument_blocks: [
+        {
+            comment:
+                "Variable name like 'box1' in the Boxes palette or action name like 'action' in the Action palette",
+            ast: {
+                identifiers: [{ property: "type", value: "Identifier" }],
+                identifier_property: "name"
+            }
+        },
+        {
+            comment:
+                "Number expression like '1 / 4' in the Number palette or boolean expressions like 'box1 >= 0' in the Boolean palette",
+            ast: {
+                identifiers: [{ property: "type", value: "BinaryExpression" }],
+                name_property: "operator",
+                argument_properties: ["left", "right"]
+            },
+            name_map: {
+                "+": "plus",
+                "-": "minus",
+                "*": "multiply",
+                "/": "divide",
+                "%": "mod",
+                "==": "equal",
+                "!=": "not_equal_to",
+                "<": "less",
+                ">": "greater",
+                "<=": "less_than_or_equal_to",
+                ">=": "greater_than_or_equal_to",
+                "|": "or",
+                "&": "and",
+                "^": "xor"
+            }
+        },
+        {
+            comment: "Logical expressions like 'a && b' or 'a || b' in the Boolean palette",
+            ast: {
+                identifiers: [{ property: "type", value: "LogicalExpression" }],
+                name_property: "operator",
+                argument_properties: ["left", "right"]
+            },
+            name_map: { "&&": "and", "||": "or" }
+        },
+        {
+            comment: "Unary expressions such as ! in boolean palette or - in number palette",
+            ast: {
+                identifiers: [{ property: "type", value: "UnaryExpression" }],
+                name_property: "operator",
+                argument_properties: ["argument"]
+            },
+            name_map: { "-": "neg", "!": "not" }
+        },
+        {
+            comment: "Literals such as numbers or booleans or strings",
+            ast: { identifiers: [{ property: "type", value: "Literal" }], value_property: "value" }
+        },
+        {
+            comment: "Dictionary get function for 2 arguments",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "AwaitExpression" },
+                    { property: "argument.type", value: "CallExpression" },
+                    { property: "argument.callee.type", value: "MemberExpression" },
+                    { property: "argument.callee.property.name", value: "getValue" },
+                    { property: "argument.arguments", size: 2 }
+                ],
+                name_property: "argument.callee.property.name",
+                argument_properties: ["argument.arguments[1]", "argument.arguments[0]"]
+            },
+            name_map: { getValue: "getDict" }
+        },
+        {
+            comment: "Dictionary get function for 1 argument",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "AwaitExpression" },
+                    { property: "argument.type", value: "CallExpression" },
+                    { property: "argument.callee.type", value: "MemberExpression" },
+                    { property: "argument.callee.property.name", value: "getValue" },
+                    { property: "argument.arguments", size: 1 }
+                ],
+                name_property: "argument.callee.property.name",
+                argument_properties: ["argument.arguments[0]"]
+            },
+            name_map: { getValue: "getDict2" }
+        },
+        {
+            comment: "Skip, this is for children",
+            ast: { identifiers: [{ property: "type", value: "ArrowFunctionExpression" }] }
+        },
+        {
+            comment: "Math operators such as absolute value or square",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "CallExpression" },
+                    { property: "callee.type", value: "MemberExpression" },
+                    { property: "callee.object.type", value: "Identifier" },
+                    { property: "callee.object.name", value: "Math" }
+                ],
+                name_property: "callee.property.name",
+                arguments_property: "arguments"
+            },
+            name_map: { abs: "abs", floor: "int", pow: "power", sqrt: "sqrt" }
+        },
+        {
+            comment: "Math utility operators such as distance or random",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "CallExpression" },
+                    { property: "callee.type", value: "MemberExpression" },
+                    { property: "callee.object.type", value: "Identifier" },
+                    { property: "callee.object.name", value: "MathUtility" }
+                ],
+                name_property: "callee.property.name",
+                arguments_property: "arguments"
+            },
+            name_map: { doCalculateDistance: "distance", doOneOf: "oneOf", doRandom: "random" }
+        },
+        {
+            comment: "Singular argument mouse blocks",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "MemberExpression" },
+                    { property: "object.name", value: "mouse" }
+                ],
+                name_property: "property.name",
+                argument_properties: []
+            },
+            name_map: {
+                MODELENGTH: "modelength",
+                SCALARCHANGEINPITCH: "deltapitch2",
+                CHANGEINPITCH: "deltapitch",
+                CURRENTKEY: "currentkey",
+                CURRENTMODE: "currentmode",
+                X: "x",
+                Y: "y",
+                HEAP: "heap",
+                HEAPLENGTH: "heapLength",
+                HEAPEMPTY: "heapEmpty",
+                GREY: "grey",
+                SHADE: "shade",
+                PENSIZE: "pensize",
+                COLOR: "color",
+                BOTTOMPOS: "bottompos",
+                CAMERA: "camera",
+                BEATCOUNT: "nopValueBlock",
+                MEASURECOUNT: "nopValueBlock",
+                BPM: "nopValueBlock",
+                WHOLENOTESPLAYED: "elapsednotes",
+                BEATFACTOR: "beatfactor",
+                NOTEVALUE: "notevalue"
+            }
+        },
+        {
+            comment: "Box getter function",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "CallExpression" },
+                    { property: "callee.type", value: "MemberExpression" },
+                    { property: "callee.object.name", value: "mouse" },
+                    { property: "callee.property.name", value: "getBox" }
+                ],
+                name_property: "callee.property.name",
+                argument_properties: ["arguments[0]"]
+            },
+            name_map: { getBox: "box" }
+        },
+        {
+            comment: "Action argument access (actionArgs[n])",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "MemberExpression" },
+                    { property: "object.type", value: "Identifier" },
+                    { property: "object.name", value: "actionArgs" },
+                    { property: "computed", value: true }
+                ],
+                name_property: "object.name",
+                argument_properties: ["property"]
+            },
+            name_map: { actionArgs: "arg" }
+        },
+        {
+            comment: "Get synth volume value",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "CallExpression" },
+                    { property: "callee.name", value: "getSynthVolume" }
+                ],
+                name_property: "callee.name",
+                argument_properties: ["arguments[0]"]
+            },
+            name_map: { getSynthVolume: "synthvolumefactor" }
+        },
+        {
+            comment: "Number to pitch/octave conversion",
+            ast: {
+                identifiers: [{ property: "type", value: "CallExpression" }],
+                name_property: "callee.name",
+                argument_properties: ["arguments[0]"]
+            },
+            name_map: { numToOctave: "number2octave", numToPitch: "number2pitch" }
+        }
+    ],
+    body_blocks: [
+        {
+            comment: "run is ignored",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "CallExpression" },
+                    { property: "expression.callee.type", value: "MemberExpression" },
+                    { property: "expression.callee.object.name", value: "MusicBlocks" },
+                    { property: "expression.callee.property.name", value: "run" }
+                ]
+            }
+        },
+        {
+            name: "storein2",
+            comment: "Variable assignment in the Boxes palette like 'var box1 = 2 * 5;'",
+            arguments: [{ type: "ValueExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "VariableDeclaration" },
+                    { property: "declarations[0].init.type", value: "Literal" },
+                    { property: "declarations[0].init.type", value: "BinaryExpression" },
+                    { property: "declarations[0].init.type", value: "UnaryExpression" },
+                    { property: "declarations[0].init.type", value: "CallExpression" }
+                ],
+                name_property: "declarations[0].id.name",
+                argument_properties: ["declarations[0].init"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "storein",
+            comment: "Store in block using mouse.setBox(name, value)",
+            arguments: [{ type: "ValueExpression" }, { type: "ValueExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setBox" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "decrementOne",
+            comment: "Decrement by one block in the Boxes palette 'box1 = box1 - 1;'",
+            arguments: [{ type: "namedbox" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.right.type", value: "BinaryExpression" },
+                    { property: "expression.right.operator", value: "-" },
+                    { property: "expression.right.right.value", value: 1 }
+                ],
+                argument_properties: ["expression.left"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "increment",
+            comment: "Increment block in the Boxes palette 'box1 = box1 + 3;'",
+            arguments: [{ type: "namedbox" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.right.type", value: "BinaryExpression" },
+                    { property: "expression.right.operator", value: "+" }
+                ],
+                argument_properties: ["expression.left", "expression.right.right"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "increment",
+            comment: "Increment block using mouse.incrementBox(name, delta)",
+            arguments: [{ type: "ValueExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "incrementBox" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "settimbre",
+            comment: "Set instrument block",
+            arguments: [{ type: "voicename" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setInstrument" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "tie",
+            comment: "Tie block in the Rhythm palette",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "tie" }
+                ],
+                children_properties: ["expression.argument.arguments[0].body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 0 }
+        },
+        {
+            name: "newswing2",
+            comment: "Swing block in the Rhythm palette",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "swing" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ],
+                children_properties: ["expression.argument.arguments[2].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "pitch",
+            comment: "Pitch block",
+            arguments: [{ type: "note_or_solfege" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "playPitch" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "hertz",
+            comment: "Hertz block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "playHertz" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "rest2",
+            comment: "Rest block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "playRest" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "nameddoArg",
+            comment: "Action palette, async block with arguments",
+            arguments: [{ type: "ValueExpression" }],
+            arguments_repeat: true,
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "Identifier" },
+                    { property: "expression.argument.arguments", size: 2 },
+                    { property: "expression.argument.arguments[1].type", value: "ArrayExpression" }
+                ],
+                name_property: "expression.argument.callee.name",
+                arguments_property: "expression.argument.arguments[1].elements",
+                arguments_offset: 1
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "nameddo",
+            comment: "Action palette, async block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "Identifier" }
+                ],
+                name_property: "expression.argument.callee.name"
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "start",
+            comment: "Start block in the Flow palette",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "NewExpression" }
+                ],
+                children_properties: ["expression.arguments[0].body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "action",
+            comment: "Action block in the Action palette",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "VariableDeclaration" },
+                    { property: "declarations[0].init.type", value: "ArrowFunctionExpression" }
+                ],
+                argument_properties: ["declarations[0].id"],
+                children_properties: ["declarations[0].init.body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "repeat",
+            comment: "Repeat block in the Flow palette",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [{ property: "type", value: "ForStatement" }],
+                argument_properties: ["test.right"],
+                children_properties: ["body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "forever",
+            comment: "Forever block in the Flow palette",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "WhileStatement" },
+                    { property: "test.raw", value: "1000" }
+                ],
+                children_properties: ["body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "while",
+            comment: "While block in the Flow palette",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: {
+                identifiers: [{ property: "type", value: "WhileStatement" }],
+                argument_properties: ["test"],
+                children_properties: ["body.body"]
+            },
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "until",
+            comment: "Do While block in the Flow palette",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: {
+                identifiers: [{ property: "type", value: "DoWhileStatement" }],
+                argument_properties: ["test"],
+                children_properties: ["body.body"]
+            },
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "switch",
+            comment: "Switch block in the Flow palette",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [{ property: "type", value: "SwitchStatement" }],
+                argument_properties: ["discriminant"],
+                children_properties: ["cases"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "defaultcase",
+            comment: "Default case block in the Flow palette",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "SwitchCase" },
+                    { property: "test", has_value: false }
+                ],
+                children_properties: ["consequent"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "case",
+            comment: "Case block in the Flow palette",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "SwitchCase" },
+                    { property: "test.type", value: "Literal" }
+                ],
+                argument_properties: ["test"],
+                children_properties: ["consequent"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "break",
+            comment: "Break block in the Flow palette",
+            ast: { identifiers: [{ property: "type", value: "BreakStatement" }] },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "if",
+            comment: "Basic if block in the Flow palette",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "IfStatement" },
+                    { property: "alternate", has_value: false }
+                ],
+                argument_properties: ["test"],
+                children_properties: ["consequent.body"]
+            },
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "ifthenelse",
+            comment: "If-then-else block in the Flow palette",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "IfStatement" },
+                    { property: "alternate", has_value: true }
+                ],
+                argument_properties: ["test"],
+                children_properties: ["consequent.body", "alternate.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "first_child",
+                "second_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "setDict",
+            comment: "Set value block for dictionary, with specific dictionary",
+            arguments: [{ type: "text" }, { type: "text" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setValue" },
+                    { property: "expression.argument.arguments", size: 3 }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[2]",
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 3 }
+        },
+        {
+            name: "setDict2",
+            comment: "Dictionary blocks, the set functions",
+            arguments: [{ type: "text" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setValue" },
+                    { property: "expression.argument.arguments", size: 2 }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "meter",
+            comment: "Set meter block from the meter palette",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setMeter" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "pickup",
+            comment: "PICKUP block from the meter palette",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.operator", value: "=" },
+                    { property: "expression.left.type", value: "MemberExpression" },
+                    { property: "expression.left.property.name", value: "PICKUP" }
+                ],
+                argument_properties: ["expression.right"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setbpm3",
+            comment: "Set BPM block from the meter palette",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setBPM" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setmasterbpm2",
+            comment: "Set master BPM block from the meter palette",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setMasterBPM" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "everybeatdo",
+            comment: "On every note do block from the meter palette",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "onEveryNoteDo" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "everybeatdonew",
+            comment: "On every beat do block from the meter palette",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "onEveryBeatDo" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "onbeatdo",
+            comment: "On strong beat do block from the meter palette",
+            arguments: [{ type: "NumberExpression" }, { type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "onStrongBeatDo"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "offbeatdo",
+            comment: "On weak beat do block from the meter palette",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "onWeakBeatDo" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "drift",
+            comment: "No clock block from the meter palette",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setNoClock" }
+                ],
+                children_properties: ["expression.argument.arguments[0].body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "steppitch",
+            comment: "Step pitch block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "stepPitch" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "nthmodalpitch",
+            comment: "Play nth modal pitch block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "playNthModalPitch"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "pitchnumber",
+            comment: "Play pitch number block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "playPitchNumber"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "accidental",
+            comment: "Set accidental block",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setAccidental" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "setscalartransposition",
+            comment: "Set scalar transposition block",
+            arguments: [{ type: "modelength" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setScalarTranspose"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "register",
+            comment: "Set register block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setRegister" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "invert1",
+            comment: "Invert block",
+            arguments: [
+                { type: "note_or_solfege" },
+                { type: "NumberExpression" },
+                { type: "text" }
+            ],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "invert" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]",
+                    "expression.argument.arguments[2]"
+                ],
+                children_properties: ["expression.argument.arguments[3].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 3 }
+        },
+        {
+            name: "setpitchnumberoffset",
+            comment: "Set pitch number offset block",
+            arguments: [{ type: "note_or_solfege" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setPitchNumberOffset"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setkey2",
+            comment: "Set key block",
+            arguments: [{ type: "notename" }, { type: "modename" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setKey" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "definemode",
+            comment: "Define mode block",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "defineMode" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "movable",
+            comment: "Movable do block",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.operator", value: "=" },
+                    { property: "expression.left.type", value: "MemberExpression" },
+                    { property: "expression.left.property.name", value: "MOVABLEDO" }
+                ],
+                argument_properties: ["expression.right"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "semitoneinterval",
+            comment: "Set semitone interval block",
+            arguments: [{ type: "intervalname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setSemitoneInterval"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "settemperament",
+            comment: "Set temperament block",
+            arguments: [
+                { type: "temperamentname" },
+                { type: "notename" },
+                { type: "NumberExpression" }
+            ],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setTemperament"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]",
+                    "expression.argument.arguments[2]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 3 }
+        },
+        {
+            name: "vibrato",
+            comment: "Vibrato effect block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doVibrato" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ],
+                children_properties: ["expression.argument.arguments[2].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "chorus",
+            comment: "Chorus effect block",
+            arguments: [
+                { type: "NumberExpression" },
+                { type: "NumberExpression" },
+                { type: "NumberExpression" }
+            ],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doChorus" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]",
+                    "expression.argument.arguments[2]"
+                ],
+                children_properties: ["expression.argument.arguments[3].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 3 }
+        },
+        {
+            name: "phaser",
+            comment: "Phaser effect block",
+            arguments: [
+                { type: "NumberExpression" },
+                { type: "NumberExpression" },
+                { type: "NumberExpression" }
+            ],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doPhaser" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]",
+                    "expression.argument.arguments[2]"
+                ],
+                children_properties: ["expression.argument.arguments[3].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 3 }
+        },
+        {
+            name: "tremolo",
+            comment: "Tremolo effect block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doTremolo" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ],
+                children_properties: ["expression.argument.arguments[2].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "neighbor2",
+            comment: "Neighbor tone block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doNeighbor" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ],
+                children_properties: ["expression.argument.arguments[2].body.body"]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "first_child",
+                "next_sibling"
+            ],
+            default_vspaces: { argument: 2 }
+        },
+        {
+            name: "setsynthvolume",
+            comment: "Set synth volume block",
+            arguments: [{ type: "voicename" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setSynthVolume"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setnotevolume",
+            comment: "Set master volume block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.operator", value: "=" },
+                    { property: "expression.left.type", value: "MemberExpression" },
+                    { property: "expression.left.property.name", value: "MASTERVOLUME" }
+                ],
+                argument_properties: ["expression.right"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setpanning",
+            comment: "Set panning block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AssignmentExpression" },
+                    { property: "expression.operator", value: "=" },
+                    { property: "expression.left.type", value: "MemberExpression" },
+                    { property: "expression.left.property.name", value: "PANNING" }
+                ],
+                argument_properties: ["expression.right"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "playdrum",
+            comment: "Play drum block",
+            arguments: [{ type: "drumname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "playDrum" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setdrum",
+            comment: "Set drum block",
+            arguments: [{ type: "effectsname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setDrum" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "mapdrum",
+            comment: "Map pitch to drum block",
+            arguments: [{ type: "drumname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "mapPitchToDrum"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "playdrum",
+            comment: "Play drum block",
+            arguments: [{ type: "drumname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "playDrum" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setdrum",
+            comment: "Set drum block",
+            arguments: [{ type: "effectsname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setDrum" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "mapdrum",
+            comment: "Map pitch to drum block",
+            arguments: [{ type: "drumname" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "mapPitchToDrum"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        },
+        {
+            name: "forward",
+            comment: "Forward block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "goForward" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "back",
+            comment: "Backward block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "goBackward" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "left",
+            comment: "Turn left block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "turnLeft" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "right",
+            comment: "Turn right block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "turnRight" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setxy",
+            comment: "Set position block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setXY" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setheading",
+            comment: "Set heading block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setHeading" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "arc",
+            comment: "Draw arc block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "drawArc" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "controlpoint1",
+            comment: "Set bezier control point 1 block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setBezierControlPoint1"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "controlpoint2",
+            comment: "Set bezier control point 2 block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setBezierControlPoint2"
+                    }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "bezier",
+            comment: "Draw bezier block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "drawBezier" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "clear",
+            comment: "Clear block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "clear" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "scrollxy",
+            comment: "Scroll XY block",
+            arguments: [{ type: "x" }, { type: "y" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "scrollXY" }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setcolor",
+            comment: "Set color block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setColor" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setgrey",
+            comment: "Set grey block",
+            arguments: [{ type: "grey" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setGrey" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setshade",
+            comment: "Set shade block",
+            arguments: [{ type: "shade" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setShade" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "sethue",
+            comment: "Set hue block",
+            arguments: [{ type: "color" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setHue" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "settranslucency",
+            comment: "Set translucency block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "setTranslucency"
+                    }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setpensize",
+            comment: "Set pen size block",
+            arguments: [{ type: "pensize" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setPensize" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "penup",
+            comment: "Pen up block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "penUp" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "pendown",
+            comment: "Pen down block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "penDown" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "beginfill",
+            comment: "Begin fill block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "beginFill" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "endfill",
+            comment: "End fill block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "endFill" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "fill",
+            comment: "Fill block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "fillShape" }
+                ],
+                children_properties: ["expression.argument.arguments[0].body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 0 }
+        },
+        {
+            name: "hollowline",
+            comment: "Hollow line block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "hollowLine" }
+                ],
+                children_properties: ["expression.argument.arguments[0].body.body"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "first_child", "next_sibling"],
+            default_vspaces: { argument: 0 }
+        },
+        {
+            name: "background",
+            comment: "Fill background block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    {
+                        property: "expression.argument.callee.property.name",
+                        value: "fillBackground"
+                    }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "setfont",
+            comment: "Set font block",
+            arguments: [{ type: "text" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setFont" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "erasemedia",
+            comment: "Erase media block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "clearMedia" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "wait",
+            comment: "Wait block",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "doWait" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "print",
+            comment: "print block",
+            arguments: [{ type: "ValueExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "print" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "emptyHeap",
+            comment: "Empty heap block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "emptyHeap" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "reverseHeap",
+            comment: "Reverse heap block",
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "reverseHeap" }
+                ]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "next_sibling"]
+        },
+        {
+            name: "push",
+            comment: "Push heap block",
+            arguments: [{ type: "ValueExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "push" },
+                    { property: "expression.argument.arguments", size: 1 }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"]
+            },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name: "setHeapEntry",
+            comment: "Set heap entry block",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setHeapEntry" },
+                    { property: "expression.argument.arguments", size: 2 }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "setHeapEntry",
+            comment: "Set heap entry block (alias)",
+            arguments: [{ type: "NumberExpression" }, { type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" },
+                    { property: "expression.argument.callee.property.name", value: "setHeap" },
+                    { property: "expression.argument.arguments", size: 2 }
+                ],
+                argument_properties: [
+                    "expression.argument.arguments[0]",
+                    "expression.argument.arguments[1]"
+                ]
+            },
+            blocklist_connections: [
+                "parent_or_previous_sibling",
+                "argument",
+                "argument",
+                "next_sibling"
+            ],
+            default_vspaces: { body: 2 }
+        },
+        {
+            name: "debugger",
+            comment: "Debugger block",
+            arguments: [{ type: "BooleanExpression" }],
+            ast: { identifiers: [{ property: "type", value: "DebuggerStatement" }] },
+            blocklist_connections: ["parent_or_previous_sibling", "argument", "next_sibling"]
+        },
+        {
+            name_map: {
+                playNote: "newnote",
+                dot: "rhythmicdot2",
+                multiplyNoteValue: "multiplybeatfactor",
+                playNoteMillis: "osctime",
+                doCrescendo: "crescendo",
+                doDecrescendo: "decrescendo",
+                setSemitoneTranspose: "settransposition",
+                setScalarInterval: "interval",
+                doDistortion: "dis",
+                doHarmonic: "harmonic2",
+                setStaccato: "newstaccato",
+                setSlur: "newslur",
+                setRelativeVolume: "articulation"
+            },
+            comment: "Flow blocks with one number argument",
+            arguments: [{ type: "NumberExpression" }],
+            ast: {
+                identifiers: [
+                    { property: "type", value: "ExpressionStatement" },
+                    { property: "expression.type", value: "AwaitExpression" },
+                    { property: "expression.argument.type", value: "CallExpression" },
+                    { property: "expression.argument.callee.type", value: "MemberExpression" }
+                ],
+                argument_properties: ["expression.argument.arguments[0]"],
+                children_properties: ["expression.argument.arguments[1].body.body"]
+            },
+            default_vspaces: { argument: 1 }
+        }
+    ]
+};

--- a/js/js-export/minify.js
+++ b/js/js-export/minify.js
@@ -5,3 +5,4 @@ const jsonContent = fs.readFileSync("ast2blocks.json", "utf8");
 const minified = JSON.stringify(JSON.parse(jsonContent));
 
 fs.writeFileSync("ast2blocks.min.json", minified);
+fs.writeFileSync("ast2blocks.config.js", `window.ast2blocklist_config = ${minified};`);

--- a/js/widgets/__tests__/jseditor.test.js
+++ b/js/widgets/__tests__/jseditor.test.js
@@ -62,6 +62,22 @@ global.AST2BlockList = {
     toBlockList: jest.fn()
 };
 
+// Mock pubsub (used by _codeToBlocks to wait for finishedLoading)
+global.pubsub = {
+    _listeners: {},
+    on(event, fn) {
+        if (!this._listeners[event]) this._listeners[event] = [];
+        this._listeners[event].push(fn);
+    },
+    off(event, fn) {
+        if (!this._listeners[event]) return;
+        this._listeners[event] = this._listeners[event].filter(f => f !== fn);
+    },
+    emit(event) {
+        (this._listeners[event] || []).forEach(fn => fn());
+    }
+};
+
 /**
  * Creates a mock widgetWindow object with all required methods.
  * The widget body is appended to document.body so getElementById works.
@@ -150,6 +166,7 @@ const { JSEditor } = require("../jseditor.js");
  * @returns {Object} A mock activity.
  */
 function createMockActivity() {
+    const stageListeners = {};
     return {
         logo: {
             statusMatrix: null,
@@ -163,13 +180,27 @@ function createMockActivity() {
                 dict: {}
             },
             moveBlock: jest.fn(),
-            loadNewBlocks: jest.fn()
+            loadNewBlocks: jest.fn(() => {
+                // Simulate the real loadNewBlocks → cleanupAfterLoad chain
+                // which emits "finishedLoading" once all blocks are processed.
+                global.pubsub.emit("finishedLoading");
+            })
         },
         stage: {
-            removeAllEventListeners: jest.fn(),
-            addEventListener: jest.fn()
+            removeAllEventListeners: jest.fn(event => {
+                if (event) delete stageListeners[event];
+            }),
+            addEventListener: jest.fn((event, fn) => {
+                stageListeners[event] = fn;
+            }),
+            _listeners: stageListeners
         },
-        sendAllToTrash: jest.fn()
+        sendAllToTrash: jest.fn(function () {
+            // Simulate the real sendAllToTrash which dispatches "trashsignal"
+            // after a timeout. In tests we fire it synchronously.
+            const listener = stageListeners["trashsignal"];
+            if (listener) listener();
+        })
     };
 }
 

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -22,7 +22,7 @@
  * Private members' names begin with underscore '_".
  */
 
-/* global docById, MusicBlocks, hljs, CodeJar, JSGenerate, JS_API */
+/* global docById, MusicBlocks, hljs, CodeJar, JSGenerate, JS_API, pubsub */
 
 /* exported JSEditor */
 
@@ -991,15 +991,26 @@ class JSEditor {
             let ast = acorn.parse(this._code, { ecmaVersion: 2020 });
             let blockList = AST2BlockList.toBlockList(ast, window.ast2blocklist_config);
             const activity = this.activity;
-            // Wait for the old blocks to be removed, then load new blocks.
-            const __listener = event => {
-                activity.blocks.loadNewBlocks(blockList);
+            // Wait for blocks to be trashed, loaded, and fully processed
+            // before returning. loadNewBlocks processes blocks in async
+            // chunks, so we must wait for the "finishedLoading" pubsub
+            // event which fires after all blocks are ready.
+            await new Promise(resolve => {
+                const __afterLoad = () => {
+                    pubsub.off("finishedLoading", __afterLoad);
+                    resolve();
+                };
+                pubsub.on("finishedLoading", __afterLoad);
+
+                const __listener = () => {
+                    activity.blocks.loadNewBlocks(blockList);
+                    activity.stage.removeAllEventListeners("trashsignal");
+                };
                 activity.stage.removeAllEventListeners("trashsignal");
-            };
-            activity.stage.removeAllEventListeners("trashsignal");
-            activity.stage.addEventListener("trashsignal", __listener, false);
-            // Clear the canvas but leave the JS editor open
-            activity.sendAllToTrash(false, false, false);
+                activity.stage.addEventListener("trashsignal", __listener, false);
+                // Clear the canvas but leave the JS editor open
+                activity.sendAllToTrash(false, false, false);
+            });
         } catch (e) {
             JSEditor.logConsole(
                 "message" in e ? e.message : e.prefix + this._code.substring(e.start, e.end),

--- a/js/widgets/jseditor.js
+++ b/js/widgets/jseditor.js
@@ -970,7 +970,7 @@ class JSEditor {
         JSEditor.clearConsole();
 
         try {
-            if (!ast2blocklist_config && window.ast2blocklist_config_ready) {
+            if (!window.ast2blocklist_config && window.ast2blocklist_config_ready) {
                 try {
                     await window.ast2blocklist_config_ready;
                 } catch {
@@ -978,7 +978,7 @@ class JSEditor {
                 }
             }
 
-            if (!ast2blocklist_config) {
+            if (!window.ast2blocklist_config) {
                 throw new Error(
                     window.ast2blocklist_config_failed
                         ? _(
@@ -989,7 +989,7 @@ class JSEditor {
             }
 
             let ast = acorn.parse(this._code, { ecmaVersion: 2020 });
-            let blockList = AST2BlockList.toBlockList(ast, ast2blocklist_config);
+            let blockList = AST2BlockList.toBlockList(ast, window.ast2blocklist_config);
             const activity = this.activity;
             // Wait for the old blocks to be removed, then load new blocks.
             const __listener = event => {


### PR DESCRIPTION
fix: wire ast2blocklist_config_ready promise to script onload (Related to #8344)

Promise.resolve() resolved immediately before the deferred script could execute, so _codeToBlocks() always found window.ast2blocklist_config undefined and threw the 'configuration file failed to load' error.

Replace the static defer script tag + immediate Promise.resolve() with a programmatically injected script element whose onload/onerror events properly gate the promise, so _codeToBlocks() waits for the config to actually be set before proceeding.

<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

The JS Widget throws a "JavaScript block conversion is unavailable because its configuration file failed to load" error when clicking the play button. 

This was caused by a timing regression where the `ast2blocklist_config_ready` promise resolved instantly (via `Promise.resolve()`) before the deferred `ast2blocks.config.js` script could execute. As a result, `_codeToBlocks()` in the widget found the config undefined and threw the error. Additionally, the widget was referencing a bare `ast2blocklist_config` variable instead of the `window` property, and the build script was not correctly generating the `.config.js` file.

This PR fixes the promise timing, updates variable references, and ensures the configuration file is correctly built and shipped.

## Related Issue

**Fixes:** #8344

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`index.html`**: Replaced the static `<script defer>` tag and `Promise.resolve()` with a programmatically injected script element. The `onload` and `onerror` events now properly gate the `ast2blocklist_config_ready` promise.
- **`js/widgets/jseditor.js`**: Updated bare references of `ast2blocklist_config` to `window.ast2blocklist_config`.
- **`js/js-export/minify.js`**: Added logic to emit `ast2blocks.config.js` alongside the standard `.min.json` file.
- **`js/js-export/ast2blocks.config.js`**: Committed the newly generated configuration file.
- **`js/js-export/__tests__/minify.test.js`**: Updated tests to assert the generation of the new config file.

---

## Testing Performed

- Ran `npm test` to verify all 8,100+ tests pass without regression (specifically `jseditor` and `minify` tests).
- Ran `npm run lint` and `npx prettier --check .` to ensure style consistency.
- Manually verified locally via `npm run serve:dev`: Loaded the default project, opened the JS Widget, clicked Play, and confirmed that "Code executed successfully!" appears in the console without throwing the sandbox error.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This properly resolves the underlying problem introduced during a previous `file://` CORS fix without re-breaking local filesystem execution.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>