### PR TITLE
fix(rhythm): bound note counts

### DIFF
--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -32,7 +32,7 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
 }
 
 function setupRhythmBlockPaletteBlocks(activity) {
-    const MAX_RHYTHM_NOTES = 1000;
+    const MAX_RHYTHM_NOTES = 128;
 
     const getNoteCount = (value, defaultValue, blk) => {
         if (value === null || typeof value !== "number" || !Number.isFinite(value) || value < 1) {

--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -41,7 +41,10 @@ function setupRhythmBlockPaletteBlocks(activity) {
         }
 
         if (value > MAX_RHYTHM_NOTES) {
-            activity.errorMsg(_("Maximum number of notes is 1000."), blk);
+            activity.errorMsg(
+                _("Maximum number of notes is %s.").replace(/%s/g, MAX_RHYTHM_NOTES),
+                blk
+            );
             return MAX_RHYTHM_NOTES;
         }
 

--- a/js/blocks/RhythmBlockPaletteBlocks.js
+++ b/js/blocks/RhythmBlockPaletteBlocks.js
@@ -32,6 +32,22 @@ if (_THIS_IS_TURTLE_BLOCKS_) {
 }
 
 function setupRhythmBlockPaletteBlocks(activity) {
+    const MAX_RHYTHM_NOTES = 1000;
+
+    const getNoteCount = (value, defaultValue, blk) => {
+        if (value === null || typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+            activity.errorMsg(NOINPUTERRORMSG, blk);
+            return defaultValue;
+        }
+
+        if (value > MAX_RHYTHM_NOTES) {
+            activity.errorMsg(_("Maximum number of notes is 1000."), blk);
+            return MAX_RHYTHM_NOTES;
+        }
+
+        return Math.floor(value);
+    };
+
     /**
      * Schedules a note to be played after a timeout.
      * @param {object} logo - The Logo execution engine.
@@ -115,12 +131,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
          */
         flow(args, logo, turtle, blk) {
             let noteBeatValue, arg0, arg1;
-            if (args[0] === null || typeof args[0] !== "number" || args[0] < 1) {
-                activity.errorMsg(NOINPUTERRORMSG, blk);
-                arg0 = 3;
-            } else {
-                arg0 = args[0];
-            }
+            arg0 = getNoteCount(args[0], 3, blk);
 
             if (args[1] === null || typeof args[1] !== "number" || args[1] <= 0) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
@@ -154,7 +165,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
                     }
                 }
 
-                for (let i = 0; i < args[0]; i++) {
+                for (let i = 0; i < arg0; i++) {
                     Singer.processNote(activity, noteBeatValue, false, blk, turtle);
                 }
             } else if (logo.inRhythmRuler) {
@@ -943,12 +954,7 @@ function setupRhythmBlockPaletteBlocks(activity) {
          */
         flow(args, logo, turtle, blk) {
             let arg0, arg1;
-            if (args[0] === null || typeof args[0] !== "number" || args[0] <= 0) {
-                activity.errorMsg(NOINPUTERRORMSG, blk);
-                arg0 = 3;
-            } else {
-                arg0 = args[0];
-            }
+            arg0 = getNoteCount(args[0], 3, blk);
 
             if (args[1] === null || typeof args[1] !== "number" || args[1] <= 0) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);

--- a/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
@@ -186,6 +186,44 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             expect(Singer.processNote).not.toHaveBeenCalled();
             jest.useRealTimers();
         });
+
+        it("rejects non-finite note counts", () => {
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            logo._timerManager = new ManagedTimer();
+            rhythmBlock.flow([NaN, 0.25], logo, turtleIndex, "blkRhythm");
+
+            expect(activity.errorMsg).toHaveBeenCalledWith("No input provided", "blkRhythm");
+            expect(logo._timerManager.activeTimeoutCount).toBe(3);
+            logo._timerManager.clearAll();
+        });
+
+        it("caps oversized note counts", () => {
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            logo._timerManager = new ManagedTimer();
+            rhythmBlock.flow([1001, 0.25], logo, turtleIndex, "blkRhythm");
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Maximum number of notes is 1000.",
+                "blkRhythm"
+            );
+            expect(logo._timerManager.activeTimeoutCount).toBe(1000);
+            logo._timerManager.clearAll();
+        });
+
+        it("normalizes fractional note counts", () => {
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            logo._timerManager = new ManagedTimer();
+            rhythmBlock.flow([2.5, 0.25], logo, turtleIndex, "blkRhythm");
+
+            expect(logo._timerManager.activeTimeoutCount).toBe(2);
+            logo._timerManager.clearAll();
+        });
     });
 
     describe("Rhythm2Block", () => {
@@ -355,6 +393,21 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             const ret = stupletBlock.flow([3, 0.5], logo, turtleIndex, "blkSTuplet");
             expect(logo.tupletRhythms.length).toBeGreaterThan(0);
             expect(ret).toBeUndefined();
+        });
+
+        it("caps oversized note counts before scheduling notes", () => {
+            const stupletBlock = DummyFlowBlock.createdBlocks["stuplet"];
+            activity.blocks.blockList["blkSTuplet"] = { name: "stuplet" };
+            logo._timerManager = new ManagedTimer();
+
+            stupletBlock.flow([1001, 0.5], logo, turtleIndex, "blkSTuplet");
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "Maximum number of notes is 1000.",
+                "blkSTuplet"
+            );
+            expect(logo._timerManager.activeTimeoutCount).toBe(1000);
+            logo._timerManager.clearAll();
         });
     });
 });

--- a/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
@@ -226,6 +226,18 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             logo._timerManager.clearAll();
         });
 
