### PR TITLE
test(cypress): add cypress coverage for temperament widget

### DIFF
--- a/cypress/e2e/temperament-widget.cy.js
+++ b/cypress/e2e/temperament-widget.cy.js
@@ -1,0 +1,124 @@
+/* global cy, beforeEach, describe, it */
+
+/**
+ * Cypress E2E test suite for the Temperament widget.
+ *
+ * The Temperament widget (js/widgets/temperament.js) allows users to explore,
+ * play, and customize musical tuning systems. It is opened by running a
+ * `temperament` block (via Play).
+ *
+ * These tests exercise the widget's launch and UI lifecycle through
+ * the real application:
+ *  1. Loading a fixture project that contains a temperament block.
+ *  2. Pressing Play to open the widget.
+ *  3. Verifying the widget window, circle layout, and toolbar render.
+ *  4. Toggling between the Circle of Notes and the Table of Notes.
+ *  5. Closing the widget and confirming it is fully removed from the DOM.
+ */
+
+const loadFixtureProject = fixtureName => {
+    cy.get("#load").click();
+    cy.get("#myOpenFile").selectFile(`cypress/fixtures/${fixtureName}`, { force: true });
+
+    // Wait for the load overlay to appear before waiting for it to disappear.
+    // Without this guard, the `not.be.visible` check passes trivially on the
+    // container's default hidden state before loading has even begun, which
+    // causes Play to run before the project is fully loaded.
+    cy.get("#load-container").should("be.visible");
+    cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
+    cy.get("#errorText").should("not.be.visible");
+};
+
+describe("Temperament widget", () => {
+    beforeEach(() => {
+        cy.visit("http://127.0.0.1:3000");
+        cy.clearLocalStorage();
+        cy.visit("http://127.0.0.1:3000");
+        cy.waitForAppReady();
+
+        // Dismiss the first-run "Take a Tour" guide.
+        cy.get("body").then($body => {
+            const closeButtons = $body.find(".windowFrame .wftButton.close");
+            if (closeButtons.length) {
+                cy.wrap(closeButtons).click({ multiple: true, force: true });
+            }
+        });
+    });
+
+    it("opens the Temperament widget and renders the circle of notes", () => {
+        loadFixtureProject("temperament-widget-minimal.tb");
+
+        cy.get("#play").click();
+
+        cy.get(".windowFrame .wftTitle", { timeout: 30000 })
+            .should("be.visible")
+            .and("contain.text", "temperament");
+        cy.get('[aria-label="temperament"]', { timeout: 30000 }).should("be.visible");
+
+        // Verify the main temperament layout container is in the DOM
+        cy.get("#temperamentTable").should("exist");
+
+        // By default, the temperament widget renders the Circle of Notes view
+        cy.get("#circ").should("exist");
+        cy.get("#wheelDiv2").should("be.visible");
+
+        // Ensure the wheelnav SVG has rendered slices for the notes
+        cy.get("[id^='wheelnav-wheelDiv2-slice-0']").should("exist");
+    });
+
+    it("renders the toolbar and can toggle between Circle and Table views", () => {
+        loadFixtureProject("temperament-widget-minimal.tb");
+        cy.get("#play").click();
+
+        cy.get('[aria-label="temperament"]', { timeout: 30000 }).should("be.visible");
+
+        // Verify toolbar buttons are present using their accessible titles
+        cy.get('[aria-label="temperament"]').find('img[title="Play all"]').should("exist");
+        cy.get('[aria-label="temperament"]').find('img[title="Save"]').should("exist");
+        cy.get('[aria-label="temperament"]').find('img[title="Add pitches"]').should("exist");
+
+        // Initially in circle mode, so the toggle button shows the table icon
+        cy.get('[aria-label="temperament"]').find('img[title="table"]').should("exist");
+
+        // Switch to Table view by clicking the toggle button
+        cy.get('[aria-label="temperament"]').find('img[title="table"]').click({ force: true });
+
+        // The circle and wheelnav components should be hidden or removed
+        cy.get("#wheelDiv2").should("not.be.visible");
+
+        // The notes graph and table body should now be visible
+        cy.get("#notesGraph").should("exist").and("be.visible");
+        cy.get("#tableOfNotes").should("exist").and("be.visible");
+
+        // The toggle button should now show the circle icon
+        cy.get('[aria-label="temperament"]').find('img[title="circle"]').should("exist");
+
+        // Switch back to Circle view
+        cy.get('[aria-label="temperament"]').find('img[title="circle"]').click({ force: true });
+
+        // The table should be removed and the wheel should be back
+        cy.get("#notesGraph").should("not.exist");
+        cy.get("#wheelDiv2").should("exist").and("be.visible");
+        cy.get('[aria-label="temperament"]').find('img[title="table"]').should("exist");
+    });
+
+    it("closes the Temperament widget and cleans up the DOM", () => {
+        loadFixtureProject("temperament-widget-minimal.tb");
+        cy.get("#play").click();
+
+        cy.get('[aria-label="temperament"]', { timeout: 30000 }).should("be.visible");
+
+        // Click the close button on the temperament widget window specifically
+        cy.get('[aria-label="temperament"]').find('[title="Close"]').first().click({ force: true });
+
+        // The window frame should be destroyed
+        cy.get('[aria-label="temperament"]').should("not.exist");
+
+        // The temperament content container should be removed from the DOM
+        cy.get("#temperamentTable").should("not.exist");
+        cy.get("#circ").should("not.exist");
+
+        // The global wheelDiv2 container is not removed from the DOM, but it should be hidden
+        cy.get("#wheelDiv2").should("not.be.visible");
+    });
+});

