### PR TITLE
fix(musicutils): honor a number passed to calcOctave as a string

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2592,6 +2592,27 @@ describe("calcOctave", () => {
         expect(calcOctave(4, 5, null, "C")).toBe(5);
     });
 
+    it("should treat a number passed as a string like the same number", () => {
+        // NumberBlocks.calculateValueWithOctave forwards a block value to
+        // calcOctave only when it is a string, so "5" is a real input here.
+        expect(calcOctave(4, "5", null, "C")).toBe(calcOctave(4, 5, null, "C"));
+        expect(calcOctave(4, "2", ["C"], "C")).toBe(2);
+        expect(calcOctave(4, "7", ["C"], "C")).toBe(7);
+    });
+
+    it("should clamp a numeric string to the 1..9 octave range", () => {
+        expect(calcOctave(4, "0", ["C"], "C")).toBe(1);
+        expect(calcOctave(4, "12", ["C"], "C")).toBe(9);
+        expect(calcOctave(4, "3.7", ["C"], "C")).toBe(3);
+    });
+
+    it("should fall back to the computed octave for a non-numeric argument", () => {
+        expect(calcOctave(4, "not a number", ["C"], "C")).toBe(
+            calcOctave(4, "current", ["C"], "C")
+        );
+        expect(calcOctave(4, "", ["C"], "C")).toBe(calcOctave(4, "current", ["C"], "C"));
+    });
+
     it("should return correct octave based on currentNote and lastNotePlayed", () => {
         expect(calcOctave(4, "next", ["C"], "C")).toBe(5);
         expect(calcOctave(4, "next", ["C"], "D")).toBe(5);

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -7954,17 +7954,18 @@ const calcOctave = (currentOctave, arg, lastNotePlayed, currentNote, temperament
         case _("previous"):
         case "previous":
             return Math.max(changedCurrent - 1, 1);
-        default:
-            try {
-                if (changedCurrent) {
-                    return changedCurrent;
-                } else {
-                    return Math.floor(Number(arg));
-                }
-            } catch (e) {
-                // console.debug("cannot convert " + arg + " to a number");
-                return currentOctave;
+        default: {
+            // A "number" passed as a string (e.g. "2") is a documented argument,
+            // but changedCurrent is always >= 1, so testing it for truthiness
+            // first made the numeric conversion unreachable and silently
+            // ignored the requested octave.
+            const parsed = typeof arg === "string" && arg.trim() !== "" ? Number(arg) : NaN;
+            if (!isNaN(parsed)) {
+                return Math.max(1, Math.min(Math.floor(parsed), 9));
             }
+
+            return changedCurrent;
+        }
     }
 };
 


### PR DESCRIPTION
## Description

`calcOctave` documents its argument as "a number, a 'number' as a string, 'current', 'previous', or 'next'", but the numeric-string case was unreachable: the default branch returned `changedCurrent` whenever it was truthy, and `changedCurrent` is always at least 1. A requested octave like `"2"` was silently replaced by the current octave.

This is reachable from the UI. `calculateValueWithOctave` in `js/blocks/NumberBlocks.js` forwards a block value to `calcOctave` specifically when that value is a string.

## Related Issue

**Fixes:** #8423

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Parse the string first and clamp it to 1..9 exactly like the numeric path at the top of the function, falling back to `changedCurrent` when the argument is not numeric. An empty or whitespace-only string is treated as non-numeric rather than as `Number("") === 0`.

The `try`/`catch` was removed along with it, since `Number()` does not throw. The `'current'`, `'next'` and `'previous'` branches are untouched.

## Steps to Reproduce

```js
calcOctave(4, 5, null, "C");    // 5, correct
calcOctave(4, "5", null, "C");  // before: 4, after: 5
calcOctave(4, "2", ["C"], "C"); // before: 4, after: 2
```

---

## Testing Performed

`npx jest js/utils/__tests__/musicutils.test.js`: 567 passed.

Three tests added, covering numeric strings agreeing with the equivalent numbers, clamping (`"0"` to 1, `"12"` to 9, `"3.7"` to 3), and the non-numeric fallback still matching `'current'`. Reverting only `musicutils.js` and keeping the tests fails two of them with `Expected: 2, Received: 4` and `Expected: 1, Received: 4`, the exact symptom above; restoring it passes all 567.

`npx eslint` and `npx prettier --check` are clean on all changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved octave selection when entering numeric values as text.
  - Octave values are now limited to the supported range of 1–9, with decimal values handled consistently.
  - Invalid, empty, or nonnumeric input now safely preserves the current octave instead of causing unexpected behavior.

- **Tests**
  - Added coverage for numeric text input, range limits, decimal values, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->