### PR TITLE
fix: update palette collapse behavior to hide only first half of options

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -2603,4 +2603,50 @@ describe("Palettes edge cases", () => {
         palettes.setSize(0);
         expect(palettes.cellSize).toBe(0); // Math.floor(0 * 0.5 + 0.5) = Math.floor(0.5) = 0
     });
+
+    describe("toggleCollapse", () => {
+        test("hides first half of palette options when collapsed and restores on toggle", () => {
+            const row1 = { style: {} };
+            const row2 = { style: {} };
+            const row3 = { style: {} };
+            const row4 = { style: {} };
+            const listBody = { children: [row1, row2, row3, row4] };
+
+            const paletteElem = {
+                querySelector: jest.fn(() => listBody),
+                style: {}
+            };
+            const toggleBtn = {
+                innerHTML: "",
+                setAttribute: jest.fn()
+            };
+
+            const origGetElementById = document.getElementById;
+            document.getElementById = jest.fn(id => {
+                if (id === "palette") return paletteElem;
+                if (id === "paletteToggle") return toggleBtn;
+                return null;
+            });
+
+            expect(palettes.collapsed).toBe(false);
+
+            palettes.toggleCollapse();
+
+            expect(palettes.collapsed).toBe(true);
+            expect(row1.style.display).toBe("none");
+            expect(row2.style.display).toBe("none");
+            expect(row3.style.display).toBe("flex");
+            expect(row4.style.display).toBe("flex");
+
+            palettes.toggleCollapse();
+
+            expect(palettes.collapsed).toBe(false);
+            expect(row1.style.display).toBe("flex");
+            expect(row2.style.display).toBe("flex");
+            expect(row3.style.display).toBe("flex");
+            expect(row4.style.display).toBe("flex");
+
+            document.getElementById = origGetElementById;
+        });
+    });
 });

--- a/js/palette.js
+++ b/js/palette.js
@@ -592,6 +592,20 @@ class Palettes {
         palette.style.top = curr + dy + "px";
     }
 
+    _updateCollapsedVisibility(listBody) {
+        if (!listBody || !listBody.children) return;
+        const rows = Array.from(listBody.children);
+        const halfCount = Math.floor(rows.length / 2);
+        rows.forEach((row, index) => {
+            if (!row || !row.style) return;
+            if (this.collapsed && index < halfCount) {
+                row.style.display = "none";
+            } else {
+                row.style.display = "flex";
+            }
+        });
+    }
+
     toggleCollapse() {
         const palette = document.getElementById("palette");
 
@@ -599,17 +613,17 @@ class Palettes {
 
         this.collapsed = !this.collapsed;
 
-        if (this.collapsed) {
-            palette.style.transform = "translateX(-100%)";
-            document.getElementById("paletteToggle").innerHTML = "▶";
-            document.getElementById("paletteToggle").setAttribute("aria-expanded", "false");
-            palette.style.transition = "transform 0.3s ease";
-            this.paletteWidth = 0;
-        } else {
-            palette.style.transform = "translateX(0)";
-            document.getElementById("paletteToggle").innerHTML = "◀";
-            document.getElementById("paletteToggle").setAttribute("aria-expanded", "true");
-            this.paletteWidth = 55 * PALETTE_WIDTH_FACTOR;
+        palette.style.transform = "translateX(0)";
+        this.paletteWidth = 55 * PALETTE_WIDTH_FACTOR;
+
+        const listBody =
+            palette.querySelector("tbody") || palette.children[0]?.children[1]?.children[1];
+        this._updateCollapsedVisibility(listBody);
+
+        const toggleBtn = document.getElementById("paletteToggle");
+        if (toggleBtn) {
+            toggleBtn.innerHTML = this.collapsed ? "▶" : "◀";
+            toggleBtn.setAttribute("aria-expanded", this.collapsed ? "false" : "true");
         }
     }
 
@@ -882,6 +896,7 @@ class Palettes {
                 listBody
             );
         }
+        this._updateCollapsedVisibility(listBody);
     }
 
     makeSearchButton(name, icon, listBody) {


### PR DESCRIPTION
## Description

Fixes the palette collapse behavior when clicking the blue left-side button.

Previously, clicking the button hid all palette options. This change hides
only the first half of the options while keeping the remaining options visible.

## Changes

- Updated palette collapse visibility behavior.
- Added a unit test covering collapse and restore behavior.

## Testing

- Tested the palette collapse behavior manually.
- Added automated coverage for hiding and restoring palette options.

Fixes #8385