### PR TITLE
fix(modewidget): keep _activeEDO at the old value while translating notes to a new EDO

### DIFF
--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -475,6 +475,105 @@ describe("ModeWidget", () => {
         expect(modeWidget._selectedNotes).toEqual(originalNotes);
     });
 
+    describe("_wireEdoSelect", () => {
+        // Fires the real listener _wireEdoSelect registered via
+        // addEventListener, since this file stubs document.createElement
+        // to a plain mock (see top of file) rather than a real jsdom
+        // element that supports dispatchEvent.
+        function fireEdoChange(select, value) {
+            select.value = value;
+            const handler = select.addEventListener.mock.calls.find(
+                call => call[0] === "change"
+            )[1];
+            handler();
+        }
+
+        test("rescales _selectedNotes to a never-before-visited EDO instead of leaving it untranslated", () => {
+            modeWidget._activeTemperamentKey = "equal";
+            modeWidget.logo.synth.inTemperament = "equal";
+            modeWidget._activeEDO = 12;
+            // 12-EDO major scale: root, 2nd, 3rd, 4th, 5th, 6th, 7th.
+            modeWidget._selectedNotes = [
+                true,
+                false,
+                true,
+                false,
+                true,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true
+            ];
+            modeWidget._edoNoteCache = {};
+
+            const savedGetCurrentEDO = global.getCurrentEDO;
+            const savedTemperament = global.TEMPERAMENT;
+            global.getCurrentEDO = jest.fn(key => (key === "equal19" ? 19 : 12));
+            global.TEMPERAMENT = {
+                ...savedTemperament,
+                equal19: { isEDO: true, pitchNumber: 19 }
+            };
+
+            fireEdoChange(modeWidget._edoSelect, "equal19");
+
+            expect(modeWidget._activeEDO).toBe(19);
+            expect(modeWidget._selectedNotes).toHaveLength(19);
+            // A correct rescale of a 7-note pattern into 19-EDO spreads notes
+            // across the full range (scalePatternToEDO puts them at 0, 3, 6,
+            // 8, 11, 14, 17). Before the fix, _translateNotesToEDO's guard
+            // always short-circuited, so nothing above index 11 ever got
+            // selected — the array just got padded with false by
+            // _reconcileNotes downstream, silently losing the scale.
+            expect(modeWidget._selectedNotes.slice(12).some(v => v === true)).toBe(true);
+
+            global.getCurrentEDO = savedGetCurrentEDO;
+            global.TEMPERAMENT = savedTemperament;
+        });
+
+        test("restores from cache instead of re-translating on a previously-visited EDO", () => {
+            modeWidget._activeTemperamentKey = "equal";
+            modeWidget.logo.synth.inTemperament = "equal";
+            modeWidget._activeEDO = 12;
+            const twelveEdoNotes = [
+                true,
+                false,
+                true,
+                false,
+                true,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true
+            ];
+            modeWidget._selectedNotes = twelveEdoNotes.slice();
+            modeWidget._edoNoteCache = {};
+
+            const savedGetCurrentEDO = global.getCurrentEDO;
+            const savedTemperament = global.TEMPERAMENT;
+            global.getCurrentEDO = jest.fn(key => (key === "equal19" ? 19 : 12));
+            global.TEMPERAMENT = {
+                ...savedTemperament,
+                equal19: { isEDO: true, pitchNumber: 19 }
+            };
+
+            // Visit 19-EDO once, then switch back to 12-EDO.
+            fireEdoChange(modeWidget._edoSelect, "equal19");
+            fireEdoChange(modeWidget._edoSelect, "equal");
+
+            expect(modeWidget._activeEDO).toBe(12);
+            expect(modeWidget._selectedNotes).toEqual(twelveEdoNotes);
+
+            global.getCurrentEDO = savedGetCurrentEDO;
+            global.TEMPERAMENT = savedTemperament;
+        });
+    });
+
     test("should fall back to generated names when numberToPitch returns a NaN octave", () => {
         modeWidget._activeEDO = 5;
         global.numberToPitch = jest.fn().mockReturnValue([undefined, NaN]);

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -332,8 +332,12 @@ class ModeWidget {
 
             this.logo.synth.inTemperament = key;
             this._activeTemperamentKey = key;
-            this._activeEDO = newEDO;
 
+            // _translateNotesToEDO() and _restoreState() must run while
+            // this._activeEDO still holds the OLD EDO: _translateNotesToEDO
+            // reads it to know what to rescale from, and its no-op guard
+            // (newEDO === this._activeEDO) would otherwise always be true if
+            // this._activeEDO were already set to newEDO here.
             if (bothEqual) {
                 if (this._edoNoteCache[newEDO] !== undefined) {
                     this._restoreState(newEDO);
@@ -341,6 +345,7 @@ class ModeWidget {
                     this._translateNotesToEDO(newEDO);
                 }
             }
+            this._activeEDO = newEDO;
 
             this._rebuildWheel(newEDO);
             const tName = TEMPERAMENT[key]?.name || key;


### PR DESCRIPTION
## Description

Switching the Mode widget's EDO/tuning dropdown to a fresh EDO (one you haven't visited yet this session) is supposed to rescale your selected scale into the new tuning. It never did, because `_activeEDO` got overwritten to the new value two lines before `_translateNotesToEDO` read it back to figure out what to rescale from.

## Related Issue

**Fixes:** #8349

## Category

- [x] Bug Fix, fixes a bug or incorrect behavior
- [x] Tests, adds or updates test coverage

## Changes Made

- `js/widgets/modewidget.js`: moved the `this._activeEDO = newEDO` assignment in `_wireEdoSelect()` to run after the translate/restore branch instead of before it. `_translateNotesToEDO` needs to see the old EDO to know what to rescale from, its no-op guard (`newEDO === this._activeEDO`) was always true otherwise. Everything downstream that needs the new value (`_rebuildWheel`, the non-EDO temperament branch) still gets it in time since the assignment happens right after.

## Testing Performed

- Added two tests under a new `_wireEdoSelect` describe block in `modewidget.test.js`, both firing the real change handler (grabbed off the mocked `addEventListener` call, since this test file stubs jsdom out) instead of calling internal helpers directly:
  - switching to a never before visited EDO now actually spreads the scale across the new range, checked against `scalePatternToEDO`'s expected output for a 12 to 19 EDO major scale switch
  - switching back to a previously visited EDO still restores from cache correctly
- Checked the first test fails against the pre-fix code (ran it with the fix reverted) and passes with it.
- `npx jest js/widgets/__tests__/modewidget.test.js`, 26/26 passing.
- Full suite: `npx jest`, 8190/8190 passing, 223 suites.
- `npx eslint` and `npx prettier --check` on both changed files, clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase, affects PR branch only).
