### PR TITLE
fix(musicutils): return correct note count for all EDOs

### DIFF
--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1036,6 +1036,16 @@ function generateNoteNames(edo) {
         const nextNatural = naturals[(n + 1) % 7];
         const edoSteps = intervals[n].steps;
 
+        // An interval with zero allocated steps means this natural letter
+        // has no distinct pitch class in this EDO (its scale step was
+        // absorbed into a neighboring interval) — skip it entirely rather
+        // than always emitting all 7 naturals, or names.length would never
+        // shrink below 7 for edo < 7 (see the edo === 5 special case above,
+        // which relies on exactly this: F and B are skipped).
+        if (edoSteps === 0) {
+            continue;
+        }
+
         names.push(natural);
 
         const numAccidentals = edoSteps - 1;


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->
## Description
Fixes `generateNoteNames(edo)` in `js/utils/musicutils.js` so it always returns exactly `edo` note names, instead of silently returning 7 names for any EDO below 7 that isn't the special-cased 5 (e.g. 2, 3, 4, 6). The fallback branch unconditionally pushed every natural letter into the output array even when its allocated step count for that interval was 0, so the returned array could never shrink below 7 entries regardless of `edo`. This isn't cosmetic — `generateNoteNames()` feeds `frequencyToPitch()`, so a custom small-EDO temperament (e.g. 4 steps) silently produced wrong pitch names and octave numbers for every note played, with no error or visual sign anything was off.

## Related Issue
**Fixes:** #8340

---

## Category
<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made
Skip pushing a natural letter (and its accidentals) into `names` when its allocated `steps` for that interval is `0` — the remainder-distribution logic already guarantees the total step count sums to `edo`, so this makes `names.length === edo` for every EDO. This generalizes the exact same pattern the existing `edo === 5` special case already relies on (skipping F and B), rather than introducing new behavior.

```diff
     for (let n = 0; n < 7; n++) {
         const natural = naturals[n];
         const nextNatural = naturals[(n + 1) % 7];
         const edoSteps = intervals[n].steps;

+        // An interval with zero allocated steps means this natural letter
+        // has no distinct pitch class in this EDO (its scale step was
+        // absorbed into a neighboring interval) — skip it entirely rather
+        // than always emitting all 7 naturals, or names.length would never
+        // shrink below 7 for edo < 7 (see the edo === 5 special case above,
+        // which relies on exactly this: F and B are skipped).
+        if (edoSteps === 0) {
+            continue;
+        }
+
         names.push(natural);

         const numAccidentals = edoSteps - 1;
```

---

## Visual Changes
<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->
Not applicable — no UI/markup changes, only the length/content of an internal note-name array.

---

## Testing Performed
- Ran the patched function directly against 18 EDO values (2–15, 19, 24, 31, 53): every one now returns exactly `edo` names with no duplicates.
- Ran `npx jest js/utils/__tests__/musicutils.test.js` — **530/530 tests pass**, no regressions. Confirmed no existing test depended on the old (buggy) 7-name output.
- Ran `npx eslint js/utils/musicutils.js` — 0 issues.
- Applied `soln.patch` to a fresh, unmodified clone of the repo — applies cleanly.

---

## Checklist
<!-- Please check the boxes that apply. Add or remove items as needed. -->
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes
Scope is intentionally narrow: this only changes the fallback branch of `generateNoteNames()`. The `edo === 12`, `edo === 7`, and `edo === 5` special cases are untouched and already correct.