### PR TITLE
fix(munsell): let searchColors consider rgba-formatted candidates

### DIFF
--- a/js/utils/__tests__/munsell.test.js
+++ b/js/utils/__tests__/munsell.test.js
@@ -88,16 +88,50 @@ describe("munsell", () => {
             expect(color).toBeLessThanOrEqual(100);
         });
 
+        // getcolor() returns "#rrggbb" only when the interpolation lands
+        // exactly on a table entry, and "rgba(...)" otherwise, so a nearest
+        // match may legitimately be in either form.
+        const COLOR_STRING = /^(#[0-9a-fA-F]{6}|rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+.*\))$/;
+
         it("should find the nearest color for black", () => {
             const color = searchColors(0, 0, 0);
             const nearestColor = getcolor(color);
-            expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
+            expect(nearestColor[2]).toMatch(COLOR_STRING);
         });
 
         it("should identify a close match for a RGB value", () => {
             const color = searchColors(100, 150, 200);
             const nearestColor = getcolor(color);
-            expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
+            expect(nearestColor[2]).toMatch(COLOR_STRING);
+        });
+
+        it("should consider every candidate, not only the hex-formatted ones", () => {
+            // Only 20 of the 100 candidates serialize as "#rrggbb"; the rest
+            // are "rgba(...)". Feeding a candidate's own RGB back in must
+            // return that candidate.
+            const rgbaCandidates = [];
+            for (let i = 0; i < 100; i++) {
+                const value = getcolor(i)[2];
+                const match = value.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+                if (match) {
+                    rgbaCandidates.push([i, Number(match[1]), Number(match[2]), Number(match[3])]);
+                }
+            }
+
+            expect(rgbaCandidates.length).toBeGreaterThan(0);
+
+            for (const [index, r, g, b] of rgbaCandidates) {
+                expect(searchColors(r, g, b)).toBe(index);
+            }
+        });
+
+        it("should round-trip a hex-formatted candidate too", () => {
+            const value = getcolor(0)[2];
+            expect(value).toMatch(/^#[0-9a-fA-F]{6}$/);
+            const r = parseInt(value.substr(1, 2), 16);
+            const g = parseInt(value.substr(3, 2), 16);
+            const b = parseInt(value.substr(5, 2), 16);
+            expect(searchColors(r, g, b)).toBe(0);
         });
     });
 });

--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -6833,14 +6833,46 @@ let getcolor = color => {
  * @param {number} b - Intensity of blue.
  * @returns {number} The color value of the nearest match.
  */
+/**
+ * Parses a color string produced by getcolor()/interpColor() into RGB
+ * components. getcolor() returns "#rrggbb" only when the interpolation
+ * parameter lands exactly on 0 or 1, and "rgba(r, g, b, a)" for every
+ * intermediate value.
+ *
+ * @param {string} color - The color string to parse.
+ * @returns {Array|null} An array [r, g, b], or null if it cannot be parsed.
+ */
+const parseColorToRGB = color => {
+    if (typeof color !== "string") {
+        return null;
+    }
+
+    if (color.charAt(0) === "#") {
+        return [
+            parseInt(color.substr(1, 2), 16),
+            parseInt(color.substr(3, 2), 16),
+            parseInt(color.substr(5, 2), 16)
+        ];
+    }
+
+    const match = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (match) {
+        return [parseInt(match[1], 10), parseInt(match[2], 10), parseInt(match[3], 10)];
+    }
+
+    return null;
+};
+
 let searchColors = (r, g, b) => {
     let nearestColor = -1;
     let distance = 10000000;
     for (let i = 0; i < 100; i++) {
         const color = getcolor(i);
-        const r1 = parseInt(color[2].substr(1, 2), 16);
-        const g1 = parseInt(color[2].substr(3, 2), 16);
-        const b1 = parseInt(color[2].substr(5, 2), 16);
+        const rgb = parseColorToRGB(color[2]);
+        if (rgb === null) {
+            continue;
+        }
+        const [r1, g1, b1] = rgb;
         const distSquared = (r1 - r) * (r1 - r) + (g1 - g) * (g1 - g) + (b1 - b) * (b1 - b);
         if (distSquared < distance) {
             distance = distSquared;


### PR DESCRIPTION
## Description

`searchColors()` could only ever return 20 of its 100 candidate colors. `getcolor(i)[2]` yields `"#rrggbb"` only when the interpolation parameter lands exactly on 0 or 1 and `"rgba(r, g, b, a)"` otherwise, but `searchColors` parsed every result as hex, so the 80 rgba candidates produced `NaN` distances and `NaN < distance` is always false.

## Related Issue

**Fixes:** #8422

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Added a small `parseColorToRGB` helper that handles both serializations and returns `null` for anything else, and used it in `searchColors`, skipping unparseable candidates rather than letting them poison the comparison.

Two existing assertions required the nearest match to be `"#rrggbb"`. That was asserting a consequence of the bug, since only hex candidates were reachable, so they now accept either serialization. No other behavior changed.

## Steps to Reproduce

```js
const m = require("./js/utils/munsell.js");
const c = m.getcolor(37)[2];   // "rgba(...)"
const [, r, g, b] = c.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
m.searchColors(+r, +g, +b);    // before: 45, after: 37
```

Before the fix, sweeping reds from 0 to 255 returned only multiples of 5.

---

## Testing Performed

`npx jest js/utils/__tests__/munsell.test.js`: 31 passed.

Two regression tests added. The main one round-trips every rgba candidate through `searchColors`; the other covers a hex candidate so the old path stays covered. Reverting only `munsell.js` and keeping the tests fails the new test with `Expected: 1, Received: 0`, and restoring it passes all 31.

`npx eslint` and `npx prettier --check` are clean on all changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color searching to correctly process both hexadecimal and `rgb`/`rgba` color formats.
  * Unrecognized color values are now skipped safely instead of causing lookup failures.
  * Improved consistency when matching colors through RGB lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->