### PR TITLE
fix: resolve MIDI percussion track bleed and drum lookup

### DIFF
--- a/js/__tests__/midi.test.js
+++ b/js/__tests__/midi.test.js
@@ -271,4 +271,146 @@ describe("transcribeMidi", () => {
         expect(drumValues).toContain("kick drum");
         expect(drumValues).toContain("snare drum");
     });
+
+    it("should fall back to the default time signature when none is provided", async () => {
+        const noTimeSigMidi = {
+            ...mockMidi,
+            header: { ...mockMidi.header, timeSignatures: [] }
+        };
+        await transcribeMidi(noTimeSigMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(Array.isArray(loadedBlocks)).toBe(true);
+    });
+
+    it("should insert a leading rest when the first note does not start at time zero", async () => {
+        const lateStartMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [{ name: "C4", midi: 60, time: 0.5, duration: 0.5, velocity: 0.8 }]
+                }
+            ]
+        };
+        await transcribeMidi(lateStartMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const restBlocks = loadedBlocks.filter(block => block[1] === "rest2");
+        expect(restBlocks.length).toBeGreaterThan(0);
+    });
+
+    it("should merge simultaneous notes into a single chord slot", async () => {
+        const chordMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 0.5, velocity: 0.8 },
+                        { name: "E4", midi: 64, time: 0, duration: 0.5, velocity: 0.9 }
+                    ]
+                }
+            ]
+        };
+        await transcribeMidi(chordMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const pitchBlocks = loadedBlocks.filter(block => block[1] === "pitch");
+        expect(pitchBlocks.length).toBe(2);
+    });
+
+    it("should handle overlapping notes by splitting the schedule slot", async () => {
+        const overlappingMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [
+                        // C4 ends at 1.5; E4 starts at 0.5 and ends at 0.8 (oldEnd > end → hits line 144)
+                        { name: "C4", midi: 60, time: 0, duration: 1.5, velocity: 0.8 },
+                        { name: "E4", midi: 64, time: 0.5, duration: 0.3, velocity: 0.8 }
+                    ]
+                }
+            ]
+        };
+        await transcribeMidi(overlappingMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        expect(loadedBlocks.length).toBeGreaterThan(0);
+    });
+
+    it("should split into multiple action block chunks when cumulative duration exceeds 16", async () => {
+        const longTrackMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 17, velocity: 0.8 },
+                        { name: "E4", midi: 64, time: 17, duration: 0.5, velocity: 0.8 }
+                    ]
+                }
+            ]
+        };
+        await transcribeMidi(longTrackMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+        const actionBlocks = loadedBlocks.filter(
+            block => Array.isArray(block[1]) && block[1][0] === "action"
+        );
+        expect(actionBlocks.length).toBeGreaterThan(1);
+    });
+
+    it("should stop and warn when the maxNoteBlocks limit is exceeded", async () => {
+        // A 17-second note forces isLastNoteInBlock=true after the first note, incrementing
+        // totalnoteblockCount, so the >= maxNoteBlocks guard fires on the second note.
+        const largeMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 1, velocity: 0.8 },
+                        { name: "E4", midi: 64, time: 1, duration: 16, velocity: 0.8 },
+                        { name: "G4", midi: 67, time: 17, duration: 1, velocity: 0.8 }
+                    ]
+                }
+            ]
+        };
+        await transcribeMidi(largeMidi, 1);
+        expect(activity.textMsg).toHaveBeenCalledWith(
+            expect.stringContaining("MIDI file is too large")
+        );
+    });
 });

--- a/js/__tests__/midi.test.js
+++ b/js/__tests__/midi.test.js
@@ -201,4 +201,74 @@ describe("transcribeMidi", () => {
         const restBlocks = loadedBlocks.filter(block => block[1] === "rest2");
         expect(restBlocks.length).toBeGreaterThan(0);
     });
