### PR TITLE
fix(piemenus): release the instrument pie menu when it closes

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -818,3 +818,140 @@ describe("pie menu Escape-key dismissal", () => {
         }
     });
 });
+
+describe("piemenuVoices teardown on close", () => {
+    let mockBlock;
+    let synth;
+
+    const openVoiceMenu = () => {
+        const { piemenuVoices } = require("../piemenus");
+        piemenuVoices(
+            mockBlock,
+            ["guitar", "piano"],
+            ["guitar", "piano"],
+            [0, 0],
+            "guitar",
+            undefined
+        );
+    };
+
+    beforeEach(() => {
+        // Real DOM nodes here: enableWheelScroll() reaches for wheelDiv through
+        // document.getElementById, so a docById stub alone would not be seen.
+        document.body.innerHTML = "";
+        const byId = document.getElementById.bind(document);
+        global.docById = jest.fn(id => {
+            let el = byId(id);
+            if (!el) {
+                el = document.createElement("div");
+                el.id = id;
+                document.body.appendChild(el);
+            }
+            return el;
+        });
+
+        global.localStorage = {};
+        global.platformColor.piemenuVoicesColors = ["#aa0000", "#00aa00"];
+        global.getDrumName = jest.fn().mockReturnValue(null);
+        global.getVoiceSynthName = jest.fn(v => v);
+        global.getDrumSynthName = jest.fn(v => v);
+
+        synth = {
+            createDefaultSynth: jest.fn(),
+            loadSynth: jest.fn(),
+            trigger: jest.fn(),
+            start: jest.fn()
+        };
+
+        mockBlock = {
+            container: { x: 100, y: 100, setChildIndex: jest.fn(), children: [] },
+            blocks: {
+                stageClick: false,
+                blockScale: 1,
+                activeBlock: null,
+                turtles: { _canvas: { width: 1000, height: 1000 } }
+            },
+            activity: {
+                canvas: { offsetLeft: 0, offsetTop: 0 },
+                blocksContainer: { x: 0, y: 0 },
+                getStageScale: jest.fn().mockReturnValue(1),
+                turtles: {
+                    ithTurtle: jest.fn().mockReturnValue({ singer: { instrumentNames: [] } })
+                },
+                logo: { synth, errorMsg: jest.fn() }
+            },
+            updateCache: jest.fn(),
+            text: { text: "" },
+            value: "guitar"
+        };
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test("the exit button removes both wheels and clears the active block", () => {
+        openVoiceMenu();
+        mockBlock.blocks.activeBlock = mockBlock;
+
+        mockBlock._exitWheel.navItems[0].navigateFunction();
+
+        // wheelnav only detaches its window keydown listener from removeWheel(),
+        // so a menu closed without this keeps answering the arrow keys.
+        expect(mockBlock._voiceWheel.removeWheel).toHaveBeenCalled();
+        expect(mockBlock._exitWheel.removeWheel).toHaveBeenCalled();
+        expect(mockBlock.blocks.activeBlock).toBeNull();
+    });
+
+    test("closing cancels a voice preview that is still waiting on the synth", () => {
+        jest.useFakeTimers();
+
+        try {
+            openVoiceMenu();
+
+            // An instrument the turtle has not loaded defers its preview by 500ms.
+            mockBlock._voiceWheel.selectedNavItemIndex = 1;
+            mockBlock._voiceWheel.navItems[1].navigateFunction();
+
+            mockBlock._exitWheel.navItems[0].navigateFunction();
+            jest.advanceTimersByTime(1000);
+
+            expect(synth.trigger).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test("the preview still plays while the menu is open", () => {
+        jest.useFakeTimers();
+
+        try {
+            openVoiceMenu();
+
+            mockBlock._voiceWheel.selectedNavItemIndex = 1;
+            mockBlock._voiceWheel.navItems[1].navigateFunction();
+            jest.advanceTimersByTime(1000);
+
+            expect(synth.trigger).toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test("hiding the wheel div detaches the scroll-to-rotate listener", () => {
+        const { hideWheelDiv } = require("../piemenus");
+
+        openVoiceMenu();
+
+        const wheelDiv = document.getElementById("wheelDiv");
+        const scrollHandler = wheelDiv._scrollHandler;
+        expect(typeof scrollHandler).toBe("function");
+
+        const removeEventListener = jest.spyOn(wheelDiv, "removeEventListener");
+        hideWheelDiv();
+
+        // Left attached, the handler holds the closed menu's wheel and block alive.
+        expect(removeEventListener).toHaveBeenCalledWith("wheel", scrollHandler);
+        expect(wheelDiv._scrollHandler).toBeNull();
+    });
+});

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -3234,6 +3234,15 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     block._exitWheel.navItems[0].navigateFunction = () => {
         that._piemenuExitTime = new Date().getTime();
         hideWheelDiv();
+        // Remove the wheels so wheelnav detaches the window keydown listener it
+        // installs for keynavigateEnabled. Without this the closed menu keeps
+        // responding to the arrow keys.
+        that._voiceWheel.removeWheel();
+        that._exitWheel.removeWheel();
+        // The pie menu covers the canvas, so the block never receives the
+        // mouseout that would normally clear this. Left set, the arrow keys
+        // move the block instead of doing nothing.
+        that.blocks.activeBlock = null;
     };
 };
 

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -250,6 +250,13 @@ const hideWheelDiv = () => {
     wheelDiv.style.display = "none";
     disableWheelResizeHandling();
 
+    // enableWheelScroll() hangs this listener on the persistent wheelDiv, so it
+    // outlives the wheel and block it closes over unless we take it off here.
+    if (wheelDiv._scrollHandler) {
+        wheelDiv.removeEventListener("wheel", wheelDiv._scrollHandler);
+        wheelDiv._scrollHandler = null;
+    }
+
     if (!isAnyPieMenuVisible()) {
         document.removeEventListener("mousedown", handleOutsideClick);
         document.removeEventListener("keydown", handleEscapeKey, true);
@@ -3149,6 +3156,10 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
         that.updateCache();
     };
 
+    // A preview of an unloaded voice is deferred to give the synth time to
+    // load. Held here so the exit handler can cancel one that is still pending.
+    let voicePreviewTimeout = null;
+
     /*
      * Preview voice
      * @return{void}
@@ -3173,7 +3184,9 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
             timeout = 500;
         }
 
-        setTimeout(() => {
+        clearTimeout(voicePreviewTimeout);
+        voicePreviewTimeout = setTimeout(() => {
+            voicePreviewTimeout = null;
             Singer.setSynthVolume(that.activity.logo, 0, voice, DEFAULTVOLUME);
             that.activity.logo.synth.trigger(0, "G4", 1 / 4, voice, null, null, false);
             that.activity.logo.synth.start();
@@ -3234,6 +3247,10 @@ const piemenuVoices = (block, voiceLabels, voiceValues, categories, voice, rotat
     block._exitWheel.navItems[0].navigateFunction = () => {
         that._piemenuExitTime = new Date().getTime();
         hideWheelDiv();
+        // A preview scheduled just before the menu closed would otherwise play
+        // into a dismissed menu.
+        clearTimeout(voicePreviewTimeout);
+        voicePreviewTimeout = null;
         // Remove the wheels so wheelnav detaches the window keydown listener it
         // installs for keynavigateEnabled. Without this the closed menu keeps
         // responding to the arrow keys.
@@ -4515,6 +4532,7 @@ if (typeof module !== "undefined" && module.exports) {
         piemenuKey,
         piemenuNumber,
         piemenuModes,
+        piemenuVoices,
         handleEscapeKey,
         dismissActivePieMenu,
         showWheelDiv,


### PR DESCRIPTION
- [x] BUG FIX

Closing the instrument pie menu does not actually release it, so the arrow keys keep acting on a menu that is no longer on screen.

### Steps to reproduce

1. Open Music Blocks. The default project has a `set instrument` block set to guitar.
2. Click the instrument name to open the pie menu.
3. Close it with the X in the middle of the wheel.
4. Press the up or down arrow key.

The block moves around the workspace, and at the same time the instrument silently changes to a different one, with a preview note. Left and right do the same. No menu is visible while this happens.

Because the arrow keys are also the normal way to move around the workspace, this means panning the canvas after closing a menu quietly rewrites the instrument in your project, and nothing tells you it changed.

### Cause

Two things are left behind when the menu closes.

`piemenuVoices` sets `keynavigateEnabled` on its wheels, which makes wheelnav attach a keydown listener to `window`. Only `removeWheel()` detaches it, but the menu closes through `hideWheelDiv()`, which just sets `display: none`. Every reopen adds another listener, so after three opens one keypress advances three steps.

`blocks.activeBlock` is also left set. It is normally cleared when the block receives a mouseout, but the pie menu covers the canvas so that never arrives. With it still set, the arrow key handler in `keyboard-controller.js` moves the block.

### Fix

Remove both wheels and clear `activeBlock` in the exit handler, which is the same teardown `piemenuPitches` already does. Arrow keys still navigate the menu while it is open, so the keyboard accessibility added in #8227 is unaffected.

This is the behaviour previously reported in #1504.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved pie-menu dismissal when pressing Escape, clicking away, resizing, scrolling, or navigating with the keyboard.
- Fixed voice menu closing so all menu wheels disappear and the previously active block is cleared.
- Prevented delayed voice previews from playing after the menu has been closed.
- Preserved voice previews while the menu remains open.
- Prevented keyboard and scrolling interactions from affecting hidden menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->