### PR TITLE
fix(turtles): detach a removed turtle's stage children

### DIFF
--- a/js/__tests__/turtles.test.js
+++ b/js/__tests__/turtles.test.js
@@ -805,3 +805,111 @@ describe("turtleCount", () => {
         expect(turtles.turtleCount()).toBe(1);
     });
 });
+
+// ---------------------------------------------------------------------------
+// removeTurtle — stage cleanup
+// ---------------------------------------------------------------------------
+
+describe("TurtlesModel.removeTurtle", () => {
+    let stage;
+    let model;
+
+    // importMembers is mocked in this file, so new Turtles() never runs the
+    // TurtlesModel constructor. Construct the model directly, the same way the
+    // doGrid tests above do, so removeTurtle is actually present.
+    const makeModel = () => {
+        stage = { addChild: jest.fn(), removeChild: jest.fn() };
+        const activity = {
+            stage: { addChild: jest.fn(), removeChild: jest.fn() },
+            turtleContainer: stage,
+            canvas: {},
+            hideAuxMenu: jest.fn(),
+            doClear: jest.fn(),
+            hideGrids: jest.fn(),
+            refreshCanvas: jest.fn()
+        };
+        return new Turtles.TurtlesModel(activity);
+    };
+
+    const makeTurtle = (overrides = {}) => ({
+        imageContainer: { id: "image" },
+        penstrokes: { id: "pen" },
+        container: { id: "body" },
+        ...overrides
+    });
+
+    beforeEach(() => {
+        model = makeModel();
+        stage.addChild.mockClear();
+        stage.removeChild.mockClear();
+    });
+
+    // add() attaches imageContainer, penstrokes and container to the stage for
+    // every turtle. Leaving them behind keeps the turtle in the display list,
+    // so it still costs a walk on every frame and whatever it displayed stays
+    // on screen.
+    it("detaches the three children that were attached to the stage", () => {
+        const turtle = makeTurtle();
+        model._turtleList = [turtle];
+
+        model.removeTurtle(0);
+
+        expect(stage.removeChild).toHaveBeenCalledWith(turtle.imageContainer);
+        expect(stage.removeChild).toHaveBeenCalledWith(turtle.penstrokes);
+        expect(stage.removeChild).toHaveBeenCalledWith(turtle.container);
+        expect(stage.removeChild).toHaveBeenCalledTimes(3);
+    });
+
+    it("drops the turtle from the list", () => {
+        const a = makeTurtle();
+        const b = makeTurtle();
+        model._turtleList = [a, b];
+
+        model.removeTurtle(0);
+
+        expect(model._turtleList).toEqual([b]);
+    });
+
+    it("still clears a pending interval", () => {
+        const clearSpy = jest.spyOn(global, "clearInterval");
+        const turtle = makeTurtle({ interval: 4242 });
+        model._turtleList = [turtle];
+
+        model.removeTurtle(0);
+
+        expect(clearSpy).toHaveBeenCalledWith(4242);
+        expect(turtle.interval).toBeUndefined();
+        clearSpy.mockRestore();
+    });
+
+    it("skips children the turtle never had", () => {
+        const turtle = makeTurtle({ imageContainer: null, penstrokes: null });
+        model._turtleList = [turtle];
+
+        expect(() => model.removeTurtle(0)).not.toThrow();
+        expect(stage.removeChild).toHaveBeenCalledTimes(1);
+        expect(stage.removeChild).toHaveBeenCalledWith(turtle.container);
+    });
+
+    it("removes the turtle even when the stage is unavailable", () => {
+        const turtle = makeTurtle();
+        model._turtleList = [turtle];
+        model._stage = null;
+
+        expect(() => model.removeTurtle(0)).not.toThrow();
+        expect(model._turtleList).toEqual([]);
+    });
+
+    it.each([
+        ["a negative index", -1],
+        ["an index past the end", 5]
+    ])("leaves the list untouched for %s", (label, index) => {
+        const turtle = makeTurtle();
+        model._turtleList = [turtle];
+
+        model.removeTurtle(index);
+
+        expect(model._turtleList).toEqual([turtle]);
+        expect(stage.removeChild).not.toHaveBeenCalled();
+    });
+});

--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -668,6 +668,9 @@ describe("MusicBlocks Class", () => {
             expect(MusicBlocks._blockNo).toBe(-1);
             expect(Mouse.MouseList).toEqual([]);
             expect(Mouse.TurtleMouseMap).toEqual({});
+            // AddedTurtles is pushed to on every run, so it has to be reset
+            // alongside its siblings or it keeps the removed turtles alive.
+            expect(Mouse.AddedTurtles).toEqual([]);
         });
     });
 });