--- a/cypress/fixtures/temperament-widget-minimal.tb
+++ b/cypress/fixtures/temperament-widget-minimal.tb
@@ -1,0 +1,12 @@
+[
+    [0, ["start", { "collapsed": false, "xcor": 0, "ycor": 0, "heading": 0, "color": 0, "shade": 50, "pensize": 5, "grey": 100 }], 100, 100, [null, 1, null]],
+    [1, "temperament", 0, 0, [0, 2, 3, 8]],
+    [2, ["temperamentname", { "value": "equal" }], 0, 0, [1]],
+    [3, "pitch", 0, 0, [1, 4, 5, 6]],
+    [4, ["notename", { "value": "C" }], 0, 0, [3]],
+    [5, ["number", { "value": 4 }], 0, 0, [3]],
+    [6, "setkey2", 0, 0, [3, 7, 9, null]],
+    [7, ["notename", { "value": "C" }], 0, 0, [6]],
+    [9, ["modename", { "value": "major" }], 0, 0, [6]],
+    [8, "hiddennoflow", 0, 0, [1, null]]
+]


### PR DESCRIPTION
## Description

Adds Cypress E2E coverage for the Temperament widget in Music Blocks. The tests exercise the widget's launch sequence, verify the default "Circle of Notes" view, toggle to the "Table of Notes" view, and confirm proper DOM cleanup upon closure.

A minimal note-based fixture is included so the widget is triggered by the real block execution flow rather than directly calling internal methods.

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

- Added `cypress/e2e/temperament-widget.cy.js`.
- Added `cypress/fixtures/temperament-widget-minimal.tb`, a minimal project containing a `start` block attached to a `temperament` block.
- Loads the minimal project through the Music Blocks file-loading UI and starts playback.
- Verifies that running the `temperament` block successfully opens the Temperament widget window.
- Asserts visibility and interaction with the default Circle of Notes canvas (`#circ`) and toolbar elements.
- Simulates toggling to the Table view and verifies the DOM correctly hides the circle layout and displays the graph/table (`#tableOfNotes`).
- Verifies that closing the widget window completely cleans up the Temperament-specific wrappers from the DOM to prevent leaks.
- Uses Cypress's default retryability for asynchronous DOM state assertions.
- No production files, package files, Cypress configuration, or workflows were modified.

## Visual Changes

Not applicable. This PR adds test coverage only and introduces no visual or UI changes.

## Testing Performed

- Focused Cypress spec:
  - `temperament-widget.cy.js` — 3/3 passed
- Full Cypress suite passes.
- Ran headless Chrome via `cypress run`.
- ESLint passes with no errors.
- Prettier passes on the applicable changed files.
- `git diff --check` passes.
- Verified local widget operation matches test expectations.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Temperament widget.
  * Verified the default Circle of Notes view, toolbar, switching between Circle and Table views, and widget closure.
  * Added a minimal fixture for reliably testing widget behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->