### PR TITLE
fix: prevent TypeError in getOscillatorTypes for empty strings

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -629,6 +629,11 @@ describe("getOscillatorTypes", () => {
         expect(getOscillatorTypes("invalid")).toBe(null);
         expect(getOscillatorTypes("random")).toBe(null);
     });
+    it("should return null for empty string, null, and undefined inputs", () => {
+        expect(getOscillatorTypes("")).toBe(null);
+        expect(getOscillatorTypes(null)).toBe(null);
+        expect(getOscillatorTypes(undefined)).toBe(null);
+    });
 });
 
 describe("getDrumIcon", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -3559,8 +3559,8 @@ const getFilterTypes = name => {
  * @returns {string|null} The oscillator type, or null if not found.
  */
 const getOscillatorTypes = name => {
-    if (name === "") {
-        name = null; // DEFAULTOSCILLATORTYPE;
+    if (name === null || name === undefined || name === "") {
+        return null;
     }
 
     for (let type = 0; type < OSCTYPES.length; type++) {


### PR DESCRIPTION
### Description
getOscillatorTypes now returns null immediately for null, undefined, and empty-string input, preventing the lookup from calling toLowerCase() on invalid input.

### Related Issue
N/A

### Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

### Changes Made
Added an early return `if (name === null || name === undefined || name === "") { return null; }` before the oscillator lookup loop.

### Steps to Reproduce
Pass an empty string to `getOscillatorTypes("")`.

### Visual Changes
N/A

### Testing Performed
Verified locally that empty strings no longer throw a TypeError.

### Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty, null, and undefined oscillator type inputs by returning no result consistently.

* **Tests**
  * Added coverage to verify the updated behavior for all supported empty-input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->