### PR TITLE
fix(toolbar): don't waste the first step-by-step click on a fresh run

### DIFF
--- a/js/activity/__tests__/toolbar-controller.test.js
+++ b/js/activity/__tests__/toolbar-controller.test.js
@@ -193,6 +193,7 @@ describe("ToolbarController.runStep", () => {
     });
 
     test("sets runMode to step and handles initial mode switch", () => {
+        jest.useFakeTimers();
         activity.logo.stepQueue = {}; // count is 0
         activity.logo.turtleDelay = 500; // not step mode
 
@@ -201,8 +202,13 @@ describe("ToolbarController.runStep", () => {
         expect(controller.runMode).toBe("step");
         expect(activity.logo.turtleDelay).toBe(-1);
         expect(activity.logo.runLogoCommands).toHaveBeenCalled();
+        // On a fresh start, step() is deferred until after runLogoCommands()
+        // has populated the step queue, so it has not run synchronously yet.
+        expect(activity.logo.step).not.toHaveBeenCalled();
+        jest.runAllTimers();
         expect(activity.logo.step).toHaveBeenCalled();
         expect(result).toBe("started");
+        jest.useRealTimers();
     });
 
     test("returns null if turtles are already running when switching modes", () => {
@@ -216,6 +222,7 @@ describe("ToolbarController.runStep", () => {
     });
 
     test("handles non-null result if started true", () => {
+        jest.useFakeTimers();
         activity.logo.stepQueue = {};
         activity.logo.turtleDelay = 500;
         activity.turtles.running.mockReturnValue(false);
@@ -224,8 +231,11 @@ describe("ToolbarController.runStep", () => {
         const result = controller.runStep();
 
         expect(activity.logo.runLogoCommands).toHaveBeenCalled();
+        // step() is deferred on a fresh start; flush the timer to run it.
+        jest.runAllTimers();
         expect(activity.logo.step).toHaveBeenCalled();
         expect(result).toBe("started");
+        jest.useRealTimers();
     });
 
     test("handles undefined synth gracefully", () => {
@@ -240,6 +250,38 @@ describe("ToolbarController.runStep", () => {
         expect(() => {
             controller.runStep();
         }).not.toThrow();
+    });
+
+    test("defers the first step() on a fresh start until the queue is populated", () => {
+        jest.useFakeTimers();
+        activity.logo.stepQueue = {}; // no queue yet
+        activity.logo.turtleDelay = 500; // not step mode
+        activity.turtles.running.mockReturnValue(false);
+
+        const result = controller.runStep();
+
+        // The first click only arms the run; step() must not fire synchronously
+        // while runLogoCommands() has yet to queue the start block(s).
+        expect(activity.logo.runLogoCommands).toHaveBeenCalled();
+        expect(activity.logo.step).not.toHaveBeenCalled();
+        expect(result).toBe("started");
+
+        // Once the (mocked) async dispatch settles, the deferred step runs.
+        jest.runAllTimers();
+        expect(activity.logo.step).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+    });
+
+    test("steps synchronously (no defer) when already running in step mode", () => {
+        activity.logo.stepQueue = { turtle0: [1, 2] };
+        activity.turtles.running.mockReturnValue(true);
+        activity.logo.turtleDelay = -1; // already in step mode
+
+        controller.runStep();
+
+        // No fresh start, so step() is called synchronously with no timer.
+        expect(activity.logo.runLogoCommands).not.toHaveBeenCalled();
+        expect(activity.logo.step).toHaveBeenCalledTimes(1);
     });
 
     test("just steps when already in step mode with turtles running", () => {

--- a/js/activity/__tests__/toolbar-controller.test.js
+++ b/js/activity/__tests__/toolbar-controller.test.js
@@ -40,6 +40,24 @@ function makeMockActivity() {
     };
 }
 
+// Mimics the real runLogoCommands(), which dispatches the start block(s)
+// asynchronously, so the stepQueue is only populated on a later tick. Returns
+// an array of the queue snapshots that step() actually observed, so a test can
+// prove the first step() ran *after* the queue was filled -- not merely that a
+// timer fired.
+function mockAsyncQueuePopulation(activity) {
+    const queueSeenByStep = [];
+    activity.logo.runLogoCommands.mockImplementation(() => {
+        setTimeout(() => {
+            activity.logo.stepQueue = { turtle0: [1] };
+        }, 0);
+    });
+    activity.logo.step.mockImplementation(() => {
+        queueSeenByStep.push(JSON.parse(JSON.stringify(activity.logo.stepQueue)));
+    });
+    return queueSeenByStep;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -194,6 +212,7 @@ describe("ToolbarController.runStep", () => {
 
     test("sets runMode to step and handles initial mode switch", () => {
         jest.useFakeTimers();
+        const queueSeenByStep = mockAsyncQueuePopulation(activity);
         activity.logo.stepQueue = {}; // count is 0
         activity.logo.turtleDelay = 500; // not step mode
 
@@ -207,6 +226,8 @@ describe("ToolbarController.runStep", () => {
         expect(activity.logo.step).not.toHaveBeenCalled();
         jest.runAllTimers();
         expect(activity.logo.step).toHaveBeenCalled();
+        // ...and when it did run, the queue was already populated.
+        expect(queueSeenByStep).toEqual([{ turtle0: [1] }]);
         expect(result).toBe("started");
         jest.useRealTimers();
     });
@@ -223,6 +244,7 @@ describe("ToolbarController.runStep", () => {
 
     test("handles non-null result if started true", () => {
         jest.useFakeTimers();
+        const queueSeenByStep = mockAsyncQueuePopulation(activity);
         activity.logo.stepQueue = {};
         activity.logo.turtleDelay = 500;
         activity.turtles.running.mockReturnValue(false);
@@ -234,6 +256,7 @@ describe("ToolbarController.runStep", () => {
         // step() is deferred on a fresh start; flush the timer to run it.
         jest.runAllTimers();
         expect(activity.logo.step).toHaveBeenCalled();
+        expect(queueSeenByStep).toEqual([{ turtle0: [1] }]);
         expect(result).toBe("started");
         jest.useRealTimers();
     });
@@ -254,6 +277,7 @@ describe("ToolbarController.runStep", () => {
 
     test("defers the first step() on a fresh start until the queue is populated", () => {
         jest.useFakeTimers();
+        const queueSeenByStep = mockAsyncQueuePopulation(activity);
         activity.logo.stepQueue = {}; // no queue yet
         activity.logo.turtleDelay = 500; // not step mode
         activity.turtles.running.mockReturnValue(false);
@@ -266,9 +290,12 @@ describe("ToolbarController.runStep", () => {
         expect(activity.logo.step).not.toHaveBeenCalled();
         expect(result).toBe("started");
 
-        // Once the (mocked) async dispatch settles, the deferred step runs.
+        // Once the (mocked) async dispatch settles, the deferred step runs --
+        // and it sees the queued start block, which is the whole point of the
+        // fix: before it, step() ran against an empty queue and advanced nothing.
         jest.runAllTimers();
         expect(activity.logo.step).toHaveBeenCalledTimes(1);
+        expect(queueSeenByStep).toEqual([{ turtle0: [1] }]);
         jest.useRealTimers();
     });
 

--- a/js/activity/toolbar-controller.js
+++ b/js/activity/toolbar-controller.js
@@ -116,7 +116,18 @@ class ToolbarController {
                 this.activity.logo.runLogoCommands();
                 started = true;
             }
-            this.activity.logo.step();
+            if (started) {
+                // runLogoCommands() dispatches the start block(s) asynchronously
+                // (via a setTimeout(0) inside runLogoCommands), so the stepQueue
+                // is still empty at this point. Calling step() synchronously here
+                // would iterate over an empty queue and advance nothing, wasting
+                // the very first click and forcing an extra click before the first
+                // block runs. Defer the first step() so it runs after the queue
+                // has been populated.
+                setTimeout(() => this.activity.logo.step(), 0);
+            } else {
+                this.activity.logo.step();
+            }
             return started ? "started" : null;
         } else {
             const noBlocks = Object.keys(this.activity.logo.stepQueue).every(


### PR DESCRIPTION
## Description

Fixes an issue where the first click in step-by-step execution did not execute the first block.

When starting a step-by-step run, `runStep()` called `logo.step()` immediately after `runLogoCommands()`. For a normal Start block, `runLogoCommands()` dispatches the block asynchronously using `setTimeout(0)`, so the `stepQueue` was still empty when `logo.step()` ran. As a result, the first click advanced nothing and users had to click Step again before execution began.

This change defers the initial `step()` call until after the command queue has been populated, ensuring that the first Step click executes the first block as expected.

## Related Issue

**Fixes:** #

---

## Category

 - [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

* Identified a timing issue between `runLogoCommands()` and `logo.step()`.
* Deferred the initial `logo.step()` call so the `stepQueue` is populated before stepping begins.
* Preserved the existing step-by-step execution flow while ensuring the first Step action executes the first block.

---

## Steps to Reproduce

1. Open Music Blocks.
2. Create a simple program starting with a normal Start block.
3. Enter step-by-step execution mode.
4. Click the Step button once.
5. Observe that previously no block was executed.
6. Click Step again and observe that execution then begins.

### Expected Behavior

The first Step click should execute the first block in the program.

### Actual Behavior Before Fix

The first Step click did nothing because the `stepQueue` was still empty. A second click was required to begin execution.

---

## Visual Changes

Not applicable. This is a functional bug fix with no intentional UI changes.

---

## Testing Performed

* Verified that the first Step click now executes the first block.
* Verified that subsequent Step clicks continue advancing through the program normally.
* Verified the behavior with a normal Start block, which previously exposed the asynchronous queue timing issue.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of this change.
* [ ] I have updated the documentation to reflect this change, if applicable.
* [ ] I have followed the project's coding style guidelines.
* [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The fix addresses the asynchronous timing between command dispatch and step execution without changing the intended step-by-step execution behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed single-step execution when starting from an idle state, ensuring queued commands are available before the first step runs.
- Preserved immediate stepping when step mode is already active.
- Maintained existing behavior when switching modes or stopping execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->