### PR TITLE
fix: export Rhythm Ruler block's collapsed state under its real block name

### DIFF
--- a/js/__tests__/project-manager.test.js
+++ b/js/__tests__/project-manager.test.js
@@ -828,6 +828,24 @@ describe("prepareExport", () => {
         expect(result[0][1]).toEqual(["action", { collapsed: true }]);
     });
 
+    it("exports rhythmruler2 block's collapsed state (regression: block name is 'rhythmruler2', not 'rhythmruler')", () => {
+        const activity = makeActivity();
+        activity.blocks.blockList = [
+            {
+                name: "rhythmruler2",
+                trash: false,
+                value: null,
+                collapsed: true,
+                container: { x: 0, y: 0 },
+                connections: [null],
+                isValueBlock: () => false
+            }
+        ];
+        const pm = new ProjectManager(activity);
+        const result = JSON.parse(pm.prepareExport());
+        expect(result[0][1]).toEqual(["rhythmruler2", { collapsed: true }]);
+    });
+
     it("remaps connections to dense indices", () => {
         const activity = makeActivity();
         activity.blocks.blockList = [

--- a/js/project-manager.js
+++ b/js/project-manager.js
@@ -521,7 +521,7 @@ class ProjectManager {
                     case "action":
                     case "matrix":
                     case "pitchdrummatrix":
-                    case "rhythmruler":
+                    case "rhythmruler2":
                     case "timbre":
                     case "pitchstaircase":
                     case "tempo":


### PR DESCRIPTION
## Description

`ProjectManager.prepareExport()` (`js/project-manager.js`) has a switch statement that attaches extra save-args (like `collapsed`) to specific widget block types. It matches on `case "rhythmruler":`, but the actual registered block name for the Rhythm Maker widget is `"rhythmruler2"` (see `js/blocks/WidgetBlocks.js`, `RhythmRulerBlock`). Since the case never matched, Rhythm Ruler blocks were exported as a bare block-name string with **no args object at all** — silently dropping their `collapsed` state on every save.

Related to #2017 (widget state not surviving save/reload) — found while investigating that issue: I verified with a live headless-browser repro that saved Rhythm Ruler blocks lose their collapsed/expanded UI state across a reload because of this exact mismatch.

## Related Issue

**Fixes:** Related to #2017

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/project-manager.js`: changed `case "rhythmruler":` to `case "rhythmruler2":` in the `prepareExport()` args switch, matching the block's actual registered name.
- `js/__tests__/project-manager.test.js`: added a regression test exporting a `rhythmruler2` block and asserting its `collapsed` state is present in the output (previously it would have exported as the bare string `"rhythmruler2"` with no args).

Note: `js/block.js` has a separate, unrelated switch (for collapsed-block label text) that already has a correct `case "rhythmruler2":` entry elsewhere in the same switch (rendering "rhythm maker") alongside a leftover dead `case "rhythmruler":` — that one is unreachable but harmless, so it's left untouched here to keep this PR scoped to the actual bug.

## Testing Performed

- Verified live in a browser: called `window.prepareExport()` on a loaded project containing a `rhythmruler2` block. Before the fix: exported as bare `"rhythmruler2"` with no args. After the fix: exported as `["rhythmruler2", {"collapsed": false}]`.
- `npx jest js/__tests__/project-manager.test.js js/__tests__/block.test.js` — 180/180 pass (117 + 63).
- `npx eslint js/project-manager.js js/block.js` — clean.
- `npx prettier --check js/project-manager.js js/block.js` — clean.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed export handling for `rhythmruler2` blocks so their collapsed or expanded state is preserved in exported projects.

- **Tests**
  - Added regression coverage to verify that the collapsed state remains intact during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->