+
+    it("should not treat a melodic track as percussion when it follows a percussion track", async () => {
+        // Track order: percussion first, then melodic.
+        const percussionFirstMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "drums",
+                        family: "percussion",
+                        number: 128,
+                        percussion: true
+                    },
+                    channel: 9,
+                    notes: [{ name: "Kick Drum", midi: 36, time: 0, duration: 0.5, velocity: 0.8 }]
+                },
+                {
+                    instrument: {
+                        name: "acoustic grand piano",
+                        family: "piano",
+                        number: 0,
+                        percussion: false
+                    },
+                    channel: 1,
+                    notes: [{ name: "C4", midi: 60, time: 0, duration: 0.5, velocity: 0.8 }]
+                }
+            ]
+        };
+
+        await transcribeMidi(percussionFirstMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+
+        // The melodic track must produce pitch blocks, not playdrum blocks.
+        const pitchBlocks = loadedBlocks.filter(block => block[1] === "pitch");
+        expect(pitchBlocks.length).toBeGreaterThan(0);
+    });
+
+    it("should map each percussion note to its own drum sound", async () => {
+        const singlePercussionMidi = {
+            ...mockMidi,
+            tracks: [
+                {
+                    instrument: {
+                        name: "drums",
+                        family: "percussion",
+                        number: 128,
+                        percussion: true
+                    },
+                    channel: 9,
+                    notes: [
+                        { name: "Kick Drum", midi: 36, time: 0, duration: 0.3, velocity: 0.8 },
+                        { name: "Snare Drum", midi: 38, time: 0.5, duration: 0.3, velocity: 0.9 }
+                    ]
+                }
+            ]
+        };
+
+        await transcribeMidi(singlePercussionMidi);
+        expect(loadNewBlocksSpy).toHaveBeenCalled();
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+
+        // Both a kick drum and a snare drum block must be present.
+        const drumnameBlocks = loadedBlocks.filter(
+            block => Array.isArray(block[1]) && block[1][0] === "drumname"
+        );
+        const drumValues = drumnameBlocks.map(block => block[1][1].value);
+        expect(drumValues).toContain("kick drum");
+        expect(drumValues).toContain("snare drum");
+    });
 });

--- a/js/midi.js
+++ b/js/midi.js
@@ -71,7 +71,6 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
         currentMidiTimeSignature = defaultTimeSignature;
     }
 
-    let precurssionFlag = false;
     // console.log("tempoBpm is: ", currentMidiTempoBpm);
     // console.log("tempo is : ",currentMidi.header.tempos);
     // console.log("time signatures are: ", currentMidi.header.timeSignatures);
@@ -80,6 +79,8 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
         if (stopProcessing) return; // Exit if flag is set
         if (!track.notes.length) return;
         const r = jsONON.length;
