### PR TITLE
fix(phrasemaker): clear playback timers to prevent overlapping audio (#6976)

### DIFF
--- a/js/widgets/PhraseMakerAudio.js
+++ b/js/widgets/PhraseMakerAudio.js
@@ -18,6 +18,23 @@
 
 const PhraseMakerAudio = {
     /**
+     * Clears all pending playback and chord timers.
+     * @param {Object} pm - The PhraseMaker instance.
+     */
+    clearPlaybackTimers(pm) {
+        if (pm._playNoteTimeout) {
+            clearTimeout(pm._playNoteTimeout);
+            pm._playNoteTimeout = null;
+        }
+        if (Array.isArray(pm._chordTimeouts)) {
+            for (let i = 0; i < pm._chordTimeouts.length; i++) {
+                clearTimeout(pm._chordTimeouts[i]);
+            }
+            pm._chordTimeouts = [];
+        }
+    },
+
+    /**
      * Plays all notes in the matrix.
      * Toggles between playing and stopping notes based on the current state.
      * @param {Object} pm - The PhraseMaker instance.
@@ -27,6 +44,9 @@ const PhraseMakerAudio = {
         pm.playingNow = !pm.playingNow;
 
         if (pm.playingNow) {
+            this.clearPlaybackTimers(pm);
+            pm._stopOrCloseClicked = false;
+
             pm.widgetWindow.modifyButton(
                 0,
                 "stop-button.svg",
@@ -75,8 +95,6 @@ const PhraseMakerAudio = {
                         pitchNotes.push(normalizeNoteAccidentals(note[i]));
                     }
                 }
-
-                pm._stopOrCloseClicked = false;
             }
 
             const noteValue = pm._notesToPlay[pm._notesCounter][1];
@@ -134,6 +152,11 @@ const PhraseMakerAudio = {
             this.__playNote(pm, 0, 0);
         } else {
             pm._stopOrCloseClicked = true;
+            this.clearPlaybackTimers(pm);
+            if (pm.activity && pm.activity.logo && pm.activity.logo.synth) {
+                pm.activity.logo.synth.stop();
+            }
+            PhraseMakerUI.resetMatrix(pm);
             pm.widgetWindow.modifyButton(
                 0,
                 "play-button.svg",
@@ -337,20 +360,34 @@ const PhraseMakerAudio = {
         if (pm.lyricsON && pm.activity) {
             pm.activity.textMsg(pm._lyrics[noteCounter], 3000);
         }
-        // If the widget is closed, stop playing.
-        if (!pm.widgetWindow.isVisible()) {
+        // If the widget is closed or stopped, stop playing.
+        if (!pm.widgetWindow.isVisible() || pm._stopOrCloseClicked) {
+            this.clearPlaybackTimers(pm);
             return;
         }
 
         let noteValue = pm._notesToPlay[noteCounter][1];
         time = 1 / noteValue;
 
-        setTimeout(
+        if (pm._playNoteTimeout) {
+            clearTimeout(pm._playNoteTimeout);
+            pm._playNoteTimeout = null;
+        }
+
+        pm._playNoteTimeout = setTimeout(
             () => {
+                pm._playNoteTimeout = null;
+                if (!pm.widgetWindow.isVisible() || pm._stopOrCloseClicked) {
+                    this.clearPlaybackTimers(pm);
+                    PhraseMakerUI.resetMatrix(pm);
+                    return;
+                }
+
                 let row, cell, tupletCell;
                 // Did we just play the last note?
                 if (noteCounter === pm._notesToPlay.length - 1) {
                     PhraseMakerUI.resetMatrix(pm);
+                    this.clearPlaybackTimers(pm);
 
                     pm.widgetWindow.modifyButton(
                         0,
@@ -479,10 +516,11 @@ const PhraseMakerAudio = {
                 }
 
                 if (noteCounter < pm._notesToPlay.length - 1) {
-                    if (!pm._stopOrCloseClicked) {
+                    if (!pm._stopOrCloseClicked && pm.playingNow) {
                         this.__playNote(pm, time, noteCounter + 1);
                     } else {
                         PhraseMakerUI.resetMatrix(pm);
+                        this.clearPlaybackTimers(pm);
                     }
                 }
             },
@@ -497,47 +535,63 @@ const PhraseMakerAudio = {
      * @param {number} noteValue - The duration value of the chord notes.
      */
     _playChord(pm, notes, noteValue) {
-        setTimeout(() => {
-            pm.activity.logo.synth.trigger(0, notes[0], noteValue, pm._instrumentName, null, null);
-        }, 1);
-
-        if (notes.length > 1) {
+        pm._chordTimeouts = pm._chordTimeouts || [];
+        pm._chordTimeouts.push(
             setTimeout(() => {
                 pm.activity.logo.synth.trigger(
                     0,
-                    notes[1],
+                    notes[0],
                     noteValue,
                     pm._instrumentName,
                     null,
                     null
                 );
-            }, 1);
+            }, 1)
+        );
+
+        if (notes.length > 1) {
+            pm._chordTimeouts.push(
+                setTimeout(() => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[1],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                }, 1)
+            );
         }
 
         if (notes.length > 2) {
-            setTimeout(() => {
-                pm.activity.logo.synth.trigger(
-                    0,
-                    notes[2],
-                    noteValue,
-                    pm._instrumentName,
-                    null,
-                    null
-                );
-            }, 1);
+            pm._chordTimeouts.push(
+                setTimeout(() => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[2],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                }, 1)
+            );
         }
 
         if (notes.length > 3) {
-            setTimeout(() => {
-                pm.activity.logo.synth.trigger(
-                    0,
-                    notes[3],
-                    noteValue,
-                    pm._instrumentName,
-                    null,
-                    null
-                );
-            }, 1);
+            pm._chordTimeouts.push(
+                setTimeout(() => {
+                    pm.activity.logo.synth.trigger(
+                        0,
+                        notes[3],
+                        noteValue,
+                        pm._instrumentName,
+                        null,
+                        null
+                    );
+                }, 1)
+            );
         }
     },
 

