### PR TITLE
fix(piemenus): close pie menus with the Escape key

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -728,3 +728,93 @@ describe("piemenuKey behavioral tests", () => {
         expect(mockActivity.blocks._makeNewBlockWithConnections).toHaveBeenCalled();
     });
 });
+
+describe("pie menu Escape-key dismissal", () => {
+    let elements;
+
+    const makeEl = () => ({
+        style: { display: "", position: "", opacity: "" },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        getBoundingClientRect: jest.fn().mockReturnValue({ x: 0, y: 0 })
+    });
+
+    beforeEach(() => {
+        elements = {};
+        global.docById = jest.fn(id => {
+            if (!elements[id]) elements[id] = makeEl();
+            return elements[id];
+        });
+        global.document = {
+            getElementById: global.docById,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        };
+        // Earlier suites may leave a module-level activeExitWheel behind;
+        // dismiss once so each test starts from the no-exit-wheel state.
+        require("../piemenus").dismissActivePieMenu();
+        elements = {};
+        global.document.removeEventListener.mockClear();
+    });
+
+    test("Escape hides every visible pie-menu container and detaches listeners", () => {
+        const { handleEscapeKey } = require("../piemenus");
+        const event = { key: "Escape", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+        handleEscapeKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(elements["wheelDiv"].style.display).toBe("none");
+        expect(elements["wheelDivptm"].style.display).toBe("none");
+        expect(global.document.removeEventListener).toHaveBeenCalledWith(
+            "keydown",
+            handleEscapeKey,
+            true
+        );
+    });
+
+    test("other keys leave the menu open", () => {
+        const { handleEscapeKey } = require("../piemenus");
+        const event = { key: "a", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+        handleEscapeKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(elements["wheelDiv"] ? elements["wheelDiv"].style.display : "").not.toBe("none");
+    });
+
+    test("Escape does nothing when no pie menu is open", () => {
+        const { handleEscapeKey } = require("../piemenus");
+        global.docById = jest.fn(id => {
+            if (!elements[id]) {
+                elements[id] = makeEl();
+                elements[id].style.display = "none";
+            }
+            return elements[id];
+        });
+        global.document.getElementById = global.docById;
+        const event = { key: "Escape", preventDefault: jest.fn(), stopPropagation: jest.fn() };
+
+        handleEscapeKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test("showWheelDiv registers the Escape listener alongside outside-click", () => {
+        jest.useFakeTimers();
+        const { showWheelDiv, handleEscapeKey } = require("../piemenus");
+
+        try {
+            showWheelDiv();
+            jest.advanceTimersByTime(50);
+
+            expect(global.document.addEventListener).toHaveBeenCalledWith(
+                "keydown",
+                handleEscapeKey,
+                true
+            );
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -177,40 +177,55 @@ const isInteractive = target => {
     return false;
 };
 
+const dismissActivePieMenu = () => {
+    if (
+        activeExitWheel &&
+        activeExitWheel.navItems &&
+        activeExitWheel.navItems[0] &&
+        typeof activeExitWheel.navItems[0].navigateFunction === "function"
+    ) {
+        activeExitWheel.navItems[0].navigateFunction();
+    } else {
+        for (let i = 0; i < PIE_MENU_CONTAINERS.length; i++) {
+            const div = docById(PIE_MENU_CONTAINERS[i]);
+            if (div && div.style && div.style.display !== "none") {
+                if (PIE_MENU_CONTAINERS[i] === "wheelDiv") {
+                    hideWheelDiv();
+                } else {
+                    div.style.display = "none";
+                }
+            }
+        }
+        const movable = docById("movable");
+        if (movable) {
+            movable.style.display = "none";
+        }
+    }
+    document.removeEventListener("mousedown", handleOutsideClick);
+    document.removeEventListener("keydown", handleEscapeKey, true);
+    activeExitWheel = null;
+};
+
 const handleOutsideClick = event => {
     if (!isAnyPieMenuVisible()) {
         return;
     }
 
     if (!isInteractive(event.target)) {
-        if (
-            activeExitWheel &&
-            activeExitWheel.navItems &&
-            activeExitWheel.navItems[0] &&
-            typeof activeExitWheel.navItems[0].navigateFunction === "function"
-        ) {
-            activeExitWheel.navItems[0].navigateFunction();
-            document.removeEventListener("mousedown", handleOutsideClick);
-            activeExitWheel = null;
-        } else {
-            for (let i = 0; i < PIE_MENU_CONTAINERS.length; i++) {
-                const div = docById(PIE_MENU_CONTAINERS[i]);
-                if (div && div.style && div.style.display !== "none") {
-                    if (PIE_MENU_CONTAINERS[i] === "wheelDiv") {
-                        hideWheelDiv();
-                    } else {
-                        div.style.display = "none";
-                    }
-                }
-            }
-            const movable = docById("movable");
-            if (movable) {
-                movable.style.display = "none";
-            }
-            document.removeEventListener("mousedown", handleOutsideClick);
-            activeExitWheel = null;
-        }
+        dismissActivePieMenu();
     }
+};
+
+// Capture-phase Escape handler: keyboard-controller disables all of its own
+// shortcuts while a pie menu is open, so without this a keyboard user has no
+// way to close the menu at all.
+const handleEscapeKey = event => {
+    if (event.key !== "Escape" || !isAnyPieMenuVisible()) {
+        return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    dismissActivePieMenu();
 };
 
 const showWheelDiv = () => {
@@ -222,6 +237,7 @@ const showWheelDiv = () => {
     setTimeout(() => {
         if (isAnyPieMenuVisible()) {
             document.addEventListener("mousedown", handleOutsideClick);
+            document.addEventListener("keydown", handleEscapeKey, true);
         }
     }, 50);
 
@@ -236,6 +252,7 @@ const hideWheelDiv = () => {
 
     if (!isAnyPieMenuVisible()) {
         document.removeEventListener("mousedown", handleOutsideClick);
+        document.removeEventListener("keydown", handleEscapeKey, true);
         activeExitWheel = null;
     }
 
@@ -319,10 +336,11 @@ const configureExitWheel = exitWheel => {
     }
     activeExitWheel = exitWheel;
 
-    // Register mousedown listener after 50ms if any pie menu is visible
+    // Register dismissal listeners after 50ms if any pie menu is visible
     setTimeout(() => {
         if (isAnyPieMenuVisible()) {
             document.addEventListener("mousedown", handleOutsideClick);
+            document.addEventListener("keydown", handleEscapeKey, true);
         }
     }, 50);
 
@@ -349,6 +367,7 @@ const configureExitWheel = exitWheel => {
             item.navigateFunction();
         }
         document.removeEventListener("mousedown", handleOutsideClick);
+        document.removeEventListener("keydown", handleEscapeKey, true);
         if (activeExitWheel === exitWheel) {
             activeExitWheel = null;
         }
@@ -4481,5 +4500,15 @@ const piemenuDissectNumber = widget => {
 };
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { piemenuPitches, piemenuIntervals, piemenuKey, piemenuNumber, piemenuModes };
+    module.exports = {
+        piemenuPitches,
+        piemenuIntervals,
+        piemenuKey,
+        piemenuNumber,
+        piemenuModes,
+        handleEscapeKey,
+        dismissActivePieMenu,
+        showWheelDiv,
+        hideWheelDiv
+    };
 }


### PR DESCRIPTION
## Description

Pie menus are how a child picks a note's pitch, octave, note value, key, mode, or accidental — the core act of making music in Music Blocks. For a keyboard user they are currently a **trap**:

-   Dismissal is exclusively mouse-driven: `handleOutsideClick` is attached to `document` on `mousedown` only (`js/piemenus.js`), and no wheel container has any key handling.
-   Worse, the moment `wheelDiv` becomes visible, `js/activity/keyboard-controller.js` sets `disableKeys` and ignores **all** of its own shortcuts — including Escape. So while a pie menu is open, no key rotates it, no key selects, and no key closes it. A keyboard user who triggers a pie menu can only sit there.

**Fix (self-contained in `js/piemenus.js`; keyboard-controller untouched):**

-   The dismissal logic that lived inside `handleOutsideClick` — invoke the active exit wheel's navigate function, or hide all five pie-menu containers (`wheelDiv`, `wheelDivptm`, `wheelDiv2`–`4`) plus `movable`, then detach listeners — is extracted into a shared `dismissActivePieMenu()`. Mouse and keyboard now go through the identical close path.
-   A new capture-phase `handleEscapeKey` on `document` closes the menu on Escape (`preventDefault` + `stopPropagation` + dismiss). It is registered wherever the outside-click listener is registered (`showWheelDiv`, `configureExitWheel`) and detached wherever that one is detached (`hideWheelDiv`, the exit wheel's `navigateWheel`, and the dismissal itself), so its lifecycle exactly mirrors the existing mouse listener.
-   Capture phase + `stopPropagation` matter: keyboard-controller's `disableKeys` gate only checks `wheelDiv`, so with `wheelDivptm`/`wheelDiv2`–`4` open its own Escape ("Hide blocks") would otherwise fire on the same keypress. Escape now closes exactly one thing — the menu.

This is the first, scoped PR of a small series toward keyboard-operable pie menus under the WCAG umbrella (sugarlabs#6608): arrow-key rotation (reusing the math already written for mouse-wheel scrolling in `enableWheelScroll`) and Enter-to-select are natural follow-ups.

## Related Issue

Part of the keyboard-navigation work tracked in sugarlabs#6608. No issue exists for the Escape trap specifically — found through code inspection while auditing keyboard access across the pie-menu layer. Complementary to (but distinct from) sugarlabs#5591, which asks for audio feedback inside pie menus.

## PR Category

-   [x] Bug Fix — Fixes a bug or incorrect behavior
-   [x] Tests — Adds or updates test coverage
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/piemenus.js`:
    -   `dismissActivePieMenu()` — shared dismissal extracted verbatim from `handleOutsideClick` (which now just guards visibility/interactivity and delegates);
    -   `handleEscapeKey` — capture-phase Escape handler; no-op for other keys or when no pie menu is visible;
    -   the keydown listener is added/removed at the same three registration and three teardown sites as the existing `mousedown` listener;
    -   the new helpers are exported alongside the existing test exports.
-   `js/__tests__/piemenus.test.js` — four new tests: Escape hides every visible container and detaches both listeners; other keys leave the menu open; Escape is a no-op when nothing is open; `showWheelDiv` registers the Escape listener alongside the outside-click one.

## Testing Performed

-   Followed TDD: all four tests were written first and failed on the old code (the helpers did not exist; no keydown listener was ever registered), then passed after the change.
-   `npx jest js/__tests__/piemenus.test.js` — 20/20 pass (16 existing + 4 new).
-   Consumer suites (`phrasemaker`, `block`) — 199/199 pass.
-   Full Jest suite: 8,358 passed; the only 5 failures (`mb-dialog`, `sampler`, `SaveInterface`) are pre-existing on `master`, re-verified on the current master commit independently of this change.
-   `npx eslint` on both changed files — clean (pre-commit hooks ran eslint + prettier); commit is DCO signed-off.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

-   Before opening this I checked for overlapping work: no open PR or issue covers pie-menu keyboard dismissal. #8373 touches the same `hideWheelDiv` region for a different concern (releasing the instrument preview on close) — the two are independent, and whichever lands second needs at most a trivial rebase.
-   `keyboard-controller.js` was deliberately left untouched: its `disableKeys` gate correctly suppresses global shortcuts while a menu is open, and a menu-owned listener keeps the dismissal logic next to the state it manages.
-   Behavior is additive — mouse dismissal, exit-wheel semantics, and all five container paths are unchanged; Escape simply joins outside-click as a second route into the same code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Escape-key support for dismissing open pie menus.
  * Pie menus now close consistently through Escape, outside clicks, or navigation actions.
  * Keyboard handling is automatically enabled when a pie menu opens and removed when it closes.

* **Bug Fixes**
  * Prevented menus from remaining visible after dismissal.
  * Preserved menu state when unrelated keys are pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->