### PR TITLE
fix: preserve track-specific MIDI percussion notes

### DIFF
--- a/js/__tests__/midi.test.js
+++ b/js/__tests__/midi.test.js
@@ -156,6 +156,115 @@ describe("transcribeMidi", () => {
         expect(drumBlocks.length).toBeGreaterThan(0);
     });
 
+    it("should keep a melodic track after percussion as pitches", async () => {
+        const mixedTrackMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "drums", percussion: true },
+                    channel: 9,
+                    notes: [{ name: "Kick Drum", midi: 36, time: 0, duration: 0.5 }]
+                },
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [{ name: "C4", midi: 60, time: 0, duration: 0.5 }]
+                }
+            ]
+        };
+
+        await expect(transcribeMidi(mixedTrackMidi)).resolves.toBeNull();
+
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(loadedBlocks.filter(block => block[1] === "pitch")).toHaveLength(1);
+        expect(loadedBlocks.filter(block => block[1] === "playdrum")).toHaveLength(1);
+    });
+
+    it("should preserve each percussion note's drum sound", async () => {
+        const percussionMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "drums", percussion: true },
+                    channel: 9,
+                    notes: [
+                        { name: "Kick Drum", midi: 36, time: 0, duration: 0.5 },
+                        { name: "Snare Drum", midi: 38, time: 0.5, duration: 0.5 }
+                    ]
+                }
+            ]
+        };
+
+        await transcribeMidi(percussionMidi);
+
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const drumNames = loadedBlocks
+            .filter(block => Array.isArray(block[1]) && block[1][0] === "drumname")
+            .map(block => block[1][1].value);
+        expect(drumNames).toEqual(["kick drum", "snare drum"]);
+    });
+
+    it("should preserve a leading rest before a note", async () => {
+        const delayedNoteMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [{ name: "C4", midi: 60, time: 0.5, duration: 0.5 }]
+                }
+            ]
+        };
+
+        await transcribeMidi(delayedNoteMidi);
+
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(loadedBlocks.filter(block => block[1] === "rest2")).toHaveLength(1);
+        expect(loadedBlocks.filter(block => block[1] === "pitch")).toHaveLength(1);
+    });
+
+    it("should preserve simultaneous notes as a chord", async () => {
+        const chordMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 0.5 },
+                        { name: "E4", midi: 64, time: 0, duration: 0.5 }
+                    ]
+                }
+            ]
+        };
+
+        await transcribeMidi(chordMidi);
+
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(loadedBlocks.filter(block => block[1] === "pitch")).toHaveLength(2);
+    });
+
+    it("should preserve notes that overlap", async () => {
+        const overlappingNotesMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 1 },
+                        { name: "E4", midi: 64, time: 0.5, duration: 0.5 }
+                    ]
+                }
+            ]
+        };
+
+        await transcribeMidi(overlappingNotesMidi);
+
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(loadedBlocks.filter(block => block[1] === "pitch")).toHaveLength(3);
+    });
+
     it("should assign correct instruments to tracks", async () => {
         await transcribeMidi(mockMidi);
         expect(loadNewBlocksSpy).toHaveBeenCalled();

--- a/js/midi.js
+++ b/js/midi.js
@@ -71,7 +71,6 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
         currentMidiTimeSignature = defaultTimeSignature;
     }
 
-    let precurssionFlag = false;
     // console.log("tempoBpm is: ", currentMidiTempoBpm);
     // console.log("tempo is : ",currentMidi.header.tempos);
     // console.log("time signatures are: ", currentMidi.header.timeSignatures);
@@ -80,6 +79,8 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
         if (stopProcessing) return; // Exit if flag is set
         if (!track.notes.length) return;
         const r = jsONON.length;
+        const isPercussionTrack =
+            track.instrument.percussion && (track.channel === 9 || track.channel === 10);
         let instrument = "electronic synth";
         if (track.instrument.name && !track.instrument.percussion) {
             for (const voices of VOICENAMES) {
@@ -87,8 +88,6 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
                     instrument = voices[0];
                 }
             }
-        } else if (track.instrument.percussion) {
-            precurssionFlag = true;
         }
         actionBlockPerTrack[trackCount] = 0;
         instruments[trackCount] = instrument;