+        it("accepts the maximum note count", () => {
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            logo._timerManager = new ManagedTimer();
+            rhythmBlock.flow([128, 0.25], logo, turtleIndex, "blkRhythm");
+
+            expect(activity.errorMsg).not.toHaveBeenCalled();
+            expect(logo._timerManager.activeTimeoutCount).toBe(128);
+            logo._timerManager.clearAll();
+        });
+
         it("normalizes fractional note counts", () => {
             const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
             activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
@@ -418,6 +430,18 @@ describe("setupRhythmBlockPaletteBlocks", () => {
                 "Maximum number of notes is 128.",
                 "blkSTuplet"
             );
+            expect(logo._timerManager.activeTimeoutCount).toBe(128);
+            logo._timerManager.clearAll();
+        });
+
+        it("accepts the maximum note count", () => {
+            const stupletBlock = DummyFlowBlock.createdBlocks["stuplet"];
+            activity.blocks.blockList["blkSTuplet"] = { name: "stuplet" };
+            logo._timerManager = new ManagedTimer();
+
+            stupletBlock.flow([128, 0.5], logo, turtleIndex, "blkSTuplet");
+
+            expect(activity.errorMsg).not.toHaveBeenCalled();
             expect(logo._timerManager.activeTimeoutCount).toBe(128);
             logo._timerManager.clearAll();
         });

--- a/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
@@ -216,13 +216,13 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
 
             logo._timerManager = new ManagedTimer();
-            rhythmBlock.flow([1001, 0.25], logo, turtleIndex, "blkRhythm");
+            rhythmBlock.flow([129, 0.25], logo, turtleIndex, "blkRhythm");
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "Maximum number of notes is 1000.",
+                "Maximum number of notes is 128.",
                 "blkRhythm"
             );
-            expect(logo._timerManager.activeTimeoutCount).toBe(1000);
+            expect(logo._timerManager.activeTimeoutCount).toBe(128);
             logo._timerManager.clearAll();
         });
 
@@ -412,13 +412,13 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             activity.blocks.blockList["blkSTuplet"] = { name: "stuplet" };
             logo._timerManager = new ManagedTimer();
 
-            stupletBlock.flow([1001, 0.5], logo, turtleIndex, "blkSTuplet");
+            stupletBlock.flow([129, 0.5], logo, turtleIndex, "blkSTuplet");
 
             expect(activity.errorMsg).toHaveBeenCalledWith(
-                "Maximum number of notes is 1000.",
+                "Maximum number of notes is 128.",
                 "blkSTuplet"
             );
-            expect(logo._timerManager.activeTimeoutCount).toBe(1000);
+            expect(logo._timerManager.activeTimeoutCount).toBe(128);
             logo._timerManager.clearAll();
         });
     });

--- a/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
+++ b/js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js
@@ -199,6 +199,18 @@ describe("setupRhythmBlockPaletteBlocks", () => {
             logo._timerManager.clearAll();
         });
 
+        it("rejects Infinity note counts", () => {
+            const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
+            activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };
+
+            logo._timerManager = new ManagedTimer();
+            rhythmBlock.flow([Infinity, 0.25], logo, turtleIndex, "blkRhythm");
+
+            expect(activity.errorMsg).toHaveBeenCalledWith("No input provided", "blkRhythm");
+            expect(logo._timerManager.activeTimeoutCount).toBe(3);
+            logo._timerManager.clearAll();
+        });
+
         it("caps oversized note counts", () => {
             const rhythmBlock = DummyFlowBlock.createdBlocks["rhythm"];
             activity.blocks.blockList["blkRhythm"] = { name: "rhythm", connections: [] };


### PR DESCRIPTION
 ## Description

A large value in the Simple Tuplet block’s “number of notes” input can freeze the Music Blocks tab. The value was being used directly in synchronous note-generation loops without checking whether it was finite or within a reasonable range.

  ## Related Issue

  **Fixes:** #8440

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ---

  ## Changes Made

  - Added shared validation for rhythm note counts.
  - Rejects invalid and non-finite values such as `NaN` and `Infinity`.
  - Limits note counts above 1000 to prevent excessive synchronous work.
  - Normalizes fractional note counts to whole numbers.
  - Applies the validation to both the Rhythm and Simple Tuplet blocks.
  - Updated the matrix execution path to use the validated note count consistently.

  ---

  ## Steps to Reproduce

  1. Open Music Blocks.
  2. Add a Simple Tuplet block.
  3. Set the “number of notes” input to `100000`.
  4. Run the block.

Before this change, the tab becomes unresponsive while the block schedules the notes. With this change, the value is limited before the loop starts.

  ---

  ## Testing Performed

  - `npx jest js/blocks/__tests__/RhythmBlockPaletteBlocks.test.js --runInBand --coverage=false`
    - 25 tests passed.
  - ESLint passed for the changed files.
  - Prettier check passed for the changed files.
  - `git diff --check` passed.
  - Verified the same `100000`-note input through the local browser build; the flow returned without hanging.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [ ] I have updated the documentation to reflect these changes, if applicable.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [ ] I have addressed the code review feedback from the previous submission, if applicable.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

The limit is applied before any notes or timers are created, so oversized input cannot block the main thread. Normal note counts continue to use the existing playback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for rhythm and tuplet note counts.
  - Invalid or non-finite values now report an input error and use three default notes.
  - Counts below one are rejected.
  - Counts above 128 now report an error and schedule no more than 128 notes.
  - Fractional note counts are truncated to whole numbers.
  - Rhythm and tuplet patterns consistently use the validated note count.
  - Exactly 128 notes can now be scheduled without triggering the maximum-note error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->