### PR TITLE
fix: resolve undefined note name for negative pitch numbers in getNote()

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1666,6 +1666,129 @@ describe("getNote", () => {
         expect(result[2]).toBeCloseTo(7, 0);
     });
 });
+describe("getNote with numeric noteArg", () => {
+    it("should resolve positive pitch numbers correctly", () => {
+        // 0 = C in sharp preference
+        expect(getNote(0, 4, 0, "C major", false)[0]).toBe("C");
+        // 1 = C♯ in G major (sharp preference)
+        expect(getNote(1, 4, 0, "G major", false)[0]).toBe("C♯");
+    });
+
+    it("should wrap negative pitch numbers using modulo (12-EDO, sharps)", () => {
+        // -1 should wrap to index 11 = B
+        const result = getNote(-1, 4, 0, "C major", false);
+        expect(result[0]).toBe("B");
+    });
+
+    it("should wrap negative pitch numbers using modulo (12-EDO, flats)", () => {
+        // -2 should wrap to index 10 = B♭ in flat preference
+        const result = getNote(-2, 4, 0, "F major", false);
+        expect(result[0]).toBe("B♭");
+    });
+
+    it("should handle large negative pitch numbers", () => {
+        // -13 should wrap to index 11 = B (same as -1 mod 12)
+        const result = getNote(-13, 4, 0, "C major", false);
+        expect(result[0]).toBe("B");
+    });
+
+    it("should handle negative pitch numbers with movable key offset", () => {
+        // With G major (kOffset=7), noteArg=-8 → (-8+7) = -1 → wraps to 11 = B
+        const result = getNote(-8, 4, 0, "G major", true);
+        expect(result[0]).toBe("B");
+    });
+
+    it("should handle movable-key offset for non-12 EDO (equal19)", () => {
+        // In equal19, generateNoteNames places G at index 11.
+        // With G major (movable=true) and noteArg=0, it should resolve to G, not E#.
+        const result = getNote(0, 4, 0, "G major", true, undefined, undefined, "equal19");
+        expect(result[0]).toBe("G");
+    });
+
+    it("should handle movable-key offset for non-12 EDO (1/3 comma meantone)", () => {
+        // 1/3 comma meantone uses a custom noteLabels table.
+        // A movable D♭ tonic should receive the correct offset from the noteLabels, not the fallback generator.
+        const result = getNote(
+            0,
+            4,
+            0,
+            "D♭ major",
+            true,
+            undefined,
+            undefined,
+            "1/3 comma meantone"
+        );
+        expect(result[0]).toBe("D♭");
+
+        // Also check that it selects the correct distinct label for index 1
+        const pos1 = getNote(1, 4, 0, "C major", false, undefined, undefined, "1/3 comma meantone");
+        expect(pos1[0]).toBe("D♭");
+    });
+});
+
+describe("getNote with lowercase non-12-EDO note names", () => {
+    it("should correctly resolve lowercase non-12-EDO note names", () => {
+        expect(getNote("c#", 4, 0, "C major", false, undefined, undefined, "equal19")).toEqual([
+            "C♯",
+            4,
+            0
+        ]);
+        expect(getNote("eb", 4, 0, "C major", false, undefined, undefined, "equal19")).toEqual([
+            "E♭",
+            4,
+            0
+        ]);
+    });
+});
+
+describe("getNote meantone and edge case tests", () => {
+    it("should correctly resolve C♭ in 1/4 comma meantone", () => {
+        // 1/4 comma meantone (21-EDO) has C♭ at index 19 of its noteLabels.
+        expect(
+            getNote(19, 4, 0, "C major", false, undefined, undefined, "1/4 comma meantone")[0]
+        ).toBe("C♭");
+        expect(
+            getNote("c♭", 4, 0, "C major", false, undefined, undefined, "1/4 comma meantone")[0]
+        ).toBe("C♭");
+        expect(
+            getNote("C♭", 4, 0, "C major", false, undefined, undefined, "1/4 comma meantone")[0]
+        ).toBe("C♭");
+    });
+
+    it("should handle 1/3-comma meantone transposition round trip", () => {
+        // 1/3 comma meantone is 19-EDO.
+        // Transposing up by 19 steps should perfectly equate to 1 octave up.
+        // getNote arguments: noteArg, octave, transposition, keySignature, movable, direction, errorMsg, temperament, isAlreadyEdoSteps
+        const resultUp = getNote(
+            "C",
+            4,
+            19,
+            "C major",
+            false,
+            undefined,
+            undefined,
+            "1/3 comma meantone",
+            true
+        );
+        expect(resultUp).toEqual(["C", 5, 0]);
+
+        // Transposing down by 19 steps should equate to 1 octave down.
+        const resultDown = getNote(
+            "C",
+            4,
+            -19,
+            "C major",
+            false,
+            undefined,
+            undefined,
+            "1/3 comma meantone",
+            true
+        );
+        expect(resultDown[0]).toBe("C");
+        expect(resultDown[1]).toBe(3);
+        expect(resultDown[2]).toBeCloseTo(0);
+    });
+});
 
 describe("getPitchInfo with frequency input", () => {
     it("should handle numeric frequency input via 1-arg form as pitch number", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4820,7 +4820,10 @@ const pitchToNumber = (pitch, octave, keySignature, temperament) => {
             // Use its proportional position from 12-EDO (A is at index 9).
             aIndex = Math.round((9 / 12) * currentEDO);
         }
-        const normalizedPitch = originalPitch.replaceAll("#", SHARP).replaceAll("b", FLAT);
+        const normalizedPitch = originalPitch
+            .replace(/^([a-g])/, (_, letter) => letter.toUpperCase())
+            .replaceAll("#", SHARP)
+            .replaceAll("b", FLAT);
         let edoPos = names.indexOf(normalizedPitch);
         if (edoPos === -1) {
             // Fallback: try the 12-EDO arrays with proportional mapping
@@ -5798,6 +5801,12 @@ function getNote(
 
     octave = Math.round(octave);
 
+    const edoNames =
+        octaveLength !== 12
+            ? (TEMPERAMENT[temperament] && TEMPERAMENT[temperament].noteLabels) ||
+              generateNoteNames(octaveLength)
+            : null;
+
     if (typeof noteArg === "number") {
         // Assume it is a pitch number.
         if (!keySignature) {
@@ -5805,13 +5814,16 @@ function getNote(
         }
         let kOffset = 0;
         if (movable) {
-            kOffset = PITCHES.indexOf(keySignature.split(" ")[0]);
-            if (kOffset === -1) {
+            if (octaveLength === 12) {
                 kOffset = PITCHES.indexOf(keySignature.split(" ")[0]);
+
+                if (kOffset === -1) {
+                    kOffset = PITCHES2.indexOf(keySignature.split(" ")[0]);
+                }
+            } else {
+                kOffset = edoNames.indexOf(keySignature.split(" ")[0]);
             }
-            if (kOffset === -1) {
-                kOffset = PITCHES2.indexOf(keySignature.split(" ")[0]);
-            }
+
             if (kOffset === -1) {
                 kOffset = 0;
 
@@ -5820,13 +5832,15 @@ function getNote(
         }
         if (octaveLength === 12) {
             if (getSharpFlatPreference(keySignature) === "sharp") {
-                noteArg = PITCHES2[(noteArg + kOffset) % octaveLength];
+                noteArg =
+                    PITCHES2[(((noteArg + kOffset) % octaveLength) + octaveLength) % octaveLength];
             } else {
-                noteArg = PITCHES[(noteArg + kOffset) % octaveLength];
+                noteArg =
+                    PITCHES[(((noteArg + kOffset) % octaveLength) + octaveLength) % octaveLength];
             }
         } else {
-            const edoNames = generateNoteNames(octaveLength);
-            noteArg = edoNames[(noteArg + kOffset) % octaveLength];
+            noteArg =
+                edoNames[(((noteArg + kOffset) % octaveLength) + octaveLength) % octaveLength];
         }
     }
 
@@ -5839,6 +5853,9 @@ function getNote(
     ) {
         // Check for double flat or double sharp. Since bb and x behave
         // funny with string operations, we jump through some hoops.
+        if (/^[a-g][#b*♯♭𝄪𝄫x♮]*$/u.test(noteArg)) {
+            noteArg = noteArg[0].toUpperCase() + noteArg.slice(1);
+        }
         articulation = getArticulation(noteArg);
         noteArg = noteArg.replace(articulation, "");
 
@@ -5895,7 +5912,6 @@ function getNote(
             // are resolved without going through 12-EDO EXTRATRANSPOSITIONS, which
             // would prematurely convert them to enharmonic equivalents and corrupt
             // the octave calculation.
-            const edoNames = generateNoteNames(octaveLength);
             const normalizedName = noteArg.replaceAll("#", SHARP).replaceAll("b", FLAT);
             const edoIdx = edoNames.indexOf(normalizedName);
             if (edoIdx !== -1) {


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->
Fixes `getNote()` in `musicutils.js` returning `undefined` when called with negative numeric pitch numbers.

JavaScript's `%` operator preserves sign: `(-1) % 12 === -1`, not `11`. This produces a negative array index, which returns `undefined` from the `PITCHES`/`PITCHES2` arrays. The `undefined` silently propagates through the audio pipeline, causing no sound, broken notation export, and potential TypeErrors downstream.

## Related Issue
**Fixes:** #8406

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---


### Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).


## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->
- Replaced `(noteArg + kOffset) % octaveLength` with the safe double-modulo idiom `((noteArg + kOffset) % octaveLength + octaveLength) % octaveLength` at lines 5823, 5825, and 5829.
- Fixed a copy-paste error at line 5810 where `PITCHES.indexOf` was duplicated as a fallback instead of trying `PITCHES2.indexOf`.
- Added focused Jest test coverage for the numeric `noteArg` path in `getNote()`, which previously had zero test cases.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved note-name resolution across non-12-tone temperaments.
  - Lowercase note input now correctly supports `*` accidentals.
  - Improved consistency when selecting pitch labels for numeric and named notes.

- **Tests**
  - Added regression coverage for 1/4-comma meantone C♭ resolution from numeric, lowercase, and uppercase inputs.
  - Added coverage for 1/3-comma meantone octave transposition round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->