### PR TITLE
fix: clean up failed project imports

### DIFF
--- a/js/__tests__/project-manager.test.js
+++ b/js/__tests__/project-manager.test.js
@@ -1802,6 +1802,9 @@ describe("_setupFileHandlers inner callbacks", () => {
             .mockImplementation((evt, handler, _flag) => {
                 handlers[evt] = handler;
             });
+        canvasHolder.addEventListener = jest.fn((evt, handler) => {
+            handlers[evt] = handler;
+        });
         return handlers;
     };
 
@@ -1817,11 +1820,11 @@ describe("_setupFileHandlers inner callbacks", () => {
         expect(mockEvent.currentTarget.value).toBe("");
     });
 
-    it("change handler shows error when file is empty (null result)", () => {
+    it.each([null, ""])("change handler cleans up when file is empty (%j result)", rawData => {
         origFileReader = global.FileReader;
         class MockFR {
             constructor() {
-                this.result = null;
+                this.result = rawData;
                 this.onload = null;
             }
             readAsText() {
@@ -1842,7 +1845,118 @@ describe("_setupFileHandlers inner callbacks", () => {
         jest.advanceTimersByTime(200);
 
         expect(activity.errorMsg).toHaveBeenCalled();
-        expect(activity.loading).toBe(true);
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("change handler reports malformed JSON without clearing the workspace", () => {
+        origFileReader = global.FileReader;
+        class MockFR {
+            constructor() {
+                this.result = "not JSON";
+                this.onload = null;
+            }
+            readAsText() {
+                if (this.onload) this.onload();
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        activity.fileChooser.files = [{ name: "broken.tb" }];
+        handlers.change();
+        jest.advanceTimersByTime(200);
+
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(activity.errorMsg).toHaveBeenCalledWith(
+            "Cannot load project from the file. Please check the file type."
+        );
+        expect(activity.sendAllToTrash).not.toHaveBeenCalled();
+        expect(activity.blocks.loadNewBlocks).not.toHaveBeenCalled();
+        expect(global.ErrorHandler.capture).toHaveBeenCalledWith(expect.any(SyntaxError), {
+            operation: "loadProjectFromFile"
+        });
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("change handler reports HTML without project data once and preserves the workspace", () => {
+        origFileReader = global.FileReader;
+        class MockFR {
+            constructor() {
+                this.result = "<html><body>No project here</body></html>";
+                this.onload = null;
+            }
+            readAsText() {
+                if (this.onload) this.onload();
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        global.extractProjectDataFromHTML.mockImplementationOnce(() => null);
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        activity.fileChooser.files = [{ name: "broken.html" }];
+        handlers.change();
+        jest.advanceTimersByTime(200);
+
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(activity.errorMsg).toHaveBeenCalledWith(
+            "Cannot find project data in this HTML file."
+        );
+        expect(global.ErrorHandler.capture).not.toHaveBeenCalled();
+        expect(activity.sendAllToTrash).not.toHaveBeenCalled();
+        expect(activity.blocks.loadNewBlocks).not.toHaveBeenCalled();
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("change handler cleans up when loading merged blocks throws", () => {
+        origFileReader = global.FileReader;
+        class MockFR {
+            constructor() {
+                this.result = "[]";
+                this.onload = null;
+            }
+            readAsText() {
+                if (this.onload) this.onload();
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+
+        const loadError = new Error("block load failed");
+        const activity = makeActivity({ merging: true });
+        activity.blocks.loadNewBlocks.mockImplementation(() => {
+            throw loadError;
+        });
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        activity.fileChooser.files = [{ name: "broken.tb" }];
+        handlers.change();
+        jest.advanceTimersByTime(200);
+
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(global.ErrorHandler.capture).toHaveBeenCalledWith(loadError, {
+            operation: "loadProjectFromFile"
+        });
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
     });
 
     it("change handler imports MIDI when .mid file selected", () => {
@@ -1914,31 +2028,65 @@ describe("_setupFileHandlers inner callbacks", () => {
         expect(() => handlers.change()).not.toThrow();
     });
 
-    it("change handler shows exactly one error when HTML has no project data", () => {
+    it("drop handler cleans up when file is empty", () => {
         origFileReader = global.FileReader;
-        const readers = [];
         class MockFR {
             constructor() {
+                this.result = "";
                 this.onload = null;
-                readers.push(this);
             }
-            readAsText() {}
+            readAsText() {
+                if (this.onload) this.onload();
+            }
             readAsArrayBuffer() {}
         }
         global.FileReader = MockFR;
-        global.extractProjectDataFromHTML.mockReturnValue(null);
+        jest.spyOn(window, "scroll").mockImplementation(() => {});
 
         const activity = makeActivity();
         const handlers = captureHandlers(activity);
         const pm = new ProjectManager(activity);
         pm._setupFileHandlers();
 
-        activity.fileChooser.files = [{ name: "song.html" }];
-        handlers.change();
+        handlers.drop({
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+            dataTransfer: { files: [{ name: "empty.tb" }] }
+        });
+        jest.advanceTimersByTime(200);
 
-        const reader = readers[0];
-        reader.result = "<html><body>no project data here</body></html>";
-        reader.onload();
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("drop handler reports HTML without project data once", () => {
+        origFileReader = global.FileReader;
+        class MockFR {
+            constructor() {
+                this.result = "<html><body>No project here</body></html>";
+                this.onload = null;
+            }
+            readAsText() {
+                if (this.onload) this.onload();
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        global.extractProjectDataFromHTML.mockImplementationOnce(() => null);
+        jest.spyOn(window, "scroll").mockImplementation(() => {});
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        handlers.drop({
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+            dataTransfer: { files: [{ name: "broken.html" }] }
+        });
         jest.advanceTimersByTime(200);
 
         expect(activity.errorMsg).toHaveBeenCalledTimes(1);
@@ -1946,8 +2094,150 @@ describe("_setupFileHandlers inner callbacks", () => {
             "Cannot find project data in this HTML file."
         );
         expect(global.ErrorHandler.capture).not.toHaveBeenCalled();
+        expect(activity.sendAllToTrash).not.toHaveBeenCalled();
+        expect(activity.blocks.loadNewBlocks).not.toHaveBeenCalled();
         expect(activity.loading).toBe(false);
         expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("drop handler catches a deferred block-load failure and restores state", () => {
+        origFileReader = global.FileReader;
+        class MockFR {
+            constructor() {
+                this.result = "[]";
+                this.onload = null;
+            }
+            readAsText() {
+                if (this.onload) this.onload();
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        jest.spyOn(window, "scroll").mockImplementation(() => {});
+
+        const loadError = new Error("deferred block load failed");
+        const listeners = {};
+        const stage = {
+            update: jest.fn(),
+            dispatchEvent: jest.fn(event => {
+                if (listeners[event]) listeners[event]();
+            }),
+            addEventListener: jest.fn((event, listener) => {
+                listeners[event] = listener;
+            }),
+            removeAllEventListeners: jest.fn(event => {
+                delete listeners[event];
+            })
+        };
+        const activity = makeActivity({ stage });
+        activity.blocks.loadNewBlocks.mockImplementation(() => {
+            throw loadError;
+        });
+        activity.sendAllToTrash = jest.fn(() => stage.dispatchEvent("trashsignal"));
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        handlers.drop({
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+            dataTransfer: { files: [{ name: "broken.tb" }] }
+        });
+        jest.advanceTimersByTime(200);
+
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(global.ErrorHandler.capture).toHaveBeenCalledWith(loadError, {
+            operation: "loadFromFile"
+        });
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("drop handler imports ABC and cleans up after ABC parsing", async () => {
+        origFileReader = global.FileReader;
+        const readers = [];
+        class MockFR {
+            constructor() {
+                this.result = "X:1\nK:C\nC";
+                this.onload = null;
+                readers.push(this);
+            }
+            readAsText() {
+                this.promise = this.onload({ target: { result: this.result } });
+                return this.promise;
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        jest.spyOn(window, "scroll").mockImplementation(() => {});
+        global.ensureABCJS.mockResolvedValueOnce(undefined);
+        global.ABCJS.parseOnly.mockReturnValueOnce([{ header: {} }]);
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        handlers.drop({
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+            dataTransfer: { files: [{ name: "song.abc" }] }
+        });
+        await readers[2].promise;
+
+        expect(global.ensureABCJS).toHaveBeenCalledTimes(1);
+        expect(global.ABCJS.parseOnly).toHaveBeenCalledWith("X:1\nK:C\nC");
+        expect(activity.parseABC).toHaveBeenCalledWith({ header: {} });
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
+    });
+
+    it("drop handler reports rejected ABCJS loading and restores state", async () => {
+        origFileReader = global.FileReader;
+        const readers = [];
+        class MockFR {
+            constructor() {
+                this.result = "X:1\nK:C\nC";
+                this.onload = null;
+                readers.push(this);
+            }
+            readAsText() {
+                this.promise = this.onload({ target: { result: this.result } });
+                return this.promise;
+            }
+            readAsArrayBuffer() {}
+        }
+        global.FileReader = MockFR;
+        jest.spyOn(window, "scroll").mockImplementation(() => {});
+        const abcError = new Error("ABCJS unavailable");
+        global.ensureABCJS.mockRejectedValueOnce(abcError);
+
+        const activity = makeActivity();
+        const handlers = captureHandlers(activity);
+        const pm = new ProjectManager(activity);
+        pm._setupFileHandlers();
+
+        handlers.drop({
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+            dataTransfer: { files: [{ name: "song.abc" }] }
+        });
+        await readers[2].promise;
+
+        expect(global.ErrorHandler.capture).toHaveBeenCalledWith(abcError, {
+            operation: "abcImport"
+        });
+        expect(activity.errorMsg).toHaveBeenCalledTimes(1);
+        expect(activity.errorMsg).toHaveBeenCalledWith(
+            "Cannot load project from the file. Please check the file type."
+        );
+        expect(activity.parseABC).not.toHaveBeenCalled();
+        expect(activity.loading).toBe(false);
+        expect(document.body.style.cursor).toBe("default");
+        expect(activity.stopLoadAnimation).toHaveBeenCalled();
     });
 });
 

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -759,6 +759,12 @@ class ProjectManager {
         const that = this.activity;
         const pm = this;
 
+        const finishLoading = () => {
+            that.loading = false;
+            document.body.style.cursor = "default";
+            that.stopLoadAnimation();
+        };
+
         that.fileChooser.addEventListener("click", event => {
             event.currentTarget.value = "";
         });
@@ -780,6 +786,7 @@ class ProjectManager {
                             that.errorMsg(
                                 _("Cannot load project from the file. Please check the file type.")
                             );
+                            finishLoading();
                         } else {
                             /* istanbul ignore next -- file-chooser change handler is browser-only; inaccessible from Jest */
                             const cleanData = rawData.replace(/\n/g, " ");
@@ -792,7 +799,7 @@ class ProjectManager {
                                         that.errorMsg(
                                             _("Cannot find project data in this HTML file.")
                                         );
-                                        pm._finishLoading();
+                                        finishLoading();
                                         return;
                                     }
                                     obj = JSON.parse(unescapeHTML(extracted));
@@ -807,10 +814,23 @@ class ProjectManager {
 
                                 if (!that.merging) {
                                     const __listener = () => {
-                                        that.blocks.loadNewBlocks(obj);
-                                        that.stage.removeAllEventListeners("trashsignal");
-                                        if (that.planet) {
-                                            that.planet.saveLocally();
+                                        try {
+                                            that.blocks.loadNewBlocks(obj);
+                                            if (that.planet) {
+                                                that.planet.saveLocally();
+                                            }
+                                        } catch (e) {
+                                            that.errorMsg(
+                                                _(
+                                                    "Cannot load project from the file. Please check the file type."
+                                                )
+                                            );
+                                            ErrorHandler.capture(e, {
+                                                operation: "loadProjectFromFile"
+                                            });
+                                            finishLoading();
+                                        } finally {
+                                            that.stage.removeAllEventListeners("trashsignal");
                                         }
                                     };
 
@@ -841,8 +861,7 @@ class ProjectManager {
                                 );
 
                                 ErrorHandler.capture(e, { operation: "loadProjectFromFile" });
-                                document.body.style.cursor = "default";
-                                that.loading = false;
+                                finishLoading();
                             }
                         }
                     }, 200);
@@ -896,6 +915,7 @@ class ProjectManager {
                         that.errorMsg(
                             _("Cannot load project from the file. Please check the file type.")
                         );
+                        finishLoading();
                     } else {
                         /* istanbul ignore next -- drag-and-drop file handler is browser-only; inaccessible from Jest */
                         const cleanData = rawData.replace(/\n/g, " ");
@@ -906,7 +926,7 @@ class ProjectManager {
                                 extracted = extractProjectDataFromHTML(cleanData);
                                 if (!extracted) {
                                     that.errorMsg(_("Cannot find project data in this HTML file."));
-                                    pm._finishLoading();
+                                    finishLoading();
                                     return;
                                 }
                                 obj = JSON.parse(unescapeHTML(extracted));
@@ -924,10 +944,20 @@ class ProjectManager {
                             };
 
                             const __listener = () => {
-                                that.blocks.loadNewBlocks(obj);
-                                that.stage.removeAllEventListeners("trashsignal");
-
-                                pubsub.on("finishedLoading", __afterLoad);
+                                try {
+                                    that.blocks.loadNewBlocks(obj);
+                                    pubsub.on("finishedLoading", __afterLoad);
+                                } catch (e) {
+                                    ErrorHandler.capture(e, { operation: "loadFromFile" });
+                                    that.errorMsg(
+                                        _(
+                                            "Cannot load project from the file. Please check the file type."
+                                        )
+                                    );
+                                    finishLoading();
+                                } finally {
+                                    that.stage.removeAllEventListeners("trashsignal");
+                                }
                             };
 
                             that.stage.addEventListener("trashsignal", __listener, false);
@@ -945,8 +975,7 @@ class ProjectManager {
                             that.errorMsg(
                                 _("Cannot load project from the file. Please check the file type.")
                             );
-                            document.body.style.cursor = "default";
-                            that.loading = false;
+                            finishLoading();
                         }
                     }
                 }, 200);
@@ -967,16 +996,25 @@ class ProjectManager {
             };
 
             abcReader.onload = async event => {
-                let abcData = event.target.result;
-                abcData = abcData.replace(/\\/g, "");
+                that.loading = true;
+                document.body.style.cursor = "wait";
+                try {
+                    let abcData = event.target.result;
+                    abcData = abcData.replace(/\\/g, "");
 
-                await ensureABCJS();
-                const tunebook = new ABCJS.parseOnly(abcData);
+                    await ensureABCJS();
+                    const tunebook = new ABCJS.parseOnly(abcData);
 
-                debugLog(tunebook);
-                tunebook.forEach(tune => {
-                    that.parseABC(tune);
-                });
+                    debugLog(tunebook);
+                    await Promise.all(tunebook.map(tune => that.parseABC(tune)));
+                    finishLoading();
+                } catch (e) {
+                    ErrorHandler.capture(e, { operation: "abcImport" });
+                    that.errorMsg(
+                        _("Cannot load project from the file. Please check the file type.")
+                    );
+                    finishLoading();
+                }
             };
 
             if (files[0] !== undefined) {

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -829,8 +829,12 @@ class ProjectManager {
                                                 operation: "loadProjectFromFile"
                                             });
                                             finishLoading();
+                                            return;
                                         } finally {
                                             that.stage.removeAllEventListeners("trashsignal");
+                                        }
+                                        if (that.planet) {
+                                            that.planet.saveLocally();
                                         }
                                     };
 


### PR DESCRIPTION
## Description

Improve failure-path handling for project-file imports.

This PR adds deterministic regression coverage for file chooser, drag-and-drop, and ABC imports. Failed imports now restore loading state, cursor state, and loading animations consistently. Invalid project data is rejected before the workspace is cleared, and import failures produce a single user-facing error message.

This extends the project-manager cleanup introduced upstream in #8330.

## Related Issue

No separate issue is linked.

**Fixes:** N/A

## Category

- [x] Bug Fix — Fixes incorrect project import failure behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates documentation
- [ ] Chore / Refactor — Maintenance or refactoring
- [ ] CI/CD — Changes CI/CD workflows

## Changes Made

- Added shared cleanup for failed file imports.
- Restored `activity.loading` after empty, malformed, or failed imports.
- Restored the document cursor from `wait` to `default`.
- Stopped loading animations after file-import failures.
- Ensured HTML files without embedded project data use the correct file-import cleanup path.
- Prevented duplicate error messages for invalid HTML imports.
- Prevented malformed project data from clearing the existing workspace.
- Added handling for exceptions thrown by deferred `blocks.loadNewBlocks()` calls.
- Added rejection handling for ABCJS loading and ABC parsing.
- Awaited ABC parsing promises so failures are reported instead of becoming unhandled rejections.
- Preserved the existing behavior of parsing project data before clearing the workspace.

## Testing Performed

Added regression tests covering:

- Empty file results: `null` and empty string.
- Malformed JSON files.
- HTML files without embedded project data.
- Chooser imports where `blocks.loadNewBlocks()` throws.
- Deferred block-loading failures during drag-and-drop imports.
- Drag-and-drop cleanup behavior.
- Successful ABC imports.
- Rejected ABCJS loading promises.
- Single error-message behavior.
- Loading-state, cursor, and animation cleanup.
- Prevention of workspace clearing for malformed input.

Validation completed:

- Project-manager tests: `116 passed`.
- Full Jest suite: `223 suites passed, 8279 tests passed`.
- ESLint passed.
- Prettier passed for modified files.
- `git diff --check` passed.

Current focused coverage for `js/project-manager.js`:

- Statements: `85.23%`
- Branches: `77.32%`
- Functions: `72.72%`
- Lines: `85.42%`

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run the lint and Prettier checks with no errors.
- [ ] I have addressed code review feedback from a previous submission, if applicable.
- [ ] I have enabled **Allow edits from maintainers**.

## Additional Notes

The production changes are limited to project-import failure handling and asynchronous ABC import error handling.

No browser, network, or E2E tests were added. The tests use the existing activity fixture, Jest mocks, and fake timers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project and drag-and-drop file loading error handling.
  * Empty or invalid files now clean up correctly without leaving loading indicators or cursor states stuck.
  * Failed imports preserve the current workspace and display appropriate error information.
  * Improved ABC tune import handling for both successful and failed loads.
  * Prevented project files from being saved after unsuccessful block loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->