### PR TITLE
fix(abc): write accidentals before pitch names

### DIFF
--- a/js/__tests__/abc.test.js
+++ b/js/__tests__/abc.test.js
@@ -68,7 +68,7 @@ describe("processABCNotes - Basic Note Processing", () => {
 
     it("should process notes and update notationNotes correctly", () => {
         processABCNotes(logo, "0");
-        expect(logo.notationNotes["0"]).toBe("G^4 G^4 F4 F4 G^2 G^8 ");
+        expect(logo.notationNotes["0"]).toBe("^G4 ^G4 F4 F4 ^G2 ^G8 ");
     });
 
     it("should handle octaves 5 and above correctly (lowercase and proper octave markers)", () => {
@@ -129,6 +129,40 @@ describe("processABCNotes - Advanced Note Handling", () => {
         expect(output).toContain("D1/2");
         expect(output).toContain("E16");
         expect(output).toContain("F5");
+    });
+
+    it("should write accidental markers before the ABC pitch", () => {
+        logo.notation.notationStaging["0"] = [
+            [["C𝄪4"], 4, 0, null, null, -1, false],
+            [["D♯4"], 4, 0, null, null, -1, false],
+            [["E♮4"], 4, 0, null, null, -1, false],
+            [["F♭4"], 4, 0, null, null, -1, false],
+            [["G𝄫4"], 4, 0, null, null, -1, false]
+        ];
+
+        processABCNotes(logo, "0");
+
+        expect(logo.notationNotes["0"]).toBe("^^C4 ^^C4 ^D4 ^D4 =E4 =E4 _F4 _F4 __G4 __G4 ");
+    });
+
+    it("should support ASCII accidentals without changing lowercase B notes", () => {
+        logo.notation.notationStaging["0"] = [
+            [["G#4"], 4, 0, null, null, -1, false],
+            [["Bb4"], 4, 0, null, null, -1, false],
+            [["b4"], 4, 0, null, null, -1, false]
+        ];
+
+        processABCNotes(logo, "0");
+
+        expect(logo.notationNotes["0"]).toBe("^G4 ^G4 _B4 _B4 B4 B4 ");
+    });
+
+    it("should preserve rests without accidental matching", () => {
+        logo.notation.notationStaging["0"] = [[["R"], 4, 0, null, null, -1, false]];
+
+        processABCNotes(logo, "0");
+
+        expect(logo.notationNotes["0"]).toBe("R4 R4 ");
     });
 });
 describe("processABCNotes - Control Strings", () => {
@@ -239,7 +273,7 @@ describe("processABCNotes - Tuplet Handling", () => {
         ];
 
         processABCNotes(logo, "0");
-        expect(logo.notationNotes["0"]).toBe("(1:1G^ 2G^ 2G^ 2 ");
+        expect(logo.notationNotes["0"]).toBe("(1:1^G 2^G 2^G 2 ");
     });
 
     it("should handle array of notes (chords) inside tuplets", () => {
@@ -376,7 +410,7 @@ describe("processABCNotes - Tuplet Handling", () => {
         };
 
         processABCNotes(logo, "0");
-        expect(logo.notationNotes["0"]).toBe("(1:1G^ 2G^ 2G^ 2 ");
+        expect(logo.notationNotes["0"]).toBe("(1:1^G 2^G 2^G 2 ");
     });
 });
 
@@ -434,11 +468,16 @@ describe("OCTAVE_NOTATION_MAP", () => {
 
 describe("ACCIDENTAL_MAP", () => {
     test("should correctly map accidentals to ABC notation", () => {
+        expect(ACCIDENTAL_MAP["𝄪"]).toBe("^^");
         expect(ACCIDENTAL_MAP["♯"]).toBe("^");
+        expect(ACCIDENTAL_MAP["#"]).toBe("^");
+        expect(ACCIDENTAL_MAP["♮"]).toBe("=");
         expect(ACCIDENTAL_MAP["♭"]).toBe("_");
+        expect(ACCIDENTAL_MAP.b).toBe("_");
+        expect(ACCIDENTAL_MAP["𝄫"]).toBe("__");
     });
 
     test("should return undefined for unmapped accidentals", () => {
-        expect(ACCIDENTAL_MAP["♮"]).toBeUndefined();
+        expect(ACCIDENTAL_MAP["x"]).toBeUndefined();
     });
 });

--- a/js/abc.js
+++ b/js/abc.js
@@ -35,9 +35,19 @@ const OCTAVE_NOTATION_MAP = {
 };
 
 const ACCIDENTAL_MAP = {
+    "𝄪": "^^",
     "♯": "^",
-    "♭": "_"
+    "#": "^",
+    "♮": "=",
+    "♭": "_",
+    "b": "_",
+    "𝄫": "__"
 };
+
+const ACCIDENTAL_SYMBOLS = Object.keys(ACCIDENTAL_MAP)
+    .map(symbol => symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("");
+const PITCH_ACCIDENTAL_PATTERN = new RegExp(`^([A-Ga-g])([${ACCIDENTAL_SYMBOLS}]*)`, "u");
 
 /**
  * Returns the header string used for the ABC notation output.
@@ -94,9 +104,15 @@ const processABCNotes = function (logo, turtle) {
             note = pitchObj[0] + pitchObj[1];
         }
 
-        // Handle accidentals first
-        for (const [symbol, replacement] of Object.entries(ACCIDENTAL_MAP)) {
-            note = note.replace(new RegExp(symbol, "g"), replacement);
+        const pitchMatch = note.match(PITCH_ACCIDENTAL_PATTERN);
+        const accidentalSymbols = pitchMatch ? pitchMatch[2] : "";
+        const accidental = accidentalSymbols
+            ? Array.from(accidentalSymbols)
+                  .map(symbol => ACCIDENTAL_MAP[symbol])
+                  .join("")
+            : "";
+        if (accidentalSymbols) {
+            note = note.replace(accidentalSymbols, "");
         }
 
         // Handle octave notation
@@ -108,9 +124,12 @@ const processABCNotes = function (logo, turtle) {
 
         // Convert case based on octave
         if (octave !== null) {
-            return octave >= 5 ? note.toLowerCase() : note.toUpperCase();
+            return accidental + (octave >= 5 ? note.toLowerCase() : note.toUpperCase());
         } else {
-            return note.includes("'") || note === "" ? note.toLowerCase() : note.toUpperCase();
+            return (
+                accidental +
+                (note.includes("'") || note === "" ? note.toLowerCase() : note.toUpperCase())
+            );
         }
     };
 


### PR DESCRIPTION
## Description

  ABC export currently writes accidental markers after the note letter. For example, `G♯4` is exported as `G^4`, while valid ABC notation requires `^G4`.

  This makes exported sharps and flats invalid for ABC readers and can cause the accidental to be ignored.

  ## Related Issue

  Fixes #8416

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring
  - [ ] CI/CD — Changes workflows or automation

  ## Changes Made

  - Move ABC accidental markers before the pitch name during export.
  - Add support for natural, double-sharp, and double-flat symbols.
  - Update existing ABC expectations to use valid notation.
  - Add regression coverage for all supported accidental symbols.

  ## Testing Performed

  - Ran `js/__tests__/abc.test.js`: 32 tests passed.
  - Verified generated `^^C4`, `^D4`, `=E4`, `_F4`, and `__G4` tokens parse with zero abcjs warnings.
  - Ran ESLint successfully.
  - Ran Prettier successfully on the changed files.
  - Ran `git diff --check` successfully.

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have followed the project's coding style guidelines.
  - [x] I have run lint and Prettier checks with no errors.
  - [x] I have enabled **Allow edits from maintainers**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Unicode and ASCII accidentals in ABC notation, including double-sharp, sharp, natural, flat, and double-flat.
  * Added accidental handling for basic notes and tuplets while preserving lowercase “b” pitch names and rests.

* **Bug Fixes**
  * Corrected accidental placement so symbols appear before pitches in ABC output.
  * Improved handling of unmapped accidental symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->