### PR TITLE
refactor(tuner): replace platformColor calls with CSS design tokens

### DIFF
--- a/js/widgets/__tests__/tuner.test.js
+++ b/js/widgets/__tests__/tuner.test.js
@@ -20,9 +20,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-global.platformColor = {
-    selectorBackground: "#8bc34a"
+const cssTokens = {
+    "--color-selector-bg": "#8cc6ff",
+    "--color-text-primary": "#000000"
 };
+
+global.getComputedStyle = jest.fn().mockReturnValue({
+    getPropertyValue: property => cssTokens[property] || ""
+});
 
 global.generateNoteNames = edo => {
     if (edo === 12) {
@@ -48,6 +53,9 @@ const createMockElement = tagName => ({
 });
 
 global.document = {
+    body: {
+        className: ""
+    },
     createElement: jest.fn().mockImplementation(tagName => {
         const element = createMockElement(tagName);
         if (tagName === "canvas") {
@@ -646,6 +654,44 @@ describe("Tuner Widget", () => {
                 display.targetPitchButton.onclick();
 
                 expect(updateSpy).toHaveBeenCalled();
+            });
+        });
+
+        describe("_getCanvasColors", () => {
+            test("returns token colors for default theme", () => {
+                const display = new TunerDisplay(mockCanvas, 400, 300);
+                const colors = display._getCanvasColors();
+
+                expect(colors.selectorBg).toBe("#8cc6ff");
+                expect(colors.textColor).toBe("#000000");
+            });
+
+            test("caches colors when theme class has not changed", () => {
+                const display = new TunerDisplay(mockCanvas, 400, 300);
+                global.getComputedStyle.mockClear();
+
+                display._getCanvasColors();
+                display._getCanvasColors();
+
+                expect(global.getComputedStyle).toHaveBeenCalledTimes(1);
+            });
+
+            test("updates cached colors when document theme class changes", () => {
+                const display = new TunerDisplay(mockCanvas, 400, 300);
+                display._getCanvasColors();
+
+                global.document.body.className = "dark";
+                global.getComputedStyle.mockReturnValueOnce({
+                    getPropertyValue: prop =>
+                        prop === "--color-selector-bg" ? "#64b5f6" : "#f9fafb"
+                });
+
+                const darkColors = display._getCanvasColors();
+
+                expect(darkColors.selectorBg).toBe("#64b5f6");
+                expect(darkColors.textColor).toBe("#f9fafb");
+
+                global.document.body.className = "";
             });
         });
     });

--- a/js/widgets/tuner.js
+++ b/js/widgets/tuner.js
@@ -11,6 +11,9 @@ function TunerDisplay(canvas, width, height) {
     this.cents = 0;
     this.frequency = 440;
     this.chromaticMode = true; // Default to chromatic mode
+    this._cachedTheme = null;
+    this._selectorBg = null;
+    this._textColor = null;
 
     // Create mode toggle container
     this.modeContainer = document.createElement("div");
@@ -96,16 +99,42 @@ function TunerDisplay(canvas, width, height) {
 }
 
 /**
+ * Resolves and caches CSS token colors for Canvas 2D rendering,
+ * updating only when document theme changes.
+ * @private
+ * @returns {{ selectorBg: string, textColor: string }}
+ */
+TunerDisplay.prototype._getCanvasColors = function () {
+    const currentTheme =
+        typeof document !== "undefined" && document.body ? document.body.className : "";
+    if (this._cachedTheme !== currentTheme || !this._selectorBg) {
+        this._cachedTheme = currentTheme;
+        if (typeof getComputedStyle !== "undefined" && document.body) {
+            const style = getComputedStyle(document.body);
+            this._selectorBg = style.getPropertyValue("--color-selector-bg").trim() || "#8cc6ff";
+            this._textColor = style.getPropertyValue("--color-text-primary").trim() || "#000000";
+        } else {
+            this._selectorBg = "#8cc6ff";
+            this._textColor = "#000000";
+        }
+    }
+    return {
+        selectorBg: this._selectorBg,
+        textColor: this._textColor
+    };
+};
+
+/**
  * Updates the styles of mode toggle buttons based on current mode
  */
 TunerDisplay.prototype.updateButtonStyles = function () {
     if (this.chromaticMode) {
-        this.chromaticButton.style.backgroundColor = platformColor.selectorBackground;
+        this.chromaticButton.style.backgroundColor = "var(--color-selector-bg)";
         this.chromaticButton.querySelector("img").style.filter = "brightness(0) invert(1)";
         this.targetPitchButton.style.backgroundColor = "transparent";
         this.targetPitchButton.querySelector("img").style.filter = "none";
     } else {
-        this.targetPitchButton.style.backgroundColor = platformColor.selectorBackground;
+        this.targetPitchButton.style.backgroundColor = "var(--color-selector-bg)";
         this.targetPitchButton.querySelector("img").style.filter = "brightness(0) invert(1)";
         this.chromaticButton.style.backgroundColor = "transparent";
         this.chromaticButton.querySelector("img").style.filter = "none";
@@ -132,6 +161,7 @@ TunerDisplay.prototype.draw = function () {
     const ctx = this.ctx;
     const width = this.width;
     const height = this.height;
+    const { selectorBg, textColor } = this._getCanvasColors();
 
     // Clear the canvas
     ctx.clearRect(0, 0, width, height);
@@ -143,11 +173,11 @@ TunerDisplay.prototype.draw = function () {
     const meterY = height - 80; // Base position of meter
 
     // Draw the tuning meter background
-    ctx.fillStyle = platformColor.selectorBackground || "#e0e0e0";
+    ctx.fillStyle = selectorBg;
     ctx.fillRect(meterX, meterY, meterWidth, meterHeight);
 
     // Draw the center line
-    ctx.fillStyle = platformColor.textColor || "#000000";
+    ctx.fillStyle = textColor;
     ctx.fillRect(meterX + meterWidth / 2 - 1, meterY, 2, meterHeight);
 
     // Draw the indicator
@@ -159,7 +189,7 @@ TunerDisplay.prototype.draw = function () {
     // Draw the note
     ctx.font = "bold 48px Arial";
     ctx.textAlign = "center";
-    ctx.fillStyle = platformColor.textColor || "#000000";
+    ctx.fillStyle = textColor;
     ctx.fillText(this.note, width / 2, height - 200); // Much lower position
 
     // Draw the cents deviation


### PR DESCRIPTION
## Description

This PR migrates the Tuner widget and its 2D canvas display from legacy `platformColor` JS variables to centralized CSS design tokens (`--color-selector-bg`, `--color-text-primary`), adding theme reactivity without layout thrashing or memory leaks.

## Related Issue

Fixes #

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* **Button Styling**: Updated Tuner HTML button backgrounds to use `var(--color-selector-bg)` instead of `platformColor.selectorBackground`.
* **Canvas Theme Reactivity**: Added a cached color resolution method `_getCanvasColors()` on `TunerDisplay` that reads CSS variables (`--color-selector-bg`, `--color-text-primary`) from `document.body` and only re-computes when `document.body.className` changes. This avoids expensive `getComputedStyle` layout recalculations during the 60fps render loop and eliminates memory leaks from unbound global event listeners.
* **Unit Tests**: Updated `js/widgets/__tests__/tuner.test.js` to mock CSS computed tokens and added unit tests validating `_getCanvasColors()` resolution and dynamic theme switching.

---

## Testing Performed

* **Jest Unit Tests**:
  ```bash
  npx jest js/widgets/__tests__/tuner.test.js

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tuner display colors to follow the active document theme.
  - Added fallback colors when theme values are unavailable.
  - Ensured color updates appear when the theme changes while avoiding unnecessary refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->