### PR TITLE
fix(toolbar): stop the click handler resetting tooltip options

### DIFF
--- a/js/__tests__/toolbar-tooltip.test.js
+++ b/js/__tests__/toolbar-tooltip.test.js
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Netram Faran
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// toolbar-ui.js binds `const $j = window.jQuery` at module load, so the stub
+// has to be in place before the module is required. Each test therefore resets
+// the module registry and requires a fresh copy.
+
+describe("ToolbarUI tooltip dismissal", () => {
+    let ToolbarUI;
+    let calls;
+    let clickHandler;
+
+    const makeElement = id => ({
+        id,
+        style: {},
+        setAttribute: jest.fn(),
+        getAttribute: jest.fn(),
+        classList: { add: jest.fn(), remove: jest.fn(), contains: jest.fn(() => false) },
+        addEventListener: jest.fn(),
+        appendChild: jest.fn(),
+        focus: jest.fn(),
+        querySelectorAll: jest.fn(() => []),
+        querySelector: jest.fn(() => null),
+        innerHTML: ""
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        calls = { tooltip: [], css: [] };
+        clickHandler = null;
+
+        const jq = jest.fn(selector => ({
+            tooltip: jest.fn(opts => calls.tooltip.push({ selector, opts })),
+            dropdown: jest.fn(),
+            css: jest.fn((prop, value) => calls.css.push({ selector, prop, value })),
+            trigger: jest.fn(),
+            on: jest.fn((event, handler) => {
+                if (selector === ".tooltipped" && event === "click") {
+                    clickHandler = handler;
+                }
+            })
+        }));
+        jq.noConflict = jest.fn(() => jq);
+
+        global.jQuery = jq;
+        global.window.jQuery = jq;
+        global.window.platformColor = { stopIconcolor: "#ea174c" };
+        global.platformColor = { stopIconcolor: "#ea174c" };
+        global.makeKeyboardAccessible = jest.fn();
+        global.docById = id => makeElement(id);
+        global.document.getElementById = jest.fn(id => makeElement(id));
+        global._THIS_IS_MUSIC_BLOCKS_ = true;
+        global._ = jest.fn(x => x);
+
+        ToolbarUI = require("../toolbar-ui");
+        const toolbar = new ToolbarUI();
+        toolbar.init({ beginnerMode: true });
+    });
+
+    afterEach(() => {
+        delete global.window.jQuery;
+        delete global.window.platformColor;
+        delete global._THIS_IS_MUSIC_BLOCKS_;
+        delete global._;
+    });
+
+    it("binds a click handler to the tooltipped elements", () => {
+        expect(typeof clickHandler).toBe("function");
+    });
+
+    it("configures the tooltips with the shorter delay at init", () => {
+        const init = calls.tooltip.find(c => c.selector === ".tooltipped" && c.opts);
+
+        expect(init.opts).toEqual({ html: true, delay: 100 });
+    });
+
+    // Materialize recognises only "remove". Any other string, "close"
+    // included, falls through to a full re-initialisation that rebuilds the
+    // tooltip with the plugin defaults, discarding the delay set at init.
+    it("does not call the tooltip plugin when a tooltip is dismissed", () => {
+        const before = calls.tooltip.length;
+
+        clickHandler.call({ getAttribute: () => "tooltip-42" });
+
+        expect(calls.tooltip).toHaveLength(before);
+    });
+
+    it("never passes a bare string to the tooltip plugin", () => {
+        clickHandler.call({ getAttribute: () => "tooltip-42" });
+
+        expect(calls.tooltip.every(c => typeof c.opts !== "string")).toBe(true);
+    });
+
+    it("hides the tooltip node belonging to the clicked element", () => {
+        clickHandler.call({ getAttribute: () => "tooltip-42" });
+
+        expect(calls.css).toContainEqual({
+            selector: "#tooltip-42",
+            prop: "visibility",
+            value: "hidden"
+        });
+    });
+
+    it("does nothing for an element that has no tooltip yet", () => {
+        clickHandler.call({ getAttribute: () => null });
+
+        expect(calls.css).toHaveLength(0);
+    });
+});

--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -416,8 +416,17 @@ class ToolbarUI {
             });
         }
 
