### PR TITLE
fix(a11y): restore Tab focus cycling broken by a display/visibility mismatch

### DIFF
--- a/js/__tests__/focus-cycle-manager.test.js
+++ b/js/__tests__/focus-cycle-manager.test.js
@@ -385,4 +385,94 @@ describe("FocusCycleManager module", () => {
             delete window.FocusCycleManager;
         });
     });
+
+    describe("notification popup bypass", () => {
+        // index.html ships both popups in the DOM permanently; css/activities.css
+        // hides them with `visibility: hidden` and reveals them by adding `.show`.
+        // Reproduce that here so getComputedStyle behaves as it does in a browser.
+        const POPUP_CSS = `
+            .popupMsg { visibility: hidden; }
+            #printText.show, #errorText.show { visibility: visible; }
+        `;
+
+        const mountPopups = () => {
+            const style = document.createElement("style");
+            style.id = "popup-css";
+            style.textContent = POPUP_CSS;
+            document.head.appendChild(style);
+            document.body.insertAdjacentHTML(
+                "beforeend",
+                '<div class="popupMsg" id="printText" tabindex="-1" aria-live="polite" role="status"></div>' +
+                    '<div class="popupMsg" id="errorText" tabindex="-1" aria-live="assertive" role="alert"></div>'
+            );
+            return {
+                printText: document.getElementById("printText"),
+                errorText: document.getElementById("errorText")
+            };
+        };
+
+        afterEach(() => {
+            const style = document.getElementById("popup-css");
+            if (style) style.remove();
+        });
+
+        test("Tab still cycles when the popups are present but hidden", () => {
+            mountPopups();
+            const manager = new FocusCycleManager();
+            manager.init();
+
+            const event = pressTab(false);
+
+            expect(manager._keyboardMode).toBe(true);
+            expect(event.defaultPrevented).toBe(true);
+
+            manager.dispose();
+        });
+
+        test("Tab is not intercepted while the print popup is shown", () => {
+            const { printText } = mountPopups();
+            printText.classList.add("show");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+
+            const event = pressTab(false);
+
+            expect(manager._keyboardMode).toBe(false);
+            expect(event.defaultPrevented).toBe(false);
+
+            manager.dispose();
+        });
+
+        test("Tab is not intercepted while the error popup is shown", () => {
+            const { errorText } = mountPopups();
+            errorText.classList.add("show");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+
+            const event = pressTab(false);
+
+            expect(manager._keyboardMode).toBe(false);
+            expect(event.defaultPrevented).toBe(false);
+
+            manager.dispose();
+        });
+
+        test("a popup hidden with display:none does not block cycling", () => {
+            const { errorText } = mountPopups();
+            // activity.js hides errorText this way rather than by class.
+            errorText.style.display = "none";
+
+            const manager = new FocusCycleManager();
+            manager.init();
+
+            const event = pressTab(false);
+
+            expect(manager._keyboardMode).toBe(true);
+            expect(event.defaultPrevented).toBe(true);
+
+            manager.dispose();
+        });
+    });
 });

--- a/js/focus-cycle-manager.js
+++ b/js/focus-cycle-manager.js
@@ -298,7 +298,16 @@ class FocusCycleManager {
         // keyboard users can Tab to the close button naturally.
         const printText = document.getElementById("printText");
         const errorText = document.getElementById("errorText");
-        const isVisible = el => el instanceof Element && getComputedStyle(el).display !== "none";
+        // The popups live in the DOM permanently and are toggled with
+        // `visibility` (see the .popupMsg / #printText.show rules in
+        // css/activities.css), so a `display` test alone is always true for
+        // them and would bypass every Tab. Check both, since errorText is
+        // additionally given display:none in activity.js.
+        const isVisible = el => {
+            if (!(el instanceof Element)) return false;
+            const style = getComputedStyle(el);
+            return style.display !== "none" && style.visibility !== "hidden";
+        };
         if (isVisible(printText) || isVisible(errorText)) {
             return true;
         }


### PR DESCRIPTION
## Description

`FocusCycleManager` implements Tab cycling between Workspace, Toolbar, Palette and the canvas controls, with aria-live zone announcements. None of it ran. Every Tab keypress was bypassed, so all 543 lines of zone logic were unreachable in the shipped app.

`_shouldBypass()` steps aside while a notification popup is on screen so keyboard users can reach its close button. It decided visibility with `getComputedStyle(el).display !== "none"`, but the popups are never hidden with `display`. `css/activities.css` hides `.popupMsg` with `visibility: hidden` and reveals it by adding `.show`, which flips visibility to visible.

`#printText` is written into `index.html:279` and stays in the DOM permanently, and nothing in any stylesheet or script sets `display` on it, so its computed `display` is the `<div>` default of `block` at all times. `isVisible(printText)` was therefore always true, the `||` short-circuited on it, and `_shouldBypass` returned true for every Tab. `_onKeyDown` exited before `preventDefault()`, so the cycle never fired.

The legacy handler could not cover for it either. `js/activity/keyboard-controller.js:135` stands down for Tab whenever the manager reports `_initialized`, which it does, so both handlers deferred and Tab fell through to native browser order.

`errorText` is additionally given `display: none` in `js/activity.js:2317`, so this checks both properties rather than swapping one for the other.

## Related Issue

**Fixes:** #8354

## Category

- [x] Bug Fix

## Changes Made

```js
-const isVisible = el => el instanceof Element && getComputedStyle(el).display !== "none";
+const isVisible = el => {
+    if (!(el instanceof Element)) return false;
+    const style = getComputedStyle(el);
+    return style.display !== "none" && style.visibility !== "hidden";
+};
```

Added a `notification popup bypass` suite. The existing tests never mounted the popups, so `getElementById` returned `null`, `isVisible(null)` was false, and the suite passed against a DOM that did not match production. The new tests mount both popups with the real stylesheet rules.

## Testing Performed

Full suite passes: **223 suites, 8192 tests**. `npm run lint` and `npx prettier --check` are both clean.

Behaviour with the production DOM, measured before and after:

| DOM state | before | after |
|---|---|---|
| popups present but hidden | Tab bypassed, cycle dead | Tab cycles |
| print popup shown (`.show`) | Tab bypassed | Tab bypassed |
| error popup shown (`.show`) | Tab bypassed | Tab bypassed |
| popup hidden via `display:none` | Tab bypassed | Tab cycles |

Two of the four added tests fail without the source change, and the other two pass either way by design, so a future change cannot "fix" this by disabling the bypass altogether.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