--- a/js/widgets/__tests__/PhraseMakerAudio.test.js
+++ b/js/widgets/__tests__/PhraseMakerAudio.test.js
@@ -338,12 +338,12 @@ describe("PhraseMakerAudio", () => {
         });
 
         test("triggers notes for a chord", () => {
-            const notes = ["C4", "E4", "G4"];
+            const notes = ["C4", "E4", "G4", "B4"];
             PhraseMakerAudio._playChord(mockPM, notes, 1);
 
             jest.runAllTimers();
 
-            expect(mockPM.activity.logo.synth.trigger).toHaveBeenCalledTimes(3);
+            expect(mockPM.activity.logo.synth.trigger).toHaveBeenCalledTimes(4);
             expect(mockPM.activity.logo.synth.trigger).toHaveBeenCalledWith(
                 0,
                 "C4",
@@ -363,6 +363,14 @@ describe("PhraseMakerAudio", () => {
             expect(mockPM.activity.logo.synth.trigger).toHaveBeenCalledWith(
                 0,
                 "G4",
+                1,
+                "piano",
+                null,
+                null
+            );
+            expect(mockPM.activity.logo.synth.trigger).toHaveBeenCalledWith(
+                0,
+                "B4",
                 1,
                 "piano",
                 null,
@@ -475,6 +483,109 @@ describe("PhraseMakerAudio", () => {
             jest.runOnlyPendingTimers(); // Run the first note's timeout
             expect(mockPM._spanCounter).toBe(1);
             expect(mockPM._colIndex).toBe(0); // Should not advance yet
+        });
+
+        test("does not schedule or execute when _stopOrCloseClicked is true", () => {
+            mockPM._stopOrCloseClicked = true;
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+            expect(mockPM._playNoteTimeout).toBeFalsy();
+            jest.runAllTimers();
+            expect(mockPM._notesCounter).toBe(0);
+        });
+
+        test("cancels execution and resets matrix if stopped before timeout fires", () => {
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+            expect(mockPM._playNoteTimeout).not.toBeNull();
+
+            // Simulate stop clicked before timer executes
+            mockPM._stopOrCloseClicked = true;
+            jest.runAllTimers();
+
+            expect(global.PhraseMakerUI.resetMatrix).toHaveBeenCalled();
+            expect(mockPM._notesCounter).toBe(0);
+        });
+
+        test("does not clear pending chord timeouts when scheduling note", () => {
+            const chordTimeout = setTimeout(() => {}, 100);
+            mockPM._chordTimeouts = [chordTimeout];
+
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+
+            expect(mockPM._chordTimeouts).toContain(chordTimeout);
+            expect(mockPM._chordTimeouts.length).toBe(1);
+        });
+
+        test("clears existing _playNoteTimeout before setting a new one", () => {
+            const previousTimeout = setTimeout(() => {}, 1000);
+            mockPM._playNoteTimeout = previousTimeout;
+
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+
+            expect(mockPM._playNoteTimeout).not.toBe(previousTimeout);
+            expect(mockPM._playNoteTimeout).not.toBeNull();
+        });
+
+        test("recursively plays next note when noteCounter < notesToPlay.length - 1 and playingNow is true", () => {
+            mockPM.playingNow = true;
+            const playNoteSpy = jest.spyOn(PhraseMakerAudio, "__playNote");
+
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+            jest.runAllTimers();
+
+            expect(playNoteSpy).toHaveBeenCalledWith(mockPM, expect.any(Number), 1);
+            playNoteSpy.mockRestore();
+        });
+
+        test("resets matrix and clears timers when playingNow becomes false during sequence", () => {
+            mockPM.playingNow = true;
+            mockPM._stopOrCloseClicked = false;
+            const clearSpy = jest.spyOn(PhraseMakerAudio, "clearPlaybackTimers");
+
+            PhraseMakerAudio.__playNote(mockPM, 0, 0);
+
+            // Change playingNow to false while timer is pending
+            mockPM.playingNow = false;
+            jest.runAllTimers();
+
+            expect(global.PhraseMakerUI.resetMatrix).toHaveBeenCalled();
+            expect(clearSpy).toHaveBeenCalled();
+            clearSpy.mockRestore();
+        });
+    });
+
+    describe("clearPlaybackTimers", () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test("clears active _playNoteTimeout and sets it to null", () => {
+            const timeoutId = setTimeout(() => {}, 1000);
+            mockPM._playNoteTimeout = timeoutId;
+
+            PhraseMakerAudio.clearPlaybackTimers(mockPM);
+
+            expect(mockPM._playNoteTimeout).toBeNull();
+        });
+
+        test("clears all timeouts in _chordTimeouts array and empties it", () => {
+            const t1 = setTimeout(() => {}, 500);
+            const t2 = setTimeout(() => {}, 600);
+            mockPM._chordTimeouts = [t1, t2];
+
+            PhraseMakerAudio.clearPlaybackTimers(mockPM);
+
+            expect(mockPM._chordTimeouts).toEqual([]);
+        });
+
+        test("handles missing or undefined timer properties safely", () => {
+            delete mockPM._playNoteTimeout;
+            delete mockPM._chordTimeouts;
+
+            expect(() => PhraseMakerAudio.clearPlaybackTimers(mockPM)).not.toThrow();
         });
     });
 });

--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -74,7 +74,8 @@ global.PhraseMakerAudio = {
     collectNotesToPlay: jest.fn(),
     __playNote: jest.fn(),
     _playChord: jest.fn(),
-    _processGraphics: jest.fn()
+    _processGraphics: jest.fn(),
+    clearPlaybackTimers: jest.fn()
 };
 window.PhraseMakerAudio = global.PhraseMakerAudio;
 global.DEFAULTVOICE = "electronic synth";
@@ -1200,7 +1201,8 @@ describe("PhraseMaker Widget", () => {
             collectNotesToPlay: jest.fn(),
             __playNote: jest.fn(),
             _playChord: jest.fn(),
-            _processGraphics: jest.fn()
+            _processGraphics: jest.fn(),
+            clearPlaybackTimers: jest.fn()
         };
 
         global.PhraseMakerUI = {
@@ -1282,7 +1284,10 @@ describe("PhraseMaker Widget", () => {
         expect(phraseMaker.activity.blocks.loadNewBlocks).toHaveBeenCalled();
     });
     test("_save wires lastConnection identically across all block types (characterization)", () => {
-        global.PhraseMakerAudio = { collectNotesToPlay: jest.fn() };
+        global.PhraseMakerAudio = {
+            collectNotesToPlay: jest.fn(),
+            clearPlaybackTimers: jest.fn()
+        };
 
         phraseMaker._rows = [];
         phraseMaker._rowBlocks = [];
@@ -1514,7 +1519,9 @@ describe("PhraseMaker Widget", () => {
             resetMatrix: jest.fn()
         };
         phraseMaker.init(mockActivity);
+        phraseMaker.widgetWindow.onclose();
 
+        expect(phraseMaker._stopOrCloseClicked).toBe(true);
         expect(mockActivity.textMsg).toHaveBeenCalled();
     });
     test("isInitial ensures the first-open message fires only once across repeated init() calls", () => {
@@ -2394,7 +2401,8 @@ describe("PhraseMaker Widget", () => {
                 collectNotesToPlay: jest.fn(),
                 __playNote: jest.fn(),
                 _playChord: jest.fn(),
-                _processGraphics: jest.fn()
+                _processGraphics: jest.fn(),
+                clearPlaybackTimers: jest.fn()
             };
             global.PhraseMakerUI = {
                 resetMatrix: jest.fn(),
@@ -2940,6 +2948,41 @@ describe("PhraseMaker Widget", () => {
             expect(phraseMaker._history.length).toBe(2);
             expect(phraseMaker._history.pop()).toEqual({ note: "la4", beat: 2 });
             expect(phraseMaker._history.length).toBe(1);
+        });
+    });
+
+    describe("handleClose", () => {
+        test("cleans up state and calls PhraseMakerAudio.clearPlaybackTimers on close", () => {
+            phraseMaker.activity = {
+                logo: {
+                    synth: {
+                        stopSound: jest.fn(),
+                        stop: jest.fn()
+                    }
+                },
+                hideMsgs: jest.fn()
+            };
+            phraseMaker.playingNow = true;
+            phraseMaker._instrumentName = "piano";
+            phraseMaker._rowOffset = [1];
+            phraseMaker._rowMap = [2, 0, 1];
+            phraseMaker.widgetWindow = {
+                destroy: jest.fn()
+            };
+
+            global.PhraseMakerAudio.clearPlaybackTimers.mockClear();
+
+            phraseMaker.handleClose();
+
+            expect(phraseMaker._stopOrCloseClicked).toBe(true);
+            expect(phraseMaker.playingNow).toBe(false);
+            expect(phraseMaker._rowOffset).toEqual([]);
+            expect(phraseMaker._rowMap).toEqual([0, 1, 2]);
+            expect(phraseMaker.activity.hideMsgs).toHaveBeenCalled();
+            expect(global.PhraseMakerAudio.clearPlaybackTimers).toHaveBeenCalledWith(phraseMaker);
+            expect(phraseMaker.activity.logo.synth.stop).toHaveBeenCalled();
+            expect(phraseMaker.activity.logo.synth.stopSound).toHaveBeenCalledWith(0, "piano");
+            expect(phraseMaker.widgetWindow.destroy).toHaveBeenCalled();
         });
     });
 });

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -609,17 +609,7 @@ class PhraseMaker {
         // Add the buttons to the top row.
 
         widgetWindow.onclose = () => {
-            this._rowOffset = [];
-            for (let i = 0; i < this._rowMap.length; i++) {
-                this._rowMap[i] = i;
-            }
-
-            this.activity.logo.synth.stopSound(0, this._instrumentName);
-            this.activity.logo.synth.stop();
-            this._stopOrCloseClicked = true;
-            this.activity.hideMsgs();
-            this.docById("wheelDivptm").style.display = "none";
-            widgetWindow.destroy();
+            this.handleClose();
         };
 
         this._playButton = widgetWindow.addButton(
@@ -1215,6 +1205,34 @@ class PhraseMaker {
                 item.titleSelectedAttr.cursor = "pointer";
                 item.titleHoverAttr.cursor = "pointer";
             }
+        }
+    }
+
+    /**
+     * Handles cleanup and state reset when PhraseMaker widget window is closed.
+     */
+    handleClose() {
+        this._rowOffset = [];
+        for (let i = 0; i < this._rowMap.length; i++) {
+            this._rowMap[i] = i;
+        }
+
+        if (this.activity && this.activity.logo && this.activity.logo.synth) {
+            this.activity.logo.synth.stopSound(0, this._instrumentName);
+            this.activity.logo.synth.stop();
+        }
+        this._stopOrCloseClicked = true;
+        this.playingNow = false;
+        PhraseMakerAudio.clearPlaybackTimers(this);
+        if (this.activity && typeof this.activity.hideMsgs === "function") {
+            this.activity.hideMsgs();
+        }
+        const wheelDiv = this.docById("wheelDivptm");
+        if (wheelDiv && wheelDiv.style) {
+            wheelDiv.style.display = "none";
+        }
+        if (this.widgetWindow && typeof this.widgetWindow.destroy === "function") {
+            this.widgetWindow.destroy();
         }
     }
 


### PR DESCRIPTION
## Description

Resolves #6976 by introducing central timer lifecycle management in `PhraseMakerAudio`.

Previously, `__playNote` and `_playChord` scheduled audio and matrix progression using unmanaged `setTimeout` calls without storing timer IDs. Rapidly clicking Stop and then Play, or closing the PhraseMaker widget during note sequencing, left orphaned timers in the event loop. When these timers fired, they triggered audio notes and advanced matrix column pointers concurrently with the new playback session, resulting in discordant audio overlap and UI desynchronization.

## Related Issue

**Fixes:** #6976

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

1. **Timer Lifecycle Management (`clearPlaybackTimers`)**:
   - Added `clearPlaybackTimers(pm)` to `PhraseMakerAudio` to clear and nullify `pm._playNoteTimeout` and all deferred chord timers in `pm._chordTimeouts`.
2. **Playback Teardown (`playAll`)**:
   - Calls `clearPlaybackTimers(pm)` when stopping playback.
   - Halts active synth voices via `pm.activity.logo.synth.stop()`.
   - Cleans up and resets prior timers before starting any new playback loop to prevent concurrent sequence overlap.
3. **Execution Guarding (`__playNote`)**:
   - Checks `pm._stopOrCloseClicked` and widget visibility both before scheduling and inside the deferred timer callback, halting further note sequencing.
   - Cleans up timers and resets matrix if stopped before the pending note delay expires.
4. **Widget Teardown (`widgetWindow.onclose`)**:
   - In `phrasemaker.js`, hooked `PhraseMakerAudio.clearPlaybackTimers(this)` into `widgetWindow.onclose` to ensure no lingering timers execute after the widget is closed.
5. **Unit Test Coverage**:
   - Added test cases in `js/widgets/__tests__/PhraseMakerAudio.test.js` verifying timer clearance, zombie callback cancellation, and matrix reset on stop.

---

## Steps to Reproduce

1. Open the PhraseMaker widget in Music Blocks.
2. Click the "Play" button.
3. Rapidly click "Stop" and then "Play" multiple times before the phrase finishes.
4. **Observed (Before)**: Notes from the previous sequence still execute in the background alongside the new sequence, creating overlapping polyphonic noise and desynchronizing the matrix column highlighter.
5. **Expected (After)**: Stopping playback immediately cancels all scheduled timers and halts synth voices; restarting playback starts cleanly from note index 0 with zero overlap.

---

## Testing Performed

- `npx jest js/widgets/__tests__/PhraseMakerAudio.test.js --coverage=false` (34/34 passing)
- `npx jest js/widgets/__tests__/PhraseMaker*.test.js --coverage=false` (190/190 passing)
- `npx jest js/widgets/__tests__/phrasemaker.test.js --coverage=false` (135/135 passing)
- `npm run lint` (0 errors, 0 warnings across entire repo)
- `npx prettier --check js/widgets/PhraseMakerAudio.js js/widgets/phrasemaker.js js/widgets/__tests__/PhraseMakerAudio.test.js` (All matched files use Prettier code style)
- `git log -1 --pretty=format:"%B" | npx commitlint` (0 errors)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PhraseMaker playback stopping, cancellation, hiding, and closing behavior.
  * Pending note and chord playback timers are now cleared reliably during playback interruptions.
  * Prevented playback from continuing when stopped or when the widget is hidden.
  * Improved cleanup of active synthesizer sounds and playback state when playback ends or the window closes.

* **Tests**
  * Added coverage for playback interruption, timer replacement and clearing, recursive note playback, and window-close cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->