### PR TITLE
fix(phrasemaker): remove every block map entry for a cleared cell

### DIFF
--- a/js/widgets/PhraseMakerGrid.js
+++ b/js/widgets/PhraseMakerGrid.js
@@ -110,7 +110,12 @@ const PhraseMakerGrid = {
         // When the matrix is changed, we may need to remove nodes.
         const blk = pm.blockNo;
         let obj;
-        for (let i = 0; i < pm._blockMap[blk].length; i++) {
+        // Walked back to front. A cell can hold more than one entry, since
+        // addNode records one per pass of a repeat and tells them apart by
+        // the trailing counter, and this match ignores that counter. Removing
+        // front to back would shift the next match down onto the index just
+        // vacated, which the loop then steps over.
+        for (let i = pm._blockMap[blk].length - 1; i >= 0; i--) {
             obj = pm._blockMap[blk][i];
             if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
                 pm._blockMap[blk].splice(i, 1);

--- a/js/widgets/__tests__/PhraseMakerGrid.test.js
+++ b/js/widgets/__tests__/PhraseMakerGrid.test.js
@@ -366,6 +366,204 @@ describe("PhraseMakerGrid", () => {
             expect(pm._blockMap[5]).toHaveLength(1);
         });
 
+        // A cell holds one entry per pass of a repeat. addNode builds them by
+        // counting the matches already present and storing that count as the
+        // trailing element, and removeNode matches on the other three fields,
+        // so every one of them is meant to go.
+        describe("when a cell holds more than one entry", () => {
+            test("removes both entries left by a two pass repeat", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                PhraseMakerGrid.addNode(pm, 10, 100, 0, 5);
+                PhraseMakerGrid.addNode(pm, 10, 100, 0, 5);
+
+                expect(pm._blockMap[5]).toEqual([
+                    [10, [100, 0], 0],
+                    [10, [100, 0], 1]
+                ]);
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([]);
+            });
+
+            test.each([[2], [3], [4], [5], [6]])(
+                "clears all %i entries in a single call",
+                count => {
+                    const pm = createMockPM();
+                    pm.blockNo = 5;
+                    for (let i = 0; i < count; i++) {
+                        PhraseMakerGrid.addNode(pm, 10, 100, 0, 5);
+                    }
+
+                    PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                    expect(pm._blockMap[5]).toEqual([]);
+                }
+            );
+
+            test("leaves surrounding entries untouched and in order", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [
+                    [10, [100, 0], 0],
+                    [20, [200, 0], 0],
+                    [20, [200, 0], 1],
+                    [30, [300, 0], 0]
+                ];
+
+                PhraseMakerGrid.removeNode(pm, 20, 200, 0);
+
+                expect(pm._blockMap[5]).toEqual([
+                    [10, [100, 0], 0],
+                    [30, [300, 0], 0]
+                ]);
+            });
+
+            test("removes adjacent duplicates sitting at the end of the list", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [
+                    [30, [300, 0], 0],
+                    [10, [100, 0], 0],
+                    [10, [100, 0], 1]
+                ];
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([[30, [300, 0], 0]]);
+            });
+
+            test("removes duplicates that are not next to each other", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [
+                    [10, [100, 0], 0],
+                    [20, [200, 0], 0],
+                    [10, [100, 0], 1],
+                    [30, [300, 0], 0],
+                    [10, [100, 0], 2]
+                ];
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([
+                    [20, [200, 0], 0],
+                    [30, [300, 0], 0]
+                ]);
+            });
+
+            test("keeps entries whose rhythm index differs, since those are other columns", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [
+                    [10, [100, 0], 0],
+                    [10, [100, 1], 0],
+                    [10, [100, 0], 1]
+                ];
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([[10, [100, 1], 0]]);
+            });
+        });
+
+        // The sequence a Phrase Maker runs for repeat 2 [ pitch + note ].
+        // addRowBlock renumbers the repeated row and addColBlock indexes the
+        // repeated column, but the cell itself is recorded with the
+        // un-augmented pitch id and a fixed 0 on both passes.
+        describe("repeat block scenario", () => {
+            const PITCH = 11;
+            const NOTE = 42;
+            const MATRIX = 7;
+
+            /**
+             * Runs both passes of a repeat over one pitch and one note block.
+             * @returns {Object} The mock PhraseMaker after both passes.
+             */
+            function buildRepeatedMatrix() {
+                const pm = createMockPM();
+                pm.blockNo = MATRIX;
+                pm._rowBlocks = [];
+                pm._rowMap = [];
+                pm._rowOffset = [];
+                pm._colBlocks = [];
+
+                for (let pass = 0; pass < 2; pass++) {
+                    PhraseMakerGrid.addRowBlock(pm, PITCH);
+                    PhraseMakerGrid.addColBlock(pm, NOTE, 1);
+                    PhraseMakerGrid.addNode(pm, PITCH, NOTE, 0, MATRIX);
+                }
+
+                return pm;
+            }
+
+            test("renumbers the repeated row but tells the cells apart only by counter", () => {
+                const pm = buildRepeatedMatrix();
+
+                expect(pm._rowBlocks).toEqual([PITCH, PITCH + 1000000]);
+                expect(pm._colBlocks).toEqual([
+                    [NOTE, 0],
+                    [NOTE, 1]
+                ]);
+                expect(pm._blockMap[MATRIX]).toEqual([
+                    [PITCH, [NOTE, 0], 0],
+                    [PITCH, [NOTE, 0], 1]
+                ]);
+            });
+
+            test("clearing the cell once clears it for both passes", () => {
+                const pm = buildRepeatedMatrix();
+
+                // _setNotes resolves row 0 through _rowMap to the un-augmented
+                // id, and that is what reaches removeNode.
+                const rowBlock = pm._rowBlocks[pm._rowMap.indexOf(0 - pm._rowOffset[0])];
+                expect(rowBlock).toBe(PITCH);
+
+                PhraseMakerGrid.removeNode(pm, rowBlock, NOTE, 0);
+
+                expect(pm._blockMap[MATRIX]).toEqual([]);
+            });
+        });
+
+        describe("edge cases", () => {
+            test("leaves an empty block map empty", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [];
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([]);
+            });
+
+            test("keeps the placeholder entries the grid marks with -1", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                pm._blockMap[5] = [
+                    [-1, [100, 0], 0],
+                    [10, [100, 0], 0],
+                    [10, [100, 0], 1]
+                ];
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([[-1, [100, 0], 0]]);
+            });
+
+            test("changes nothing when called a second time for the same cell", () => {
+                const pm = createMockPM();
+                pm.blockNo = 5;
+                PhraseMakerGrid.addNode(pm, 10, 100, 0, 5);
+                PhraseMakerGrid.addNode(pm, 10, 100, 0, 5);
+
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+                PhraseMakerGrid.removeNode(pm, 10, 100, 0);
+
+                expect(pm._blockMap[5]).toEqual([]);
+            });
+        });
+
         test("does not remove nodes with different n", () => {
             const pm = createMockPM();
             pm.blockNo = 5;


### PR DESCRIPTION
## Description

`removeNode` spliced `_blockMap` while walking it front to back:

```js
for (let i = 0; i < pm._blockMap[blk].length; i++) {
    obj = pm._blockMap[blk][i];
    if (obj[0] === rowBlock && obj[1][0] === rhythmBlock && obj[1][1] === n) {
        pm._blockMap[blk].splice(i, 1);
    }
}
```

Each removal shifted the next match down onto the index just vacated, and the loop then stepped over it. A cell holding more than one entry only lost about half of them.

Those entries are not accidental. `addNode`, directly above, counts the matches already present and stores the count as the trailing element, and `removeNode` matches on the other three fields and has no `break`, so every occurrence is meant to go.

A repeat is what creates them. `addRowBlock` renumbers the repeated row and `addColBlock` indexes the repeated column, but `js/turtle-singer.js:1678` records the cell with the un-augmented pitch id and a fixed `0` on every pass. For `repeat 2`:

```
_rowBlocks : [11, 1000011]
_colBlocks : [[42, 0], [42, 1]]
_blockMap  : [[11, [42, 0], 0], [11, [42, 0], 1]]
```

Clearing that cell resolves row 0 to `11` and calls `removeNode(11, 42, 0)`, which matches both. One survived, and `js/widgets/phrasemaker.js:4410` used its counter to select the repeated row and set the cell back to black.

## Related Issue

Fixes #8442

## Category

- [x] Bug fix

## Changes Made

Walk the list back to front, so a splice cannot move an unvisited entry behind the cursor:

```js
for (let i = pm._blockMap[blk].length - 1; i >= 0; i--) {
```

One line of behaviour change, plus a comment explaining why the direction matters.

The existing `removeNode` tests only ever used lists with a single match, so the duplicate case was never exercised. Added sixteen tests covering it: the two entry repeat case, two through six matching entries in one call, duplicates that are adjacent, trailing and separated, entries that must survive because their rhythm index differs, an empty map, the `-1` placeholder rows, and a second call being a no-op.

One test drives the real `addRowBlock` and `addColBlock` sequence for `repeat 2 [ pitch + note ]` and resolves the row the way `_setNotes` does, so the scenario is pinned end to end rather than asserted from a hand-written map.

## Testing Performed

**Ten of the sixteen new tests fail on master and pass with the fix.** The other six guard behaviour that was already correct.

| entries for one cell | before | after |
|---:|---:|---:|
| 1 | 0 left | 0 left |
| 2 | 1 left | 0 left |
| 3 | 1 left | 0 left |
| 4 | 2 left | 0 left |
| 5 | 2 left | 0 left |
| 6 | 3 left | 0 left |

Full suite passes: **229 suites, 8677 tests**. `npm run lint` and `npx prettier --check` are both clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed removal of repeated phrase-maker grid entries so all matching cells are removed reliably.
  - Preserved unrelated entries, placeholder rows, and row/column mappings during removal.
  - Improved behavior when removing entries repeatedly or when no entries are present.

- **Tests**
  - Added coverage for duplicate, nonadjacent, repeated, and empty-entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->