### PR TITLE
fix: palette overflow when auxiliary menu is open

### DIFF
--- a/cypress/e2e/block-drag-drop.cy.js
+++ b/cypress/e2e/block-drag-drop.cy.js
@@ -33,7 +33,7 @@ describe("Block palette drag-and-drop", () => {
         // (js/palette.js _showMenuItems: itemRow.setAttribute("aria-label", ...)),
         // which is a stable way to find the plain "pitch" block among the
         // Pitch category's many blocks (pitch, pitch2, steppitch, hertz, ...).
-        cy.get('#palette tbody tr[aria-label="pitch"] img', { timeout: 15000 })
+        cy.get('#PaletteBody tbody tr[aria-label="pitch"] img', { timeout: 15000 })
             .scrollIntoView()
             .should("be.visible");
 
@@ -76,7 +76,7 @@ describe("Block palette drag-and-drop", () => {
         });
 
         cy.get("@dropPlan").then(plan => {
-            cy.get('#palette tbody tr[aria-label="pitch"] img').then($img => {
+            cy.get('#PaletteBody tbody tr[aria-label="pitch"] img').then($img => {
                 const rect = $img[0].getBoundingClientRect();
                 const startX = rect.x + rect.width / 2;
                 const startY = rect.y + rect.height / 2;
@@ -90,7 +90,7 @@ describe("Block palette drag-and-drop", () => {
                 const endX = plan.targetContainerX + rect.width / 2;
                 const endY = plan.targetContainerY + rect.height / 2;
 
-                cy.get('#palette tbody tr[aria-label="pitch"] img')
+                cy.get('#PaletteBody tbody tr[aria-label="pitch"] img')
                     .trigger("mousedown", { which: 1, pageX: startX, pageY: startY, force: true })
                     .then($draggedImg => {
                         // The real handler listens for mousemove on document

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -4,7 +4,7 @@
  * MusicBlocks v3.7.0
  * Copyright (C) 2025 Om Santosh Suneri
  *
- * This program is free software: you can redistribute it and/or modify
+                ],
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -1151,11 +1151,9 @@ describe("Palettes Class", () => {
         });
 
         test("_hideMenuItems hides search widget and removes palette body", () => {
-            const paletteBody = {};
-            const paletteElement = { removeChild: jest.fn() };
+            const paletteBody = { remove: jest.fn() };
             global.docById = jest.fn(id => {
                 if (id === "PaletteBody") return paletteBody;
-                if (id === "palette") return paletteElement;
                 return null;
             });
             palettes.add("search");
@@ -1164,7 +1162,7 @@ describe("Palettes Class", () => {
             palette._hideMenuItems();
 
             expect(mockActivity.hideSearchWidget).toHaveBeenCalledWith(true);
-            expect(paletteElement.removeChild).toHaveBeenCalledWith(paletteBody);
+            expect(paletteBody.remove).toHaveBeenCalled();
         });
 
         test("setupGrabScroll updates scrollTop on drag", () => {
@@ -1430,8 +1428,11 @@ describe("Palettes Class", () => {
         test("showMenu creates header and menu container", () => {
             const palDiv = {
                 childNodes: [{ style: {} }],
-                appendChild: jest.fn(),
-                removeChild: jest.fn()
+                children: [{ offsetWidth: 180 }],
+                offsetLeft: 0,
+                offsetTop: 0,
+                style: {},
+                parentNode: { appendChild: jest.fn() }
             };
             const paletteBody = {
                 insertAdjacentHTML: jest.fn(),
@@ -1450,10 +1451,12 @@ describe("Palettes Class", () => {
                     {}
                 ]
             };
+            paletteBody.childNodes[1].getBoundingClientRect = jest.fn(() => ({ top: 180 }));
             const elementFactory = tag => {
                 if (tag === "table") return paletteBody;
                 return {
                     style: {},
+                    removeAttribute: jest.fn(),
                     setAttribute: jest.fn(),
                     appendChild: jest.fn(),
                     children: [],
@@ -1464,6 +1467,7 @@ describe("Palettes Class", () => {
             global.docById = jest.fn(id => {
                 if (id === "palette") return palDiv;
                 if (id === "PaletteBody") return null;
+                if (id === "PaletteBody_items") return paletteBody.childNodes[1];
                 return null;
             });
 
@@ -1473,9 +1477,68 @@ describe("Palettes Class", () => {
 
             palette.showMenu(true);
 
-            expect(palDiv.appendChild).toHaveBeenCalledWith(paletteBody);
+            expect(palDiv.parentNode.appendChild).toHaveBeenCalledWith(paletteBody);
             expect(palette.menuContainer).toBe(paletteBody);
             expect(palette._showMenuItems).toHaveBeenCalled();
+        });
+
+        test("showMenu sizes the scrollable body from its rendered top", () => {
+            const paletteItems = {
+                style: { overflow: "auto", overflowX: "hidden" },
+                getBoundingClientRect: jest.fn(() => ({ top: 180 }))
+            };
+            const paletteBody = {
+                insertAdjacentHTML: jest.fn(),
+                style: {},
+                childNodes: [{ style: {} }, paletteItems],
+                children: [
+                    {
+                        insertRow: jest.fn(() => ({
+                            style: {},
+                            appendChild: jest.fn(),
+                            children: [{ style: {}, appendChild: jest.fn() }]
+                        }))
+                    }
+                ]
+            };
+            const paletteParent = { appendChild: jest.fn() };
+            const palDiv = {
+                childNodes: [{ style: {} }],
+                children: [{ offsetWidth: 180 }],
+                offsetLeft: 0,
+                offsetTop: 0,
+                style: {},
+                parentNode: paletteParent
+            };
+
+            global.document.createElement = jest.fn(tag =>
+                tag === "table"
+                    ? paletteBody
+                    : {
+                          style: {},
+                          children: [],
+                          appendChild: jest.fn(),
+                          removeAttribute: jest.fn(),
+                          setAttribute: jest.fn()
+                      }
+            );
+            global.docById = jest.fn(id => {
+                if (id === "palette") return palDiv;
+                if (id === "PaletteBody") return null;
+                if (id === "PaletteBody_items") return paletteItems;
+                return null;
+            });
+            Object.defineProperty(window, "innerHeight", { value: 900, configurable: true });
+
+            palettes.add("test");
+            const palette = palettes.dict.test;
+            palette._showMenuItems = jest.fn();
+
+            palette.showMenu(true);
+
+            expect(paletteItems.style.height).toBe("720px");
+            expect(paletteItems.style.overflow).toBe("auto");
+            expect(paletteItems.style.overflowX).toBe("hidden");
         });
 
         test("_showMenuItems renders a basic block", () => {

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -4,7 +4,7 @@
  * MusicBlocks v3.7.0
  * Copyright (C) 2025 Om Santosh Suneri
  *
-                ],
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1484,7 +1484,7 @@ describe("Palettes Class", () => {
 
         test("showMenu sizes the scrollable body from its rendered top", () => {
             const paletteItems = {
-                style: { overflow: "auto", overflowX: "hidden" },
+                style: {},
                 getBoundingClientRect: jest.fn(() => ({ top: 180 }))
             };
             const paletteBody = {
@@ -1537,8 +1537,9 @@ describe("Palettes Class", () => {
             palette.showMenu(true);
 
             expect(paletteItems.style.height).toBe("720px");
-            expect(paletteItems.style.overflow).toBe("auto");
-            expect(paletteItems.style.overflowX).toBe("hidden");
+            const insertedMarkup = paletteBody.insertAdjacentHTML.mock.calls[0][1];
+            expect(insertedMarkup).toContain("overflow: auto");
+            expect(insertedMarkup).toContain("overflow-x: hidden");
         });
 
         test("_showMenuItems renders a basic block", () => {

--- a/js/palette.js
+++ b/js/palette.js
@@ -1523,7 +1523,7 @@ class Palette {
     showMenu(createHeader) {
         const palDiv = docById("palette");
         palDiv.childNodes[0].style.borderRight = "0";
-        if (docById("PaletteBody")) palDiv.removeChild(docById("PaletteBody"));
+        if (docById("PaletteBody")) docById("PaletteBody").remove();
         const palBody = document.createElement("table");
         palBody.id = "PaletteBody";
         const palBodyHeight = window.innerHeight - this.palettes.top - this.palettes.cellSize - 26;
@@ -1538,13 +1538,17 @@ class Palette {
         palBody.style.minWidth = "180px";
         palBody.style.background = platformColor.paletteBackground;
         palBody.style.float = "left";
+        palBody.style.position = "fixed";
+        palBody.style.left = `${palDiv.offsetLeft + palDiv.children[0].offsetWidth}px`;
+        palBody.style.top = `${palDiv.offsetTop}px`;
+        palBody.style.zIndex = palDiv.style.zIndex;
 
         palBody.style.border = `1px solid ${platformColor.selectorSelected}`;
         [palBody.childNodes[0], palBody.childNodes[1]].forEach(item => {
             item.style.boxSizing = "border-box";
             item.style.padding = "8px";
         });
-        palDiv.appendChild(palBody);
+        palDiv.parentNode.appendChild(palBody);
 
         this.menuContainer = palBody;
 
@@ -1598,6 +1602,8 @@ class Palette {
         }
 
         this._showMenuItems();
+        const paletteItems = docById("PaletteBody_items");
+        paletteItems.style.height = `${window.innerHeight - paletteItems.getBoundingClientRect().top}px`;
 
         // Close palette menu on outside click
         // Remove any existing outside-click listener
@@ -1625,7 +1631,7 @@ class Palette {
         if (this.name === "search" && this.activity.hideSearchWidget !== null) {
             this.activity.hideSearchWidget(true);
         }
-        if (docById("PaletteBody")) docById("palette").removeChild(docById("PaletteBody"));
+        if (docById("PaletteBody")) docById("PaletteBody").remove();
     }
 
     _showMenuItems() {

--- a/js/palette.js
+++ b/js/palette.js
@@ -1602,6 +1602,9 @@ class Palette {
         }
 
         this._showMenuItems();
+        if (this.palettes.mobile) {
+            return;
+        }
         const paletteItems = docById("PaletteBody_items");
         paletteItems.style.height = `${window.innerHeight - paletteItems.getBoundingClientRect().top}px`;
 


### PR DESCRIPTION
## Description

Fixes an overflow issue in the palette panels when the Auxiliary Menu is opened.

Previously, opening the Auxiliary Menu could cause palette panels, such as the Widgets and other scrollable panels, to extend beyond the visible viewport. Although the panels already had scrollbars, the scrollable areas were not properly constrained to the available viewport height. As a result, content could overflow outside the visible area, preventing users from scrolling down and accessing the remaining content.

This fix constrains the existing scrollable areas to the available viewport while preserving the existing palette movement and scrolling behavior, improving the overall usability and user experience.


## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] UI/UX — Changes to the user interface or user experience
- [x] Tests — Adds or updates test coverage



## Changes Made

- Constrained the existing Widgets scroll viewport to the available browser viewport height.
- Preserved the existing `overflow: auto` scrolling behavior.
- Ensured the Widgets panel remains within the visible viewport when the Auxiliary Menu is opened.
- Preserved the existing Auxiliary Menu and palette positioning behavior.
- Fixed the panel border styling so the Widgets panel retains a consistent thin outline.
- Updated the affected palette tests and added regression coverage for the viewport-height behavior.
- Updated the affected Cypress E2E selectors to match the updated `#PaletteBody` DOM structure.
- Added an early return for the mobile palette path to prevent accessing removed palette elements.


## Steps to Reproduce

1. Open Music Blocks.
2. Open the Auxiliary Menu.
3. Select the **Widgets** palette.
4. Observe the Widgets panel.
5. Try scrolling through the Widgets list.

### Before

When the Auxiliary Menu was opened, the Widgets panel could extend beyond the visible viewport. The existing scroll area did not provide access to all of the content, causing the panel to overflow and preventing users from scrolling down to the remaining Widgets.

### After

The Widgets panel remains within the visible viewport, and its existing scroll area allows users to scroll through the complete list of Widgets without the panel overflowing.



## Visual Changes

### Before


https://github.com/user-attachments/assets/01760a72-abc8-4dd4-bfee-b95b8831663c



### After


https://github.com/user-attachments/assets/422f8996-68f4-429c-925b-698dee153d35





## Testing Performed

- Added/updated regression tests for the Widgets palette viewport-height behavior.
- `palette.test.js`: **105/105 tests passed** with coverage disabled.
- Prettier passed.
- Manually verified the Widgets panel with the Auxiliary Menu open and closed.
- Verified the updated palette selectors with the Cypress E2E tests.



## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


## Additional Notes

The fix intentionally reuses the existing Widgets scrolling mechanism rather than introducing a second scrollbar or changing the workspace/block boundary logic.

The change is focused specifically on constraining the Widgets scroll viewport when the Auxiliary Menu is opened, while preserving the existing palette positioning and scrolling behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved palette menu positioning so it aligns correctly with its container.
  - Adjusted the palette’s scrollable area to fit the available viewport height.
  - Preserved expected overflow behavior when displaying palette items.
  - Improved palette menu cleanup when refreshing or hiding palette items, preventing stale content from remaining visible.

- **Tests**
  - Expanded coverage for palette menu rendering, sizing, positioning, cleanup, and drag-and-drop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->