+        // Reset per-track: a percussion track must not bleed into the next melodic track.
+        let precurssionFlag = false;
         let instrument = "electronic synth";
         if (track.instrument.name && !track.instrument.percussion) {
             for (const voices of VOICENAMES) {
@@ -107,6 +108,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
 
         track.notes.forEach((note, index) => {
             const name = note.name;
+            const midi = note.midi;
             const start = Math.round(note.time * 100) / 100;
             const end = Math.round((note.time + note.duration) * 100) / 100;
 
@@ -115,33 +117,40 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             const lastNote = sched[sched.length - 1];
 
             if (index === 0 && start > 0) {
-                sched.push({ start: 0, end: start, notes: ["R"] });
+                sched.push({ start: 0, end: start, notes: ["R"], midis: [null] });
             }
 
             if (lastNote && lastNote.start === start && lastNote.end === end) {
                 lastNote.notes.push(name);
+                lastNote.midis.push(midi);
                 return;
             }
 
             if (lastNote && lastNote.start <= start && lastNote.end > start) {
                 const prevNotes = [...lastNote.notes];
+                const prevMidis = [...lastNote.midis];
                 const oldEnd = lastNote.end;
 
                 lastNote.end = start;
 
-                sched.push({ start: start, end: end, notes: [...prevNotes, name] });
+                sched.push({
+                    start: start,
+                    end: end,
+                    notes: [...prevNotes, name],
+                    midis: [...prevMidis, midi]
+                });
 
                 if (oldEnd > end) {
-                    sched.push({ start: end, end: oldEnd, notes: prevNotes });
+                    sched.push({ start: end, end: oldEnd, notes: prevNotes, midis: prevMidis });
                 }
                 return;
             }
 
             if (lastNote && lastNote.end < start) {
-                sched.push({ start: lastNote.end, end: start, notes: ["R"] });
+                sched.push({ start: lastNote.end, end: start, notes: ["R"], midis: [null] });
             }
 
-            sched.push({ start: start, end: end, notes: [name] });
+            sched.push({ start: start, end: end, notes: [name], midis: [midi] });
         });
 
         let noteSum = 0;
@@ -190,7 +199,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
 
         for (const i in sched) {
             if (stopProcessing) break; // Exit inner loop if flag is set
-            const { notes, start, end } = sched[i];
+            const { notes, midis, start, end } = sched[i];
             const duration = end - start;
             noteSum += duration;
             const isLastNoteInBlock =
@@ -204,12 +213,18 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             const last = isLastNoteInBlock || isLastNoteInSched;
             const first = i === 0;
             let val = jsONON.length + currentActionBlock.length;
-            const getPitch = (x, notes, prev) => {
+            const getPitch = (x, notes, midis, prev) => {
                 const ar = [];
                 if (notes[0] === "R") {
                     ar.push([x, "rest2", 0, 0, [prev, null]]);
                 } else if (precurssionFlag) {
-                    const drumname = drumMidi[track.notes[0].midi][0] || "kick drum";
+                    const drumMidiNumber = midis[0];
+                    const drumname =
+                        (drumMidiNumber !== null &&
+                            drumMidiNumber !== undefined &&
+                            drumMidi[drumMidiNumber] &&
+                            drumMidi[drumMidiNumber][0]) ||
+                        "kick drum";
                     ar.push(
                         [x, "playdrum", 0, 0, [first ? prev : x - 1, x + 1, null]],
                         [x + 1, ["drumname", { value: drumname }], 0, 0, [x]]
@@ -263,7 +278,7 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
 
             // Since we are going to add action block in the front later
             if (k !== 0) val = val + 2;
-            const pitches = getPitch(val + 5, notes, val);
+            const pitches = getPitch(val + 5, notes, midis, val);
             currentActionBlock.push(
                 [
                     val,


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes two bugs in the MIDI importer that caused incorrect block generation when importing MIDI files containing percussion tracks:
1. `precurssionFlag` was declared once and never reset between tracks, causing melodic tracks following a percussion track to incorrectly emit `playdrum` blocks instead of `pitch` blocks.
2. Every drum block in a track repeated the first drum sound because the lookup always referenced `track.notes[0].midi` instead of the current note being processed.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #8350

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`js/midi.js`**: Moved `let precurssionFlag = false` into the `forEach` callback body so the flag is re-evaluated cleanly for every track. Added a parallel `midis[]` array to every `sched` entry and updated `getPitch()` to use the current note's MIDI for drum lookup instead of always reading the first note in the track.
- **`js/__tests__/midi.test.js`**: Added a regression test to ensure a melodic track following a percussion track imports as pitch blocks. Added a test to verify each percussion note uses its own drum sound mapping.

---

## Visual Changes

<!-- If this PR introduces visual or UI changes, provide before and after screenshots or videos. Remove this entire section if not applicable. -->
*Not applicable.*

---

## Testing Performed

- Ran `npm test -- --testPathPattern=midi` to verify all 10 tests pass (8 pre-existing + 2 new regression tests).
- Ran `npm run lint` and `npx prettier --check .` with no errors.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

No block names were changed in this fix, ensuring backward compatibility with saved projects.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>