### PR TITLE
refactor(arpeggio): replace platformColor calls with CSS design tokens

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -28,6 +28,7 @@
     /* Selector / Widget Colors */
     --color-selector-bg: #8cc6ff;
     --color-selector-selected: #1a8cff;
+    --color-label-bg: #a0a0a0;
 
     --color-success: #10b981;
     --color-success-bg: #d1fae5;
@@ -128,6 +129,7 @@ body.dark {
 
     --color-selector-bg: #64b5f6;
     --color-selector-selected: #1e88e5;
+    --color-label-bg: #bdbdbd;
 
     /* Adjusted state backgrounds for dark mode */
     --color-success-bg: rgba(16, 185, 129, 0.2);
@@ -168,6 +170,7 @@ body.highcontrast {
 
     --color-selector-bg: #00ffff;
     --color-selector-selected: #00cccc;
+    --color-label-bg: #ffffff;
 
     --color-success: #00ff00;
     --color-success-bg: #000000;

--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -453,3 +453,18 @@
   background-color: var(--color-selector-selected);
 }
 
+/* Arpeggio widget tokens */
+.arpeggio-label-cell {
+  background-color: var(--color-label-bg);
+}
+
+.arpeggio-selector-cell {
+  background-color: var(--color-selector-bg);
+}
+
+.arpeggio-selector-cell.selected,
+.arpeggio-selector-selected {
+  background-color: var(--color-selector-selected);
+}
+
+

--- a/js/widgets/__tests__/arpeggio.test.js
+++ b/js/widgets/__tests__/arpeggio.test.js
@@ -423,14 +423,14 @@ describe("Arpeggio Widget", () => {
         test("_getBackgroundColor returns selectorSelected for a mode row", () => {
             // row 0 maps to ii = (13 - 0 - 1) % 12 = 0, which is in mode
             const color = arpeggio._getBackgroundColor(0);
-            expect(color).toBe(platformColor.selectorSelected);
+            expect(color).toBe("var(--color-selector-selected)");
         });
 
         test("_getBackgroundColor returns selectorBackground for a non-mode row", () => {
             // row 1 maps to ii = (13 - 1 - 1) % 12 = 11, which is in mode
             // row 2 maps to ii = (13 - 2 - 1) % 12 = 10, which is NOT in mode
             const color = arpeggio._getBackgroundColor(2);
-            expect(color).toBe(platformColor.selectorBackground);
+            expect(color).toBe("var(--color-selector-bg)");
         });
     });
 

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -15,7 +15,7 @@
 /*
    global
 
-   platformColor, _, docById, getNote, setCustomChord, keySignatureToMode,
+   _, docById, getNote, setCustomChord, keySignatureToMode,
    getModeNumbers, getTemperament, normalizeNoteAccidentals, DEFAULTVOICE
 */
 /*
@@ -24,8 +24,6 @@
        getNote, setCustomChord
    js/utils/utils.js
         _, docById
-    js/utils/platformstyle.js
-        platformColor
 */
 /* exported Arpeggio */
 
@@ -187,7 +185,7 @@ class Arpeggio {
 
             // A cell for the row label
             labelCell = arpeggioTableRow.insertCell();
-            labelCell.style.backgroundColor = platformColor.labelColor;
+            labelCell.style.backgroundColor = "var(--color-label-bg)";
             labelCell.style.fontSize = this._cellScale * 50 + "%";
             labelCell.style.height = Arpeggio.CELLSIZE + "px";
             labelCell.style.width = Arpeggio.CELLSIZE + "px";
@@ -216,7 +214,7 @@ class Arpeggio {
         // An extra row for the time values
         arpeggioTableRow = arpeggioTable.insertRow();
         labelCell = arpeggioTableRow.insertCell();
-        labelCell.style.backgroundColor = platformColor.labelColor;
+        labelCell.style.backgroundColor = "var(--color-label-bg)";
         labelCell.style.fontSize = this._cellScale * 50 + "%";
         labelCell.style.height = Arpeggio.CELLSIZE + "px";
         labelCell.style.width = Arpeggio.CELLSIZE + "px";
@@ -351,9 +349,9 @@ class Arpeggio {
      */
     _getBackgroundColor(i) {
         if (this._rowInMode(i)) {
-            return platformColor.selectorSelected;
+            return "var(--color-selector-selected)";
         }
-        return platformColor.selectorBackground;
+        return "var(--color-selector-bg)";
     }
 
     /**
@@ -384,12 +382,12 @@ class Arpeggio {
 
             cell.onmouseover = () => {
                 if (cell.style.backgroundColor !== "black") {
-                    cell.style.backgroundColor = platformColor.selectorSelected;
+                    cell.style.backgroundColor = "var(--color-selector-selected)";
                 }
             };
             cell.onmouseout = () => {
                 if (cell.style.backgroundColor !== "black") {
-                    cell.style.backgroundColor = platformColor.selectorBackground;
+                    cell.style.backgroundColor = "var(--color-selector-bg)";
                 }
             };
         }
@@ -408,7 +406,7 @@ class Arpeggio {
         cell.setAttribute("id", arpeggioIdx);
         cell.className = "headcol";
         cell.textContent = arpeggioName;
-        cell.style.backgroundColor = platformColor.selectorBackground;
+        cell.style.backgroundColor = "var(--color-selector-bg)";
     }
 
     /**


### PR DESCRIPTION
## Description

This PR migrates the Arpeggio widget styling from legacy `platformColor` JS variables to centralized CSS design tokens (`tokens.css`), supporting automatic and instant multi-theme adaptation (Light, Dark, and High-Contrast modes).

## Related Issue

Fixes #

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Added `--color-label-bg` design token across `:root`, `body.dark`, and `body.highcontrast` in `css/tokens.css`.
* Added Arpeggio widget styling classes (`.arpeggio-label-cell`, `.arpeggio-selector-cell`) in `dist/css/windows.css`.
* Migrated `js/widgets/arpeggio.js` cell and label background styling from `platformColor` to `var(--color-label-bg)`, `var(--color-selector-bg)`, and `var(--color-selector-selected)`.
* Removed unused `platformColor` imports/comments in `js/widgets/arpeggio.js`.
* Updated `js/widgets/__tests__/arpeggio.test.js` to assert against CSS tokens.

---

## Testing Performed

* **Jest Unit Tests**:
  ```bash
  npx jest js/widgets/__tests__/arpeggio.test.js
<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>
