### PR TITLE
test: ast generated test validation

### DIFF
--- a/scripts/generate-tests/README.md
+++ b/scripts/generate-tests/README.md
@@ -18,6 +18,8 @@ source file
     -> deterministic prompt      (prompt-builder.js)
     -> provider                  (llm-client.js: NoopClient / ManualClient / ...)
     -> generated Jest test       (in-memory string)
+    -> validator                 (validate-generated.js: { valid, errors, warnings })
+    -> safe writer               (write-generated.js -> *.generated.test.js)
 ```
 
 The extractor reads and parses the analysed source but never executes it. The
@@ -25,6 +27,13 @@ generation layer does not read source files, write to the source tree, require a
 credential, or make a network call. The only providers shipped are credential-free
 (`noop`, `manual`); a real model-backed provider is left for a later change and
 would be a new class in `llm-client.js` only.
+
+The **validator** and **safe writer** are the deterministic safety layer between
+a generated string and the repository. A candidate that fails validation never
+reaches the writer; the writer itself only ever creates a single, predictable
+file inside the module's own `__tests__/` directory and never overwrites
+anything. `write-generated.js` is the only file here that touches the
+filesystem, and only under the guards described below.
 
 ## Usage
 
@@ -45,9 +54,29 @@ node scripts/generate-tests/cli.js js/utils/utils-logic.js --prompt
 # candidate test source (nothing is written to disk).
 node scripts/generate-tests/cli.js js/utils/utils-logic.js --generate
 node scripts/generate-tests/cli.js js/utils/utils-logic.js --generate=manual
+
+# Generate a candidate, validate it, and report the exact path the safe writer
+# would use. Nothing is written without --write; a candidate that fails
+# validation is reported and the command exits non-zero.
+node scripts/generate-tests/cli.js js/utils/utils-logic.js --emit
+node scripts/generate-tests/cli.js js/utils/utils-logic.js --emit --write
 ```
 
-`--check`, `--prompt` and `--generate` are mutually exclusive.
+`--check`, `--prompt`, `--generate` and `--emit` are mutually exclusive;
+`--write` only applies together with `--emit`. `node cli.js --help` prints the
+same summary.
+
+`--generate` vs `--emit` (easy to confuse):
+
+|              | `--generate`                       | `--emit`                                               |
+| ------------ | ---------------------------------- | ------------------------------------------------------ |
+| output       | raw candidate **source** to stdout | a one-line **verdict** + the path the writer would use |
+| validation   | none                               | full `validateGeneratedTest`                           |
+| exit code    | 0 unless the provider errors       | 1 if the candidate is invalid                          |
+| touches disk | never                              | only with `--emit --write`, and only a valid candidate |
+
+Use `--generate` to eyeball what a provider produced; use `--emit` to see
+whether that output is safe to keep, and `--emit --write` to actually keep it.
 
 ## Programmatic API
 
@@ -56,6 +85,8 @@ const { extractFile } = require("./extract-module");
 const { buildGenerationRequest } = require("./generation-request");
 const { buildPrompt, buildPromptFromPlan } = require("./prompt-builder");
 const { generateTests, createClient, NoopClient, ManualClient } = require("./llm-client");
+const { validateGeneratedTest } = require("./validate-generated");
+const { writeGeneratedTest, generatedTestPathFor } = require("./write-generated");
 
 const plan = extractFile("js/utils/utils-logic.js");
 const prompt = buildPromptFromPlan(plan); // string, deterministic
@@ -66,19 +97,29 @@ const { request, prompt: p, source, meta } = await generateTests(plan);
 // Bring your own provider (any object with `name` and `generate(request)`):
 await generateTests(plan, { client: myClient });
 await generateTests(plan, { provider: "manual", clientOptions: { responses } });