+        // Hide the tooltip node directly. Materialize has no "close" command:
+        // it recognises only "remove", and anything else falls through to a
+        // full re-initialisation that rebuilds the tooltip with the plugin
+        // defaults, discarding the delay set just above. Setting visibility is
+        // what Materialize's own mouseleave handler does, and it leaves the
+        // element's configuration and its cached tooltip node untouched.
         $j(".tooltipped").on("click", function () {
-            $j(this).tooltip("close");
+            const tooltipId = this.getAttribute("data-tooltip-id");
+            if (tooltipId) {
+                $j("#" + tooltipId).css("visibility", "hidden");
+            }
         });
 
         const restoreWidgetFocus = () => {

--- a/js/turtles.js
+++ b/js/turtles.js
@@ -1213,7 +1213,13 @@ Turtles.TurtlesView = class {
         const __makeAllButtons = () => {
             let second = false;
             if (docById("buttoncontainerTOP")) {
-                window.jQuery(".tooltipped").tooltip("close");
+                // "remove" is the only teardown Materialize recognises. It
+                // deletes the tooltip nodes and unbinds the hover handlers,
+                // which matters because the buttons below are about to be
+                // destroyed and would otherwise leave their tooltip nodes
+                // orphaned in the body. Every tooltipped element is
+                // re-initialised at the end of this function.
+                window.jQuery(".tooltipped").tooltip("remove");
                 docById("buttoncontainerTOP").parentElement.removeChild(
                     docById("buttoncontainerTOP")
                 );


### PR DESCRIPTION
## Description

Materialize's tooltip plugin recognises only `"remove"`. Any other string falls through to a full re-initialisation, because the plugin does `options = $.extend(defaults, options)` and then rebuilds the tooltip. This is the plugin as it ships in `dist/vendor.min.js`:

```js
fn.tooltip = function (i) {
    var n = { delay: 350, tooltip: "", position: "bottom", html: !1 };
    return "remove" === i
        ? (this.each(function () { /* remove path */ }), !1)
        : (i = t.extend(n, i), this.each(function () { /* full re-init */ }))
}
```

Passing `"close"` spreads the string into index keys and leaves every real option at its default:

```
$.extend({ delay: 350, tooltip: "", position: "bottom", html: false }, "close")
  -> { "0":"c","1":"l","2":"o","3":"s","4":"e",
       delay: 350, tooltip: "", position: "bottom", html: false }
```

`toolbar-ui.js` configured its tooltips with a 100 ms delay and then bound a click handler six lines later that called `tooltip("close")` on the clicked element:

```js
if (!this.tooltipsDisabled) {
    $j(".tooltipped").tooltip({ html: true, delay: 100 });
}

$j(".tooltipped").on("click", function () {
    $j(this).tooltip("close");
});
```

So every click on a tooltipped toolbar button rebuilt that tooltip with the default 350 ms delay, three and a half times slower, and nothing re-initialised those tooltips afterwards, so it persisted for the session.

Worth ruling out explicitly: jQuery UI's tooltip widget does have a `close` method, and jQuery UI is bundled. It is not the plugin in play. In `dist/vendor.min.js`, `widget("ui.tooltip")` appears at byte 335338 and Materialize's tooltip at byte 416368, so Materialize is defined later and overwrites it.

## Related Issue

**Fixes:** #8400

## Category

- [x] Bug Fix

## Changes Made

Hide the tooltip node directly rather than routing through the plugin. Setting visibility is what Materialize's own `mouseleave` handler does, and it leaves both the element's configuration and the cached tooltip node that the `mouseenter` closure holds untouched:

```js
$j(".tooltipped").on("click", function () {
    const tooltipId = this.getAttribute("data-tooltip-id");
    if (tooltipId) {
        $j("#" + tooltipId).css("visibility", "hidden");
    }
});
```

`turtles.js` also called `tooltip("close")`, but on a path that re-initialises every tooltipped element a few lines later, so the options were restored immediately and nothing was user visible there. It is switched to `"remove"`, which is the real teardown command and the right call given the buttons it guards are about to be destroyed.

## Testing Performed

Full suite passes: **225 suites, 8372 tests**. `npm run lint` and `npx prettier --check` are both clean.

Added `js/__tests__/toolbar-tooltip.test.js`. `toolbar-ui.js` binds `const $j = window.jQuery` at module load, so the existing `toolbar-ui.test.js` cannot reach the handler: it sets `global.$j` after the module has already captured its own reference. The new file resets the module registry and installs the stub on `window.jQuery` before requiring, which lets the click handler be captured and invoked.

| assertion | before | after |
|---|---|---|
| dismissing calls the tooltip plugin | yes, with `"close"` | no |
| a bare string reaches the plugin | yes | no |
| the clicked element's tooltip node is hidden | no | yes |
| handler is bound at init | yes | yes |
| init asks for `delay: 100` | yes | yes |
| element with no tooltip is left alone | yes | yes |

Three of the six fail without the source change. The rest are regression guards.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toolbar tooltip dismissal so tooltips reliably hide when selected.
  * Improved cleanup of tooltip elements and hover behavior when toolbar buttons are recreated.
  * Prevented stale tooltip elements from remaining after toolbar updates.

* **Tests**
  * Added coverage for tooltip dismissal, initialization, click handling, and non-tooltip elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->