### PR TITLE
fix(blocks): stop viewport culling from killing the render loop

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -209,6 +209,7 @@ describe("Viewport Culling", () => {
             container: {
                 x: 900,
                 y: 100,
+                bitmapCache: {},
                 updateCache: jest.fn(() => {
                     cachedHighlightVisible = block.highlightVisible;
                 })
@@ -234,6 +235,63 @@ describe("Viewport Culling", () => {
 
         expect(block.container.updateCache).toHaveBeenCalledTimes(1);
         expect(cachedHighlightVisible).toBe(false);
+    });
+
+    it("should not touch the cache of a block whose artwork is being rebuilt", () => {
+        // Regenerating a block's artwork uncaches the container and rebuilds it
+        // asynchronously. A block that re-enters the viewport inside that window
+        // has no bitmapCache, and createjs throws on updateCache() without one.
+        const block = {
+            trash: false,
+            container: {
+                x: 900,
+                y: 100,
+                bitmapCache: null,
+                updateCache: jest.fn(() => {
+                    throw "cache() must be called before updateCache()";
+                })
+            },
+            width: 50,
+            height: 30,
+            _viewportVisible: false
+        };
+        blocks.blockList = [block];
+
+        block.container.x = 100;
+
+        expect(() => blocks._updateViewportCulling()).not.toThrow();
+        expect(block.container.updateCache).not.toHaveBeenCalled();
+        expect(block._viewportVisible).toBe(true);
+    });
+
+    it("should keep culling the rest of the list past an uncached block", () => {
+        const rebuilding = {
+            trash: false,
+            container: {
+                x: 100,
+                y: 100,
+                bitmapCache: null,
+                updateCache: jest.fn(() => {
+                    throw "cache() must be called before updateCache()";
+                })
+            },
+            width: 50,
+            height: 30,
+            _viewportVisible: false
+        };
+        const trailing = {
+            trash: false,
+            container: { x: 2000, y: 2000 },
+            width: 50,
+            height: 30,
+            _viewportVisible: true
+        };
+        blocks.blockList = [rebuilding, trailing];
+
+        blocks._updateViewportCulling();
+
+        // The throw used to abort the loop, leaving every later block stale.
+        expect(trailing._viewportVisible).toBe(false);
     });
 
     it("should skip trashed blocks without modifying their visibility", () => {

--- a/js/activity.js
+++ b/js/activity.js
@@ -594,22 +594,31 @@ class Activity {
                         this.selectionController.isDragging || this.selectionController.isSelecting;
 
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
-                        // Recompute culling when container moved.
-                        if (
-                            this.blocks &&
-                            this.blocksContainer &&
-                            (this._lastCullContainerX !== this.blocksContainer.x ||
-                                this._lastCullContainerY !== this.blocksContainer.y)
-                        ) {
-                            this.blocks._updateViewportCulling();
-                            this._lastCullContainerX = this.blocksContainer.x;
-                            this._lastCullContainerY = this.blocksContainer.y;
-                        }
+                        try {
+                            // Recompute culling when container moved.
+                            if (
+                                this.blocks &&
+                                this.blocksContainer &&
+                                (this._lastCullContainerX !== this.blocksContainer.x ||
+                                    this._lastCullContainerY !== this.blocksContainer.y)
+                            ) {
+                                this.blocks._updateViewportCulling();
+                                this._lastCullContainerX = this.blocksContainer.x;
+                                this._lastCullContainerY = this.blocksContainer.y;
+                            }
 
-                        this.stage.update();
-                        this.stageDirty = false;
-                        // Continue the loop if there's work or ongoing interaction
-                        this._renderLoopRafId = requestAnimationFrame(renderLoop);
+                            this.stage.update();
+                        } catch (err) {
+                            // Anything thrown here used to leave _renderLoopRunning set
+                            // with no frame queued, and _startRenderLoop() refuses to
+                            // restart on that flag, so the canvas stopped repainting for
+                            // the rest of the session. Report the frame and keep going.
+                            console.error("Music Blocks: render frame failed", err);
+                        } finally {
+                            this.stageDirty = false;
+                            // Continue the loop if there's work or ongoing interaction
+                            this._renderLoopRafId = requestAnimationFrame(renderLoop);
+                        }
                     } else {
                         // Nothing to render — let the loop go idle
                         this._renderLoopRunning = false;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -6975,9 +6975,12 @@ class Blocks {
                     c.y + block.height <= vpTop ||
                     c.y >= vpBottom
                 );
-                if (wasViewportVisible === false && block._viewportVisible) {
+                if (wasViewportVisible === false && block._viewportVisible && c.bitmapCache) {
                     // Visual state may have changed while its cache update was culled.
-                    block.container.updateCache();
+                    // The bitmap cache can legitimately be missing here: regenerating a
+                    // block's artwork uncaches the container and rebuilds it
+                    // asynchronously, and updateCache() throws if we land in that window.
+                    c.updateCache();
                 }
             }
         };


### PR DESCRIPTION
- [x] BUG FIX

Dragging a block on the canvas can throw `cache() must be called before updateCache()` from createjs, and the workspace stops repainting after that. Blocks no longer follow the pointer, the canvas will not pan, and the only way back is a page reload.

### Steps to reproduce

1. Open Music Blocks.
2. Turn on advanced mode from the hamburger menu.
3. Drag the `meter` widget block out of the Widgets palette and drop it near the edge of the canvas.
4. Drag it around while blocks are moving in and out of view.

The console shows `Uncaught cache() must be called before updateCache()` and the canvas freezes. It is a race, so it does not fire on every drag.

### Cause

`_updateViewportCulling()` calls `container.updateCache()` on every block that comes back into view. A block that is still on the canvas can have no bitmap cache at that moment: regenerating a block's artwork uncaches the container and rebuilds it asynchronously through `_createCache`, and createjs throws if `updateCache()` lands inside that window. #8324 fixed the same class of call in `block.js`, but this one was missed.

The freeze is the second half. The throw escapes `renderLoop()` before `stage.update()` and before the next `requestAnimationFrame`, while `_renderLoopRunning` is still `true`. `_startRenderLoop()` returns early on that flag, so every later `refreshCanvas()` is a no-op and the loop never comes back.

### Fix

Guard the culling call on `container.bitmapCache`, and wrap the render frame so a failure is reported but the next frame is still scheduled. One bad block should not be able to take the canvas down for the rest of the session.

### Testing

Two unit tests cover the culling guard: one for a block that re-enters the viewport while its cache is being rebuilt, and one that the rest of the block list still gets culled past it. Both fail without the change.

I also checked it in the running app. Recreating the state on a live block used to throw and freeze the canvas; with the fix the same steps leave the canvas panning normally and the render loop idles cleanly. Dragging, pie menus, and running a project all still work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved canvas rendering stability so a single frame error no longer stops future repainting.
  - Fixed viewport handling for blocks while their artwork is being rebuilt asynchronously.
  - Prevented unnecessary cache updates when cached artwork is unavailable.
  - Ensured uncached blocks remain visible and do not interfere with culling of subsequent blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->