@@ -101,12 +100,9 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
         );
 
         const sched = [];
-        isPercussion.push(
-            track.instrument.percussion && (track.channel === 9 || track.channel === 10)
-        );
+        isPercussion.push(isPercussionTrack);
 
         track.notes.forEach((note, index) => {
-            const name = note.name;
             const start = Math.round(note.time * 100) / 100;
             const end = Math.round((note.time + note.duration) * 100) / 100;
 
@@ -115,11 +111,11 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             const lastNote = sched[sched.length - 1];
 
             if (index === 0 && start > 0) {
-                sched.push({ start: 0, end: start, notes: ["R"] });
+                sched.push({ start: 0, end: start, notes: [{ name: "R" }] });
             }
 
             if (lastNote && lastNote.start === start && lastNote.end === end) {
-                lastNote.notes.push(name);
+                lastNote.notes.push(note);
                 return;
             }
 
@@ -129,7 +125,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
 
                 lastNote.end = start;
 
-                sched.push({ start: start, end: end, notes: [...prevNotes, name] });
+                sched.push({ start: start, end: end, notes: [...prevNotes, note] });
 
                 if (oldEnd > end) {
                     sched.push({ start: end, end: oldEnd, notes: prevNotes });
@@ -138,10 +134,10 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             }
 
             if (lastNote && lastNote.end < start) {
-                sched.push({ start: lastNote.end, end: start, notes: ["R"] });
+                sched.push({ start: lastNote.end, end: start, notes: [{ name: "R" }] });
             }
 
-            sched.push({ start: start, end: end, notes: [name] });
+            sched.push({ start: start, end: end, notes: [note] });
         });
 
         let noteSum = 0;
@@ -206,10 +202,10 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             let val = jsONON.length + currentActionBlock.length;
             const getPitch = (x, notes, prev) => {
                 const ar = [];
-                if (notes[0] === "R") {
+                if (notes[0].name === "R") {
                     ar.push([x, "rest2", 0, 0, [prev, null]]);
-                } else if (precurssionFlag) {
-                    const drumname = drumMidi[track.notes[0].midi][0] || "kick drum";
+                } else if (isPercussionTrack) {
+                    const drumname = drumMidi[notes[0].midi]?.[0] || "kick drum";
                     ar.push(
                         [x, "playdrum", 0, 0, [first ? prev : x - 1, x + 1, null]],
                         [x + 1, ["drumname", { value: drumname }], 0, 0, [x]]
@@ -217,7 +213,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
                     x += 2;
                 } else {
                     for (const na in notes) {
-                        const name = notes[na];
+                        const name = notes[na].name;
                         const first = na === 0;
                         const last = na === notes.length - 1;
                         ar.push(


### PR DESCRIPTION
## Description

This fixes MIDI imports where a percussion track is followed by a melodic track. The melodic notes could be treated as drum notes and cause the import to fail. It also fixes percussion tracks so each note uses its own drum mapping instead of reusing the first drum sound.

  ## Related Issue

  **Fixes:** #8350

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ---

  ## Changes Made

  - Determine whether a track is percussion on a per-track basis.
  - Keep the original scheduled MIDI note so drum mapping uses that note’s MIDI value.
  - Add regression tests for a melodic track after percussion and for consecutive kick/snare notes.

  ---

  ## Testing Performed

  - Ran the focused MIDI test suite: 10 tests passed.
  - Ran the full test suite: 223 suites and 8,190 tests passed.
  - Ran `npm run lint` successfully.
  - Ran Prettier on the changed files successfully.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run `npm run lint` with no errors.
  - [x] The changed files pass Prettier formatting checks.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

`npx prettier --check .` reports formatting problems in pre-existing unrelated repository files, including malformed HTML in `examples/5-Limit-Lattice.html`. The two files changed in this PR pass Prettier.