### PR TITLE
fix: resolve reciprocal return, sign, and reduction in rationalToFraction

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -36,9 +36,8 @@ describe("MusicBlocks Application", () => {
     describe("Audio Controls", () => {
         it("should have a functional play button", () => {
             cy.get("#play").should("be.visible").click();
-            cy.window().then(win => {
-                const audioContext = win.Tone.context;
-                cy.wrap(audioContext.state).should("eq", "running");
+            cy.window().should(win => {
+                expect(win.Tone.context.state).to.eq("running");
             });
             // Assert the underlying Tone.Transport clock actually started, not only that
             // the audio context was resumed -- Tone.Transport is the scheduling API
@@ -209,7 +208,7 @@ describe("MusicBlocks Application", () => {
         it("should transition audio context correctly on play and stop", () => {
             cy.get("#play").click();
 
-            cy.window().then(win => {
+            cy.window().should(win => {
                 const ctx = win.Tone.context;
                 expect(ctx.state).to.eq("running");
             });
@@ -223,7 +222,7 @@ describe("MusicBlocks Application", () => {
 
             cy.get("#stop").click({ force: true });
 
-            cy.window().then(win => {
+            cy.window().should(win => {
                 const ctx = win.Tone.context;
                 expect(ctx.state === "suspended" || ctx.state === "running").to.be.true;
             });

--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -22,6 +22,7 @@ const {
     nearestBeat,
     oneHundredToFraction,
     rationalToFraction,
+    GCD,
     rationalSum,
     rgbToHex,
     hexToRGB,
@@ -190,12 +191,60 @@ describe("Utility Logic Functions", () => {
         it("converts float to fraction", () => {
             expect(rationalToFraction(0.5)).toEqual([1, 2]);
             expect(rationalToFraction(2)).toEqual([2, 1]);
+            expect(rationalToFraction(1)).toEqual([1, 1]);
+            expect(rationalToFraction(4 / 3)).toEqual([4, 3]);
         });
 
-        it("handles 0, NaN, Infinity", () => {
+        it("handles 0, NaN, Infinity, -Infinity", () => {
             expect(rationalToFraction(0)).toEqual([0, 1]);
             expect(rationalToFraction(NaN)).toEqual([0, 1]);
             expect(rationalToFraction(Infinity)).toEqual([0, 1]);
+            expect(rationalToFraction(-Infinity)).toEqual([0, 1]);
+        });
+
+        it("handles negative numbers preserving sign on numerator", () => {
+            expect(rationalToFraction(-0.5)).toEqual([-1, 2]);
+            expect(rationalToFraction(-2.5)).toEqual([-5, 2]);
+            expect(rationalToFraction(-0.75)).toEqual([-3, 4]);
+        });
+
+        it("handles values greater than one that exhaust iteration cap without reciprocal bug (pi, e)", () => {
+            const [nPi, dPi] = rationalToFraction(Math.PI);
+            expect(nPi / dPi).toBeGreaterThan(1);
+            expect(Math.abs(nPi / dPi - Math.PI)).toBeLessThan(0.001);
+            expect(GCD(nPi, dPi)).toBe(1);
+            expect(dPi).toBeGreaterThan(0);
+
+            const [nE, dE] = rationalToFraction(Math.E);
+            expect(nE / dE).toBeGreaterThan(1);
+            expect(Math.abs(nE / dE - Math.E)).toBeLessThan(0.001);
+            expect(GCD(nE, dE)).toBe(1);
+            expect(dE).toBeGreaterThan(0);
+        });
+
+        it("handles negative numbers greater than one without unreduced denominator", () => {
+            const [n, d] = rationalToFraction(-Math.PI);
+            expect(n).toBeLessThan(0);
+            expect(d).toBeGreaterThan(0);
+            expect(d).toBeLessThan(5000);
+            expect(Math.abs(n / d - -Math.PI)).toBeLessThan(0.001);
+            expect(GCD(Math.abs(n), d)).toBe(1);
+        });
+
+        it("reduces fractions via GCD on iteration cap", () => {
+            const [n, d] = rationalToFraction(0.0003);
+            expect(GCD(n, d)).toBe(1);
+            expect(n).toBe(1);
+            expect(d).toBe(3334);
+        });
+
+        it("ensures standard musical subdivisions stay exact and reduced", () => {
+            for (let j = 1; j <= 64; j++) {
+                const [n, d] = rationalToFraction(j / 64);
+                expect(Math.abs(n / d - j / 64)).toBeLessThan(0.000001);
+                expect(GCD(n, d)).toBe(1);
+                expect(d).toBeGreaterThan(0);
+            }
         });
     });
 

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -383,6 +383,19 @@ describe("Utility Functions (logic-only)", () => {
 
         it("handles numbers greater than 1", () => {
             expect(rationalToFraction(2)).toEqual([2, 1]);
+            expect(rationalToFraction(4 / 3)).toEqual([4, 3]);
+        });
+
+        it("handles negative numbers", () => {
+            expect(rationalToFraction(-0.5)).toEqual([-1, 2]);
+            expect(rationalToFraction(-2.5)).toEqual([-5, 2]);
+        });
+
+        it("handles numbers exceeding iteration cap without returning reciprocal", () => {
+            const [n, d] = rationalToFraction(Math.PI);
+            expect(n / d).toBeGreaterThan(1);
+            expect(Math.abs(n / d - Math.PI)).toBeLessThan(0.001);
+            expect(d).toBeGreaterThan(0);
         });
     });
 

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -236,25 +236,30 @@ var LCD = (a, b) => {
 
 /**
  * Convert float to its approximate fractional representation.
+ *
+ * Returns a reduced [numerator, denominator] pair with a positive denominator.
+ * Values above 1 are handled by inverting on entry and swapping back on
+ * every exit path (including the iteration-cap path); the sign of the
+ * input is carried on the numerator.
  */
 function rationalToFraction(d) {
     if (d === 0 || isNaN(d) || !isFinite(d)) {
         return [0, 1];
     }
 
-    let invert;
-    if (d > 1) {
-        invert = true;
+    const sign = Math.sign(d);
+    d = Math.abs(d);
+
+    let invert = d > 1;
+    if (invert) {
         d = 1 / d;
-    } else {
-        invert = false;
     }
 
     let df = 1.0;
     let top = 1;
+    let bot = 1;
     let iterations = 0;
     const maxIterations = 10000;
-    let bot = 1;
 
     while (Math.abs(df - d) > 0.00000001 && iterations < maxIterations) {
         if (df < d) {
@@ -268,19 +273,23 @@ function rationalToFraction(d) {
         iterations++;
     }
 
-    if (iterations === maxIterations) {
-        return [top, bot];
+    // Swap back on every exit path, including the iteration cap.
+    if (invert) {
+        const temp = top;
+        top = bot;
+        bot = temp;
     }
 
     if (bot === 0 || top === 0) {
         return [0, 1];
     }
 
-    if (invert) {
-        return [bot, top];
-    } else {
-        return [top, bot];
-    }
+    // Reduce the result so it comes back in standard musical subdivision form.
+    const divisor = GCD(top, bot);
+    top /= divisor;
+    bot /= divisor;
+
+    return [sign * top, bot];
 }
 
 /**

--- a/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
@@ -547,9 +547,9 @@
       "hasRestParam": false,
       "isAsync": false,
       "isGenerator": false,
-      "returns": 5,
+      "returns": 3,
       "throws": 0,
-      "branches": 10
+      "branches": 9
     },
     {
       "name": "resolveObject",
@@ -839,7 +839,7 @@
     },
     {
       "target": "rationalToFraction",
-      "description": "Convert float to its approximate fractional representation.",
+      "description": "Convert float to its approximate fractional representation. Returns a reduced [numerator, denominator] pair with a positive denominator. Values above 1 are handled by inverting on entry and swapping back on every exit path (including the iteration-cap path); the sign of the input is carried on the numerator.",
       "tags": []
     },
     {
@@ -921,8 +921,8 @@
     }
   ],
   "totals": {
-    "branches": 196,
-    "returns": 107,
+    "branches": 195,
+    "returns": 105,
     "throws": 0
   }
 }


### PR DESCRIPTION

## Description

This pull request will fix the following three math bugs in the rationalToFraction helper function:

Incorrect reciprocal output bug: For numbers bigger than 1 which exceeded the 10,000 iterations in loop, it ended prematurely and did not reverse the position of top and bottom again. This caused the function to return the incorrect reciprocal of the number (returned 0.3183 instead of 3.14159).

Negative number processing: There was no proper handling of negative numbers greater than 1 causing improper sign or large fractions.

Uncanceled fractions: If the numbers exceeded the iterations then they were returned without simplifying the fraction (returned 2/6668 instead of 1/3334).

This fix will reverse the position of all numbers upon all exit paths from the function, will maintain the negative sign of the numerator and simplify the fraction using the GCD helper function. 


## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

1] Updated rationalToFraction in js/utils/utils-logic.js to swap top and bottom on all exit paths, handle negative signs cleanly, and reduce fractions using GCD.

2] Added comprehensive unit tests in js/utils/tests/utils-logic.test.js and js/utils/tests/utils.test.js covering Math.PI, Math.E, negative numbers, and standard musical fractions.

3] Updated the test plan fixture in scripts/generate-tests/tests/fixtures/utils-logic.plan.json to match the updated code.

## Steps to Reproduce

In the browser console or Node environment:

1] Run rationalToFraction(Math.PI). Notice it outputs [2121, 6663] which equals 0.3183 (the reciprocal 1 divided by pi instead of pi).
2] Run rationalToFraction(0.0003). Notice it outputs [2, 6668] which is unsimplified instead of [1, 3334].
3] Run rationalToFraction(-Math.PI). Notice it outputs [-20885, 6648] with an oversized unreduced denominator.

## Visual Changes

### Before

rationalToFraction(Math.PI) gave [2121, 6663] which equals 0.3183 (returned the flipped reciprocal)
rationalToFraction(0.0003) gave [2, 6668] (not simplified)
rationalToFraction(-Math.PI) gave [-20885, 6648] (oversized unreduced denominator)

### After

<img width="417" height="238" alt="image" src="https://github.com/user-attachments/assets/06b900c2-e7e7-4b7b-9249-c4e7badcfbe5" />


rationalToFraction(Math.PI) gives [2221, 707] which equals 3.14144 (correct approximation)
rationalToFraction(0.0003) gives [1, 3334] (fully simplified fraction)
rationalToFraction(-Math.PI) gives [-2221, 707] (correct negative sign and simplified)

## Testing Performed

<img width="422" height="82" alt="Screenshot 2026-09-01 224509" src="https://github.com/user-attachments/assets/41d3373e-02e4-4ee1-b152-8940d79a84f1" />

<img width="432" height="78" alt="Screenshot 2026-09-01 224435" src="https://github.com/user-attachments/assets/f5f83b55-39c2-4013-8f19-a509a79ae34c" />

<img width="464" height="80" alt="Screenshot 2026-09-01 224345" src="https://github.com/user-attachments/assets/544b881e-50ea-4603-873f-87d01dc37aa1" />


## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This fix is strictly focused and preserves the exact behavior for all existing musical subdivision numbers while resolving the three edge-case bugs.

Neither failure is related to the changes in this pull request.

Security audit: This failed because of an older third-party package in the main repository, not from any code added here.
Coverage delta vs base: This failed while testing the base master branch during a cache miss, while all unit tests for this PR passed completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decimal-to-fraction conversion for negative values, improper fractions, and values greater than one.
  - Results are now consistently reduced, use positive denominators, and preserve the original sign.
  - Improved handling of zero, infinite values, iteration limits, and common fractional subdivisions.
  - Increased accuracy for approximations such as π and e.

- **Tests**
  - Expanded automated coverage for conversion accuracy, reduction, sign handling, and boundary cases.
  - Improved reliability of audio playback and stopping state checks in automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->