### PR TITLE
fix(logo): keep persistent turtle listeners across stop/completion

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -680,6 +680,89 @@ describe("Logo setTurtleListener", () => {
             false
         );
     });
+
+    test("defaults a listener to non-persistent", () => {
+        const listener = jest.fn();
+        mockActivity.turtles.ithTurtle = jest.fn(() => ({ listeners: {} }));
+
+        logo.setTurtleListener(0, "testListener", listener);
+
+        expect(listener.persistent).toBe(false);
+    });
+
+    test("marks a listener persistent when requested", () => {
+        const listener = jest.fn();
+        mockActivity.turtles.ithTurtle = jest.fn(() => ({ listeners: {} }));
+
+        logo.setTurtleListener(0, "testListener", listener, true);
+
+        expect(listener.persistent).toBe(true);
+    });
+});
+
+// ─── Logo clearTurtleListeners ─────────────────────────────────────────────────
+
+describe("Logo clearTurtleListeners", () => {
+    let logo;
+    let mockActivity;
+    let turtle;
+
+    beforeEach(() => {
+        setupLogoEnv();
+        turtle = createMockTurtle();
+        mockActivity = createMockActivity(turtle);
+        logo = new Logo(mockActivity);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    test("removes every listener when preservePersistent is not set", () => {
+        const persistentListener = jest.fn();
+        persistentListener.persistent = true;
+        const ephemeralListener = jest.fn();
+        turtle.listeners = { clickListener: persistentListener, beatListener: ephemeralListener };
+
+        logo.clearTurtleListeners();
+
+        expect(mockActivity.stage.removeEventListener).toHaveBeenCalledWith(
+            "clickListener",
+            persistentListener,
+            false
+        );
+        expect(mockActivity.stage.removeEventListener).toHaveBeenCalledWith(
+            "beatListener",
+            ephemeralListener,
+            false
+        );
+        expect(turtle.listeners).toEqual({});
+    });
+
+    test("preserves persistent listeners when preservePersistent is true", () => {
+        const persistentListener = jest.fn();
+        persistentListener.persistent = true;
+        const ephemeralListener = jest.fn();
+        turtle.listeners = { clickListener: persistentListener, beatListener: ephemeralListener };
+
+        logo.clearTurtleListeners(true);
+
+        expect(mockActivity.stage.removeEventListener).not.toHaveBeenCalledWith(
+            "clickListener",
+            persistentListener,
+            false
+        );
+        expect(mockActivity.stage.removeEventListener).toHaveBeenCalledWith(
+            "beatListener",
+            ephemeralListener,
+            false
+        );
+        expect(turtle.listeners).toEqual({ clickListener: persistentListener });
+    });
+
+    test("does nothing when a turtle has no listeners object", () => {
+        mockActivity.turtles.turtleList = [null, { listeners: null }];
+
+        expect(() => logo.clearTurtleListeners()).not.toThrow();
+    });
 });
 
 // ─── Logo initTurtle ─────────────────────────────────────────────────────────
@@ -1010,6 +1093,33 @@ describe("Logo doStopTurtles", () => {
         expect(turtle.listeners).toEqual({});
     });
 
+    test("keeps a persistent listener attached on stop (#8367)", () => {
+        // A listener set up by a Listen block is marked persistent so it keeps
+        // responding to its event (e.g. a click) after Stop is pressed, the
+        // same way it did before #8244 started sweeping all listeners here.
+        const persistentListener = jest.fn();
+        persistentListener.persistent = true;
+        const ephemeralListener = jest.fn();
+        turtle.listeners = {
+            clickListener: persistentListener,
+            __beat_1_0__: ephemeralListener
+        };
+
+        logo.doStopTurtles();
+
+        expect(mockActivity.stage.removeEventListener).toHaveBeenCalledWith(
+            "__beat_1_0__",
+            ephemeralListener,
+            false
+        );
+        expect(mockActivity.stage.removeEventListener).not.toHaveBeenCalledWith(
+            "clickListener",
+            persistentListener,
+            false
+        );
+        expect(turtle.listeners).toEqual({ clickListener: persistentListener });
+    });
+
     describe("with Transport and audio streams", () => {
         let turtle0;
         let turtle1;
@@ -1319,6 +1429,25 @@ describe("Logo runLogoCommands", () => {
         expect(disposeSpy).toHaveBeenCalledTimes(1);
 
         global.Tone = savedTone;
+    });
+
+    test("keeps a persistent listener attached after natural playback completion (#8367)", () => {
+        // Before #8244, a Listen block's click listener stayed on the stage once
+        // a project finished playing on its own. _cleanupAfterCompletion() now
+        // runs clearTurtleListeners() automatically, so listeners marked
+        // persistent must survive this path too, not just an explicit Stop.
+        const persistentListener = jest.fn();
+        persistentListener.persistent = true;
+        turtle0.listeners = { clickListener: persistentListener };
+
+        logo._cleanupAfterCompletion();
+
+        expect(mockActivity.stage.removeEventListener).not.toHaveBeenCalledWith(
+            "clickListener",
+            persistentListener,
+            false
+        );
+        expect(turtle0.listeners).toEqual({ clickListener: persistentListener });
     });
 
     describe("performance instrumentation", () => {

--- a/js/blocks/ActionBlocks.js
+++ b/js/blocks/ActionBlocks.js
@@ -1119,8 +1119,10 @@ function setupActionBlocks(activity) {
                     }
                 };
 
-                // If there is already a listener, remove it before adding the new one
-                logo.setTurtleListener(turtle, args[0], __listener);
+                // If there is already a listener, remove it before adding the new one.
+                // Mark it persistent so it keeps listening for events (e.g. a click)
+                // after this run stops or finishes, which is the whole point of Listen.
+                logo.setTurtleListener(turtle, args[0], __listener, true);
             }
         }
     }

--- a/js/blocks/__tests__/ActionBlocks.test.js
+++ b/js/blocks/__tests__/ActionBlocks.test.js
@@ -352,7 +352,7 @@ describe("ActionBlocks", () => {
     });
 
     describe("ListenBlock", () => {
-        test("sets up listener when action exists", () => {
+        test("sets up a persistent listener when action exists (#8367: must survive stop/completion)", () => {
             const block = getBlock("listen");
             logo.actions["testAction"] = [];
 
@@ -361,7 +361,8 @@ describe("ActionBlocks", () => {
             expect(logo.setTurtleListener).toHaveBeenCalledWith(
                 0,
                 expect.any(String),
-                expect.any(Function)
+                expect.any(Function),
+                true
             );
         });
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -722,14 +722,18 @@ class Logo {
      * @param {Number} turtle - Turtle index in turtles.turtleList
      * @param {String} listenerName
      * @param {Function} listener
+     * @param {boolean} persistent - when true, clearTurtleListeners() leaves this
+     *  listener attached on stop/completion (e.g. a Listen block's click handler
+     *  is meant to keep firing after the run that registered it has ended).
      * @returns {void}
      */
-    setTurtleListener(turtle, listenerName, listener) {
+    setTurtleListener(turtle, listenerName, listener, persistent = false) {
         const tur = this.turtles.ithTurtle(turtle);
         if (listenerName in tur.listeners) {
             this.stage.removeEventListener(listenerName, tur.listeners[listenerName], false);
         }
 
+        listener.persistent = persistent;
         tur.listeners[listenerName] = listener;
         this.stage.addEventListener(listenerName, listener, false);
     }
@@ -737,15 +741,21 @@ class Logo {
     /**
      * Removes active event listeners from all turtles and clears listener objects.
      *
+     * @param {boolean} preservePersistent - when true, listeners registered as
+     *  persistent (see setTurtleListener) are left attached instead of removed.
      * @returns {void}
      */
-    clearTurtleListeners() {
+    clearTurtleListeners(preservePersistent = false) {
         for (const turtle of this.turtles.turtleList) {
             if (turtle && turtle.listeners) {
-                for (const listener in turtle.listeners) {
-                    this.stage.removeEventListener(listener, turtle.listeners[listener], false);
+                for (const listenerName in turtle.listeners) {
+                    const listener = turtle.listeners[listenerName];
+                    if (preservePersistent && listener && listener.persistent) {
+                        continue;
+                    }
+                    this.stage.removeEventListener(listenerName, listener, false);
+                    delete turtle.listeners[listenerName];
                 }
-                turtle.listeners = {};
             }
         }
     }
@@ -1260,7 +1270,7 @@ class Logo {
         this.synth.disposeAllInstruments();
         this._synthsInitialized = false;
 
-        this.clearTurtleListeners();
+        this.clearTurtleListeners(true);
 
         // eslint-disable-next-line eqeqeq
         if (this.cameraID != null) {
@@ -1286,8 +1296,9 @@ class Logo {
             );
         }
 
-        // Remove active stage listeners and clear listener objects across all turtles.
-        this.clearTurtleListeners();
+        // Remove active stage listeners and clear listener objects across all turtles,
+        // except ones marked persistent (e.g. a Listen block's click handler).
+        this.clearTurtleListeners(true);
 
         // Prevent stale timeout from firing cleanup on next run.
         this._lastNoteTimeout = null;


### PR DESCRIPTION
## Description

`clearTurtleListeners()` in `js/logo.js` was added in #8244 to stop Meter block listeners from piling up on the stage. Two of the places it's wired into, `_cleanupAfterCompletion()` (runs automatically after any project finishes playing on its own) and `doStopTurtles()` (runs on Stop), remove every stage listener for every turtle with no exceptions. That breaks the `Listen` block, whose whole purpose is to keep listening for an event (e.g. a click) after the script that set it up has stopped or finished, so a sprite can be clicked like a button once the program's done running. Since #8244 that listener gets ripped off the stage the moment playback ends, so clicking the sprite afterward does nothing.

Fixes #8367

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Root Cause

`setTurtleListener()`/`clearTurtleListeners()` treated "listener used during this run" and "listener should be discarded when the run ends" as the same thing. They're not. `setTurtleListener()` already de-duplicates correctly by name (removes any existing listener with the same name before adding the new one), which is what actually stops Meter listeners from accumulating. Wiping every listener on every stop/completion goes further than that fix needed, and it collides with the Listen block's designed behavior of surviving past the end of a run (see the `else` branch in `ListenBlock.flow()` in `js/blocks/ActionBlocks.js`, which only makes sense if the listener is still attached once the turtle has stopped).

## Changes Made

- `js/logo.js`: `setTurtleListener()` takes a new `persistent` parameter (default `false`) and stamps it onto the listener function. `clearTurtleListeners()` takes a `preservePersistent` parameter (default `false`); when `true`, it skips listeners marked persistent instead of removing everything.
- `_cleanupAfterCompletion()` and `doStopTurtles()` now call `clearTurtleListeners(true)`, so persistent listeners survive both an explicit Stop and a natural end of playback.
- `runLogoCommands()`'s existing call (unconditional full wipe on a fresh Play) is untouched. It doesn't need to change: when a run re-executes a Listen block, `setTurtleListener()` replaces that block's own listener by name regardless of whether it was already removed, so the outcome is the same either way, and I didn't want to touch behavior outside what #8367 actually reported.
- `js/blocks/ActionBlocks.js`: `ListenBlock.flow()` now registers its listener with `persistent: true`.
- Every other `setTurtleListener` call site in the codebase (Meter beat/drift listeners, backward-action dispatch listeners) is untouched and defaults to non-persistent, so the leak #8244 fixed stays fixed.

## Testing Performed

- Added tests in `js/__tests__/logo.test.js`:
  - `setTurtleListener` defaults a listener to non-persistent, and marks it persistent when asked.
  - New `describe("Logo clearTurtleListeners")` block covering: removes everything when `preservePersistent` isn't set, preserves persistent listeners when it is, and doesn't throw when a turtle has no listeners object.
  - `doStopTurtles()` keeps a persistent listener attached while still removing an ephemeral one (regression test for #8367).
  - `_cleanupAfterCompletion()` keeps a persistent listener attached after natural playback completion (regression test for #8367).
- Updated the existing `ListenBlock` test in `js/blocks/__tests__/ActionBlocks.test.js` to assert it registers its listener with `persistent: true`.
- `npx jest js/__tests__/logo.test.js js/blocks/__tests__/ActionBlocks.test.js js/turtleactions/__tests__/MeterActions.test.js` — 282/282 passing (confirms the original Meter-listener fix from #8244 is untouched).
- Full suite: `npx jest` — 223/223 suites, 8276/8276 tests passing.
- `npx eslint` and `npx prettier --check` on all four changed files, clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event listeners can now remain active after a project stops or finishes.
  * Listeners are automatically cleaned up unless explicitly marked to persist.
  * Persistent listeners remain available across subsequent runs.

* **Bug Fixes**
  * Improved listener cleanup when stopping projects or handling natural completion.
  * Safely handles missing listener records during cleanup.

* **Tests**
  * Added coverage for persistent and temporary listener behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->