### PR TITLE
fix(blocks): release isBlockMoving when a drag ends any other way

### DIFF
--- a/js/activity/__tests__/block-drag-controller.test.js
+++ b/js/activity/__tests__/block-drag-controller.test.js
@@ -1427,4 +1427,86 @@ describe("BlockDragController", () => {
             expect(blocks._cachedDragGroup).toEqual([1]);
         });
     });
+
+    // ------------------------------------------------------------------
+    // isBlockMoving lifecycle
+    // ------------------------------------------------------------------
+
+    describe("isBlockMoving lifecycle", () => {
+        const oneBlock = () => [
+            makeFlowBlock({ x: 0, y: 0, docks: [[0, 0, "in"]], connections: [null] })
+        ];
+
+        it("is raised by moveBlockRelativeBatched", () => {
+            const blocks = makeBlocks(oneBlock());
+
+            expect(blocks.isBlockMoving).toBe(false);
+            blocks.moveBlockRelativeBatched(0, 5, 5);
+
+            expect(blocks.isBlockMoving).toBe(true);
+        });
+
+        it("is raised by moveBlockRelative", () => {
+            const blocks = makeBlocks(oneBlock());
+
+            blocks.moveBlockRelative(0, 5, 5);
+
+            expect(blocks.isBlockMoving).toBe(true);
+        });
+
+        it("is lowered by a completed blockMoved", async () => {
+            const blocks = makeBlocks(oneBlock());
+            blocks.moveBlockRelativeBatched(0, 5, 5);
+
+            await blocks.blockMoved(0);
+
+            expect(blocks.isBlockMoving).toBe(false);
+        });
+
+        // The drag teardown path. block.js calls clearCachedDragGroup() from
+        // both the mouseout and pressup handlers once a drag is over, whether
+        // or not blockMoved ran, so a drag that ended on the trashcan or that
+        // never passed the 5px movement threshold is released here.
+        it("is lowered by the drag teardown even when blockMoved never runs", () => {
+            const blocks = makeBlocks(oneBlock());
+            blocks.moveBlockRelativeBatched(0, 2, 1);
+            expect(blocks.isBlockMoving).toBe(true);
+
+            blocks.clearCachedDragGroup();
+
+            expect(blocks.isBlockMoving).toBe(false);
+        });
+
+        it("is lowered when blockMoved bails out on a null block", async () => {
+            const blocks = makeBlocks(oneBlock());
+            blocks.moveBlockRelativeBatched(0, 5, 5);
+
+            await blocks.blockMoved(null);
+
+            expect(blocks.isBlockMoving).toBe(false);
+        });
+
+        it("is lowered when blockMoved bails out on a missing block", async () => {
+            const blockList = oneBlock();
+            const blocks = makeBlocks(blockList);
+            blocks.moveBlockRelativeBatched(0, 5, 5);
+
+            // An index that is not present in blockList reaches the second
+            // guard, after the expandable scan has already run.
+            await blocks.blockMoved(99);
+
+            expect(blocks.isBlockMoving).toBe(false);
+        });
+
+        it("leaves the rest of the cached drag state cleared too", () => {
+            const blocks = makeBlocks(oneBlock());
+            blocks.moveBlockRelativeBatched(0, 5, 5);
+
+            blocks.clearCachedDragGroup();
+
+            expect(blocks._cachedDragGroup).toBeNull();
+            expect(blocks._dragActiveGroup).toBeNull();
+            expect(blocks.isBlockMoving).toBe(false);
+        });
+    });
 });

--- a/js/activity/block-drag-controller.js
+++ b/js/activity/block-drag-controller.js
@@ -100,6 +100,13 @@ class BlockDragController {
         const blocks = this.blocks;
         blocks._cachedDragGroup = null;
         blocks._dragActiveGroup = null;
+        // moveBlockRelative/moveBlockRelativeBatched raise isBlockMoving on
+        // every pressmove, but blockMoved() is the only place that lowers it
+        // and it runs only for a drag that passed the movement threshold and
+        // ended away from the trashcan. Clearing here instead covers every
+        // way a drag can finish, since both the mouseout and pressup handlers
+        // call this unconditionally once the drag is over.
+        blocks.isBlockMoving = false;
     }
 
     /**
@@ -258,6 +265,7 @@ class BlockDragController {
         blocks.clampBlocksToCheck = [];
         if (thisBlock === null) {
             console.debug("blockMoved called with null block.");
+            blocks.isBlockMoving = false;
             return;
         }
 
@@ -292,6 +300,7 @@ class BlockDragController {
         const myBlock = blocks.blockList[thisBlock];
         if (myBlock === null || myBlock === undefined) {
             console.debug("null block found in blockMoved method: " + thisBlock);
+            blocks.isBlockMoving = false;
             return;
         }
 


### PR DESCRIPTION
## Description

`blocks.isBlockMoving` could latch on for the rest of the session, silently disabling rubber-band block selection with no error and no visible cause.

`moveBlockRelative` and `moveBlockRelativeBatched` raise the flag, and `js/block.js:3455` calls `moveBlockRelativeBatched` on every pressmove before any threshold is applied. The only place that lowered it was the tail of `blockMoved()`, which `js/block.js:3628` reaches only when a drag passed the 5px movement threshold, ended, and finished away from the trashcan:

```js
if (moved && dragEnded) {
    if ( ...overTrashcan... ) {
        this.blocks.sendStackToTrash(this);   // never touches the flag
    } else {
        this.blocks.blockMoved(thisBlock);    // the only path that lowered it
    }
}
```

So two everyday actions latched it. Pressing a block and moving less than 5px runs the move but leaves `moved` false, skipping the whole branch. Dragging a stack onto the trashcan runs `sendStackToTrash` instead. `blockMoved`'s own two guard clauses also returned early past the clear.

`js/activity/selection-controller.js:126-129` gates the entire drag-select animation frame on `!isBlockMoving`, and `drawSelectionArea`, `selectBlocksInDragArea` and `setSelectedBlocks` are reachable from nowhere else, so all of drag-select stopped working until the user happened to perform a normal drag that ran `blockMoved` to completion.

Worth noting "Select" and "Move to trash" are adjacent entries in the same helpful wheel, so deleting a stack and then enabling Select lands directly on this.

## Related Issue

**Fixes:** #8362

## Category

- [x] Bug Fix

## Changes Made

Lower the flag in `clearCachedDragGroup()`. Both the mouseout and pressup handlers in `js/block.js` call it unconditionally once a drag is over, whichever way it ended, so the trashcan and sub-threshold paths are covered together:

```js
 clearCachedDragGroup() {
     const blocks = this.blocks;
     blocks._cachedDragGroup = null;
     blocks._dragActiveGroup = null;
+    blocks.isBlockMoving = false;
 }
```

The two guard clauses in `blockMoved` also clear it, since `blockMoved` is additionally reachable from the keyboard controller and the palette, which do not run the drag teardown.

## Testing Performed

Full suite passes: **223 suites, 8208 tests**. `npm run lint` and `npx prettier --check` are both clean.

| scenario | before | after |
|---|---|---|
| after `moveBlockRelativeBatched` | raised | raised |
| completed `blockMoved` | lowered | lowered |
| drag teardown, `blockMoved` never ran (trash / sub-threshold) | **stuck raised** | lowered |
| `blockMoved` bails on a null block | **stuck raised** | lowered |
| `blockMoved` bails on a missing block | **stuck raised** | lowered |

Four of the seven added tests fail without the source change. The other three assert the flag is still raised on a move and still lowered by a completed `blockMoved`, so this cannot be "fixed" by simply dropping the flag.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.
