### PR TITLE
fix(notation): route notationMarkup through the queue and run the meter reorder

### DIFF
--- a/js/__tests__/notation.test.js
+++ b/js/__tests__/notation.test.js
@@ -79,10 +79,29 @@ describe("Notation Class", () => {
             expect(notation.notationDrumStaging).toEqual(drumStaging);
         });
 
-        it("should correctly set and get notationMarkup", () => {
-            const markup = { turtle1: ["markup1", "markup2"] };
-            notation.notationMarkup = markup;
-            expect(notation.notationMarkup).toEqual(markup);
+        it("should queue markup for the next note using notationMarkup", () => {
+            const turtle = "turtle1";
+            notation.notationMarkup(turtle, 440.25);
+            notation.notationMarkup(turtle, "adagio");
+            expect(notation._markup[turtle]).toEqual([440.25, "adagio"]);
+            // Nothing is staged until the next note arrives.
+            expect(notation._notationStaging[turtle]).toEqual([]);
+        });
+
+        it("should initialize the markup queue for an unseen turtle", () => {
+            notation.notationMarkup("turtle2", 220.5);
+            expect(notation._markup["turtle2"]).toEqual([220.5]);
+        });
+
+        it("should attach queued markup after the note staged by doUpdateNotation", () => {
+            const turtle = "turtle1";
+            notation.notationMarkup(turtle, 440.25);
+            notation.doUpdateNotation(["A4"], 4, turtle, false, "");
+            const staging = notation._notationStaging[turtle];
+            expect(Array.isArray(staging[0])).toBe(true);
+            expect(staging[0][0]).toEqual(["A4"]);
+            expect(staging.slice(1)).toEqual(["markup", 440.25]);
+            expect(notation._markup[turtle]).toEqual([]);
         });
 
         it("should correctly return pickupPOW2 and pickupPoint", () => {
@@ -211,6 +230,17 @@ describe("Notation Class", () => {
             expect(notation._notationStaging[turtle]).toEqual(["meter", count, value]);
         });
 
+        it("should move the meter before a staged pickup", () => {
+            const turtle = "turtle1";
+            // convertFactor is mocked to return 4, so this stages "pickup", 4.
+            notation.notationPickup(turtle, 0.25);
+            expect(notation._notationStaging[turtle]).toEqual(["pickup", 4]);
+            notation.notationMeter(turtle, 3, 4);
+            // Lilypond prefers meter to be before partials.
+            expect(notation._notationStaging[turtle]).toEqual(["meter", 3, 4, "pickup", 4]);
+            expect(notation._pickupPoint[turtle]).toBeNull();
+        });
+
         it("should handle notationSwing", () => {
             const turtle = "turtle1";
             notation.notationSwing(turtle);
@@ -324,20 +354,6 @@ describe("Notation Class", () => {
             notation.notationRemoveTie(turtle);
             expect(notation._notationStaging[turtle].length).toBe(initialLength - 1);
             expect(notation._pickupPoint[turtle]).toBeNull();
-        });
-    });
-
-    describe("Static Methods", () => {
-        it("should handle notation markup via static method", () => {
-            // Mock the static property that the method uses
-            const originalMarkup = Notation._markup;
-            Notation._markup = { turtle1: [] };
-
-            Notation.notationMarkup("turtle1", "staccato");
-            expect(Notation._markup["turtle1"]).toContain("staccato");
-
-            // Restore the original
-            Notation._markup = originalMarkup;
         });
     });
 

--- a/js/notation.js
+++ b/js/notation.js
@@ -92,20 +92,6 @@ class Notation {
     }
 
     /**
-     * @param {Object.<String[]>} notationMarkup
-     */
-    set notationMarkup(notationMarkup) {
-        this._notationMarkup = notationMarkup;
-    }
-
-    /**
-     * @returns {Object.<String[]>}
-     */
-    get notationMarkup() {
-        return this._notationMarkup;
-    }
-
-    /**
      * @returns {Object.<Boolean>}
      */
     get pickupPOW2() {
@@ -213,13 +199,14 @@ class Notation {
     }
 
     /**
-     * Adds a markup.
+     * Queues a markup so that it is attached to the next note staged by
+     * doUpdateNotation.
      *
      * @param turtle
      * @param arg
      * @returns {void}
      */
-    static notationMarkup(turtle, arg) {
+    notationMarkup(turtle, arg) {
         if (turtle in this._markup) {
             this._markup[turtle].push(arg);
         } else {
@@ -283,13 +270,13 @@ class Notation {
             const d = this._notationStaging[turtle].length - this._pickupPoint[turtle];
             const pickup = [];
 
-            for (const i in d) {
+            for (let i = 0; i < d; i++) {
                 pickup.push(this._notationStaging[turtle].pop());
             }
 
             this._notationStaging[turtle].push("meter", count, value);
 
-            for (const i in d) {
+            for (let i = 0; i < d; i++) {
                 this._notationStaging[turtle].push(pickup.pop());
             }
         } else {


### PR DESCRIPTION
## Description

Two related staging bugs in `js/notation.js`.

`notationMarkup` is declared `static` and queues into `this._markup` for `doUpdateNotation` to attach after the note. But both production callers (`ExtrasBlocks.js:536`, `PitchActions.js:362`) call it on the instance, where a stray accessor pair `get notationMarkup() { return this._notationMarkup; }` routes the call to the internal `_notationMarkup(turtle, arg, undefined)` instead. The markup token is staged before the note rather than queued, so lilypond attaches `^\markup{...}` to the wrong note, Print-block below-note markup renders above, and the `_markup` drain in `doUpdateNotation` is dead code. The PitchActions tests already mock `notationMarkup` as an instance method, which is the intended contract.

`notationMeter`'s comment says "Lilypond prefers meter to be before partials", but its reorder loop was `for (const i in d)` over a number and never iterated, so staging pickup then meter left `["pickup", 4, "meter", 3, 4]`. Closed PR #5714 spotted the loop bug in 2023 but was never reviewed and the bug remains on master.

## Related Issue

**Fixes:** #8444

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Removed the accessor pair and the `static` keyword so `notationMarkup` is a normal instance method that queues into `_markup`, and replaced the two `for..in`-over-a-number loops in `notationMeter` with counted loops. Updated the two tests that codified the broken surface (one asserted the accessor, one injected a fake static `_markup` to make the static call appear to work) and added regression tests for both behaviors.

## Steps to Reproduce

```js
const n = new Notation(activity);
n.notationMarkup(0, 440.25);   // before: stages a premature markup token, _markup stays {}
Notation._markup;              // before: {} (queue never populated)

n.notationPickup(0, 4);
n.notationMeter(0, 3, 4);      // before: ["pickup", 4, "meter", 3, 4], meter after partial
```

---

## Testing Performed

`npx jest js/__tests__/notation.test.js`: 35 passed. Reverting only `js/notation.js` and keeping the tests fails 4 of them with the exact symptoms (`Expected [440.25, "adagio"], Received []`, a `TypeError` from the misrouted internal call, and the pickup-before-meter ordering diff); restoring passes all 35. Regression: lilypond and turtle-singer suites pass 188/188. `npm run lint` and `npx prettier --check` clean on both changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notation markup handling for queued notation and newly encountered turtles.
  - Ensured markup is correctly attached while notes are being staged.
  - Corrected meter placement around musical pickups for more accurate notation.
- **Tests**
  - Added coverage for notation markup initialization, queued markup, note staging, and pickup meter placement.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->