+
+// Validate a candidate against the plan, then write it only if it is valid.
+const result = validateGeneratedTest(source, { plan });
+// -> { valid, errors: [...], warnings: [...], modulePath }
+
+if (result.valid) {
+    const { written, path } = writeGeneratedTest(source, { plan }); // or { dryRun: true }
+}
 ```
 
 ## Files
 
-| File                    | Responsibility                                                                        |
-| ----------------------- | ------------------------------------------------------------------------------------- |
-| `extract-module.js`     | Reads a file, parses it with the vendored Acorn (`lib/acorn.min.js`), returns a plan. |
-| `module-test-plan.js`   | Pure AST walker that builds the plan structure.                                       |
-| `generation-request.js` | Turns a plan into a structured `{ module, plan, instructions, ... }` request.         |
-| `prompt-builder.js`     | Renders a request as one deterministic prompt string.                                 |
-| `llm-client.js`         | Provider seam: `NoopClient`, `ManualClient`, `createClient`, `generateTests`.         |
-| `cli.js`                | Command-line wrapper: `--check`, `--prompt`, `--generate`.                            |
-| `__tests__/`            | Jest tests plus fixtures and their committed `.plan.json` plans.                      |
+| File                    | Responsibility                                                                               |
+| ----------------------- | -------------------------------------------------------------------------------------------- |
+| `extract-module.js`     | Reads a file, parses it with the vendored Acorn (`lib/acorn.min.js`), returns a plan.        |
+| `module-test-plan.js`   | Pure AST walker that builds the plan structure.                                              |
+| `generation-request.js` | Turns a plan into a structured `{ module, plan, instructions, ... }` request.                |
+| `prompt-builder.js`     | Renders a request as one deterministic prompt string.                                        |
+| `llm-client.js`         | Provider seam: `NoopClient`, `ManualClient`, `createClient`, `generateTests`.                |
+| `validate-generated.js` | Deterministic safety checks on a generated candidate; returns `{ valid, errors, warnings }`. |
+| `write-generated.js`    | Safe writer: one deterministic `*.generated.test.js` path, never overwrites, no traversal.   |
+| `cli.js`                | Command-line wrapper: `--check`, `--prompt`, `--generate`, `--emit [--write]`.               |
+| `__tests__/`            | Jest tests plus fixtures and their committed `.plan.json` plans.                             |
 
 ## Generation layer
 
@@ -100,6 +141,93 @@ await generateTests(plan, { provider: "manual", clientOptions: { responses } });
 - The prompt instructs a generator to test **observable behaviour** through the
   public API, not to emit a test per AST node, not to mock the module under
   test, and never to emit code that writes to disk.
+
+## Validation and safe writing
+
+**`validateGeneratedTest(source, { plan, modulePath, existingTitles, allowedGlobals, allowedModules })`**
+parses the candidate with the vendored Acorn and returns
+`{ valid, errors, warnings, modulePath }`. It never executes the candidate,
+never reads the module under test, and never touches the filesystem. The same
+inputs always produce the same result.
+
+It is a **static, heuristic filter**, not a JavaScript security sandbox: it
+rejects the known-unsafe and known-meaningless _patterns_ listed below, but it
+cannot catch a construct it has no rule for, and code that only does its damage
+at runtime will pass the parse-only check. Access through a **string literal**
+is covered (`fs["writeFileSync"]`, `require("fs")`), but **fully dynamic**
+access - a method name or module specifier held in a variable, `eval`,
+`Function(...)` - is out of scope. The concrete "a bad string cannot corrupt the
+repo" guarantee comes from the writer (one deterministic path, `wx` create), not
+from this list.
+
+A candidate is **rejected** (an `error`) when it:
+
+- does not parse as JavaScript, or is empty;
+- declares no `it()`/`test()` case, or contains no `expect()` assertion;
+- does not `require`/`import` the real module the plan describes;
+- `jest.mock`s / `doMock`s / `setMock`s the module under test;
+- `require`s / `import`s **anything other than the module under test** - a
+  relative path to another file, _or a bare package specifier_ - unless it is
+  listed in `options.allowedModules`. Bare package imports are not trusted: an
+  installed package is opaque to every rule below;
+- `require`s `fs`/`fs-extra` or `child_process`/`worker_threads` (these can
+  never be allow-listed);
+- uses an unsafe filesystem call (`writeFileSync`, `rmSync`, `mkdtempSync`, ...),
+  including computed `obj["writeFileSync"]` access;
+- assigns `module.exports` / `exports.*` (a test must not add exports anywhere);
+- reaches into `_`-prefixed private members (member access, computed
+  `obj["_x"]`, or destructuring);
+- has only meaningless assertions - literal-vs-equal-literal
+  (`expect(true).toBe(true)`), bare existence checks on the import
+  (`expect(target).toBeDefined()`), or only `toMatchSnapshot()`;
+- uses `Math.random` with no `jest.spyOn`/stub, or `setTimeout`/`setInterval`
+  with no `jest.useFakeTimers()`;
+- references an undeclared global from another subsystem;
+- duplicates a test title (full `describe › it` path) within the file or against
+  the supplied `existingTitles`.
+
+`warnings` (non-blocking) cover an uncontrolled `Date.now()` / `new Date()` and a
+`describe` title that names a different module file.
+
+**Allow-lists.** `options.allowedGlobals` (undeclared identifiers) and
+`options.allowedModules` (extra `require`/`import` specifiers) are the only
+escape hatches. For globals the effective list is three tiers:
+
+1. the fixed JS / Node / Jest / jsdom surface (`ALLOWED_GLOBALS` in
+   `validate-generated.js`);
+2. the module's own `plan.referencedGlobals` - the module under test already
+   depends on these, so its test legitimately may too;
+3. `options.allowedGlobals` - an explicit, per-call escape hatch.
+
+Widening either list only ever permits the named identifier / specifier. It does
+**not** disable any other rule: an aliased `writeFileSync`, `Math.random`, a
+bare timer, `fs`, `child_process` and so on are still caught by their own checks.
+Both lists are **trusted configuration supplied by the calling code** - they
+must never be derived from the candidate string or from provider output, or the
+thing being validated could widen its own allow-list.
+
+**`writeGeneratedTest(source, { plan, dryRun, cwd, existingTitles, allowedGlobals, allowedModules })`**
+resolves the deterministic output path first (so a malformed module path fails
+fast and every result still reports the path that _would_ be used), then
+validates, and only when the candidate is valid calls the safe writer. The
+writer:
+
+- writes exactly one path -
+  `<dir>/__tests__/<module>.generated.test.js` - derived deterministically from
+  the plan's module path;
+- refuses an absolute module/output path, any `..` traversal, a path outside a
+  `__tests__/` directory, and any path not ending in `.generated.test.js`
+  (`assertSafeTestPath`, lexical);
+- before writing, resolves the real path of the nearest existing ancestor and
+  refuses it if a symlink there escapes the repository
+  (`assertRealContainment`);
+- never overwrites an existing file: the create uses the `wx` open flag, which
+  fails atomically if the path exists - there is no preceding `stat` to race -
+  so a hand-written `<module>.test.js` or a previous generated run is always
+  safe;
+- creates the `__tests__/` directory only when it is missing;
+- always reports the exact repo-relative path, and writes nothing under
+  `dryRun`.
 
 ## What is extracted
 

--- a/scripts/generate-tests/__tests__/extract-module.test.js
+++ b/scripts/generate-tests/__tests__/extract-module.test.js
@@ -324,7 +324,9 @@ describe("cli helpers", () => {
             check: false,
             expected: null,
             prompt: false,
-            generate: null
+            generate: null,
+            emit: null,
+            write: false
         });
     });
 

--- a/scripts/generate-tests/__tests__/fixtures/generated/valid-language-utils.txt
+++ b/scripts/generate-tests/__tests__/fixtures/generated/valid-language-utils.txt
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const LanguageUtils = require("../language-utils");
+
+describe("normalizeLanguageCode", () => {
+    it("maps a menu code to its locale file name", () => {
+        expect(LanguageUtils.normalizeLanguageCode("enUK")).toBe("en_GB");
+    });
+
+    it("defaults an empty or non-string input to English", () => {
+        expect(LanguageUtils.normalizeLanguageCode("")).toBe("en");
+        expect(LanguageUtils.normalizeLanguageCode(null)).toBe("en");
+    });
+
+    it("routes any Japanese variant to the ja translations", () => {
+        expect(LanguageUtils.normalizeLanguageCode("ja-something")).toBe("ja");
+    });
+
+    it("passes an already-normalised code straight through", () => {
+        expect(LanguageUtils.normalizeLanguageCode("de")).toBe("de");
+    });
+});

--- a/scripts/generate-tests/__tests__/fixtures/generated/valid-utils-logic.txt
+++ b/scripts/generate-tests/__tests__/fixtures/generated/valid-utils-logic.txt
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { clampNumber, GCD, toTitleCase } = require("../utils-logic");
+
+describe("clampNumber", () => {
+    it("returns the value untouched when it is already within bounds", () => {
+        expect(clampNumber(5, 0, 10)).toBe(5);
+    });
+
+    it("clamps to the nearest bound when the value is outside the range", () => {
+        expect(clampNumber(42, 0, 10)).toBe(10);
+        expect(clampNumber(-7, 0, 10)).toBe(0);
+    });
+
+    it("falls back to min when the value is not numeric", () => {
+        expect(clampNumber("nope", 3, 9)).toBe(3);
+    });
+});
+
+describe("GCD", () => {
+    it("computes the greatest common divisor of two integers", () => {
+        expect(GCD(12, 18)).toBe(6);
+    });
+});
+
+describe("toTitleCase", () => {
+    it("capitalises the first letter of each word", () => {
+        expect(toTitleCase("hello world")).toBe("Hello World");
+    });
+});

--- a/scripts/generate-tests/__tests__/llm-client.test.js
+++ b/scripts/generate-tests/__tests__/llm-client.test.js
@@ -18,6 +18,7 @@
  */
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const http = require("http");
 const https = require("https");
@@ -255,5 +256,69 @@ describe("cli: --prompt and --generate", () => {
     it("--prompt and --generate exit 1 for an unreadable source file", () => {
         expect(cli.main(["does/not/exist.js", "--prompt"])).toBe(1);
         expect(cli.main(["does/not/exist.js", "--generate"])).toBe(1);
+    });
+});
+
+describe("cli: --emit (generate -> validate -> safe write)", () => {
+    // The CLI writes relative to process.cwd() (the repo root under Jest), so a
+    // regression that made the NoopClient candidate valid would drop a real file
+    // here. Remove it after every test, even one that failed mid-way.
+    const GENERATED_IN_TREE = path.join(
+        SCRIPT_DIR,
+        "..",
+        "..",
+        "js",
+        "utils",
+        "__tests__",
+        "utils-logic.generated.test.js"
+    );
+    afterEach(() => {
+        fs.rmSync(GENERATED_IN_TREE, { force: true });
+    });
+
+    it("parses --emit and --write", () => {
+        expect(cli.parseArgs(["m.js", "--emit"])).toMatchObject({ emit: "noop", write: false });
+        expect(cli.parseArgs(["m.js", "--emit=manual", "--write"])).toMatchObject({
+            emit: "manual",
+            write: true
+        });
+    });
+
+    it("rejects --write without --emit", () => {
+        expect(() => cli.parseArgs(["m.js", "--write"])).toThrow(/--write only applies/);
+    });
+
+    it("rejects combining --emit with another mode", () => {
+        expect(() => cli.parseArgs(["m.js", "--emit", "--generate"])).toThrow(/mutually exclusive/);
+    });
+
+    it("exits 1 and writes nothing when the candidate fails validation", () => {
+        // The NoopClient emits an it.todo skeleton whose only assertion is an
+        // existence check - the validator correctly rejects it.
+        const before = fs.readdirSync(
+            path.join(SCRIPT_DIR, "..", "..", "js", "utils", "__tests__")
+        );
+        expect(cli.main(["js/utils/utils-logic.js", "--emit"])).toBe(1);
+        expect(cli.main(["js/utils/utils-logic.js", "--emit", "--write"])).toBe(1);
+        const after = fs.readdirSync(path.join(SCRIPT_DIR, "..", "..", "js", "utils", "__tests__"));
+        expect(after).toEqual(before);
+    });
+
+    it("exits 1 (no uncaught throw) for a source file that resolves outside the repo", () => {
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "mb-emit-outside-"));
+        const modPath = path.join(outside, "stray.js");
+        fs.writeFileSync(modPath, "function f(x) { return x; }\nmodule.exports = { f };\n");
+        try {
+            // plan.file becomes a "../../.." path -> generatedTestPathFor throws;
+            // the CLI must convert that to exit code 1, not an exception.
+            let code;
+            expect(() => {
+                code = cli.main([modPath, "--emit"]);
+            }).not.toThrow();
+            expect(code).toBe(1);
+            expect(code).not.toBe(0);
+        } finally {
+            fs.rmSync(outside, { recursive: true, force: true });
+        }
     });
 });

--- a/scripts/generate-tests/__tests__/validate-generated.test.js
+++ b/scripts/generate-tests/__tests__/validate-generated.test.js
@@ -1,0 +1,872 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { extractFile } = require("../extract-module");
+const { validateGeneratedTest } = require("../validate-generated");
+
+const utilsLogicPlan = () => extractFile("js/utils/utils-logic.js");
+const languageUtilsPlan = () => extractFile("js/utils/language-utils.js");
+
+const FIXTURES = path.join(__dirname, "fixtures", "generated");
+const fixture = name => fs.readFileSync(path.join(FIXTURES, name), "utf8");
+
+/**
+ * Wraps a test body around a real require of utils-logic so a candidate only has
+ * to vary the interesting part.
+ */
+const withUtilsLogic = body =>
+    `const { clampNumber, GCD } = require("../utils-logic");\n\n${body}\n`;
+
+describe("validateGeneratedTest: a good candidate", () => {
+    it("accepts a legitimate Music Blocks-style Jest test", () => {
+        const result = validateGeneratedTest(fixture("valid-utils-logic.txt"), {
+            plan: utilsLogicPlan()
+        });
+        expect(result).toMatchObject({ valid: true, errors: [] });
+    });
+
+    it("accepts a multi-describe test that exercises several behaviours", () => {
+        const result = validateGeneratedTest(fixture("valid-language-utils.txt"), {
+            plan: languageUtilsPlan()
+        });
+        expect(result.valid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    it("accepts multiple it() cases in one generated file", () => {
+        const source = withUtilsLogic(`
+describe("clampNumber", () => {
+    it("keeps an in-range value", () => {
+        expect(clampNumber(5, 0, 10)).toBe(5);
+    });
+    it("clamps an over-range value", () => {
+        expect(clampNumber(99, 0, 10)).toBe(10);
+    });
+    it("clamps an under-range value", () => {
+        expect(clampNumber(-1, 0, 10)).toBe(0);
+    });
+});`);
+        expect(validateGeneratedTest(source, { plan: utilsLogicPlan() }).valid).toBe(true);
+    });
+
+    it("is deterministic for the same input", () => {
+        const a = validateGeneratedTest(fixture("valid-utils-logic.txt"), {
+            plan: utilsLogicPlan()
+        });
+        const b = validateGeneratedTest(fixture("valid-utils-logic.txt"), {
+            plan: utilsLogicPlan()
+        });
+        expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+});
+
+describe("validateGeneratedTest: structural rejections", () => {
+    it("rejects empty source", () => {
+        const result = validateGeneratedTest("   \n  ", { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/empty/);
+    });
+
+    it("rejects a syntax error", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(
+                'describe("x", () => { it("y", () => { expect(clampNumber(1,0,2).toBe(1); }); });'
+            ),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/does not parse/);
+    });
+
+    it("rejects a file with no it()/test() cases", () => {
+        const result = validateGeneratedTest(withUtilsLogic('describe("clampNumber", () => {});'), {
+            plan: utilsLogicPlan()
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/no it\(\)\/test\(\) cases/);
+    });
+});
+
+describe("validateGeneratedTest: the real module under test", () => {
+    it("rejects a candidate that never requires the module", () => {
+        const source = `
+describe("clampNumber", () => {
+    it("does something", () => {
+        expect(1 + 1).toBe(2);
+    });
+});
+`;
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/does not import the module under test/);
+    });
+
+    it("rejects a candidate that mocks the module under test", () => {
+        const source =
+            'jest.mock("../utils-logic");\n' +
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("uses the mock", () => {
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`);
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/mocks the module under test/);
+    });
+
+    it("rejects a candidate that also imports an unrelated production module", () => {
+        const source =
+            'const other = require("../../logo.js");\n' +
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("still asserts something", () => {
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`);
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(
+            /imports "\.\.\/\.\.\/logo\.js", which is not the module under test/
+        );
+    });
+
+    it.each(["../utils-logic", "../utils-logic.js", "./../utils-logic", "./../utils-logic.js"])(
+        "accepts the equivalent relative require %p",
+        spec => {
+            const source =
+                `const { clampNumber } = require("${spec}");\n` +
+                'describe("clampNumber", () => {\n' +
+                '    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });\n' +
+                "});\n";
+            expect(validateGeneratedTest(source, { plan: utilsLogicPlan() }).valid).toBe(true);
+        }
+    );
+
+    it("does not accept a look-alike module whose basename only shares a prefix", () => {
+        const source =
+            'const x = require("../utils-logic-extra");\n' +
+            'describe("x", () => { it("y", () => { expect(x.f(1)).toBe(1); }); });\n';
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/does not import the module under test/);
+    });
+
+    it("rejects the correct module plus an unrelated production import", () => {
+        const source =
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`) + 'const helper = require("../language-utils");\n';
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(
+            /imports "\.\.\/language-utils", which is not the module under test/
+        );
+    });
+
+    it("does not accept a bare (package-style) specifier as the module import", () => {
+        const source =
+            'const { clampNumber } = require("utils-logic");\n' +
+            'describe("x", () => { it("y", () => { expect(clampNumber(9, 0, 3)).toBe(3); }); });\n';
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/does not import the module under test/);
+    });
+
+    it("rejects an arbitrary npm package import (P1: bare specifiers are not trusted)", () => {
+        const source =
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`) + 'const rimraf = require("rimraf");\n';
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/imports the package "rimraf"/);
+    });
+
+    it("rejects a Node core module that is not on any allow-list", () => {
+        const source =
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`) + 'const os = require("os");\n';
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/imports the package "os"/);
+    });
+
+    it("permits a package named in options.allowedModules", () => {
+        const source =
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`) + 'const { EOL } = require("os");\n';
+        const result = validateGeneratedTest(source, {
+            plan: utilsLogicPlan(),
+            allowedModules: ["os"]
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    it("still rejects fs / child_process even when allow-listed", () => {
+        const source =
+            'const fs = require("fs");\nconst cp = require("child_process");\n' +
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`);
+        const result = validateGeneratedTest(source, {
+            plan: utilsLogicPlan(),
+            allowedModules: ["fs", "child_process"]
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/filesystem module/);
+        expect(result.errors.join(" ")).toMatch(/spawn processes or threads/);
+    });
+});
+
+describe("validateGeneratedTest: assertion quality", () => {
+    it("rejects a candidate with no expect() calls", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(
+                'describe("clampNumber", () => { it("runs", () => { clampNumber(1, 0, 2); }); });'
+            ),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/no expect\(\) assertions/);
+    });
+
+    it("rejects expect(true).toBe(true) style fake assertions", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("pretends to test", () => {
+        expect(true).toBe(true);
+        expect(1).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/no meaningful assertions/);
+    });
+
+    it("rejects a test that only checks the import exists", () => {
+        const source = `
+const target = require("../utils-logic");
+
+describe("utils-logic", () => {
+    it("is importable", () => {
+        expect(target).toBeDefined();
+    });
+});
+`;
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/no meaningful assertions/);
+    });
+
+    it("rejects a snapshot-only test", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("matches the snapshot", () => {
+        expect(clampNumber(5, 0, 10)).toMatchSnapshot();
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/snapshot assertions/);
+    });
+
+    it("allows a snapshot alongside a concrete assertion", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps and is stable", () => {
+        expect(clampNumber(5, 0, 10)).toBe(5);
+        expect(clampNumber(5, 0, 10)).toMatchSnapshot();
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it.each([
+        ["toEqual on a computed object", "expect(deepClone({ a: 1 })).toEqual({ a: 1 });"],
+        ["toContain on a computed array", 'expect(toArray("x")).toContain("x");'],
+        ["toBeTruthy on a call result", 'expect(isValidHex("#fff")).toBeTruthy();'],
+        ["toThrow on a wrapped call", 'expect(() => safeJSONParse("{", undefined)).not.toThrow();'],
+        ["toBeCloseTo on arithmetic", "expect(GCD(8, 12)).toBeCloseTo(4);"]
+    ])("treats a real value passed to %s as a meaningful assertion", (_label, line) => {
+        const source =
+            'const { deepClone, toArray, isValidHex, safeJSONParse, GCD } = require("../utils-logic");\n' +
+            `describe("meaningful", () => { it("asserts", () => { ${line} }); });\n`;
+        const result = validateGeneratedTest(source, { plan: utilsLogicPlan() });
+        expect(result.valid).toBe(true);
+    });
+
+    it.each(["expect(5).toEqual(5);", 'expect("x").toStrictEqual("x");', "expect(0).toBeFalsy();"])(
+        "still rejects the literal-vs-literal assertion %p",
+        line => {
+            const result = validateGeneratedTest(
+                withUtilsLogic(`describe("x", () => { it("y", () => { ${line} }); });`),
+                { plan: utilsLogicPlan() }
+            );
+            expect(result.valid).toBe(false);
+            expect(result.errors.join(" ")).toMatch(/no meaningful assertions/);
+        }
+    );
+});
+
+describe("validateGeneratedTest: private API", () => {
+    it("rejects access to a _-prefixed member", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("internal", () => {
+    it("reaches inside", () => {
+        expect(GCD._reduce(4, 2)).toBe(2);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/private, "_"-prefixed members/);
+    });
+
+    it("rejects destructuring a _-prefixed member", () => {
+        const result = validateGeneratedTest(
+            'const { _secret } = require("../utils-logic");\n' +
+                'describe("x", () => { it("y", () => { expect(_secret(1)).toBe(1); }); });\n',
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/private, "_"-prefixed members/);
+    });
+
+    it('rejects computed (string-literal) private access, e.g. target["_reduce"]', () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("internal", () => {
+    it("reaches inside with a computed key", () => {
+        expect(GCD["_reduce"](4, 2)).toBe(2);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/private, "_"-prefixed members: _reduce/);
+    });
+});
+
+describe("validateGeneratedTest: filesystem and production safety", () => {
+    it("rejects requiring fs", () => {
+        const result = validateGeneratedTest(
+            'const fs = require("fs");\n' +
+                withUtilsLogic(`
+describe("clampNumber", () => {
+    it("writes a file", () => {
+        fs.writeFileSync("x.txt", "boom");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/filesystem module/);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation/);
+    });
+
+    it("rejects an unsafe write even when fs is aliased", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("writes via a helper", () => {
+        writeFileSync("x", "y");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan(), allowedGlobals: ["writeFileSync"] }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation/);
+    });
+
+    it('rejects a computed (string-literal) unsafe fs call, e.g. fs["writeFileSync"]', () => {
+        const result = validateGeneratedTest(
+            'const nodeFs = require("fs");\n' +
+                withUtilsLogic(`
+describe("clampNumber", () => {
+    it("writes through a computed member", () => {
+        nodeFs["writeFileSync"]("x", "y");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation: writeFileSync/);
+    });
+
+    it("rejects spawning a child process", () => {
+        const result = validateGeneratedTest(
+            'const cp = require("child_process");\n' +
+                withUtilsLogic(
+                    'describe("x", () => { it("y", () => { cp.execSync("ls"); expect(clampNumber(1,0,2)).toBe(1); }); });'
+                ),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/spawn processes/);
+    });
+
+    it("does NOT treat a same-named method on an arbitrary receiver as an fs op", () => {
+        // `remove`, `move`, `rm`, `cp` are all in UNSAFE_FS_CALLS but also common
+        // method names. Only real fs receivers should trip the check.
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("cleans up a DOM node", () => {
+        const element = document.createElement("div");
+        document.body.appendChild(element);
+        element.remove();
+        const seq = [1, 2, 3];
+        seq.copyWithin(0, 1);
+        expect(clampNumber(seq.length, 0, 10)).toBe(3);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+        expect(result.errors.join(" ")).not.toMatch(/filesystem/);
+    });
+
+    it("does NOT flag a locally declared function that shares an fs name", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+function remove(list, i) {
+    return list.filter((_, k) => k !== i);
+}
+
+describe("clampNumber", () => {
+    it("uses a local helper", () => {
+        expect(remove([1, 2, 3], 1)).toEqual([1, 3]);
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it('still flags a real fs receiver, incl. destructured off require("fs")', () => {
+        const result = validateGeneratedTest(
+            'const { rmSync } = require("fs");\n' +
+                withUtilsLogic(`
+describe("clampNumber", () => {
+    it("deletes a path", () => {
+        rmSync("/tmp/x", { recursive: true });
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation: rmSync/);
+    });
+
+    it("rejects a forbidden static ESM import alongside a valid require of the target", () => {
+        const result = validateGeneratedTest(
+            'import fs from "fs";\n' +
+                withUtilsLogic(`
+describe("clampNumber", () => {
+    it("still imports the target too", () => {
+        fs.writeFileSync("x", "y");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/filesystem module \("fs"\)/);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation/);
+    });
+
+    it("rejects a dynamic import() of a process module", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("dynamically imports child_process", async () => {
+        const cp = await import("child_process");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/spawn processes or threads/);
+    });
+
+    it("rejects an unrelated static ESM import", () => {
+        const result = validateGeneratedTest(
+            'import { normalizeLanguageCode } from "../language-utils";\n' +
+                withUtilsLogic(`
+describe("clampNumber", () => {
+    it("imports another module via ESM", () => {
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(
+            /imports "\.\.\/language-utils", which is not the module under test/
+        );
+    });
+
+    it("accepts a static ESM import of the target module itself", () => {
+        const result = validateGeneratedTest(
+            'import { clampNumber } from "../utils-logic";\n' +
+                'describe("clampNumber", () => {\n' +
+                '    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });\n' +
+                "});\n",
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects a candidate that assigns module.exports", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+module.exports = { clampNumber };
+
+describe("clampNumber", () => {
+    it("clamps", () => {
+        expect(clampNumber(9, 0, 3)).toBe(3);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/module\.exports/);
+    });
+
+    it("rejects a candidate that assigns exports.foo", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+exports.helper = clampNumber;
+
+describe("clampNumber", () => {
+    it("clamps", () => {
+        expect(clampNumber(9, 0, 3)).toBe(3);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/module\.exports/);
+    });
+});
+
+describe("validateGeneratedTest: determinism of the test itself", () => {
+    it("rejects Math.random with no control", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("uses randomness", () => {
+        expect(clampNumber(Math.random(), 0, 1)).toBeLessThanOrEqual(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/Math\.random without deterministic control/);
+    });
+
+    it("accepts Math.random when it is spied on", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("uses controlled randomness", () => {
+        jest.spyOn(Math, "random").mockReturnValue(0.5);
+        expect(clampNumber(Math.random(), 0, 1)).toBe(0.5);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects a bare setTimeout without fake timers", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("waits", () => {
+        setTimeout(() => {}, 10);
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/useFakeTimers/);
+    });
+
+    it("accepts setTimeout with jest.useFakeTimers()", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("waits deterministically", () => {
+        jest.useFakeTimers();
+        setTimeout(() => {}, 10);
+        jest.runAllTimers();
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("warns (does not reject) on an uncontrolled Date.now", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("stamps a time", () => {
+        const t = Date.now();
+        expect(clampNumber(t, 0, t)).toBe(t);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+        expect(result.warnings.join(" ")).toMatch(/Date\.now/);
+    });
+});
+
+describe("validateGeneratedTest: undeclared globals and duplicate titles", () => {
+    it("rejects an undeclared global from another subsystem", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("leans on activity", () => {
+        expect(clampNumber(activity.foo, 0, 10)).toBe(0);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/undeclared globals: activity/);
+    });
+
+    it("permits a global listed in the plan's referencedGlobals (tier 2)", () => {
+        // utils-logic references `document`; a test may use it too.
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("touches the dom", () => {
+        const el = document.createElement("div");
+        expect(clampNumber(el.childNodes.length, 0, 10)).toBe(0);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("caller-supplied allowedGlobals (tier 3) permits only the named identifier", () => {
+        const body = `
+describe("clampNumber", () => {
+    it("uses two project globals", () => {
+        expect(clampNumber(platformColor.x, 0, wheelnav.y)).toBe(0);
+    });
+});`;
+        // platformColor is allow-listed; wheelnav is not -> still rejected, and
+        // only wheelnav is named.
+        const partial = validateGeneratedTest(withUtilsLogic(body), {
+            plan: utilsLogicPlan(),
+            allowedGlobals: ["platformColor"]
+        });
+        expect(partial.valid).toBe(false);
+        expect(partial.errors.join(" ")).toMatch(/undeclared globals: wheelnav/);
+        expect(partial.errors.join(" ")).not.toMatch(/platformColor/);
+
+        // both allow-listed -> passes
+        const both = validateGeneratedTest(withUtilsLogic(body), {
+            plan: utilsLogicPlan(),
+            allowedGlobals: ["platformColor", "wheelnav"]
+        });
+        expect(both.valid).toBe(true);
+    });
+
+    it("allowedGlobals cannot switch off another rule (aliased fs write still caught)", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("tries to sneak a write past the global check", () => {
+        writeFileSync("x", "y");
+        expect(clampNumber(1, 0, 2)).toBe(1);
+    });
+});`),
+            { plan: utilsLogicPlan(), allowedGlobals: ["writeFileSync"] }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/unsafe filesystem operation/);
+        // the global check itself no longer fires for the now-allowed name
+        expect(result.errors.join(" ")).not.toMatch(/undeclared globals/);
+    });
+
+    it("rejects duplicate test titles in the same describe", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+    it("clamps", () => { expect(clampNumber(-9, 0, 3)).toBe(0); });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/duplicate test titles/);
+    });
+
+    it("allows the same it() title under different describe blocks", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("handles the boundary", () => { expect(clampNumber(3, 0, 3)).toBe(3); });
+});
+describe("GCD", () => {
+    it("handles the boundary", () => { expect(GCD(3, 3)).toBe(3); });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects a title that collides with one already in the suite", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps an over-range value", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+});`),
+            {
+                plan: utilsLogicPlan(),
+                existingTitles: ["clampNumber › clamps an over-range value"]
+            }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/already used elsewhere/);
+    });
+});
+
+describe("validateGeneratedTest: parameterized (it.each) tests", () => {
+    it("recognises an it.each(table)(...) title and accepts a real assertion", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it.each([
+        [5, 0, 10, 5],
+        [42, 0, 10, 10],
+        [-7, 0, 10, 0]
+    ])("clamps %p into [%p, %p]", (v, lo, hi, want) => {
+        expect(clampNumber(v, lo, hi)).toBe(want);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("flows it.each titles through the no-test-case check", () => {
+        // an it.each with no assertion in its body must still count as a test
+        // case, so this fails on 'no meaningful assertions', not 'no it()/test()'
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it.each([[1], [2]])("case %p", n => {
+        clampNumber(n, 0, 5);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/no expect\(\) assertions/);
+        expect(result.errors.join(" ")).not.toMatch(/no it\(\)\/test\(\) cases/);
+    });
+
+    it("detects a duplicate title between a plain it() and an it.each()", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it("clamps", () => { expect(clampNumber(9, 0, 3)).toBe(3); });
+    it.each([[1]])("clamps", n => { expect(clampNumber(n, 0, 3)).toBe(1); });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(" ")).toMatch(/duplicate test titles/);
+    });
+
+    it("recognises describe.each and it.concurrent.each", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe.each([[0], [1]])("clampNumber batch %p", offset => {
+    it.concurrent.each([[3], [4]])("clamps with offset %p", v => {
+        expect(clampNumber(v + offset, 0, 20)).toBeGreaterThanOrEqual(0);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+
+    it("recognises the it.each`table` tagged-template form", () => {
+        const result = validateGeneratedTest(
+            withUtilsLogic(`
+describe("clampNumber", () => {
+    it.each\`
+        value | want
+        \${5}  | \${5}
+        \${99} | \${10}
+    \`("clamps $value to $want", ({ value, want }) => {
+        expect(clampNumber(value, 0, 10)).toBe(want);
+    });
+});`),
+            { plan: utilsLogicPlan() }
+        );
+        expect(result.valid).toBe(true);
+    });
+});
+
+describe("validateGeneratedTest: without a plan", () => {
+    it("still checks syntax and assertion quality but warns about the skipped checks", () => {
+        const result = validateGeneratedTest(
+            'describe("x", () => { it("y", () => { expect(2 + 2).toBe(4); }); });\n'
+        );
+        expect(result.valid).toBe(true);
+        expect(result.warnings.join(" ")).toMatch(/no module path supplied/);
+    });
+});

--- a/scripts/generate-tests/__tests__/write-generated.test.js
+++ b/scripts/generate-tests/__tests__/write-generated.test.js
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { extractFile } = require("../extract-module");
+const {
+    GENERATED_SUFFIX,
+    generatedTestPathFor,
+    assertSafeTestPath,
+    safeWrite,
+    writeGeneratedTest
+} = require("../write-generated");
+
+const GENERATED_REL = `js/utils/__tests__/utils-logic${GENERATED_SUFFIX}`;
+
+// Repository root resolved from this file's location, not from process.cwd()
+// (which only happens to equal the repo root because Jest's rootDir does).
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+const FIXTURES = path.join(__dirname, "fixtures", "generated");
+const validSource = fs.readFileSync(path.join(FIXTURES, "valid-utils-logic.txt"), "utf8");
+const utilsLogicPlan = () => extractFile("js/utils/utils-logic.js");
+
+let sandbox;
+beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "mb-write-generated-"));
+});
+afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe("generatedTestPathFor", () => {
+    it("derives a deterministic __tests__ path with the generated suffix", () => {
+        expect(generatedTestPathFor("js/utils/utils-logic.js")).toBe(
+            `js/utils/__tests__/utils-logic${GENERATED_SUFFIX}`
+        );
+        expect(generatedTestPathFor("js/utils/utils-logic.js")).toBe(
+            generatedTestPathFor("js/utils/utils-logic.js")
+        );
+    });
+
+    it("rejects an absolute module path", () => {
+        expect(() => generatedTestPathFor("/etc/passwd.js")).toThrow(/repo-relative/);
+    });
+
+    it("rejects a traversing module path", () => {
+        expect(() => generatedTestPathFor("js/../../evil.js")).toThrow(/".."/);
+    });
+
+    it("rejects a non-js module path", () => {
+        expect(() => generatedTestPathFor("js/utils/data.json")).toThrow(/\.js file/);
+    });
+});
+
+describe("assertSafeTestPath", () => {
+    const root = "/repo";
+
+    it("accepts a normal generated test path", () => {
+        expect(assertSafeTestPath(`js/utils/__tests__/x${GENERATED_SUFFIX}`, root)).toBe(
+            path.resolve(root, `js/utils/__tests__/x${GENERATED_SUFFIX}`)
+        );
+    });
+
+    it("rejects an absolute path", () => {
+        expect(() => assertSafeTestPath(`/repo/js/__tests__/x${GENERATED_SUFFIX}`, root)).toThrow(
+            /absolute output path/
+        );
+    });
+
+    it("rejects a path that traverses upward", () => {
+        expect(() =>
+            assertSafeTestPath(`js/utils/__tests__/../../../x${GENERATED_SUFFIX}`, root)
+        ).toThrow(/traverses upward/);
+    });
+
+    it("rejects a path outside a __tests__ directory", () => {
+        expect(() => assertSafeTestPath(`js/utils/x${GENERATED_SUFFIX}`, root)).toThrow(
+            /outside a __tests__/
+        );
+    });
+
+    it("rejects a path without the generated suffix", () => {
+        expect(() => assertSafeTestPath("js/utils/__tests__/x.test.js", root)).toThrow(
+            /must end in/
+        );
+    });
+
+    it("is documented as lexical-only: it does not resolve symlinks", () => {
+        // A path that is lexically fine is accepted here; the real-path guard
+        // that catches a symlinked directory lives in safeWrite (see below).
+        expect(assertSafeTestPath(`js/x/__tests__/y${GENERATED_SUFFIX}`, root)).toBe(
+            path.resolve(root, `js/x/__tests__/y${GENERATED_SUFFIX}`)
+        );
+    });
+});
+
+describe("safeWrite", () => {
+    it("writes a validated candidate to its deterministic location", () => {
+        const report = safeWrite(validSource, {
+            modulePath: "js/utils/utils-logic.js",
+            cwd: sandbox
+        });
+        expect(report).toMatchObject({
+            path: `js/utils/__tests__/utils-logic${GENERATED_SUFFIX}`,
+            written: true,
+            created: true,
+            dryRun: false
+        });
+        expect(fs.readFileSync(report.absolutePath, "utf8")).toBe(validSource);
+    });
+
+    it("dry-run reports the exact path and writes nothing", () => {
+        const report = safeWrite(validSource, {
+            modulePath: "js/utils/utils-logic.js",
+            cwd: sandbox,
+            dryRun: true
+        });
+        expect(report).toMatchObject({ written: false, dryRun: true });
+        expect(fs.existsSync(report.absolutePath)).toBe(false);
+    });
+
+    it("never overwrites an existing file (wx create fails, EEXIST is mapped)", () => {
+        const first = safeWrite(validSource, {
+            modulePath: "js/utils/utils-logic.js",
+            cwd: sandbox
+        });
+        // A file now sits at the target path (here a hand-written test). The
+        // second call must not clobber it: safeWrite has no stat pre-check, it
+        // opens with the `wx` flag and maps the resulting EEXIST to a clear
+        // error.
+        fs.writeFileSync(first.absolutePath, "// a hand-written test\n");
+        expect(() =>
+            safeWrite(validSource, { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
+        ).toThrow(/refusing to overwrite an existing test/);
+        expect(fs.readFileSync(first.absolutePath, "utf8")).toBe("// a hand-written test\n");
+    });
+
+    it("refuses to write empty source", () => {
+        expect(() =>
+            safeWrite("   ", { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
+        ).toThrow(/empty source/);
+    });
+
+    it("refuses an absolute module path", () => {
+        expect(() =>
+            safeWrite(validSource, { modulePath: path.join(sandbox, "x.js"), cwd: sandbox })
+        ).toThrow(/repo-relative/);
+    });
+
+    it("refuses to write through a __tests__ symlink that escapes the repo", () => {
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "mb-outside-"));
+        try {
+            fs.mkdirSync(path.join(sandbox, "js", "utils"), { recursive: true });
+            fs.symlinkSync(outside, path.join(sandbox, "js", "utils", "__tests__"), "dir");
+            expect(() =>
+                safeWrite(validSource, { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
+            ).toThrow(/real path resolves outside the repository/);
+            // even a dry run refuses it
+            expect(() =>
+                safeWrite(validSource, {
+                    modulePath: "js/utils/utils-logic.js",
+                    cwd: sandbox,
+                    dryRun: true
+                })
+            ).toThrow(/real path resolves outside the repository/);
+            expect(fs.readdirSync(outside)).toEqual([]);
+        } finally {
+            fs.rmSync(outside, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("writeGeneratedTest: validate-then-write", () => {
+    it("writes a valid candidate and reports the path", () => {
+        const result = writeGeneratedTest(validSource, { plan: utilsLogicPlan(), cwd: sandbox });
+        expect(result).toMatchObject({ valid: true, written: true });
+        expect(result.path).toBe(`js/utils/__tests__/utils-logic${GENERATED_SUFFIX}`);
+        expect(fs.existsSync(path.join(sandbox, result.path))).toBe(true);
+    });
+
+    it("never writes an invalid candidate but still reports the would-be path", () => {
+        const bad = `
+const target = require("../utils-logic");
+describe("utils-logic", () => {
+    it("exists", () => { expect(target).toBeDefined(); });
+});
+`;
+        const result = writeGeneratedTest(bad, { plan: utilsLogicPlan(), cwd: sandbox });
+        expect(result.valid).toBe(false);
+        expect(result.written).toBe(false);
+        // path is kept for diagnostics even though nothing was written
+        expect(result.path).toBe(GENERATED_REL);
+        expect(fs.existsSync(path.join(sandbox, GENERATED_REL))).toBe(false);
+    });
+
+    it("fails fast on a malformed module path, before source validation", () => {
+        const result = writeGeneratedTest(validSource, {
+            modulePath: "js/../../evil.js",
+            cwd: sandbox
+        });
+        expect(result.valid).toBe(false);
+        expect(result.written).toBe(false);
+        expect(result.path).toBeNull();
+        expect(result.validation.errors.join(" ")).toMatch(/".."/);
+    });
+
+    it("dry-run validates and resolves the path without writing", () => {
+        const result = writeGeneratedTest(validSource, {
+            plan: utilsLogicPlan(),
+            cwd: sandbox,
+            dryRun: true
+        });
+        expect(result.valid).toBe(true);
+        expect(result.written).toBe(false);
+        expect(result.path).toBe(`js/utils/__tests__/utils-logic${GENERATED_SUFFIX}`);
+        expect(fs.existsSync(path.join(sandbox, result.path))).toBe(false);
+    });
+
+    it("does not overwrite: the safe writer throws through the pipeline", () => {
+        writeGeneratedTest(validSource, { plan: utilsLogicPlan(), cwd: sandbox });
+        expect(() =>
+            writeGeneratedTest(validSource, { plan: utilsLogicPlan(), cwd: sandbox })
+        ).toThrow(/refusing to overwrite/);
+    });
+});
+
+describe("write-generated does not touch the real source tree", () => {
+    it("has no generated test committed under js/utils/__tests__", () => {
+        const dir = path.join(REPO_ROOT, "js", "utils", "__tests__");
+        const generated = fs.readdirSync(dir).filter(f => f.endsWith(GENERATED_SUFFIX));
+        expect(generated).toEqual([]);
+    });
+});

--- a/scripts/generate-tests/cli.js
+++ b/scripts/generate-tests/cli.js
@@ -38,8 +38,16 @@
  *       ("noop" by default, or "manual") and prints the candidate test source
  *       to stdout. Nothing is written to disk and no network call is made.
  *
- * This tool only reads and parses the target file. It never requires, imports,
- * executes or modifies it, and it never writes to the source tree.
+ *   node scripts/generate-tests/cli.js path/to/module.js --emit[=provider] [--write]
+ *       Generates a candidate, runs it through the deterministic validator
+ *       (./validate-generated.js) and reports the result plus the exact path
+ *       the safe writer would use. Without --write nothing is written; with
+ *       --write a valid candidate is written to
+ *       `<dir>/__tests__/<module>.generated.test.js` (an existing file is never
+ *       overwritten). Exits non-zero when the candidate is invalid.
+ *
+ * Without --emit --write this tool only reads and parses the target file. It
+ * never requires, imports or executes it.
  */
 
 const fs = require("fs");
@@ -48,10 +56,29 @@ const { extractFile, stringifyPlan } = require("./extract-module");
 const { buildGenerationRequest } = require("./generation-request");
 const { buildPrompt } = require("./prompt-builder");
 const { createClient } = require("./llm-client");
+const { validateGeneratedTest } = require("./validate-generated");
+const { writeGeneratedTest, generatedTestPathFor } = require("./write-generated");
 
 const USAGE =
     "usage: node scripts/generate-tests/cli.js <module.js> " +
-    "[--check [expected.json] | --prompt | --generate[=provider]]";
+    "[--check [expected.json] | --prompt | --generate[=provider] | --emit[=provider] [--write]]";
+
+const HELP = [
+    USAGE,
+    "",
+    "modes (mutually exclusive):",
+    "  (none)              print the module test plan as JSON",
+    "  --check [file]      compare the plan against a committed expected plan; exit 1 on mismatch",
+    "  --prompt            print the deterministic generation prompt; no provider is run",
+    "  --generate[=prov]   run the pipeline through a provider and print the RAW candidate source.",
+    "                      No validation, no file path, nothing written. For eyeballing output.",
+    "  --emit[=prov]       run the pipeline, then VALIDATE the candidate and report the exact",
+    "                      path the safe writer would use. Exit 1 if the candidate is invalid.",
+    "    --write           with --emit only: actually write a valid candidate to",
+    "                      <dir>/__tests__/<module>.generated.test.js (never overwrites).",
+    "",
+    'provider is "noop" (default) or "manual"; both are credential-free and offline.'
+].join("\n");
 
 /**
  * Parses argv into `{ file, check, expected }`.
@@ -65,10 +92,19 @@ function parseArgs(argv) {
     let expected = null;
     let prompt = false;
     let generate = null;
+    let emit = null;
+    let write = false;
 
     for (let i = 0; i < argv.length; i += 1) {
         const arg = argv[i];
-        if (arg === "--check") {
+        if (arg === "--write") {
+            write = true;
+        } else if (arg === "--emit") {
+            emit = "noop";
+        } else if (arg.startsWith("--emit=")) {
+            emit = arg.slice("--emit=".length);
+            if (emit === "") throw new Error("--emit= requires a provider name");
+        } else if (arg === "--check") {
             check = true;
             const next = argv[i + 1];
             if (next && !next.startsWith("--")) {
@@ -87,7 +123,7 @@ function parseArgs(argv) {
             generate = arg.slice("--generate=".length);
             if (generate === "") throw new Error("--generate= requires a provider name");
         } else if (arg === "--help" || arg === "-h") {
-            process.stdout.write(USAGE + "\n");
+            process.stdout.write(HELP + "\n");
             process.exit(0);
         } else if (arg.startsWith("--")) {
             throw new Error(`unknown option: ${arg}`);
@@ -99,9 +135,12 @@ function parseArgs(argv) {
     }
 
     if (!file) throw new Error(USAGE);
-    const modes = [check, prompt, generate !== null].filter(Boolean).length;
-    if (modes > 1) throw new Error("--check, --prompt and --generate are mutually exclusive");
-    return { file, check, expected, prompt, generate };
+    const modes = [check, prompt, generate !== null, emit !== null].filter(Boolean).length;
+    if (modes > 1) {
+        throw new Error("--check, --prompt, --generate and --emit are mutually exclusive");
+    }
+    if (write && emit === null) throw new Error("--write only applies together with --emit");
+    return { file, check, expected, prompt, generate, emit, write };
 }
 
 /**
@@ -151,8 +190,68 @@ function main(argv) {
             return 1;
         }
         const request = buildGenerationRequest(plan);
-        const result = client.generate(request);
+        let result;
+        try {
+            result = client.generate(request);
+        } catch (err) {
+            process.stderr.write(err.message + "\n");
+            return 1;
+        }
         process.stdout.write(result.source);
+        return 0;
+    }
+
+    if (args.emit !== null) {
+        let client;
+        try {
+            client = createClient(args.emit);
+        } catch (err) {
+            process.stderr.write(err.message + "\n");
+            return 1;
+        }
+
+        // Generation and the deterministic output-path derivation can both throw
+        // (a provider error, or a `plan.file` that resolves outside the repo);
+        // convert either into the CLI's numeric failure contract.
+        let source;
+        let outPath;
+        try {
+            source = client.generate(buildGenerationRequest(plan)).source;
+            outPath = generatedTestPathFor(plan.file);
+        } catch (err) {
+            process.stderr.write(err.message + "\n");
+            return 1;
+        }
+        const validation = validateGeneratedTest(source, { plan });
+
+        for (const warning of validation.warnings) {
+            process.stderr.write(`warning: ${warning}\n`);
+        }
+        if (!validation.valid) {
+            for (const error of validation.errors) {
+                process.stderr.write(`invalid: ${error}\n`);
+            }
+            process.stderr.write(`${plan.file}: candidate rejected; nothing written\n`);
+            return 1;
+        }
+
+        if (!args.write) {
+            process.stdout.write(`${plan.file}: candidate is valid; would write ${outPath}\n`);
+            return 0;
+        }
+
+        let outcome;
+        try {
+            outcome = writeGeneratedTest(source, { plan });
+        } catch (err) {
+            process.stderr.write(err.message + "\n");
+            return 1;
+        }
+        if (!outcome.written) {
+            process.stderr.write(`${plan.file}: not written\n`);
+            return 1;
+        }
+        process.stdout.write(`${plan.file}: wrote ${outcome.path}\n`);
         return 0;
     }
 

--- a/scripts/generate-tests/validate-generated.js
+++ b/scripts/generate-tests/validate-generated.js
@@ -1,0 +1,1095 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A deterministic first-pass filter between a generated Jest test (an in-memory
+ * string produced by ./llm-client.js) and the source tree.
+ *
+ *     generated source -> parse AST -> structural checks -> semantic safety
+ *                      -> { valid, errors, warnings }
+ *
+ * A candidate that fails validation must not reach ./write-generated.js.
+ *
+ * This module only parses the candidate string with the repository's vendored
+ * Acorn. It never executes it, never reads the module under test, and never
+ * touches the filesystem or a network. Given the same inputs it always returns
+ * the same result.
+ *
+ * Scope and limits - read before relying on this:
+ *
+ *   - It is a *static, heuristic* check. It rejects the known-unsafe and
+ *     known-meaningless *patterns* enumerated below (mocking the module under
+ *     test, importing anything but the target module, `fs` writes, `_`-private
+ *     access, fake assertions, uncontrolled randomness/timers, ...). It is NOT
+ *     a JavaScript security sandbox: it cannot catch an unsafe construct it has
+ *     no rule for, and code that only *computes* its damage at runtime will
+ *     pass.
+ *   - Access via a string literal is covered (`fs["writeFileSync"]`,
+ *     `require("fs")`), but *fully dynamic* access - a method name or module
+ *     specifier held in a variable, `eval`, `Function(...)` - is out of scope.
+ *   - `options.allowedGlobals` / `options.allowedModules` are trusted inputs
+ *     from the *calling code*. They must never be populated from the generated
+ *     candidate or from provider output - that would let the thing being
+ *     validated widen its own allow-list.
+ *   - The concrete guarantee that a bad string cannot corrupt the repository
+ *     comes from ./write-generated.js (one deterministic path, `wx` create,
+ *     never overwrites), not from this file.
+ *   - The checks are deliberately narrow so ordinary Music Blocks Jest tests
+ *     are not rejected.
+ */
+
+const { parseSource } = require("./extract-module");
+const { normalizePlan } = require("./generation-request");
+
+const NODE_META_KEYS = new Set(["type", "start", "end", "loc", "range", "sourceFile"]);
+
+/**
+ * Tier 1 of the global-name allow-list: the fixed, always-safe surface a
+ * generated Jest test may use without declaring - the JavaScript language
+ * builtins, the Node/CommonJS module frame, the Jest API, and the browser
+ * surface jsdom provides (jest.config.js runs tests under jsdom).
+ *
+ * The full allow-list a run uses is:
+ *   1. this set (fixed);
+ *   2. the module's own `plan.referencedGlobals` (project-approved: the module
+ *      under test already depends on them, so its test legitimately may too);
+ *   3. `options.allowedGlobals` (caller-supplied: an explicit, per-call escape
+ *      hatch for a known project global).
+ * A name outside all three is an error. Widening the list only ever permits
+ * that one identifier - it does not disable any other check (an aliased
+ * `writeFileSync`, `Math.random`, a timer, ... are still caught by their own
+ * rules).
+ */
+const ALLOWED_GLOBALS = new Set([
+    // language builtins / well-known values
+    "undefined",
+    "NaN",
+    "Infinity",
+    "globalThis",
+    "arguments",
+    "Object",
+    "Array",
+    "String",
+    "Number",
+    "Boolean",
+    "Symbol",
+    "BigInt",
+    "Math",
+    "JSON",
+    "Date",
+    "RegExp",
+    "Function",
+    "Promise",
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+    "Proxy",
+    "Reflect",
+    "Error",
+    "TypeError",
+    "RangeError",
+    "SyntaxError",
+    "ReferenceError",
+    "EvalError",
+    "URIError",
+    "AggregateError",
+    "parseInt",
+    "parseFloat",
+    "isNaN",
+    "isFinite",
+    "encodeURI",
+    "decodeURI",
+    "encodeURIComponent",
+    "decodeURIComponent",
+    "ArrayBuffer",
+    "SharedArrayBuffer",
+    "DataView",
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "BigInt64Array",
+    "BigUint64Array",
+    "structuredClone",
+    "queueMicrotask",
+    "atob",
+    "btoa",
+    // Node / CommonJS frame
+    "require",
+    "module",
+    "exports",
+    "process",
+    "Buffer",
+    "global",
+    "__dirname",
+    "__filename",
+    "console",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    "setImmediate",
+    "clearImmediate",
+    "URL",
+    "URLSearchParams",
+    "TextEncoder",
+    "TextDecoder",
+    // Jest API
+    "describe",
+    "it",
+    "test",
+    "expect",
+    "jest",
+    "beforeEach",
+    "afterEach",
+    "beforeAll",
+    "afterAll",
+    "xit",
+    "xdescribe",
+    "xtest",
+    "fit",
+    "fdescribe",
+    // browser surface provided by jsdom
+    "window",
+    "document",
+    "navigator",
+    "location",
+    "history",
+    "screen",
+    "getComputedStyle",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "MutationObserver",
+    "ResizeObserver",
+    "IntersectionObserver",
+    "localStorage",
+    "sessionStorage",
+    "Node",
+    "Element",
+    "HTMLElement",
+    "SVGElement",
+    "DocumentFragment",
+    "Event",
+    "CustomEvent",
+    "EventTarget",
+    "DOMParser",
+    "XMLSerializer",
+    "Blob",
+    "File",
+    "FileReader",
+    "FormData",
+    "Headers",
+    "Request",
+    "Response",
+    "Image",
+    "Audio",
+    "HTMLCanvasElement",
+    "CanvasRenderingContext2D",
+    "performance",
+    "CSS",
+    "customElements",
+    "AbortController",
+    "AbortSignal"
+]);
+
+/**
+ * `fs`-style calls that write, delete or otherwise mutate the filesystem. Their
+ * mere textual presence in a generated test is treated as unsafe.
+ */
+const UNSAFE_FS_CALLS = new Set([
+    "writeFile",
+    "writeFileSync",
+    "appendFile",
+    "appendFileSync",
+    "createWriteStream",
+    "rm",
+    "rmSync",
+    "rmdir",
+    "rmdirSync",
+    "unlink",
+    "unlinkSync",
+    "mkdir",
+    "mkdirSync",
+    "mkdtemp",
+    "mkdtempSync",
+    "rename",
+    "renameSync",
+    "copyFile",
+    "copyFileSync",
+    "cp",
+    "cpSync",
+    "truncate",
+    "truncateSync",
+    "chmod",
+    "chmodSync",
+    "symlink",
+    "symlinkSync",
+    "outputFile",
+    "outputFileSync",
+    "ensureDir",
+    "ensureFile",
+    "remove",
+    "move"
+]);
+
+const NODE_FS_MODULES = new Set(["fs", "node:fs", "fs/promises", "node:fs/promises", "fs-extra"]);
+const NODE_PROCESS_MODULES = new Set(["child_process", "node:child_process", "worker_threads"]);
+
+const SNAPSHOT_MATCHERS = new Set(["toMatchSnapshot", "toMatchInlineSnapshot"]);
+const EXISTENCE_MATCHERS = new Set(["toBeDefined", "toBeTruthy", "toBeUndefined", "toBeNull"]);
+const EQUALITY_MATCHERS = new Set(["toBe", "toEqual", "toStrictEqual"]);
+const TITLE_BLOCKS = new Set(["describe", "it", "test", "xdescribe", "xit", "fdescribe", "fit"]);
+
+/**
+ * Minimal generic ESTree traversal, matching the style of ./module-test-plan.js.
+ *
+ * @param {object} root - node to start from.
+ * @param {function} visit - `visit(node, parent)` for every node.
+ * @returns {void}
+ */
+function walk(root, visit) {
+    const stack = [{ node: root, parent: null }];
+    while (stack.length > 0) {
+        const { node, parent } = stack.pop();
+        if (!node || typeof node.type !== "string") continue;
+        visit(node, parent);
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const item of child) stack.push({ node: item, parent: node });
+            } else if (child && typeof child.type === "string") {
+                stack.push({ node: child, parent: node });
+            }
+        }
+    }
+}
+
+/**
+ * The literal string title of a `describe(...)` / `it(...)` / `test(...)` call
+ * (including `it.each`, `it.only`, ...), or `null`.
+ *
+ * @param {object} node - a CallExpression node.
+ * @returns {{ kind: string, title: string } | null}
+ */
+function readTitleCall(node) {
+    if (node.type !== "CallExpression") return null;
+    const first = node.arguments && node.arguments[0];
+    const title =
+        first && first.type === "Literal" && typeof first.value === "string" ? first.value : null;
+    if (title === null) return null;
+
+    let callee = node.callee;
+    // Unwrap the wrappers Jest puts between the title call and `it`/`test`/
+    // `describe`:
+    //   it.each(table)("title", fn)          -> callee is itself a CallExpression
+    //   it.each`table`("title", fn)          -> callee is a TaggedTemplateExpression
+    //   it.only("title", fn) / it.skip / ... -> callee is a MemberExpression
+    //   it.concurrent.each(table)("title")   -> a chain of the above
+    if (callee.type === "CallExpression") callee = callee.callee;
+    if (callee.type === "TaggedTemplateExpression") callee = callee.tag;
+    while (
+        callee.type === "MemberExpression" &&
+        !callee.computed &&
+        callee.property.type === "Identifier" &&
+        ["each", "only", "skip", "concurrent", "failing", "todo"].includes(callee.property.name)
+    ) {
+        callee = callee.object;
+    }
+    const name = callee.type === "Identifier" ? callee.name : null;
+    if (!name || !TITLE_BLOCKS.has(name)) return null;
+    const kind =
+        name === "describe" || name === "xdescribe" || name === "fdescribe" ? "describe" : "test";
+    return { kind, title };
+}
+
+/**
+ * Collects every test title with its full `describe > ... > it` path, so the
+ * same `it` title under two different `describe` blocks is not a duplicate.
+ *
+ * @param {object} ast - parsed program.
+ * @returns {{ describeTitles: string[], testPaths: string[], leafTitles: string[] }}
+ */
+function collectTitlePaths(ast) {
+    const describeTitles = [];
+    const testPaths = [];
+    const leafTitles = [];
+
+    const descend = (node, trail) => {
+        if (!node || typeof node.type !== "string") return;
+        let nextTrail = trail;
+        const info = readTitleCall(node);
+        if (info) {
+            if (info.kind === "describe") {
+                describeTitles.push(info.title);
+                nextTrail = [...trail, info.title];
+            } else {
+                testPaths.push([...trail, info.title].join(" › "));
+                leafTitles.push(info.title);
+            }
+        }
+        for (const key of Object.keys(node)) {
+            if (NODE_META_KEYS.has(key)) continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const item of child) descend(item, nextTrail);
+            } else if (child && typeof child.type === "string") {
+                descend(child, nextTrail);
+            }
+        }
+    };
+    descend(ast, []);
+    return { describeTitles, testPaths, leafTitles };
+}
+
+/**
+ * Strips a trailing `.js` / `.mjs` / `.cjs` and returns the final path segment.
+ *
+ * @param {string} spec - a path or module specifier.
+ * @returns {string}
+ */
+function basenameNoExt(spec) {
+    const clean = String(spec).replace(/\.(?:js|mjs|cjs|jsx|ts|tsx)$/, "");
+    const slash = clean.lastIndexOf("/");
+    return slash === -1 ? clean : clean.slice(slash + 1);
+}
+
+/**
+ * Reads the module specifier from any node that pulls in another module - a
+ * `require("x")` call, a `jest.mock("x", ...)` call, a static ESM
+ * `import`/`export ... from`, or a dynamic `import("x")` - or `null` when the
+ * node is not one of those.
+ *
+ * @param {object} node - any AST node.
+ * @returns {{ kind: string, spec: string, node: object } | null}
+ */
+function readModuleCall(node) {
+    // static ESM: `import ... from "x"`, `export ... from "x"`, `export * from "x"`
+    if (
+        (node.type === "ImportDeclaration" ||
+            node.type === "ExportNamedDeclaration" ||
+            node.type === "ExportAllDeclaration") &&
+        node.source &&
+        node.source.type === "Literal" &&
+        typeof node.source.value === "string"
+    ) {
+        return { kind: "import", spec: node.source.value, node };
+    }
+    // dynamic `import("x")` (acorn emits ImportExpression at ecmaVersion 2020)
+    if (node.type === "ImportExpression") {
+        const arg = node.source;
+        return arg && arg.type === "Literal" && typeof arg.value === "string"
+            ? { kind: "import", spec: arg.value, node }
+            : null;
+    }
+    if (node.type !== "CallExpression") return null;
+    const callee = node.callee;
+    const firstArg = node.arguments && node.arguments[0];
+    const spec =
+        firstArg && firstArg.type === "Literal" && typeof firstArg.value === "string"
+            ? firstArg.value
+            : null;
+
+    if (callee.type === "Identifier" && callee.name === "require" && spec !== null) {
+        return { kind: "require", spec, node };
+    }
+    if (callee.type === "Identifier" && callee.name === "import" && spec !== null) {
+        return { kind: "import", spec, node };
+    }
+    if (
+        callee.type === "MemberExpression" &&
+        !callee.computed &&
+        callee.object.type === "Identifier" &&
+        (callee.object.name === "jest" || callee.object.name === "require") &&
+        callee.property.type === "Identifier"
+    ) {
+        const method = callee.property.name;
+        if (["mock", "doMock", "setMock", "unmock", "dontMock"].includes(method) && spec !== null) {
+            return { kind: `jest.${method}`, spec, node };
+        }
+        if (["requireActual", "requireMock"].includes(method) && spec !== null) {
+            return { kind: `jest.${method}`, spec, node };
+        }
+    }
+    return null;
+}
+
+/**
+ * Flattens an `expect(x).not.resolves.matcher(y)` chain into
+ * `{ subject, matcher, matcherArgs }`, or `null` when `node` is not the outer
+ * call of an `expect(...)` assertion.
+ *
+ * @param {object} node - a CallExpression node.
+ * @returns {{ subject: object, matcher: string, matcherArgs: object[] } | null}
+ */
+function readAssertion(node) {
+    if (node.type !== "CallExpression" || node.callee.type !== "MemberExpression") return null;
+    if (node.callee.computed || node.callee.property.type !== "Identifier") return null;
+
+    const matcher = node.callee.property.name;
+    let obj = node.callee.object;
+    // walk back through .not / .resolves / .rejects modifier chain
+    while (
+        obj.type === "MemberExpression" &&
+        !obj.computed &&
+        obj.property.type === "Identifier" &&
+        ["not", "resolves", "rejects"].includes(obj.property.name)
+    ) {
+        obj = obj.object;
+    }
+    if (
+        obj.type === "CallExpression" &&
+        obj.callee.type === "Identifier" &&
+        obj.callee.name === "expect"
+    ) {
+        return { subject: obj.arguments[0] || null, matcher, matcherArgs: node.arguments || [] };
+    }
+    return null;
+}
+
+/**
+ * A literal's primitive value, or the marker `NO_LITERAL` for a non-literal.
+ */
+const NO_LITERAL = Symbol("not-a-literal");
+function literalValue(node) {
+    if (!node) return NO_LITERAL;
+    if (node.type === "Literal") return node.value;
+    if (
+        node.type === "UnaryExpression" &&
+        node.operator === "-" &&
+        node.argument.type === "Literal"
+    ) {
+        return -node.argument.value;
+    }
+    if (node.type === "Identifier" && (node.name === "undefined" || node.name === "NaN")) {
+        return node.name === "undefined" ? undefined : NaN;
+    }
+    return NO_LITERAL;
+}
+
+/**
+ * Collects every name bound anywhere in the tree (declarations, params, imports,
+ * catch clauses). Name-based, not scope-accurate - the same heuristic the
+ * extractor uses.
+ *
+ * @param {object} ast - the parsed program.
+ * @returns {Set<string>}
+ */
+function collectBoundNames(ast) {
+    const bound = new Set();
+    const addPattern = pattern => {
+        if (!pattern) return;
+        switch (pattern.type) {
+            case "Identifier":
+                bound.add(pattern.name);
+                break;
+            case "ObjectPattern":
+                for (const prop of pattern.properties) {
+                    if (prop.type === "RestElement") addPattern(prop.argument);
+                    else addPattern(prop.value);
+                }
+                break;
+            case "ArrayPattern":
+                for (const el of pattern.elements) addPattern(el);
+                break;
+            case "AssignmentPattern":
+                addPattern(pattern.left);
+                break;
+            case "RestElement":
+                addPattern(pattern.argument);
+                break;
+            default:
+                break;
+        }
+    };
+
+    walk(ast, node => {
+        if (node.type === "VariableDeclarator") addPattern(node.id);
+        else if (
+            node.type === "FunctionDeclaration" ||
+            node.type === "FunctionExpression" ||
+            node.type === "ArrowFunctionExpression"
+        ) {
+            if (node.id) bound.add(node.id.name);
+            for (const param of node.params) addPattern(param);
+        } else if (node.type === "ClassDeclaration" && node.id) {
+            bound.add(node.id.name);
+        } else if (node.type === "CatchClause") {
+            addPattern(node.param);
+        } else if (
+            node.type === "ImportDefaultSpecifier" ||
+            node.type === "ImportNamespaceSpecifier"
+        ) {
+            bound.add(node.local.name);
+        } else if (node.type === "ImportSpecifier") {
+            bound.add(node.local.name);
+        }
+    });
+    return bound;
+}
+
+/**
+ * Names introduced by `const x = require("<module under test>")` or an
+ * equivalent `import`, so an existence-only assertion on them can be recognised.
+ *
+ * @param {object} ast - parsed program.
+ * @param {function} isTargetSpec - predicate on a module specifier.
+ * @returns {Set<string>}
+ */
+function collectTargetBindings(ast, isTargetSpec) {
+    const names = new Set();
+    walk(ast, node => {
+        if (
+            node.type === "VariableDeclarator" &&
+            node.init &&
+            node.init.type === "CallExpression"
+        ) {
+            const call = readModuleCall(node.init);
+            if (call && (call.kind === "require" || call.kind === "jest.requireActual")) {
+                if (isTargetSpec(call.spec) && node.id.type === "Identifier") {
+                    names.add(node.id.name);
+                }
+            }
+        }
+        if (node.type === "ImportDeclaration" && isTargetSpec(node.source.value)) {
+            for (const spec of node.specifiers) names.add(spec.local.name);
+        }
+    });
+    return names;
+}
+
+/**
+ * Identifiers a candidate has bound to a Node filesystem module, so an unsafe
+ * method call can be attributed to a real `fs` receiver rather than to any
+ * object that happens to have a same-named method (`element.remove()`).
+ *
+ * @param {object} ast - parsed program.
+ * @returns {{ namespaces: Set<string>, calls: Set<string> }} `namespaces` are
+ *     whole-module bindings (`const fs = require("fs")`), `calls` are names
+ *     destructured straight off the module (`const { writeFileSync } = ...`).
+ */
+function collectFsBindings(ast) {
+    const namespaces = new Set();
+    const calls = new Set();
+
+    const fromModuleCall = (idNode, spec) => {
+        if (!NODE_FS_MODULES.has(spec)) return;
+        if (idNode.type === "Identifier") {
+            namespaces.add(idNode.name);
+        } else if (idNode.type === "ObjectPattern") {
+            for (const prop of idNode.properties) {
+                if (prop.type === "Property" && prop.value.type === "Identifier") {
+                    calls.add(prop.value.name);
+                }
+            }
+        }
+    };
+
+    walk(ast, node => {
+        if (node.type === "VariableDeclarator" && node.init) {
+            const call = readModuleCall(node.init);
+            if (call && (call.kind === "require" || call.kind === "import")) {
+                fromModuleCall(node.id, call.spec);
+            }
+        }
+        if (node.type === "ImportDeclaration" && NODE_FS_MODULES.has(node.source.value)) {
+            for (const spec of node.specifiers) {
+                if (
+                    spec.type === "ImportDefaultSpecifier" ||
+                    spec.type === "ImportNamespaceSpecifier"
+                ) {
+                    namespaces.add(spec.local.name);
+                } else if (spec.type === "ImportSpecifier") {
+                    calls.add(spec.local.name);
+                }
+            }
+        }
+    });
+    return { namespaces, calls };
+}
+
+/**
+ * Validates a generated Jest test candidate against a ModuleTestPlan.
+ *
+ * @param {string} source - the candidate test source.
+ * @param {object} [options]
+ * @param {object} [options.plan] - a ModuleTestPlan (or partial) for the module
+ *     under test. Used to identify the real module and its known globals.
+ * @param {string} [options.modulePath] - overrides `plan.file` when identifying
+ *     the module under test.
+ * @param {string[]} [options.existingTitles] - `describe > it` titles already
+ *     present elsewhere in the suite; a collision is an error.
+ * @param {string[]} [options.allowedGlobals] - caller-supplied free identifiers
+ *     to add to the allow-list (tier 3; see {@link ALLOWED_GLOBALS}). Each entry
+ *     permits exactly that one name and nothing else - it never relaxes another
+ *     rule.
+ * @param {string[]} [options.allowedModules] - caller-supplied module specifiers
+ *     the test may `require`/`import` in addition to the module under test.
+ *     `fs`/`child_process` and friends are always rejected and cannot be added
+ *     here.
+ *
+ *     `allowedGlobals` and `allowedModules` are trusted configuration from the
+ *     caller. Never derive them from the candidate string or provider output.
+ * @returns {{ valid: boolean, errors: string[], warnings: string[], modulePath: string|null }}
+ */
+function validateGeneratedTest(source, options = {}) {
+    const errors = [];
+    const warnings = [];
+    const plan = options.plan ? normalizePlan(options.plan) : null;
+    const modulePath =
+        typeof options.modulePath === "string"
+            ? options.modulePath
+            : plan && plan.file !== "<unknown>"
+              ? plan.file
+              : null;
+    const moduleBase = modulePath ? basenameNoExt(modulePath) : null;
+
+    if (typeof source !== "string" || source.trim() === "") {
+        errors.push("generated source is empty");
+        return { valid: false, errors, warnings, modulePath };
+    }
+
+    // ---- structural: must parse -------------------------------------------
+    let ast;
+    try {
+        ast = parseSource(source, "<generated>").ast;
+    } catch (err) {
+        errors.push(`does not parse as JavaScript: ${err.message}`);
+        return { valid: false, errors, warnings, modulePath };
+    }
+
+    const isTargetSpec = spec => {
+        if (!moduleBase) return false;
+        if (basenameNoExt(spec) !== moduleBase) return false;
+        // a bare specifier like "utils-logic" is a package lookup, not our file
+        return (
+            spec.startsWith(".") || spec === modulePath || spec === modulePath.replace(/\.js$/, "")
+        );
+    };
+
+    // ---- gather module calls, assertions, titles, identifiers ------------
+    const moduleCalls = [];
+    const assertions = [];
+    const { describeTitles, testPaths, leafTitles } = collectTitlePaths(ast);
+    const memberProps = [];
+    const computedStringProps = [];
+    const freeIdentifierNames = new Set();
+    const calledNames = new Set();
+    let usesFakeTimers = false;
+    let controlsRandom = false;
+    let controlsClock = false;
+    let assignsModuleExports = false;
+    let usesTimerFn = false;
+    let usesDateNow = false;
+    let usesMathRandom = false;
+
+    const bound = collectBoundNames(ast);
+
+    walk(ast, (node, parent) => {
+        const modCall = readModuleCall(node);
+        if (modCall) moduleCalls.push(modCall);
+
+        const assertion = readAssertion(node);
+        if (assertion) assertions.push(assertion);
+
+        // member expressions: private access + jest fake-timer / spy detection
+        if (
+            node.type === "MemberExpression" &&
+            !node.computed &&
+            node.property.type === "Identifier"
+        ) {
+            memberProps.push({ node, parent });
+            const oname = node.object.type === "Identifier" ? node.object.name : null;
+            const pname = node.property.name;
+            if (oname === "jest" && pname === "useFakeTimers") usesFakeTimers = true;
+            if (oname === "jest" && (pname === "setSystemTime" || pname === "useFakeTimers")) {
+                controlsClock = true;
+            }
+            if (oname === "Math" && pname === "random") usesMathRandom = true;
+            if (oname === "Date" && pname === "now") usesDateNow = true;
+            if (oname === "jest" && pname === "spyOn") {
+                const spyArgs = parent && parent.type === "CallExpression" ? parent.arguments : [];
+                const target =
+                    spyArgs[0] && spyArgs[0].type === "Identifier" ? spyArgs[0].name : null;
+                const prop = spyArgs[1] && spyArgs[1].type === "Literal" ? spyArgs[1].value : null;
+                if (target === "Math" && prop === "random") controlsRandom = true;
+                if (target === "Date" && (prop === "now" || prop === "prototype"))
+                    controlsClock = true;
+            }
+        }
+
+        // computed member access with a string-literal key: fs["writeFileSync"],
+        // target["_private"]. Fully dynamic access (a name held in a variable)
+        // is out of this static filter's scope - see the module header.
+        if (
+            node.type === "MemberExpression" &&
+            node.computed &&
+            node.property.type === "Literal" &&
+            typeof node.property.value === "string"
+        ) {
+            computedStringProps.push({
+                recv: node.object.type === "Identifier" ? node.object.name : null,
+                prop: node.property.value
+            });
+        }
+
+        // assignment to Math.random / Date.now, or to module.exports
+        if (node.type === "AssignmentExpression" && node.left.type === "MemberExpression") {
+            const left = node.left;
+            if (
+                left.object.type === "Identifier" &&
+                left.object.name === "Math" &&
+                left.property.type === "Identifier" &&
+                left.property.name === "random"
+            ) {
+                controlsRandom = true;
+            }
+            if (
+                left.object.type === "Identifier" &&
+                (left.object.name === "module" || left.object.name === "exports")
+            ) {
+                assignsModuleExports = true;
+            }
+            if (
+                left.object.type === "MemberExpression" &&
+                left.object.object.type === "Identifier" &&
+                left.object.object.name === "module" &&
+                left.object.property.name === "exports"
+            ) {
+                assignsModuleExports = true;
+            }
+        }
+
+        // bare timer / clock / random calls
+        if (node.type === "CallExpression" && node.callee.type === "Identifier") {
+            calledNames.add(node.callee.name);
+            if (["setTimeout", "setInterval", "setImmediate"].includes(node.callee.name)) {
+                usesTimerFn = true;
+            }
+        }
+    });
+
+    // free identifiers (value position, not bound, not a property key)
+    walk(ast, (node, parent) => {
+        if (node.type !== "Identifier") return;
+        if (parent) {
+            if (
+                parent.type === "MemberExpression" &&
+                parent.property === node &&
+                !parent.computed
+            ) {
+                return;
+            }
+            if (parent.type === "Property" && parent.key === node && !parent.computed) return;
+            if (parent.type === "MethodDefinition" && parent.key === node && !parent.computed)
+                return;
+            if (
+                (parent.type === "FunctionDeclaration" ||
+                    parent.type === "FunctionExpression" ||
+                    parent.type === "ClassDeclaration" ||
+                    parent.type === "ClassExpression") &&
+                parent.id === node
+            ) {
+                return;
+            }
+            if (
+                parent.type === "LabeledStatement" ||
+                parent.type === "BreakStatement" ||
+                parent.type === "ContinueStatement"
+            ) {
+                return;
+            }
+        }
+        if (!bound.has(node.name)) freeIdentifierNames.add(node.name);
+    });
+
+    // ---- semantic: imports the real module ------------------------------
+    if (moduleBase) {
+        const requires = moduleCalls.filter(c => c.kind === "require" || c.kind === "import");
+        const importsTarget = requires.some(c => isTargetSpec(c.spec));
+        if (!importsTarget) {
+            errors.push(
+                `does not import the module under test (expected a relative require of "${moduleBase}")`
+            );
+        }
+
+        // mocks the module under test
+        const mocked = moduleCalls.filter(
+            c =>
+                ["jest.mock", "jest.doMock", "jest.setMock"].includes(c.kind) &&
+                isTargetSpec(c.spec)
+        );
+        if (mocked.length > 0) {
+            errors.push("mocks the module under test (jest.mock/doMock/setMock on its own path)");
+        }
+    } else {
+        warnings.push("no module path supplied; skipped the real-module and relatedness checks");
+    }
+
+    // ---- semantic: import policy --------------------------------------------
+    // Every require()/import must be the module under test or a caller-approved
+    // dependency. Anything else is rejected - including a *bare package*
+    // specifier: an installed package is opaque to the pattern rules below and
+    // could perform filesystem / network / process work this validator never
+    // sees. `fs`/`child_process` get their own, more specific message and can
+    // never be allow-listed.
+    const allowedModules = new Set(
+        Array.isArray(options.allowedModules)
+            ? options.allowedModules.filter(m => typeof m === "string")
+            : []
+    );
+    for (const c of moduleCalls) {
+        if (c.kind !== "require" && c.kind !== "import") continue;
+        if (moduleBase && isTargetSpec(c.spec)) continue;
+        if (NODE_FS_MODULES.has(c.spec)) {
+            errors.push(
+                `requires a filesystem module ("${c.spec}"); a generated test must not do I/O`
+            );
+            continue;
+        }
+        if (NODE_PROCESS_MODULES.has(c.spec)) {
+            errors.push(
+                `requires "${c.spec}"; a generated test must not spawn processes or threads`
+            );
+            continue;
+        }
+        if (allowedModules.has(c.spec)) continue;
+        const isRelative = c.spec.startsWith(".") || c.spec.startsWith("/");
+        if (isRelative && !moduleBase) continue; // cannot tell if it is the target
+        errors.push(
+            isRelative
+                ? `imports "${c.spec}", which is not the module under test ("${moduleBase}"); ` +
+                      "a generated test must exercise only its target module"
+                : `imports the package "${c.spec}"; a generated test may require only its target ` +
+                      "module (pass options.allowedModules to permit a specific dependency)"
+        );
+    }
+
+    // ---- semantic: unsafe filesystem calls --------------------------------
+    // Only flag a filesystem method when it is reached through a real `fs`
+    // binding (`fs.writeFileSync`, `fs["writeFileSync"]`, a name destructured
+    // off `fs`) or called bare as a free identifier. `element.remove()`,
+    // `list.move()` and similar on arbitrary receivers are NOT filesystem ops.
+    const { namespaces: fsNamespaces, calls: fsDestructuredCalls } = collectFsBindings(ast);
+    const unsafeFsCall = new Set();
+    for (const n of calledNames) {
+        if (fsDestructuredCalls.has(n)) unsafeFsCall.add(n);
+        else if (UNSAFE_FS_CALLS.has(n) && !bound.has(n)) unsafeFsCall.add(n);
+    }
+    for (const { node } of memberProps) {
+        const recv = node.object.type === "Identifier" ? node.object.name : null;
+        if (recv && fsNamespaces.has(recv) && UNSAFE_FS_CALLS.has(node.property.name)) {
+            unsafeFsCall.add(node.property.name);
+        }
+    }
+    for (const { recv, prop } of computedStringProps) {
+        if (recv && fsNamespaces.has(recv) && UNSAFE_FS_CALLS.has(prop)) unsafeFsCall.add(prop);
+    }
+    if (unsafeFsCall.size > 0) {
+        errors.push(`uses an unsafe filesystem operation: ${[...unsafeFsCall].sort().join(", ")}`);
+    }
+
+    // ---- semantic: does not modify production source -------------------
+    if (assignsModuleExports) {
+        errors.push("assigns module.exports / exports.*; a test must not add exports to any file");
+    }
+
+    // ---- semantic: no private (_-prefixed) member access --------------
+    const privateNames = new Set();
+    for (const { node } of memberProps) {
+        const name = node.property.name;
+        if (/^_[A-Za-z0-9]/.test(name) && name !== "__proto__") privateNames.add(name);
+    }
+    // computed access with a string literal: target["_private"]
+    for (const { prop } of computedStringProps) {
+        if (/^_[A-Za-z0-9]/.test(prop) && prop !== "__proto__") privateNames.add(prop);
+    }
+    // also `const { _x } = target`
+    walk(ast, node => {
+        if (node.type === "ObjectPattern") {
+            for (const prop of node.properties) {
+                if (
+                    prop.type === "Property" &&
+                    prop.key.type === "Identifier" &&
+                    /^_[A-Za-z0-9]/.test(prop.key.name)
+                ) {
+                    privateNames.add(prop.key.name);
+                }
+            }
+        }
+    });
+    if (privateNames.size > 0) {
+        errors.push(
+            `accesses private, "_"-prefixed members: ${[...privateNames].sort().join(", ")}; ` +
+                "test the public API and observable behaviour instead"
+        );
+    }
+
+    // ---- structural: has at least one test case ----------------------
+    if (testPaths.length === 0) {
+        errors.push("declares no it()/test() cases");
+    }
+
+    // ---- semantic: meaningful assertions -----------------------------
+    if (assertions.length === 0) {
+        errors.push("contains no expect() assertions");
+    } else {
+        const targetBindings = moduleBase ? collectTargetBindings(ast, isTargetSpec) : new Set();
+        const snapshotOnly = assertions.every(a => SNAPSHOT_MATCHERS.has(a.matcher));
+        if (snapshotOnly) {
+            errors.push(
+                "relies only on snapshot assertions (toMatchSnapshot / toMatchInlineSnapshot); " +
+                    "assert concrete values and behaviour"
+            );
+        }
+
+        const isTrivial = a => {
+            const subjVal = literalValue(a.subject);
+            const argVal = a.matcherArgs.length > 0 ? literalValue(a.matcherArgs[0]) : NO_LITERAL;
+            // expect(<literal>).toBe(<equal literal>)
+            if (
+                EQUALITY_MATCHERS.has(a.matcher) &&
+                subjVal !== NO_LITERAL &&
+                argVal !== NO_LITERAL &&
+                Object.is(subjVal, argVal)
+            ) {
+                return true;
+            }
+            // expect(true).toBeTruthy() / expect(1).toBeTruthy() / expect(false).toBeFalsy()
+            if (a.matcher === "toBeTruthy" && subjVal !== NO_LITERAL && subjVal) return true;
+            if (a.matcher === "toBeFalsy" && subjVal !== NO_LITERAL && !subjVal) return true;
+            // existence-only checks on the imported module binding
+            if (
+                EXISTENCE_MATCHERS.has(a.matcher) &&
+                a.subject &&
+                a.subject.type === "Identifier" &&
+                targetBindings.has(a.subject.name)
+            ) {
+                return true;
+            }
+            return false;
+        };
+
+        const meaningful = assertions.filter(
+            a => !isTrivial(a) && !SNAPSHOT_MATCHERS.has(a.matcher)
+        );
+        if (!snapshotOnly && meaningful.length === 0) {
+            errors.push(
+                "contains no meaningful assertions (only literal-vs-literal checks such as " +
+                    "expect(true).toBe(true), or bare existence checks on the import)"
+            );
+        }
+    }
+
+    // ---- semantic: determinism -------------------------------------
+    if (usesMathRandom && !controlsRandom) {
+        errors.push(
+            'uses Math.random without deterministic control (jest.spyOn(Math, "random") or a stub)'
+        );
+    }
+    if (usesTimerFn && !usesFakeTimers) {
+        errors.push("uses setTimeout/setInterval without jest.useFakeTimers()");
+    }
+    if (usesDateNow && !controlsClock) {
+        warnings.push(
+            "uses Date.now without jest.useFakeTimers()/jest.setSystemTime(); assert on a fixed clock if timing matters"
+        );
+    }
+    // `new Date()` with no argument
+    let usesLiveDate = false;
+    walk(ast, node => {
+        if (
+            node.type === "NewExpression" &&
+            node.callee.type === "Identifier" &&
+            node.callee.name === "Date" &&
+            (!node.arguments || node.arguments.length === 0)
+        ) {
+            usesLiveDate = true;
+        }
+    });
+    if (usesLiveDate && !controlsClock) {
+        warnings.push(
+            "constructs `new Date()` with no argument; use a fixed timestamp for a deterministic test"
+        );
+    }
+
+    // ---- semantic: undeclared globals --------------------------------
+    const permitted = new Set(ALLOWED_GLOBALS);
+    if (plan) for (const g of plan.referencedGlobals) permitted.add(g);
+    if (Array.isArray(options.allowedGlobals))
+        for (const g of options.allowedGlobals) permitted.add(g);
+    const undeclared = [...freeIdentifierNames].filter(n => !permitted.has(n)).sort();
+    if (undeclared.length > 0) {
+        errors.push(
+            `references undeclared globals: ${undeclared.join(", ")}; ` +
+                "a generated test must not depend on ambient state from other subsystems"
+        );
+    }
+
+    // ---- structural: duplicate titles ------------------------------
+    const seenPaths = new Set();
+    const dupes = new Set();
+    for (const p of testPaths) {
+        if (seenPaths.has(p)) dupes.add(p);
+        seenPaths.add(p);
+    }
+    if (dupes.size > 0) {
+        errors.push(`duplicate test titles within the file: ${[...dupes].sort().join("; ")}`);
+    }
+    if (Array.isArray(options.existingTitles) && options.existingTitles.length > 0) {
+        const existing = new Set(options.existingTitles);
+        const collisions = [...new Set([...testPaths, ...leafTitles].filter(t => existing.has(t)))];
+        if (collisions.length > 0) {
+            errors.push(
+                `test titles already used elsewhere in the suite: ${collisions.sort().join("; ")}`
+            );
+        }
+    }
+
+    // ---- structural: relatedness of describe titles ---------------
+    if (moduleBase) {
+        const other = [...new Set(describeTitles)].filter(
+            title => /\.js$/.test(title) && basenameNoExt(title) !== moduleBase
+        );
+        if (other.length > 0) {
+            warnings.push(
+                `describe title names a different module file: ${other.sort().join(", ")}`
+            );
+        }
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        warnings,
+        modulePath: modulePath
+    };
+}
+
+module.exports = {
+    validateGeneratedTest,
+    ALLOWED_GLOBALS,
+    UNSAFE_FS_CALLS
+};

--- a/scripts/generate-tests/write-generated.js
+++ b/scripts/generate-tests/write-generated.js
@@ -1,0 +1,338 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The safe writer at the end of the generation pipeline:
+ *
+ *     ModuleTestPlan -> generated source -> validate -> (if valid) safe write
+ *
+ * It writes a validated candidate to a single, deterministic location - the
+ * module's own `__tests__/` directory, as `<module>.generated.test.js` - and
+ * refuses everything else:
+ *
+ *   - it never writes outside that `__tests__/` directory (checked both
+ *     lexically and, before writing, against the real path so a symlink in the
+ *     existing directory tree cannot redirect the write out of the repo);
+ *   - it never overwrites an existing file (generated or hand-written): the
+ *     actual create uses the `wx` open flag, which fails atomically if the path
+ *     already exists;
+ *   - it never writes a production (non-`.generated.test.js`) file;
+ *   - it rejects `..` path traversal and absolute path overrides;
+ *   - it creates the `__tests__/` directory only when it is missing;
+ *   - it always reports the exact path it would write;
+ *   - `dryRun` reports that path and writes nothing.
+ *
+ * `writeGeneratedTest` additionally runs ./validate-generated.js first, so an
+ * invalid candidate is never written. That validator is a static, heuristic
+ * check on known-unsafe constructs, not a JavaScript sandbox - see its own
+ * header. This writer's guarantee is narrower and concrete: whatever string it
+ * is handed, it only ever creates one new file at the deterministic path below.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { validateGeneratedTest } = require("./validate-generated");
+
+const GENERATED_SUFFIX = ".generated.test.js";
+
+/**
+ * Resolves the deterministic output path for a module's generated test.
+ *
+ *   `js/utils/utils-logic.js` -> `js/utils/__tests__/utils-logic.generated.test.js`
+ *
+ * @param {string} modulePath - repo-relative path of the module under test.
+ * @returns {string} a repo-relative POSIX path.
+ * @throws {Error} when `modulePath` is empty, absolute, escapes the repo, or is
+ *     not a `.js` file.
+ */
+function generatedTestPathFor(modulePath) {
+    if (typeof modulePath !== "string" || modulePath.trim() === "") {
+        throw new Error("generatedTestPathFor: a module path is required");
+    }
+    const normalized = modulePath.split(path.sep).join("/");
+    if (path.isAbsolute(modulePath) || /^[a-zA-Z]:/.test(modulePath)) {
+        throw new Error(
+            `generatedTestPathFor: module path must be repo-relative, got "${modulePath}"`
+        );
+    }
+    const parts = normalized.split("/");
+    if (parts.includes("..") || parts.includes(".")) {
+        throw new Error(
+            `generatedTestPathFor: module path must not contain "." or "..": "${modulePath}"`
+        );
+    }
+    if (!normalized.endsWith(".js")) {
+        throw new Error(
+            `generatedTestPathFor: module under test must be a .js file: "${modulePath}"`
+        );
+    }
+    const dir = parts.slice(0, -1).join("/");
+    const base = parts[parts.length - 1].replace(/\.js$/, "");
+    const prefix = dir === "" ? "" : `${dir}/`;
+    return `${prefix}__tests__/${base}${GENERATED_SUFFIX}`;
+}
+
+/**
+ * Lexical safety check on `candidatePath`: repo-relative, no `..` traversal,
+ * inside a `__tests__/` directory, ending in the generated suffix, and - after
+ * `path.resolve(root, candidatePath)` - still lexically under `root`.
+ *
+ * This is string-level only. It does not resolve symlinks; the real-path check
+ * that closes that gap lives in {@link safeWrite}, which has a concrete `cwd`.
+ *
+ * @param {string} candidatePath - repo-relative path proposed for the write.
+ * @param {string} root - absolute path the write must stay within (the repo).
+ * @returns {string} the absolute, lexically-verified path.
+ * @throws {Error} with a specific reason when the path is unsafe.
+ */
+function assertSafeTestPath(candidatePath, root) {
+    if (typeof candidatePath !== "string" || candidatePath.trim() === "") {
+        throw new Error("assertSafeTestPath: a path is required");
+    }
+    if (path.isAbsolute(candidatePath) || /^[a-zA-Z]:/.test(candidatePath)) {
+        throw new Error(`refusing an absolute output path: "${candidatePath}"`);
+    }
+    const posix = candidatePath.split(path.sep).join("/");
+    if (posix.split("/").includes("..")) {
+        throw new Error(`refusing a path that traverses upward ("..") : "${candidatePath}"`);
+    }
+    if (!posix.endsWith(GENERATED_SUFFIX)) {
+        throw new Error(
+            `refusing to write "${candidatePath}": generated tests must end in "${GENERATED_SUFFIX}"`
+        );
+    }
+    if (!posix.split("/").includes("__tests__")) {
+        throw new Error(`refusing to write outside a __tests__/ directory: "${candidatePath}"`);
+    }
+    const absolute = path.resolve(root, candidatePath);
+    const contained = absolute === root || absolute.startsWith(root + path.sep);
+    if (!contained) {
+        throw new Error(`refusing to write outside the repository: "${candidatePath}"`);
+    }
+    return absolute;
+}
+
+/**
+ * Real-path containment: walks up from `absolute` to the nearest ancestor that
+ * exists on disk, resolves its symlinks, and confirms the result is still inside
+ * the resolved `root`. This catches a symlinked `__tests__/` (or any ancestor)
+ * that lexical checks cannot see.
+ *
+ * @param {string} absolute - the absolute target path.
+ * @param {string} root - the repository root.
+ * @param {string} relPath - repo-relative path, for the error message.
+ * @throws {Error} when the real destination is outside the repository.
+ */
+function assertRealContainment(absolute, root, relPath) {
+    let realRoot;
+    try {
+        realRoot = fs.realpathSync(root);
+    } catch (err) {
+        throw new Error(`safeWrite: repository root "${root}" is not accessible (${err.code})`);
+    }
+
+    let probe = absolute;
+    while (!fs.existsSync(probe)) {
+        const parent = path.dirname(probe);
+        if (parent === probe) break;
+        probe = parent;
+    }
+
+    let realProbe;
+    try {
+        realProbe = fs.realpathSync(probe);
+    } catch {
+        realProbe = probe;
+    }
+
+    if (realProbe !== realRoot && !realProbe.startsWith(realRoot + path.sep)) {
+        throw new Error(
+            `refusing to write "${relPath}": its real path resolves outside the repository ` +
+                `(a symlink in the existing path escapes "${realRoot}")`
+        );
+    }
+}
+
+/**
+ * Writes an already-produced source string to a module's generated-test path,
+ * with every safety guard applied. Does not validate the source - callers that
+ * want validation should use {@link writeGeneratedTest}.
+ *
+ * @param {string} source - the test source to write.
+ * @param {object} options
+ * @param {string} options.modulePath - repo-relative path of the module under test.
+ * @param {boolean} [options.dryRun=false] - report the path, write nothing.
+ * @param {string} [options.cwd] - repository root (defaults to `process.cwd()`).
+ * @returns {{ path: string, absolutePath: string, written: boolean, created: boolean, dryRun: boolean }}
+ * @throws {Error} when the source is empty, the path is unsafe, or the target
+ *     already exists.
+ */
+function safeWrite(source, options = {}) {
+    if (typeof source !== "string" || source.trim() === "") {
+        throw new Error("safeWrite: refusing to write empty source");
+    }
+    const cwd = options.cwd || process.cwd();
+    const root = path.resolve(cwd);
+    const relPath = generatedTestPathFor(options.modulePath);
+    const absolute = assertSafeTestPath(relPath, root);
+    assertRealContainment(absolute, root, relPath);
+
+    const report = {
+        path: relPath,
+        absolutePath: absolute,
+        written: false,
+        created: false,
+        dryRun: Boolean(options.dryRun)
+    };
+
+    if (options.dryRun) {
+        // No atomic create happens in a dry run, so a plain existence check is
+        // the only signal available; surface the collision the real write would
+        // hit rather than silently reporting a path that could not be written.
+        if (fs.existsSync(absolute)) {
+            throw new Error(`refusing to overwrite an existing test: "${relPath}" already exists`);
+        }
+        return report;
+    }
+
+    const dir = path.dirname(absolute);
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+        report.created = true;
+    }
+
+    try {
+        // `wx` fails with EEXIST if the path already exists. This single atomic
+        // operation - not a preceding stat - is what guarantees no overwrite.
+        fs.writeFileSync(absolute, source, { encoding: "utf8", flag: "wx" });
+    } catch (err) {
+        if (err.code === "EEXIST") {
+            throw new Error(`refusing to overwrite an existing test: "${relPath}" already exists`);
+        }
+        throw err;
+    }
+    report.written = true;
+    return report;
+}
+
+/**
+ * Validates a generated test candidate and, only if it is valid, writes it to
+ * its deterministic path. An invalid candidate is never written.
+ *
+ * The deterministic output path is resolved first (from `modulePath` / the
+ * plan), so a malformed module path fails fast and every result - valid or not -
+ * still reports the path that *would* have been used, for diagnostics.
+ *
+ * @param {string} source - the candidate test source.
+ * @param {object} options
+ * @param {object} [options.plan] - the ModuleTestPlan; also supplies `modulePath`.
+ * @param {string} [options.modulePath] - repo-relative module path (overrides the plan).
+ * @param {boolean} [options.dryRun=false] - validate and report the path only.
+ * @param {string[]} [options.existingTitles] - forwarded to the validator.
+ * @param {string[]} [options.allowedGlobals] - forwarded to the validator.
+ * @param {string[]} [options.allowedModules] - forwarded to the validator.
+ * @param {string} [options.cwd] - repository root.
+ * @returns {{
+ *     valid: boolean,
+ *     validation: object,
+ *     written: boolean,
+ *     path: string|null,
+ *     report: object|null
+ * }}
+ * @throws {Error} propagated from {@link safeWrite} once a candidate is *valid*
+ *     and about to be written: the target file already exists, the resolved
+ *     path is unsafe (absolute, `..` traversal, outside a `__tests__/` dir, or
+ *     not `*.generated.test.js`), or a symlink in the existing path escapes the
+ *     repository. A malformed module path and every validation failure are
+ *     reported as `{ valid: false }`, never thrown.
+ */
+function writeGeneratedTest(source, options = {}) {
+    const modulePath =
+        typeof options.modulePath === "string"
+            ? options.modulePath
+            : options.plan && typeof options.plan.file === "string"
+              ? options.plan.file
+              : null;
+
+    // Resolve (and validate) the output path before the heavier source
+    // validation, and keep it on every return value for diagnostics.
+    let plannedPath = null;
+    if (modulePath) {
+        try {
+            plannedPath = generatedTestPathFor(modulePath);
+        } catch (err) {
+            return {
+                valid: false,
+                validation: { valid: false, errors: [err.message], warnings: [], modulePath },
+                written: false,
+                path: null,
+                report: null
+            };
+        }
+    }
+
+    const validation = validateGeneratedTest(source, {
+        plan: options.plan,
+        modulePath: modulePath || undefined,
+        existingTitles: options.existingTitles,
+        allowedGlobals: options.allowedGlobals,
+        allowedModules: options.allowedModules
+    });
+
+    if (!validation.valid) {
+        return { valid: false, validation, written: false, path: plannedPath, report: null };
+    }
+    if (!modulePath) {
+        return {
+            valid: false,
+            validation: {
+                ...validation,
+                valid: false,
+                errors: [...validation.errors, "no module path available to derive an output path"]
+            },
+            written: false,
+            path: null,
+            report: null
+        };
+    }
+
+    const report = safeWrite(source, {
+        modulePath,
+        dryRun: options.dryRun,
+        cwd: options.cwd
+    });
+
+    return {
+        valid: true,
+        validation,
+        written: report.written,
+        path: report.path,
+        report
+    };
+}
+
+module.exports = {
+    GENERATED_SUFFIX,
+    generatedTestPathFor,
+    assertSafeTestPath,
+    assertRealContainment,
+    safeWrite,
+    writeGeneratedTest
+};


### PR DESCRIPTION

## Description

Add deterministic validation and a safe writer for AST-generated Jest tests.

This PR extends the generation infrastructure from PR-3 with a static validation layer that checks generated test source before it can be written, plus a writer that only creates new `.generated.test.js` files under a controlled `__tests__` path.

The validator never executes generated code and performs no network access. The writer never overwrites existing files and rejects unsafe paths.

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
- [x] Tests
* [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change

---

## Changes Made

* Added `validate-generated.js` with deterministic static validation for generated Jest tests.
* Validate syntax and require meaningful test structure (`it`/`test` and `expect`).
* Verify the generated test imports the module described by the `ModuleTestPlan`.
* Reject unsafe behavior including:

  * mocking the module under test;
  * unrelated production imports;
  * filesystem/process-related modules and unsafe filesystem operations;
  * `module.exports` / `exports` mutation;
  * private `_`-prefixed member access;
  * meaningless or snapshot-only assertions;
  * uncontrolled randomness and timers;
  * undeclared globals;
  * duplicate test titles.
* Emit warnings for potentially nondeterministic `Date.now()` / `new Date()` usage and mismatched `describe` titles.
* Added `write-generated.js` with a controlled generated-test path:

  * `<dir>/__tests__/<module>.generated.test.js`;
  * rejects absolute paths and traversal;
  * requires the `.generated.test.js` suffix;
  * never overwrites an existing file;
  * uses exclusive file creation with `wx`;
  * supports dry-run mode;
  * validates generated source before writing.
* Extended `cli.js` with `--emit[=provider]` and `--write`.
* Made `--write` require `--emit` and kept generation modes mutually exclusive with `--check`.
* Updated `README.md` with the validation/writer pipeline, safeguards, CLI usage, and API details.
* Added regression fixtures for valid generated tests from real Music Blocks utility modules.
* Added focused tests covering validation rules, writer safety, CLI behavior, determinism, and invalid-output handling.

The AST extractor and `ModuleTestPlan` implementation are unchanged.

## Testing Performed

* Focused `scripts/generate-tests` suite: **7 suites / 184 tests passed**.
* Full Jest suite: **229 suites / 8416 tests passed**.
* `eslint .`: passed.
* Prettier checks on modified files: passed.
* `git diff --check`: passed.
* Commitlint: passed.
* Verified invalid generated tests are rejected before reaching disk.
* Verified existing generated tests are never overwritten.
* Verified `dryRun` performs no writes.
* Verified absolute paths, traversal, invalid output locations, and incorrect suffixes are rejected.
* Verified `--emit` / `--write` CLI failure behavior.
* Verified deterministic validation results across repeated runs.
* Verified the validator performs static parsing only and does not execute generated code or access the network.

A stale, gitignored `.stryker-tmp` sandbox was removed after an early full-suite run caused unrelated test discovery failures; subsequent full-suite runs passed consistently.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [x] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [x] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Validation is deliberately static and heuristic: it checks structural, safety, determinism, and test-quality requirements but does not attempt to prove that a generated test is semantically correct.

Generated tests use the dedicated `.generated.test.js` suffix so existing handwritten `.test.js` files remain unaffected. The writer also uses exclusive file creation (`wx`) to ensure an existing generated test cannot be replaced accidentally.

No production application code, AST extractor, CI configuration, Stryker configuration, Cypress configuration, coverage configuration, or dependencies are modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an emit mode for generating, validating, and optionally writing test files.
  * Added validation for unsafe, invalid, duplicate, or module-mismatched generated tests.
  * Added dry-run support, deterministic output paths, overwrite protection, and symlink-safe writing.
  * Expanded command-line help, argument validation, warnings, error reporting, and write-status reporting.

* **Tests**
  * Added coverage for CLI options, validation rules, path safety, dry runs, and protected file writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->