### PR TITLE
test(cypress): add E2E coverage for pitch staircase widget

### DIFF
--- a/cypress/e2e/pitch-staircase-widget.cy.js
+++ b/cypress/e2e/pitch-staircase-widget.cy.js
@@ -1,4 +1,4 @@
-/* global cy, beforeEach, describe, it */
+/* global cy, beforeEach, describe, expect, it */
 
 /**
  * Cypress E2E test suite for the Pitch Staircase widget.
@@ -20,11 +20,13 @@ const loadFixtureProject = fixtureName => {
     cy.get("#load").click();
     cy.get("#myOpenFile").selectFile(`cypress/fixtures/${fixtureName}`, { force: true });
 
-    // Wait for the load overlay to appear before waiting for it to disappear.
-    // Without this guard, the `not.be.visible` check passes trivially on the
-    // container's default hidden state before loading has even begun, which
-    // causes Play to run before the project is fully loaded.
-    cy.get("#load-container").should("be.visible");
+    cy.window({ timeout: 30000 }).should(win => {
+        const { blocks } = win.ActivityContext.getActivity();
+        const fixtureLoaded = blocks.blockList.some(
+            block => !block.trash && block.name === "pitchstaircase"
+        );
+        expect(fixtureLoaded, "fixture pitch staircase block should be loaded").to.be.true;
+    });
     cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
     cy.get("#errorText").should("not.be.visible");
 };
@@ -68,13 +70,11 @@ describe("Pitch Staircase widget", () => {
         // PitchStaircase._makeStairs() builds the staircase inside this._pscTable
         // which is appended to the widget body. The table must be present and
         // contain at least one row (one per pitch in the Stairs array).
-        cy.get('[aria-label="pitch staircase"]')
-            .find("table.pitch-staircase-step, .pitch-staircase-step")
-            .should("have.length.greaterThan", 0);
-
-        // Each row contains a play button cell with class "headcol" and a
-        // frequency/note cell with class "pitch-staircase-step".
-        cy.get(".pitch-staircase-step").first().should("be.visible");
+        cy.get('[aria-label="pitch staircase"] .pitch-staircase-step')
+            .should("have.length.greaterThan", 0)
+            .first()
+            .should("be.visible")
+            .and("contain.text", "G3");
     });
 
     it("renders the full toolbar with all expected action buttons", () => {
@@ -83,23 +83,11 @@ describe("Pitch Staircase widget", () => {
 
         cy.get('[aria-label="pitch staircase"]', { timeout: 30000 }).should("be.visible");
 
-        // PitchStaircase.init() adds buttons to the widget toolbar in this order:
-        // Play chord, Play scale, Save, (ratio inputs), Undo, Clear.
-
-        // The "Play chord" button plays all pitches simultaneously.
-        cy.get('[aria-label="pitch staircase"]').find('img[title="Play chord"]').should("exist");
-
-        // The "Play scale" button plays pitches sequentially up and down.
-        cy.get('[aria-label="pitch staircase"]').find('img[title="Play scale"]').should("exist");
-
-        // The "Save" button generates a new action block from the current staircase.
-        cy.get('[aria-label="pitch staircase"]').find('img[title="Save"]').should("exist");
-
-        // The "Undo" button removes the last added stair step.
-        cy.get('[aria-label="pitch staircase"]').find('img[title="Undo"]').should("exist");
-
-        // The "Clear" button removes all added stair steps.
-        cy.get('[aria-label="pitch staircase"]').find('img[title="Clear"]').should("exist");
+        for (const label of ["Play chord", "Play scale", "Save", "Undo", "Clear"]) {
+            cy.get(`[aria-label="pitch staircase"] [role="button"][aria-label="${label}"]`).should(
+                "be.visible"
+            );
+        }
     });
 
     it("closes the Pitch Staircase widget and cleans up the DOM", () => {
@@ -115,10 +103,7 @@ describe("Pitch Staircase widget", () => {
         // PitchStaircase.init() wires widgetWindow.onclose to clear all
         // timeouts, stop synth audio, and call widgetWindow.destroy() -
         // which removes the .windowFrame from the DOM.
-        cy.get('[aria-label="pitch staircase"]')
-            .find('[title="Close"]')
-            .first()
-            .click({ force: true });
+        cy.get('[aria-label="pitch staircase"] [role="button"][aria-label="Close window"]').click();
 
         // The window frame should be fully destroyed.
         cy.get('[aria-label="pitch staircase"]').should("not.exist");

--- a/cypress/e2e/pitch-staircase-widget.cy.js
+++ b/cypress/e2e/pitch-staircase-widget.cy.js
@@ -1,0 +1,132 @@
+/* global cy, beforeEach, describe, it */
+
+/**
+ * Cypress E2E test suite for the Pitch Staircase widget.
+ *
+ * The Pitch Staircase widget (js/widgets/pitchstaircase.js) generates a series
+ * of pitches from a starting pitch by applying a musical ratio (numerator /
+ * denominator). It is opened by running a `pitchstaircase` block (via Play).
+ *
+ * These tests exercise the widget's complete launch and UI lifecycle through
+ * the real application without any mocks:
+ *  1. Loading a fixture project that contains a pitchstaircase block.
+ *  2. Pressing Play to open the widget through the real block-execution path.
+ *  3. Verifying the widget window, staircase table, and toolbar render correctly.
+ *  4. Confirming toolbar action buttons (Play chord, Play scale, Save, Undo, Clear) are present.
+ *  5. Closing the widget and confirming it is fully removed from the DOM.
+ */
+
+const loadFixtureProject = fixtureName => {
+    cy.get("#load").click();
+    cy.get("#myOpenFile").selectFile(`cypress/fixtures/${fixtureName}`, { force: true });
+
+    // Wait for the load overlay to appear before waiting for it to disappear.
+    // Without this guard, the `not.be.visible` check passes trivially on the
+    // container's default hidden state before loading has even begun, which
+    // causes Play to run before the project is fully loaded.
+    cy.get("#load-container").should("be.visible");
+    cy.get("#load-container", { timeout: 30000 }).should("not.be.visible");
+    cy.get("#errorText").should("not.be.visible");
+};
+
+describe("Pitch Staircase widget", () => {
+    beforeEach(() => {
+        // Each test gets a fresh app load to prevent Music Blocks' localStorage
+        // auto-save from re-triggering the widget on subsequent test runs.
+        cy.visit("http://127.0.0.1:3000");
+        cy.clearLocalStorage();
+        cy.visit("http://127.0.0.1:3000");
+        cy.waitForAppReady();
+
+        // Dismiss the first-run "Take a Tour" guide if it appears, so that
+        // the .windowFrame selectors used in tests are unambiguous.
+        cy.get("body").then($body => {
+            const closeButtons = $body.find(".windowFrame .wftButton.close");
+            if (closeButtons.length) {
+                cy.wrap(closeButtons).click({ multiple: true, force: true });
+            }
+        });
+    });
+
+    it("opens the Pitch Staircase widget and renders the staircase table", () => {
+        loadFixtureProject("pitch-staircase-minimal.tb");
+
+        // Pressing Play executes every start stack, which triggers the
+        // pitchstaircase block and calls PitchStaircase.init() - the same
+        // path a real user takes.
+        cy.get("#play").click();
+
+        // The widget window frame title is set by widgetWindows.windowFor()
+        // with the label "pitch staircase".
+        cy.get(".windowFrame .wftTitle", { timeout: 30000 })
+            .should("be.visible")
+            .and("contain.text", "pitch staircase");
+
+        // The window frame itself is scoped by the aria-label attribute.
+        cy.get('[aria-label="pitch staircase"]', { timeout: 30000 }).should("be.visible");
+
+        // PitchStaircase._makeStairs() builds the staircase inside this._pscTable
+        // which is appended to the widget body. The table must be present and
+        // contain at least one row (one per pitch in the Stairs array).
+        cy.get('[aria-label="pitch staircase"]')
+            .find("table.pitch-staircase-step, .pitch-staircase-step")
+            .should("have.length.greaterThan", 0);
+
+        // Each row contains a play button cell with class "headcol" and a
+        // frequency/note cell with class "pitch-staircase-step".
+        cy.get(".pitch-staircase-step").first().should("be.visible");
+    });
+
+    it("renders the full toolbar with all expected action buttons", () => {
+        loadFixtureProject("pitch-staircase-minimal.tb");
+        cy.get("#play").click();
+
+        cy.get('[aria-label="pitch staircase"]', { timeout: 30000 }).should("be.visible");
+
+        // PitchStaircase.init() adds buttons to the widget toolbar in this order:
+        // Play chord, Play scale, Save, (ratio inputs), Undo, Clear.
+
+        // The "Play chord" button plays all pitches simultaneously.
+        cy.get('[aria-label="pitch staircase"]').find('img[title="Play chord"]').should("exist");
+
+        // The "Play scale" button plays pitches sequentially up and down.
+        cy.get('[aria-label="pitch staircase"]').find('img[title="Play scale"]').should("exist");
+
+        // The "Save" button generates a new action block from the current staircase.
+        cy.get('[aria-label="pitch staircase"]').find('img[title="Save"]').should("exist");
+
+        // The "Undo" button removes the last added stair step.
+        cy.get('[aria-label="pitch staircase"]').find('img[title="Undo"]').should("exist");
+
+        // The "Clear" button removes all added stair steps.
+        cy.get('[aria-label="pitch staircase"]').find('img[title="Clear"]').should("exist");
+    });
+
+    it("closes the Pitch Staircase widget and cleans up the DOM", () => {
+        loadFixtureProject("pitch-staircase-minimal.tb");
+        cy.get("#play").click();
+
+        cy.get('[aria-label="pitch staircase"]', { timeout: 30000 }).should("be.visible");
+
+        // Confirm the staircase is rendered before closing.
+        cy.get(".pitch-staircase-step").should("exist");
+
+        // Click the close button on the widget window titlebar.
+        // PitchStaircase.init() wires widgetWindow.onclose to clear all
+        // timeouts, stop synth audio, and call widgetWindow.destroy() -
+        // which removes the .windowFrame from the DOM.
+        cy.get('[aria-label="pitch staircase"]')
+            .find('[title="Close"]')
+            .first()
+            .click({ force: true });
+
+        // The window frame should be fully destroyed.
+        cy.get('[aria-label="pitch staircase"]').should("not.exist");
+
+        // The staircase step cells should no longer exist in the DOM.
+        cy.get(".pitch-staircase-step").should("not.exist");
+
+        // The play button cells (class "headcol") should also be gone.
+        cy.get(".headcol").should("not.exist");
+    });
+});

