### PR TITLE
fix(musicutils): correct diminished 7 interval ratio from 9/5 to 128/75

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -436,6 +436,66 @@ describe("getIntervalRatio", () => {
         expect(getIntervalRatio("perfect 5")).toBe(1.5);
         expect(getIntervalRatio("major 3")).toBe(1.25);
     });
+
+    it("should return the just diminished seventh for diminished 7", () => {
+        expect(getIntervalRatio("diminished 7")).toBeCloseTo(128 / 75, 10);
+    });
+
+    it("should keep every diminished ratio the octave inversion of its augmented complement", () => {
+        // A diminished nth and an augmented (9 - n)th add up to an octave, so
+        // their ratios must multiply to 2.
+        const complements = [
+            ["diminished 2", "augmented 7"],
+            ["diminished 3", "augmented 6"],
+            ["diminished 4", "augmented 5"],
+            ["diminished 5", "augmented 4"],
+            ["diminished 6", "augmented 3"],
+            ["diminished 7", "augmented 2"],
+            ["diminished 8", "augmented 1"]
+        ];
+
+        for (const [diminished, augmented] of complements) {
+            expect(getIntervalNumber(diminished) + getIntervalNumber(augmented)).toBe(12);
+            expect(getIntervalRatio(diminished) * getIntervalRatio(augmented)).toBeCloseTo(2, 10);
+        }
+    });
+
+    it("should keep every ratio within half a semitone of its semitone count", () => {
+        const intervals = [
+            "perfect 1",
+            "diminished 2",
+            "augmented 1",
+            "minor 2",
+            "major 2",
+            "diminished 3",
+            "augmented 2",
+            "minor 3",
+            "major 3",
+            "diminished 4",
+            "augmented 3",
+            "perfect 4",
+            "augmented 4",
+            "diminished 5",
+            "perfect 5",
+            "diminished 6",
+            "augmented 5",
+            "minor 6",
+            "major 6",
+            "diminished 7",
+            "augmented 6",
+            "minor 7",
+            "major 7",
+            "diminished 8",
+            "augmented 7",
+            "perfect 8",
+            "augmented 8"
+        ];
+
+        for (const interval of intervals) {
+            const semitones = 12 * Math.log2(getIntervalRatio(interval));
+            expect(Math.abs(semitones - getIntervalNumber(interval))).toBeLessThan(0.5);
+        }
+    });
 });
 
 describe("getModeNumbers", () => {

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -73,6 +73,7 @@ const {
     getIntervalNumber,
     getIntervalDirection,
     getIntervalRatio,
+    INTERVALVALUES,
     getModeNumbers,
     getDrumIndex,
     getDrumName,
@@ -461,35 +462,9 @@ describe("getIntervalRatio", () => {
     });
 
     it("should keep every ratio within half a semitone of its semitone count", () => {
-        const intervals = [
-            "perfect 1",
-            "diminished 2",
-            "augmented 1",
-            "minor 2",
-            "major 2",
-            "diminished 3",
-            "augmented 2",
-            "minor 3",
-            "major 3",
-            "diminished 4",
-            "augmented 3",
-            "perfect 4",
-            "augmented 4",
-            "diminished 5",
-            "perfect 5",
-            "diminished 6",
-            "augmented 5",
-            "minor 6",
-            "major 6",
-            "diminished 7",
-            "augmented 6",
-            "minor 7",
-            "major 7",
-            "diminished 8",
-            "augmented 7",
-            "perfect 8",
-            "augmented 8"
-        ];
+        // Derived from the table itself so a newly added interval is covered
+        // automatically rather than needing to be listed here.
+        const intervals = Object.keys(INTERVALVALUES);
 
         for (const interval of intervals) {
             const semitones = 12 * Math.log2(getIntervalRatio(interval));

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -1745,7 +1745,7 @@ const INTERVALVALUES = {
     "augmented 5": [8, 1, 25 / 16],
     "minor 6": [8, -1, 8 / 5],
     "major 6": [9, 1, 5 / 3],
-    "diminished 7": [9, -1, 9 / 5],
+    "diminished 7": [9, -1, 128 / 75],
     "augmented 6": [10, 1, 125 / 72],
     "minor 7": [10, -1, 16 / 9],
     "major 7": [11, 1, 15 / 8],


### PR DESCRIPTION
## Description

The `INTERVALVALUES` entry `"diminished 7": [9, -1, 9 / 5]` pairs 9 semitones with 9/5, a ten-semitone (minor seventh) ratio. This is the remaining half of the copy-paste that #7638 already fixed for `minor 7` one line below. The ratio feeds `getIntervalRatio`, which the ratio-interval blocks use directly as a frequency multiplier, so a "diminished 7" ratio interval sounds more than a semitone sharp of its named interval.

## Related Issue

**Fixes:** #8434

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

One value changed: `9 / 5` to `128 / 75`, the just diminished seventh (the octave inversion of the 75/64 augmented second, implying 9.25 semitones).

Two invariants of the table itself justify the value. Every other entry implies a pitch within half a semitone of its declared semitone count, and every other diminished interval is the exact octave inversion of its complementary augmented interval (dim N x aug(9-N) = 2). The old value broke both, off by 1.18 semitones and inverting to 2.109; the new value restores both.

## Steps to Reproduce

```js
const [semitones, , ratio] = INTERVALVALUES["diminished 7"]; // [9, -1, 1.8]
12 * Math.log2(ratio); // 10.18 semitones, declared 9
INTERVALVALUES["diminished 7"][2] * INTERVALVALUES["augmented 2"][2]; // 2.109, every other dim/aug pair gives 2
```

---

## Testing Performed

`npx jest js/utils/__tests__/musicutils.test.js`: 567 passed.

Three regression tests added: the exact 128/75 value, the inversion invariant across all seven dim/aug complement pairs, and a table-wide half-semitone bound. Reverting only `musicutils.js` while keeping the tests fails exactly those three (received 1.8, received 2.109375, received deviation 1.176); restoring passes all 567.

`npx eslint` and `npx prettier --check` clean on both changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculated ratio for diminished seventh intervals.
  - Improved interval ratio accuracy and consistency for diminished and augmented intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->