### PR TITLE
fix: resolve case mismatch in pitchToNumber includes check

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1311,20 +1311,23 @@ describe("pitchToNumber", () => {
     });
 
     it("should work with equal19 temperament", () => {
-        global.TEMPERAMENT = { equal19: [] };
         const result = pitchToNumber("C", 4, "C major", "equal19");
         // 4 * 19 + 0 (C index) - 14 (A index in 19-EDO table) = 62
         expect(result).toBe(62);
     });
 
+    it("should handle lowercase pitches in alternate tunings (equal19)", () => {
+        // Verifies that lowercase 'c' and uppercase 'C' resolve identically in equal19
+        const upperCaseResult = pitchToNumber("C", 4, "C major", "equal19");
+        expect(pitchToNumber("c", 4, "C major", "equal19")).toBe(upperCaseResult);
+    });
+
     it("should fallback to 12-EDO for undefined temperament", () => {
-        global.TEMPERAMENT = {};
         const result = pitchToNumber("C", 4, "C major", undefined);
         expect(result).toBe(39);
     });
 
     it("should fallback to 12-EDO for unknown temperament", () => {
-        global.TEMPERAMENT = {};
         const result = pitchToNumber("C", 4, "C major", "unknown");
         expect(result).toBe(39);
     });

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4820,7 +4820,10 @@ const pitchToNumber = (pitch, octave, keySignature, temperament) => {
             // Use its proportional position from 12-EDO (A is at index 9).
             aIndex = Math.round((9 / 12) * currentEDO);
         }
-        const normalizedPitch = originalPitch.replaceAll("#", SHARP).replaceAll("b", FLAT);
+        const normalizedPitch = originalPitch
+            .replace(/^([a-g])/, (_, letter) => letter.toUpperCase())
+            .replaceAll("#", SHARP)
+            .replaceAll("b", FLAT);
         let edoPos = names.indexOf(normalizedPitch);
         if (edoPos === -1) {
             // Fallback: try the 12-EDO arrays with proportional mapping
@@ -4848,7 +4851,7 @@ const pitchToNumber = (pitch, octave, keySignature, temperament) => {
     }
 
     let pitchNumber = 0;
-    if (PITCHES.includes(pitch)) {
+    if (PITCHES.includes(pitch.toUpperCase())) {
         pitchNumber = PITCHES.indexOf(pitch.toUpperCase());
     } else {
         // obj[1] is the solfege mapping for the current key/mode


### PR DESCRIPTION
### Description

Fixes `pitchToNumber()` in `musicutils.js` failing to recognize lowercase pitch names.

Previously, passing a lowercase pitch (e.g., "c") failed the `PITCHES.includes()` check. This caused the function to silently fall through to an expensive solfege calculation path, and resulted in incorrect note resolutions for non-12-EDO alternate tunings like `equal19`. This PR normalizes the note letter to uppercase early in the execution to ensure correct array lookups and consistent behavior across all tunings.

### Related Issue
Fixes: # 8409

### Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

### Changes Made
- Modified `pitchToNumber()` in `js/utils/musicutils.js` to use `.toUpperCase()` in the `PITCHES.includes()` check. This prevents lowercase notes from failing the includes check and falling through to the expensive solfege path.
- Added a test case in `js/utils/__tests__/musicutils.test.js` to verify lowercase basic notes (e.g., "c") are correctly processed.

### Steps to Reproduce
1. Pass a lowercase pitch to the function, e.g., `pitchToNumber("c", 4, "C major")`.
2. Without the fix, the code generates a spurious `console.debug` warning ("pitch c not found in mode") and takes the fallback path. 
3. With the fix, the pitch is successfully matched in the `PITCHES` array using the uppercase conversion.

### Visual Changes
Before: N/A
After: N/A

### Testing Performed
Added a Jest unit test to `musicutils.test.js` confirming that `pitchToNumber("c", 4, "C major")` cleanly returns 39.

### Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run npm run lint and npx prettier --check . with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pitch lookups now handle lowercase note names consistently across supported tuning systems, including 12-tone equal temperament.
  - Integer validation now more reliably distinguishes valid integer values from non-integer input.

- **Tests**
  - Updated pitch conversion tests to use built-in temperament data and verify fallback behavior without modifying global settings.
  - Improved regression coverage for case-insensitive pitch handling and integer validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->