--- a/cypress/fixtures/pitch-staircase-minimal.tb
+++ b/cypress/fixtures/pitch-staircase-minimal.tb
@@ -1,0 +1,8 @@
+[
+    [0, ["start", { "collapsed": false, "xcor": 0, "ycor": 0, "heading": 0, "color": 0, "shade": 50, "pensize": 5, "grey": 100 }], 100, 100, [null, 1, null]],
+    [1, "pitchstaircase", 0, 0, [0, 2, 5]],
+    [2, "pitch", 0, 0, [1, 3, 4, null]],
+    [3, ["solfege", { "value": "sol" }], 0, 0, [2]],
+    [4, ["number", { "value": 3 }], 0, 0, [2]],
+    [5, "hiddennoflow", 0, 0, [1, null]]
+]


### PR DESCRIPTION
## Description

Adds a Cypress end-to-end test suite for the **Pitch Staircase** widget (`js/widgets/pitchstaircase.js`), following the same pattern as the recently merged Music Keyboard E2E tests (#8308).

The Pitch Staircase widget allows users to generate pitches from a starting note by applying musical ratios. These tests exercise the widget's full lifecycle through the production application — no mocks.

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

- Added `cypress/e2e/pitch-staircase-widget.cy.js`.
- Added `cypress/fixtures/pitch-staircase-minimal.tb` as a minimal test project containing a `pitchstaircase` block with a single `sol-3` pitch (mirroring the default macro).
- **Widget launch & rendering**: Loads the fixture project, presses Play, and verifies the widget window frame and staircase table render correctly.
- **Toolbar button verification**: Confirms all five toolbar action buttons are present and accessible: **Play chord**, **Play scale**, **Save**, **Undo**, and **Clear**.
- **DOM cleanup on close**: Clicks the Close button and asserts the widget frame, staircase step cells, and play button cells are fully removed from the DOM.

## Visual Changes

Not applicable. This PR adds E2E test coverage only.

## Testing Performed

- **Focused Cypress test:** passing.
- **Full Cypress suite:** passing locally.
- **ESLint:** passing.
- **git diff --check:** passing.

All 3 tests pass locally:


## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

## Additional Notes

The tests use the real application UI and live data rather than mocks. 

No production code is changed by this PR; the changes are limited to Cypress coverage and a minimal test fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for launching and closing the Pitch Staircase widget.
  * Verified the widget’s staircase display and toolbar controls.
  * Added a minimal fixture project to support reliable testing of pitch-staircase behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->