### PR TITLE
fix: cancel stale chunked project loads

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -853,7 +853,62 @@ describe("Blocks Foundation", () => {
             expect(mockActivity._suppressRefresh).toBe(false);
         });
 
-        it("cancels stale chunks and ignores their cleanup after a new load starts", async () => {
+        it("queues a new load until the active chunked load finishes", async () => {
+            jest.useFakeTimers();
+
+            try {
+                const blocks = new Blocks(mockActivity);
+                blocks.blockList = [];
+                blocks.protoBlockDict = {};
+                blocks.newStorein2Block = jest.fn();
+                blocks.newNamedboxBlock = jest.fn();
+                blocks.setActionProtoVisibility = jest.fn();
+                blocks.customTemperamentDefined = true;
+                blocks._processOneBlock = jest.fn();
+                blocks._findDrumURLs = jest.fn();
+                blocks.updateBlockPositions = jest.fn();
+                blocks._cleanupStacks = jest.fn();
+                blocks._rebuildSpatialGrid = jest.fn();
+
+                const oldBlockObjs = Array.from({ length: 40 }, (_, index) => [
+                    index,
+                    "forward",
+                    0,
+                    0,
+                    [null, null, null]
+                ]);
+                const newBlockObjs = [[0, "forward", 0, 0, [null, null, null]]];
+
+                blocks.loadNewBlocks(oldBlockObjs);
+                const oldGeneration = blocks._activeLoadGeneration;
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
+                expect(jest.getTimerCount()).toBe(1);
+
+                blocks.loadNewBlocks(newBlockObjs);
+
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
+                expect(blocks._pendingBlockLoads).toEqual([newBlockObjs]);
+                expect(jest.getTimerCount()).toBe(1);
+
+                jest.runOnlyPendingTimers();
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(40);
+                expect(jest.getTimerCount()).toBe(0);
+
+                for (let i = 0; i < oldBlockObjs.length; i++) {
+                    await blocks.cleanupAfterLoad("forward", oldGeneration);
+                }
+
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(41);
+                expect(blocks._pendingBlockLoads).toEqual([]);
+
+                await blocks.cleanupAfterLoad("forward", blocks._activeLoadGeneration);
+                expect(blocks._activeLoadGeneration).toBe(null);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it("clears queued appends when the active load is explicitly cancelled", () => {
             jest.useFakeTimers();
 
             try {
@@ -876,22 +931,84 @@ describe("Blocks Foundation", () => {
                 const newBlockObjs = [[0, "forward", 0, 0, [null, null, null]]];
 
                 blocks.loadNewBlocks(oldBlockObjs);
-                const oldGeneration = blocks._activeLoadGeneration;
-                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
-                expect(jest.getTimerCount()).toBe(1);
-
                 blocks.loadNewBlocks(newBlockObjs);
+                blocks.cancelPendingLoad();
 
-                expect(blocks._processOneBlock).toHaveBeenCalledTimes(21);
+                expect(blocks._pendingBlockLoads).toEqual([]);
+                expect(blocks._activeLoadGeneration).toBe(null);
                 expect(jest.getTimerCount()).toBe(0);
-                await blocks.cleanupAfterLoad("forward", oldGeneration);
-                expect(blocks._loadCounter).toBe(1);
 
                 jest.runOnlyPendingTimers();
-                expect(blocks._processOneBlock).toHaveBeenCalledTimes(21);
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
             } finally {
                 jest.useRealTimers();
             }
+        });
+
+        it("ignores a chunk callback that runs after load cancellation", () => {
+            jest.useFakeTimers();
+            const scheduledChunks = [];
+            const setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(callback => {
+                scheduledChunks.push(callback);
+                return 1;
+            });
+
+            try {
+                const blocks = new Blocks(mockActivity);
+                blocks.blockList = [];
+                blocks.protoBlockDict = {};
+                blocks.newStorein2Block = jest.fn();
+                blocks.newNamedboxBlock = jest.fn();
+                blocks.setActionProtoVisibility = jest.fn();
+                blocks.customTemperamentDefined = true;
+                blocks._processOneBlock = jest.fn();
+
+                const blockObjs = Array.from({ length: 40 }, (_, index) => [
+                    index,
+                    "forward",
+                    0,
+                    0,
+                    [null, null, null]
+                ]);
+
+                blocks.loadNewBlocks(blockObjs);
+                blocks.cancelPendingLoad();
+                scheduledChunks[0]();
+
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
+            } finally {
+                setTimeoutSpy.mockRestore();
+                jest.useRealTimers();
+            }
+        });
+
+        it("ignores cleanup from a cancelled load", async () => {
+            const blocks = new Blocks(mockActivity);
+            blocks._activeLoadGeneration = 1;
+            blocks._loadCounter = 1;
+
+            blocks.cancelPendingLoad();
+            await blocks.cleanupAfterLoad("forward", 1);
+
+            expect(blocks._loadCounter).toBe(0);
+            expect(mockActivity.refreshCanvas).not.toHaveBeenCalled();
+        });
+
+        it("does not refresh the workspace when cleanup is cancelled", async () => {
+            const blocks = new Blocks(mockActivity);
+            blocks._activeLoadGeneration = 1;
+            blocks._loadCounter = 1;
+            blocks.blockList = [];
+            blocks.blocksToCollapse = [];
+            blocks._findDrumURLs = jest.fn(() => blocks.cancelPendingLoad());
+            blocks.updateBlockPositions = jest.fn();
+            blocks._cleanupStacks = jest.fn();
+            blocks._rebuildSpatialGrid = jest.fn();
+
+            await blocks.cleanupAfterLoad("forward", 1);
+
+            expect(mockActivity.refreshCanvas).not.toHaveBeenCalled();
+            expect(mockActivity._suppressRefresh).toBe(false);
         });
     });
 

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -852,6 +852,47 @@ describe("Blocks Foundation", () => {
             expect(() => blocks.loadNewBlocks(blockObjs)).toThrow("simulated processing error");
             expect(mockActivity._suppressRefresh).toBe(false);
         });
+
+        it("cancels stale chunks and ignores their cleanup after a new load starts", async () => {
+            jest.useFakeTimers();
+
+            try {
+                const blocks = new Blocks(mockActivity);
+                blocks.blockList = [];
+                blocks.protoBlockDict = {};
+                blocks.newStorein2Block = jest.fn();
+                blocks.newNamedboxBlock = jest.fn();
+                blocks.setActionProtoVisibility = jest.fn();
+                blocks.customTemperamentDefined = true;
+                blocks._processOneBlock = jest.fn();
+
+                const oldBlockObjs = Array.from({ length: 40 }, (_, index) => [
+                    index,
+                    "forward",
+                    0,
+                    0,
+                    [null, null, null]
+                ]);
+                const newBlockObjs = [[0, "forward", 0, 0, [null, null, null]]];
+
+                blocks.loadNewBlocks(oldBlockObjs);
+                const oldGeneration = blocks._activeLoadGeneration;
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(20);
+                expect(jest.getTimerCount()).toBe(1);
+
+                blocks.loadNewBlocks(newBlockObjs);
+
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(21);
+                expect(jest.getTimerCount()).toBe(0);
+                await blocks.cleanupAfterLoad("forward", oldGeneration);
+                expect(blocks._loadCounter).toBe(1);
+
+                jest.runOnlyPendingTimers();
+                expect(blocks._processOneBlock).toHaveBeenCalledTimes(21);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
     });
 
     describe("renameNameddos", () => {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1921,9 +1921,7 @@ class Activity {
          * @param {boolean} closeAllWidgets  {if true close all open widgets}
          */
         this.sendAllToTrash = (addStartBlock, doNotSave, closeAllWidgets = true) => {
-            if (typeof this.blocks.cancelPendingLoad === "function") {
-                this.blocks.cancelPendingLoad();
-            }
+            this.blocks.cancelPendingLoad?.();
 
             // Return to home position after loading new blocks.
             this.blocksContainer.x = 0;

--- a/js/activity.js
+++ b/js/activity.js
@@ -1921,6 +1921,10 @@ class Activity {
          * @param {boolean} closeAllWidgets  {if true close all open widgets}
          */
         this.sendAllToTrash = (addStartBlock, doNotSave, closeAllWidgets = true) => {
+            if (typeof this.blocks.cancelPendingLoad === "function") {
+                this.blocks.cancelPendingLoad();
+            }
+
             // Return to home position after loading new blocks.
             this.blocksContainer.x = 0;
             this.blocksContainer.y = 0;

--- a/js/block.js
+++ b/js/block.js
@@ -1591,7 +1591,7 @@ class Block {
             }
 
             // this.activity.refreshCanvas();
-            this.blocks.cleanupAfterLoad(this.name);
+            this.blocks.cleanupAfterLoad(this.name, this.loadGeneration);
         } else {
             // Some blocks, e.g., Start blocks and Action blocks can
             // collapse, so add an event handler.
@@ -1651,7 +1651,7 @@ class Block {
             }
 
             that.activity.refreshCanvas();
-            that.blocks.cleanupAfterLoad(that.name);
+            that.blocks.cleanupAfterLoad(that.name, that.loadGeneration);
             if (that.trash) {
                 that.collapseText.visible = false;
                 that.collapseButtonBitmap.visible = false;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -211,6 +211,10 @@ class Blocks {
         this._expandablesList = [];
         /** Number of blocks to load */
         this._loadCounter = 0;
+        /** Generation for invalidating stale asynchronous block loads. */
+        this._loadGeneration = 0;
+        this._activeLoadGeneration = null;
+        this._loadTimeoutId = null;
         /**
          * Stacks of blocks that need adjusting as blocks are repositioned
          * due to expanding and contracting or insertion into the flow.
@@ -2639,6 +2643,7 @@ class Blocks {
             // Cache the block's index for O(1) lookups instead of
             // O(N) blockList.indexOf() scans.
             myBlock.blockIndex = this.blockList.length - 1;
+            myBlock.loadGeneration = this._activeLoadGeneration;
             myBlock.copySize();
 
             /** We may need to do some postProcessing to the block */
@@ -4769,12 +4774,30 @@ class Blocks {
         };
 
         /**
+         * Cancel any pending chunk from the current block load.
+         * @public
+         * @returns {void}
+         */
+        this.cancelPendingLoad = () => {
+            if (this._loadTimeoutId !== null) {
+                clearTimeout(this._loadTimeoutId);
+                this._loadTimeoutId = null;
+            }
+
+            this._loadGeneration += 1;
+            this._activeLoadGeneration = null;
+            this._loadCounter = 0;
+            this.activity._suppressRefresh = false;
+        };
+
+        /**
          * Load new blocks.
          * @param - blockObj - Block Objects
          * @public
          * return {void}
          */
         this.loadNewBlocks = blockObjs => {
+            this.cancelPendingLoad();
             /** Suppress intermediate canvas redraws during block loading. */
             this.activity._suppressRefresh = true;
 
@@ -5317,6 +5340,8 @@ class Blocks {
                 this._adjustTheseStacks = [];
                 this._adjustTheseDocks = [];
                 this._loadCounter = blockObjs.length;
+                const loadGeneration = this._loadGeneration;
+                this._activeLoadGeneration = loadGeneration;
 
                 // Preload audio samples for instruments used in this project (background task)
                 if (this.activity && this.activity.logo && this.activity.logo.synth) {
@@ -5357,6 +5382,11 @@ class Blocks {
                 }
 
                 const processChunk = () => {
+                    if (loadGeneration !== this._activeLoadGeneration) {
+                        return;
+                    }
+
+                    this._loadTimeoutId = null;
                     const chunkEnd = Math.min(bIndex + CHUNK_SIZE, totalBlocks);
                     for (let b = bIndex; b < chunkEnd; b++) {
                         this._processOneBlock(b, blockObjs, blockOffset, firstBlock);
@@ -5368,7 +5398,7 @@ class Blocks {
                         // silently stalls loading after the first chunk. setTimeout(0)
                         // still yields to the main thread but keeps running regardless
                         // of tab visibility.
-                        setTimeout(processChunk, 0);
+                        this._loadTimeoutId = setTimeout(processChunk, 0);
                     }
                 };
 
@@ -6232,7 +6262,11 @@ class Blocks {
          * @public
          * @returns {void}
          */
-        this.cleanupAfterLoad = async () => {
+        this.cleanupAfterLoad = async (name, loadGeneration = this._activeLoadGeneration) => {
+            if (loadGeneration !== this._activeLoadGeneration) {
+                return;
+            }
+
             this._loadCounter -= 1;
             // Early return BEFORE the try block is intentional:
             // intermediate calls must not run the finally, which resets
@@ -6318,8 +6352,11 @@ class Blocks {
                 pubsub.emit("finishedLoading");
             } finally {
                 /** All blocks loaded — allow canvas redraws again. */
-                this.activity._suppressRefresh = false;
-                this.activity.refreshCanvas();
+                if (loadGeneration === this._activeLoadGeneration) {
+                    this._activeLoadGeneration = null;
+                    this.activity._suppressRefresh = false;
+                    this.activity.refreshCanvas();
+                }
             }
         };
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -215,6 +215,8 @@ class Blocks {
         this._loadGeneration = 0;
         this._activeLoadGeneration = null;
         this._loadTimeoutId = null;
+        /** Block batches requested while another batch is loading. */
+        this._pendingBlockLoads = [];
         /**
          * Stacks of blocks that need adjusting as blocks are repositioned
          * due to expanding and contracting or insertion into the flow.
@@ -4787,6 +4789,7 @@ class Blocks {
             this._loadGeneration += 1;
             this._activeLoadGeneration = null;
             this._loadCounter = 0;
+            this._pendingBlockLoads = [];
             this.activity._suppressRefresh = false;
         };
 
@@ -4797,6 +4800,11 @@ class Blocks {
          * return {void}
          */
         this.loadNewBlocks = blockObjs => {
+            if (this._activeLoadGeneration !== null) {
+                this._pendingBlockLoads.push(blockObjs);
+                return;
+            }
+
             this.cancelPendingLoad();
             /** Suppress intermediate canvas redraws during block loading. */
             this.activity._suppressRefresh = true;
@@ -6275,6 +6283,8 @@ class Blocks {
                 return;
             }
 
+            let pendingBlockLoads = [];
+
             try {
                 this._findDrumURLs();
 
@@ -6350,12 +6360,18 @@ class Blocks {
                     this.activity.stopLoadAnimation();
                 }
                 pubsub.emit("finishedLoading");
+                pendingBlockLoads = this._pendingBlockLoads;
+                this._pendingBlockLoads = [];
             } finally {
                 /** All blocks loaded — allow canvas redraws again. */
                 if (loadGeneration === this._activeLoadGeneration) {
                     this._activeLoadGeneration = null;
                     this.activity._suppressRefresh = false;
                     this.activity.refreshCanvas();
+
+                    for (const blockObjs of pendingBlockLoads) {
+                        this.loadNewBlocks(blockObjs);
+                    }
                 }
             }
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5781,9 +5781,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.43",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+            "version": "2.11.21",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+            "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -5942,22 +5942,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "es-define-property": "^1.0.1",
-                "side-channel": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "license": "ISC"
@@ -5988,9 +5972,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.6",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+            "version": "4.28.8",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6007,11 +5991,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001803",
-                "electron-to-chromium": "^1.5.389",
-                "node-releases": "^2.0.51",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -6310,9 +6294,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001805",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7771,9 +7755,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.389",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+            "version": "1.5.422",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+            "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -12958,9 +12942,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.51",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -14261,9 +14245,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "es-define-property": "^1.0.1",
@@ -16143,7 +16127,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
             "postcss": "^8.4.31"
         },
         "body-parser": "2.3.0",
-        "qs": "6.15.3"
+        "browserslist": "4.28.8",
+        "qs": "6.16.0"
     },
     "lint-staged": {
         "*.{js,mjs}": [


### PR DESCRIPTION
## Description

Prevents stale asynchronous chunks from an earlier project load from modifying the workspace after a newer load or workspace replacement begins.

Large projects are loaded in chunks so the browser remains responsive. Previously, pending `setTimeout` callbacks could continue processing old block data after the workspace had changed.

## Related Issue

**Fixes:** No Linked issue

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage

---

## Changes Made

- Track the timeout used for the next block-loading chunk.
- Add load-generation checks to invalidate stale chunk callbacks.
- Tag loaded blocks so stale asynchronous cleanup callbacks are ignored.
- Cancel pending loads before `sendAllToTrash()` replaces the workspace.
- Add regression coverage using Jest fake timers.

The existing chunk size, block ordering, connection handling, and normal loading behavior remain unchanged.

## Steps to Reproduce

1. Start loading a large project containing more than 40 blocks.
2. Before loading finishes, start a new project or load another project.
3. Flush or wait for the pending timers.

Before this change, stale chunks could append blocks from the previous project.

Expected result: only the latest project modifies the workspace, with no duplicate or stale blocks.

## Testing Performed

- Targeted Blocks tests passed.
- Related Block and Activity tests passed.
- Full Jest suite passed: 224 suites and 8346 tests.


## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading multiple content batches, including queued, repeated, empty, and circular loads.
  - Prevented outdated load results from affecting current content.
  - Ensured loading completes correctly after deferred failures.
  - Improved recovery when rendering or viewport updates encounter errors.
- **Tests**
  - Expanded regression coverage for loading, cleanup, completion events, and timer handling.
- **Chores**
  - Updated package compatibility overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->