### PR TITLE
test: close remaining branch coverage gaps in turtle-painter.js

### DIFF
--- a/js/__tests__/turtle-painter.test.js
+++ b/js/__tests__/turtle-painter.test.js
@@ -1211,4 +1211,95 @@ describe("Additional Robustness & Missing Coverage Tests", () => {
         expect(clearRectSpy).toHaveBeenCalledWith(0, 0, 800, 600);
         expect(painter.turtles.c1ctx.clearRect).toHaveBeenCalledWith(0, 0, 2400, 1800);
     });
+    test("_doArcPart with fillState false applies stroke/lineCap", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter._fillState = false;
+        painter.doArc(45, 20);
+        expect(mockTurtle.ctx.lineWidth).toBe(painter.stroke);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+
+    test("_arc pen-up fallback just moves to point", () => {
+        painter._penDown = false;
+        painter._arc(0, 0, 0, 0, 100, 200, 10, 0, Math.PI, false, false);
+        expect(mockTurtle.ctx.moveTo).toHaveBeenCalledWith(100, 200);
+    });
+
+    test("_arc clockwise diff-normalization (diff < 0)", () => {
+        painter._penDown = true;
+        painter._hollowState = false;
+        painter._arc(0, 0, 0, 0, 100, 200, 10, Math.PI * 1.5, Math.PI * 0.5, false, false);
+        expect(mockTurtle.ctx.stroke).toHaveBeenCalled();
+    });
+
+    test("_arc anticlockwise diff-normalization (diff > 0)", () => {
+        painter._penDown = true;
+        painter._hollowState = false;
+        painter._arc(0, 0, 0, 0, 100, 200, 10, Math.PI * 0.5, Math.PI * 1.5, true, false);
+        expect(mockTurtle.ctx.stroke).toHaveBeenCalled();
+    });
+
+    test("doBezier hollow branch: degreesFinal negative gets normalized", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter._penDown = true;
+        painter._hollowState = true;
+        painter.setControlPoint1([10, 10]);
+        painter.setControlPoint2([5, -5]);
+        painter.doBezier(0, -20);
+        expect(mockTurtle.ctx.stroke).toHaveBeenCalled();
+    });
+
+    test("doSetXY applies lineCap when ctx starts mismatched", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter.doSetXY(50, 60);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+
+    test("doBezier non-hollow branch applies lineWidth/lineCap when ctx starts mismatched", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter._penDown = true;
+        painter._hollowState = false;
+        painter.setControlPoint1([10, 10]);
+        painter.setControlPoint2([20, 20]);
+        painter.doBezier(30, 30);
+        expect(mockTurtle.ctx.lineWidth).toBe(painter.stroke);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+
+    test("doScrollXY applies lineWidth/lineCap for pen-down turtles when ctx starts mismatched", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        const turtle1 = {
+            inTrash: false,
+            painter: { penState: true, stroke: 5, _processColor: jest.fn() },
+            container: { x: 10, y: 20 }
+        };
+        painter.turtles.getTurtleCount = jest.fn(() => 1);
+        painter.turtles.getTurtle = jest.fn(() => turtle1);
+        painter.doScrollXY(10, 20);
+        expect(mockTurtle.ctx.lineWidth).toBe(5);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+
+    test("_move hollow branch applies lineCap when called directly with mismatched ctx", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter._penDown = true;
+        painter._hollowState = true;
+        painter._move(0, 0, 100, 200, false);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+
+    test("_arc hollow branch applies lineCap when called directly with mismatched ctx", () => {
+        mockTurtle.ctx.lineWidth = 999;
+        mockTurtle.ctx.lineCap = "butt";
+        painter._penDown = true;
+        painter._hollowState = true;
+        painter._arc(0, 0, 0, 0, 100, 200, 10, 0, Math.PI, false, false);
+        expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
 });


### PR DESCRIPTION
## Summary
Closes remaining branch-coverage gaps in `turtle-painter.js`.

## Context
Coverage on `turtle-painter.js` was already at 97.6% statements / 100% functions / 83.26% branches on `master`, from test work merged separately after the earlier closed PR #7079. This PR closes most of the remaining branch gap rather than rebuilding coverage from scratch.

## Changes
Added 10 targeted tests to `js/__tests__/turtle-painter.test.js`, covering:
- `_doArcPart` with `fillState = false`
- `_arc`'s pen-up fallback branch
- `_arc`'s clockwise/anticlockwise angle-diff normalization
- `doBezier`'s hollow-line `degreesFinal < 0` normalization
- `doSetXY`, `doBezier` (non-hollow), `doScrollXY`, and direct `_move`/`_arc` hollow-branch calls, each forcing a `ctx.lineWidth`/`ctx.lineCap` mismatch so the existing guard actually runs (the mocked canvas context is shared across the whole test file and never reset, so several guards were silently skipped once an earlier test left it in its "already correct" state)

## Result
`turtle-painter.js`: 99.57% statements / 89.95% branches / 100% functions / 99.57% lines.

Lines 391, 657, and 1231 remain uncovered. Each is a second, redundant occurrence of the same `lineCap !== "round"` guard within a single call (in `_move`, `_arc`, and `doBezier`'s hollow branches respectively) — nothing between the two checks can change `ctx.lineCap` back, so they're unreachable under the current code, not a missed test.

## Testing
- `npm run test:coverage -- turtle-painter` — 124/124 tests passing
- `npx eslint js/__tests__/turtle-painter.test.js` — clean

Closes #8123
## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation