### PR TITLE
fix(blocks): serialize loadNewBlocks() calls to prevent state corruption

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1215,7 +1215,8 @@ describe("Blocks Foundation", () => {
                 }
             });
 
-            window.addEventListener("error", event => event.preventDefault());
+            const onWindowError = event => event.preventDefault();
+            window.addEventListener("error", onWindowError);
 
             const finishedLoadingCalls = [];
             const loadBFinished = new Promise(resolve => {
@@ -1253,6 +1254,8 @@ describe("Blocks Foundation", () => {
             expect(finishedLoadingCalls).toHaveLength(1);
             expect(blocks._loadInProgress).toBe(false);
             expect(blocks._loadQueue).toHaveLength(0);
+
+            window.removeEventListener("error", onWindowError);
         });
     });
 

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1136,6 +1136,49 @@ describe("Blocks Foundation", () => {
             expect(blocks._loadInProgress).toBe(true);
             expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
         });
+
+        it("does not leave the queue stuck if a deferred chunk (block 21+) throws", async () => {
+            // Block 20 is the first block of the second chunk, the one
+            // processed inside the deferred setTimeout(processChunk, 0)
+            // callback rather than the first, synchronous chunk. A throw
+            // there runs outside any caller's try/catch, so it can only be
+            // observed here as a window error event, the same way a real
+            // browser would surface it.
+            let callCount = 0;
+            blocks._processOneBlock = jest.fn((b, blockObjs, blockOffset) => {
+                callCount++;
+                if (callCount === 21) {
+                    throw new Error("deferred chunk failure");
+                }
+                const thisBlock = blockOffset + b;
+                blocks.blockList[thisBlock] = { connections: null, trash: false };
+                blocks._adjustTheseStacks.push(thisBlock);
+                setTimeout(() => blocks.cleanupAfterLoad(), 0);
+            });
+
+            const windowErrors = [];
+            const onWindowError = event => {
+                event.preventDefault();
+                windowErrors.push(event.error || event.message);
+            };
+            window.addEventListener("error", onWindowError);
+
+            blocks.loadNewBlocks(makeBatch(25));
+            await new Promise(r => setTimeout(r, 50));
+
+            window.removeEventListener("error", onWindowError);
+
+            expect(windowErrors.length).toBeGreaterThan(0);
+            expect(mockActivity._suppressRefresh).toBe(false);
+            expect(blocks._loadInProgress).toBe(false);
+
+            // A load issued after the failure must not be stranded behind it.
+            blocks._processOneBlock = stubProcessOneBlock();
+            blocks.loadNewBlocks(makeBatch(2));
+
+            expect(blocks._loadInProgress).toBe(true);
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe("renameNameddos", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -978,6 +978,166 @@ describe("Blocks Foundation", () => {
         });
     });
 
+    describe("loadNewBlocks re-entrancy (#8392)", () => {
+        const { PubSub } = require("../pubsub");
+        let mockActivity;
+        let loadContainer;
+        let blocks;
+
+        // Block objects: [id, name, x, y, connections]. blockOffset is 0 for
+        // every one of these tests, so a batch of length N occupies indices
+        // 0..N-1 in blockList/_adjustTheseStacks.
+        const makeBatch = n =>
+            Array.from({ length: n }, (_, i) => [i, "forward", 0, 0, [null, null, null]]);
+
+        // Stands in for the real path: block.js calls cleanupAfterLoad()
+        // once a block's own artwork generation finishes, asynchronously,
+        // after _processOneBlock has already recorded the block for the
+        // finalize step.
+        const stubProcessOneBlock = () =>
+            jest.fn((b, blockObjs, blockOffset) => {
+                const thisBlock = blockOffset + b;
+                blocks.blockList[thisBlock] = { connections: null, trash: false };
+                blocks._adjustTheseStacks.push(thisBlock);
+                setTimeout(() => blocks.cleanupAfterLoad(), 0);
+            });
+
+        beforeEach(() => {
+            global.pubsub = new PubSub();
+            mockActivity = {
+                storage: {},
+                trashcan: {},
+                turtles: {},
+                boundary: {},
+                macroDict: {},
+                palettes: {
+                    dict: {},
+                    show: jest.fn(),
+                    updatePalettes: jest.fn(),
+                    showPalette: jest.fn()
+                },
+                logo: { synth: { loadSynth: jest.fn(), preloadProjectSamples: jest.fn() } },
+                blocksContainer: { x: 0, y: 0 },
+                canvas: { width: 800, height: 600 },
+                refreshCanvas: jest.fn(),
+                errorMsg: jest.fn(),
+                setSelectionMode: jest.fn(),
+                stopLoadAnimation: jest.fn(),
+                setHomeContainers: jest.fn(),
+                __tick: jest.fn(),
+                _suppressRefresh: false
+            };
+            loadContainer = document.createElement("div");
+            loadContainer.id = "load-container";
+            document.body.appendChild(loadContainer);
+
+            blocks = new Blocks(mockActivity);
+            blocks.blockList = [];
+            blocks.customTemperamentDefined = true;
+            blocks._processOneBlock = stubProcessOneBlock();
+            // These tests are only about load serialization, not the
+            // finalize step's internals, so stub it out the same way the
+            // "cleanupAfterLoad" describe block above does.
+            blocks._findDrumURLs = jest.fn();
+            blocks.updateBlockPositions = jest.fn();
+            blocks._rebuildSpatialGrid = jest.fn();
+            blocks._cleanupStacks = jest.fn();
+        });
+
+        afterEach(async () => {
+            // Drain any cleanupAfterLoad callbacks still pending from a test
+            // that didn't await every scheduled block completion, so they
+            // can't fire during a later test against its fresh blocks
+            // instance.
+            await new Promise(r => setTimeout(r, 50));
+            loadContainer.remove();
+            delete global.pubsub;
+        });
+
+        it("does not start a second call while a first call is still processing", () => {
+            blocks.loadNewBlocks(makeBatch(25));
+
+            expect(blocks._loadInProgress).toBe(true);
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(20); // first CHUNK_SIZE
+
+            blocks.loadNewBlocks(makeBatch(3));
+
+            // The second call is queued, not run: _processOneBlock has not
+            // been called any additional times for it yet.
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
+            expect(blocks._loadQueue).toHaveLength(1);
+        });
+
+        it("does not lose the first call's in-flight _adjustTheseStacks entries when a second call arrives mid-load", async () => {
+            blocks.loadNewBlocks(makeBatch(25));
+            // Let the first chunk's 20 synchronous _processOneBlock calls'
+            // queued cleanupAfterLoad callbacks start landing.
+            await new Promise(r => setTimeout(r, 0));
+
+            blocks.loadNewBlocks(makeBatch(3));
+
+            // Let everything settle: remaining chunks, all cleanupAfterLoad
+            // callbacks, and the queued second load running to completion.
+            await new Promise(r => setTimeout(r, 50));
+
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(28); // 25 + 3
+            expect(blocks._loadInProgress).toBe(false);
+            expect(blocks._loadQueue).toHaveLength(0);
+        });
+
+        it("emits finishedLoading once per queued load, not merged into a single early event", async () => {
+            const finishedLoadingCalls = [];
+            global.pubsub.on("finishedLoading", () => finishedLoadingCalls.push(Date.now()));
+
+            blocks.loadNewBlocks(makeBatch(25));
+            await new Promise(r => setTimeout(r, 0));
+            blocks.loadNewBlocks(makeBatch(3));
+
+            await new Promise(r => setTimeout(r, 50));
+
+            expect(finishedLoadingCalls).toHaveLength(2);
+        });
+
+        it("starts a queued load once an earlier load's circular-connection early return resolves", () => {
+            // Block connected to itself: connections[0] === block id.
+            const circularBatch = [[0, "forward", 0, 0, [0, null, null]]];
+            blocks.loadNewBlocks(circularBatch);
+
+            // The early return must not leave the queue stuck: a load
+            // queued behind it should still get its turn.
+            expect(blocks._loadInProgress).toBe(false);
+
+            blocks.loadNewBlocks(makeBatch(2));
+
+            expect(blocks._loadInProgress).toBe(true);
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
+        });
+
+        it("runs a second call immediately when no load is already in progress", () => {
+            blocks.loadNewBlocks(makeBatch(2));
+
+            expect(blocks._loadQueue).toHaveLength(0);
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
+        });
+
+        it("loading an empty batch does not hang and still advances the queue", async () => {
+            const finishedLoadingCalls = [];
+            global.pubsub.on("finishedLoading", () => finishedLoadingCalls.push(Date.now()));
+
+            blocks.loadNewBlocks([]);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(finishedLoadingCalls).toHaveLength(1);
+            expect(blocks._loadInProgress).toBe(false);
+
+            // A load queued behind the empty one must not be stranded.
+            blocks.loadNewBlocks(makeBatch(2));
+
+            expect(blocks._loadInProgress).toBe(true);
+            expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe("renameNameddos", () => {
         let blocksInstance;
 

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1179,6 +1179,81 @@ describe("Blocks Foundation", () => {
             expect(blocks._loadInProgress).toBe(true);
             expect(blocks._processOneBlock).toHaveBeenCalledTimes(2);
         });
+
+        it("does not let a stale completion from a failed load corrupt the next queued load's counter", async () => {
+            // One stub shared by both loads (load B is queued while load A
+            // is still running, so swapping _processOneBlock out from under
+            // it mid-flight would mean load A's own deferred chunk never
+            // actually calls the code meant to fail). Mirrors what
+            // makeNewBlock() really does: every block created is tagged
+            // with the generation active at the moment it was made, and
+            // carries that tag to its own (possibly much later)
+            // cleanupAfterLoad() call, the same way a real Block instance
+            // carries _loadGeneration to block.js's
+            // cleanupAfterLoad(this._loadGeneration) call.
+            //
+            // Load A's chunk-1 (b < 20) completions are collected as plain
+            // functions rather than scheduled with a timer: under parallel
+            // test-worker load, real timer delays aren't a reliable way to
+            // force "arrives after load B finishes" ordering, so that
+            // ordering is enforced explicitly below instead.
+            const staleCleanups = [];
+            blocks._processOneBlock = jest.fn((b, blockObjs, blockOffset) => {
+                const thisBlock = blockOffset + b;
+                const myGeneration = blocks._activeLoadGeneration;
+                blocks.blockList[thisBlock] = { connections: null, trash: false };
+                blocks._adjustTheseStacks.push(thisBlock);
+                if (myGeneration === 1 && b === 20) {
+                    // Load A's first block of its deferred (second) chunk.
+                    throw new Error("deferred chunk failure");
+                }
+                if (myGeneration === 1) {
+                    staleCleanups.push(() => blocks.cleanupAfterLoad(myGeneration));
+                } else {
+                    // Load B's blocks: complete promptly, like a normal load.
+                    setTimeout(() => blocks.cleanupAfterLoad(myGeneration), 0);
+                }
+            });
+
+            window.addEventListener("error", event => event.preventDefault());
+
+            const finishedLoadingCalls = [];
+            const loadBFinished = new Promise(resolve => {
+                global.pubsub.on("finishedLoading", () => {
+                    finishedLoadingCalls.push(Date.now());
+                    resolve();
+                });
+            });
+
+            // Load A: 25 blocks, fails on block 20 (first of the deferred
+            // chunk, which only runs once the setTimeout(0) scheduling it
+            // fires). Load B: queued behind A, starts as soon as A's
+            // failure advances the queue.
+            blocks.loadNewBlocks(makeBatch(25));
+            blocks.loadNewBlocks(makeBatch(3));
+
+            // Wait specifically for load B to finish (not a fixed delay),
+            // so this isn't sensitive to how busy the test runner is.
+            await loadBFinished;
+
+            expect(staleCleanups).toHaveLength(20);
+
+            // Now let load A's 20 chunk-1 completions land, well after load
+            // B has already finished and _activeLoadGeneration has moved on.
+            for (const cleanup of staleCleanups) {
+                await cleanup();
+            }
+
+            // Load B's own 3 blocks are all that should count toward it. If
+            // a stale straggler from A had been accepted, B's shared
+            // _loadCounter would go negative, and every one of A's 20
+            // stragglers would independently satisfy the "<= 0" finalize
+            // check again, firing finishedLoading many more times than the
+            // one legitimate completion of load B.
+            expect(finishedLoadingCalls).toHaveLength(1);
+            expect(blocks._loadInProgress).toBe(false);
+            expect(blocks._loadQueue).toHaveLength(0);
+        });
     });
 
     describe("renameNameddos", () => {

--- a/js/block.js
+++ b/js/block.js
@@ -1591,7 +1591,7 @@ class Block {
             }
 
             // this.activity.refreshCanvas();
-            this.blocks.cleanupAfterLoad(this.name);
+            this.blocks.cleanupAfterLoad(this._loadGeneration);
         } else {
             // Some blocks, e.g., Start blocks and Action blocks can
             // collapse, so add an event handler.
@@ -1651,7 +1651,7 @@ class Block {
             }
 
             that.activity.refreshCanvas();
-            that.blocks.cleanupAfterLoad(that.name);
+            that.blocks.cleanupAfterLoad(that._loadGeneration);
             if (that.trash) {
                 that.collapseText.visible = false;
                 that.collapseButtonBitmap.visible = false;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -5479,7 +5479,23 @@ class Blocks {
                         // silently stalls loading after the first chunk. setTimeout(0)
                         // still yields to the main thread but keeps running regardless
                         // of tab visibility.
-                        setTimeout(processChunk, 0);
+                        //
+                        //
+                        // A deferred chunk runs on its own event-loop turn, outside
+                        // the synchronous try/catch below that only covers the very
+                        // first, synchronous processChunk() call. Without catching
+                        // here too, a throw from block 21 onward would leave
+                        // _loadInProgress stuck true forever, silently blocking
+                        // every future loadNewBlocks() call.
+                        setTimeout(() => {
+                            try {
+                                processChunk();
+                            } catch (e) {
+                                this.activity._suppressRefresh = false;
+                                this._advanceLoadQueue();
+                                throw e;
+                            }
+                        }, 0);
                     }
                 };
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -212,6 +212,15 @@ class Blocks {
         /** Number of blocks to load */
         this._loadCounter = 0;
         /**
+         * loadNewBlocks() is not re-entrant: it tracks the in-progress load
+         * on _loadCounter/_adjustTheseStacks/_adjustTheseDocks below, shared
+         * instance state. A second call made while one is still chunking
+         * through blocks would otherwise reset that state out from under the
+         * first (issue #8392), so calls are queued and run one at a time.
+         */
+        this._loadQueue = [];
+        this._loadInProgress = false;
+        /**
          * Stacks of blocks that need adjusting as blocks are repositioned
          * due to expanding and contracting or insertion into the flow.
          */
@@ -4769,12 +4778,47 @@ class Blocks {
         };
 
         /**
-         * Load new blocks.
+         * Load new blocks. Queues the call instead of running it immediately
+         * if another load is still in progress, so the two loads' bookkeeping
+         * never overlaps (issue #8392).
          * @param - blockObj - Block Objects
          * @public
          * return {void}
          */
         this.loadNewBlocks = blockObjs => {
+            if (this._loadInProgress) {
+                this._loadQueue.push(blockObjs);
+                return;
+            }
+
+            this._loadInProgress = true;
+            this._loadNewBlocksNow(blockObjs);
+        };
+
+        /**
+         * Marks the current load as finished and, if another load was
+         * queued while it ran, starts that one.
+         * @private
+         * @returns {void}
+         */
+        this._advanceLoadQueue = () => {
+            this._loadInProgress = false;
+
+            if (this._loadQueue.length > 0) {
+                const nextBlockObjs = this._loadQueue.shift();
+                this._loadInProgress = true;
+                this._loadNewBlocksNow(nextBlockObjs);
+            }
+        };
+
+        /**
+         * Does the actual work of loading new blocks. Only ever runs for one
+         * call to loadNewBlocks at a time, see _advanceLoadQueue above.
+         * @private
+         * @param - blockObj - Block Objects
+         * @returns {void}
+         */
+        this._loadNewBlocksNow = blockObjs => {
             /** Suppress intermediate canvas redraws during block loading. */
             this.activity._suppressRefresh = true;
 
@@ -4898,6 +4942,7 @@ class Blocks {
                         );
                     }
                     this.activity._suppressRefresh = false;
+                    this._advanceLoadQueue();
                     return;
                 }
 
@@ -5438,9 +5483,19 @@ class Blocks {
                     }
                 };
 
-                processChunk();
+                if (totalBlocks === 0) {
+                    // No blocks means no per-block async completion will ever
+                    // call cleanupAfterLoad, so nothing would otherwise mark
+                    // this load finished. Route through the same finalize
+                    // path a normal load ends on so finishedLoading still
+                    // fires and the queue still advances.
+                    this.cleanupAfterLoad();
+                } else {
+                    processChunk();
+                }
             } catch (e) {
                 this.activity._suppressRefresh = false;
+                this._advanceLoadQueue();
                 throw e;
             }
         };
@@ -6386,6 +6441,7 @@ class Blocks {
                 /** All blocks loaded — allow canvas redraws again. */
                 this.activity._suppressRefresh = false;
                 this.activity.refreshCanvas();
+                this._advanceLoadQueue();
             }
         };
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -221,6 +221,14 @@ class Blocks {
         this._loadQueue = [];
         this._loadInProgress = false;
         /**
+         * Bumped once per load attempt (see _loadNewBlocksNow). Every block
+         * created during a load is tagged with the value active at the time,
+         * so a completion callback that lands after its own load has already
+         * been abandoned (queue advanced past it on failure) can recognize
+         * itself as stale and skip touching the next load's _loadCounter.
+         */
+        this._activeLoadGeneration = 0;
+        /**
          * Stacks of blocks that need adjusting as blocks are repositioned
          * due to expanding and contracting or insertion into the flow.
          */
@@ -2648,6 +2656,10 @@ class Blocks {
             // Cache the block's index for O(1) lookups instead of
             // O(N) blockList.indexOf() scans.
             myBlock.blockIndex = this.blockList.length - 1;
+            // Tag with the load this block belongs to, so a stale
+            // cleanupAfterLoad() completion from an abandoned load can be
+            // told apart from one belonging to whatever load is active now.
+            myBlock._loadGeneration = this._activeLoadGeneration;
             myBlock.copySize();
 
             /** We may need to do some postProcessing to the block */
@@ -4821,6 +4833,11 @@ class Blocks {
         this._loadNewBlocksNow = blockObjs => {
             /** Suppress intermediate canvas redraws during block loading. */
             this.activity._suppressRefresh = true;
+            // Every load attempt gets its own generation, win or lose, so a
+            // completion that lands after this one has been abandoned can be
+            // told apart from a completion belonging to whatever load is
+            // active by the time it fires.
+            this._activeLoadGeneration += 1;
 
             try {
                 /**
@@ -6365,11 +6382,21 @@ class Blocks {
 
         /**
          * If all the blocks are loaded, we can make the final adjustments.
-         * @param - name
+         * @param {Number} [loadGeneration] - the calling block's _loadGeneration
+         *  (see makeNewBlock). A load that failed mid-chunk advances the queue
+         *  immediately rather than waiting for its remaining blocks, so a
+         *  completion arriving afterward belongs to an already-abandoned
+         *  load; ignore it instead of decrementing whatever load is active
+         *  now. Callers that don't pass this (e.g. existing direct calls)
+         *  are treated as always belonging to the current load.
          * @public
          * @returns {void}
          */
-        this.cleanupAfterLoad = async () => {
+        this.cleanupAfterLoad = async loadGeneration => {
+            if (loadGeneration !== undefined && loadGeneration !== this._activeLoadGeneration) {
+                return;
+            }
+
             this._loadCounter -= 1;
             // Early return BEFORE the try block is intentional:
             // intermediate calls must not run the finally, which resets


### PR DESCRIPTION
## Description

`Blocks.loadNewBlocks()` (`js/blocks.js`) isn't re-entrant. It keeps its per-load bookkeeping, `_loadCounter`, `_adjustTheseStacks`, `_adjustTheseDocks`, on the shared `Blocks` instance instead of state scoped to the call, and it processes blocks in chunks of 20, yielding to the event loop between chunks. Any load bigger than that already spans several ticks, so a second call made while the first is still chunking through blocks resets that shared state out from under it, and both calls' completions end up decrementing the same counter.

Fixes #8392

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Root Cause

`loadNewBlocks()` sets `this._adjustTheseStacks = []`, `this._adjustTheseDocks = []`, and `this._loadCounter = blockObjs.length` synchronously at the top of every call, on `this`. Nothing stops a second call from running that reset while a first call's chunked `processChunk` loop and its blocks' async completions (each block calls `cleanupAfterLoad()` from `block.js` once its own artwork generation finishes) are still in flight. `cleanupAfterLoad()` only checks the shared counter, it has no way to tell "my batch is done" from "some other batch's completions happened to zero the counter", so the finalize step (`adjustDocks`/`raiseStackToTop`) can run, and `finishedLoading` can fire, while blocks from either batch are still mid-construction. Blocks from the first batch can end up permanently skipped by that finalize step.

The easiest real trigger is the JS Editor's Run button (`js/widgets/jseditor.js`), `_runCode()` has no re-entrancy guard and doesn't disable the button while it's running, so two quick clicks on a project over 20 blocks fires `loadNewBlocks()` twice while the first is still mid-chunk.

## Changes Made

- `js/blocks.js`: added `_loadQueue` and `_loadInProgress` instance state. `loadNewBlocks()` is now a thin dispatcher, if a load is already in progress it pushes the call onto the queue instead of running it; otherwise it runs it immediately via the renamed `_loadNewBlocksNow()` (the previous body of `loadNewBlocks()`, unchanged).
- Added `_advanceLoadQueue()`, called from every place a load can end: the circular-connection early return, the catch block around a thrown error, and `cleanupAfterLoad()`'s `finally` block. It marks the current load finished and starts the next queued one, if any.
- A load that trims down to zero blocks (all entries were deprecated playback-queue/metadata, or the caller passed an empty array) previously never reached `cleanupAfterLoad()` at all, since that's only called from a block's own async completion. With a queue in front of it, that would have permanently blocked every future load, so `_loadNewBlocksNow()` now calls `cleanupAfterLoad()` directly when `totalBlocks === 0` instead of calling `processChunk()`, so `finishedLoading` still fires and the queue still advances. This also happens to fix a pre-existing (separate) latent hang for that same edge case: before this PR, an empty-batch load never emitted `finishedLoading` or reset `_suppressRefresh` either.

## Testing Performed

- Reproduced the bug directly with the existing Jest mocking setup in `js/__tests__/blocks.test.js`: stubbed `_processOneBlock` to push onto `_adjustTheseStacks` and call `cleanupAfterLoad()` asynchronously (mirroring the real `block.js` path), called `loadNewBlocks()` with a 25-block batch, let one chunk boundary pass, called it again with a 3-block batch. On the pre-fix code, `_adjustTheseStacks` ended up with only 3 entries instead of the expected 28.
- Added a new `describe("loadNewBlocks re-entrancy (#8392)")` block with 6 tests: a second call is queued instead of run while one is in progress; the first call's `_adjustTheseStacks` entries survive a second call arriving mid-load; `finishedLoading` fires once per queued load rather than merged into one early event; a queued load starts once an earlier call's circular-connection early return resolves; a second call runs immediately when nothing is in progress; an empty-batch load doesn't hang and still advances the queue.
- `npx jest js/__tests__/blocks.test.js` — 61/61 passing.
- Full suite: `npx jest` — 224/224 suites, 8302/8302 tests passing.
- `npx eslint` and `npx prettier --check` on both changed files, clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple block-loading operations occur simultaneously.
  * Prevented outdated loading activity from affecting newer loads or triggering duplicate completion events.
  * Ensured queued loads continue after errors, circular connections, empty loads, or interrupted processing.
  * Correctly surfaced deferred loading failures and completed projects with no asynchronous block processing.
  * Refreshed block visuals when content re-enters the visible area.

* **Tests**
  * Updated regression coverage for stale loading completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->