--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -205,6 +205,10 @@ class MusicBlocks {
 
         Mouse.MouseList = [];
         Mouse.TurtleMouseMap = {};
+        // Every run pushes onto AddedTurtles, so it has to be reset alongside
+        // its siblings. Otherwise it keeps the removed turtles referenced and
+        // the loop above re-walks every turtle from every previous run.
+        Mouse.AddedTurtles = [];
     }
 
     /**

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -475,6 +475,20 @@ Turtles.TurtlesModel = class {
                 turtle.interval = undefined;
             }
 
+            // addTurtle() attaches three children to the stage for every
+            // turtle: imageContainer, penstrokes and container. Detach them
+            // here, otherwise a removed turtle keeps costing a display-list
+            // walk on every frame and cannot be garbage collected. Anything
+            // the turtle drew or displayed also stays on screen.
+            const turtlesStage = this._stage;
+            if (turtlesStage) {
+                for (const child of [turtle.imageContainer, turtle.penstrokes, turtle.container]) {
+                    if (child) {
+                        turtlesStage.removeChild(child);
+                    }
+                }
+            }
+
             this._turtleList.splice(index, 1);
         }
     }


### PR DESCRIPTION
## Description

`add()` attaches three children to the stage for every turtle (`js/turtles.js:504-510`): an `imageContainer` holding whatever the `show` block drew, a `penstrokes` bitmap holding its pen output, and the `container` for the turtle itself.

`removeTurtle()` detached none of them. Grepping the tree for `removeChild` against those three properties returns nothing, so once a turtle was added its children stayed in the display list for the lifetime of the page, still walked on every frame, and the turtle could not be garbage collected.

The interval cleanup already present in `removeTurtle` was added in #5106 for the same reason, to stop the function leaking. The stage children were not part of that change.

`removeTurtle` has one caller, the JS Editor cleanup in `js/js-export/export.js:197`, which runs after every program that spawns mice:

```js
for (const turtle of Mouse.AddedTurtles) {
    turtle.container.visible = false;
    turtle.inTrash = true;
    globalActivity.turtles.removeTurtle(globalActivity.turtles.getIndexOfTurtle(turtle));
}

MusicBlocks._blockNo = -1;
Mouse.MouseList = [];
Mouse.TurtleMouseMap = {};
```

It hides `container` but leaves `imageContainer` and `penstrokes` attached and visible, so anything a temporary mouse displayed stayed on the canvas after the mouse was gone, and each run added three more orphaned children.

That loop also never reset `Mouse.AddedTurtles`, while `Mouse.MouseList` and `Mouse.TurtleMouseMap` on the next two lines are both reset. The array grew on every run, kept the removed turtles referenced, and made each subsequent cleanup re-walk every turtle from every previous run. The unit tests had to reset it by hand for the same reason.

## Related Issue

**Fixes:** #8389

## Category

- [x] Bug Fix

## Changes Made

Detach the three children in `removeTurtle`, guarding both for a turtle that never received one and for a stage that is not ready yet:

```js
const turtlesStage = this._stage;
if (turtlesStage) {
    for (const child of [turtle.imageContainer, turtle.penstrokes, turtle.container]) {
        if (child) {
            turtlesStage.removeChild(child);
        }
    }
}
```

And reset `Mouse.AddedTurtles` alongside its two siblings in the JS Editor cleanup.

## Testing Performed

Full suite passes: **224 suites, 8303 tests**. `npm run lint` and `npx prettier --check` are both clean.

| behaviour | before | after |
|---|---|---|
| `imageContainer` detached on remove | no | yes |
| `penstrokes` detached on remove | no | yes |
| `container` detached on remove | no | yes |
| turtle with a missing child | n/a | skipped, no throw |
| stage not ready | n/a | turtle still removed |
| interval cleared | yes | yes |
| out-of-range index ignored | yes | yes |
| `Mouse.AddedTurtles` reset after a run | no | yes |

Three of the seven added tests fail without the source change. The rest assert that the list splice, the interval clear and the out-of-range guard still behave as before, so this cannot be "fixed" by weakening those.

`importMembers` is mocked in `turtles.test.js`, so `new Turtles()` never runs the `TurtlesModel` constructor. The tests construct `Turtles.TurtlesModel` directly, following the pattern the existing `doGrid` tests in that file already use.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed turtles now disappear completely from the stage, including their graphics and pen marks.
  * Cleanup now correctly handles turtles with missing children or unavailable stages.
  * Resetting a run now clears previously added turtle references, preventing stale state from carrying over.

* **Tests**
  * Added coverage for turtle removal, stage cleanup, interval clearing, invalid indices, and run-reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->