### PR TITLE
feat(block-drag): defer spatial grid updates during block dragging

### DIFF
--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -883,6 +883,158 @@ describe("Block Foundation", () => {
         });
     });
 
+    describe("drag spatial-grid deferral", () => {
+        const makeEventBlock = () => {
+            const handlers = {};
+            const block = new Block(mockProtoBlock, mockBlocks);
+
+            block.blockIndex = 0;
+            block.connections = [null, null];
+            block.container = {
+                x: 100,
+                y: 100,
+                children: [],
+                on: jest.fn((type, handler) => {
+                    handlers[type] = handler;
+                }),
+                setChildIndex: jest.fn()
+            };
+            block.original = { x: 100, y: 100 };
+            block.offset = { x: 0, y: 0 };
+            block._calculateBlockHitArea = jest.fn();
+            block._setDragGroupTrashHoverScale = jest.fn();
+            block.isValueBlock = jest.fn().mockReturnValue(false);
+
+            mockBlocks.blockList = [block, { container: { x: 100, y: 120 } }];
+            mockBlocks._cachedDragGroup = [0, 1];
+            mockBlocks.longPressTimeout = null;
+            mockBlocks.selectionModeOn = false;
+            mockBlocks.getLongPressStatus = jest.fn().mockReturnValue(false);
+            mockBlocks.clearLongPress = jest.fn();
+            mockBlocks.cacheDragGroup = jest.fn();
+            mockBlocks.raiseStackToTop = jest.fn();
+            mockBlocks.moveBlockRelativeBatched = jest.fn();
+            mockBlocks.scheduleCheckBounds = jest.fn();
+            mockBlocks.clearCachedDragGroup = jest.fn();
+            mockBlocks.invalidateTopBlockCache = jest.fn();
+            mockBlocks.unhighlight = jest.fn();
+
+            block.activity.getStageScale = jest.fn().mockReturnValue(1);
+            block.activity.blocksContainer = { y: 0 };
+            block.activity.scrollBlockContainer = false;
+            block.activity.trashcan = {
+                show: jest.fn(),
+                overTrashcan: jest.fn().mockReturnValue(false),
+                startHighlightAnimation: jest.fn(),
+                stopHighlightAnimation: jest.fn()
+            };
+
+            block._loadEventHandlers();
+            return { block, handlers };
+        };
+
+        it("defers cached drag-group updates and marks the release dirty", () => {
+            const { block, handlers } = makeEventBlock();
+            const mouseoutSpy = jest.spyOn(block, "_mouseoutCallback").mockImplementation(() => {});
+            global.docById.mockReturnValue({ style: {} });
+
+            handlers.mousedown({ stageX: 100, stageY: 100 });
+
+            handlers.pressmove({
+                stageX: 110,
+                stageY: 100,
+                nativeEvent: { preventDefault: jest.fn() }
+            });
+            handlers.pressup({ stageX: 110, stageY: 100 });
+
+            expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(0, 10, 0, true);
+            expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(1, 10, 0, true);
+            expect(mouseoutSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                false,
+                false,
+                false,
+                true,
+                true
+            );
+        });
+
+        it("defers drag-group updates when the cached group is unavailable", () => {
+            const { handlers } = makeEventBlock();
+            mockBlocks._cachedDragGroup = null;
+            mockBlocks.dragGroup = [0, 1];
+            mockBlocks.findDragGroup = jest.fn();
+
+            handlers.pressmove({
+                stageX: 100,
+                stageY: 110,
+                nativeEvent: { preventDefault: jest.fn() }
+            });
+
+            expect(mockBlocks.findDragGroup).toHaveBeenCalledWith(0);
+            expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(0, 0, 10, true);
+            expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(1, 0, 10, true);
+        });
+
+        it("reports a clean grid when release follows no coordinate movement", () => {
+            const { block, handlers } = makeEventBlock();
+            const mouseoutSpy = jest.spyOn(block, "_mouseoutCallback").mockImplementation(() => {});
+
+            handlers.pressup({ stageX: 100, stageY: 100 });
+
+            expect(mouseoutSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                false,
+                false,
+                false,
+                true,
+                false
+            );
+        });
+
+        it("reconciles the grid after restoring trash-hover positions and before docking", () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            const order = [];
+
+            block.blockIndex = 0;
+            block._setDragGroupTrashHoverScale = jest.fn(() => order.push("restore"));
+            block.hasValueDrivenLabel = jest.fn().mockReturnValue(false);
+            block.activity.logo.runningLilypond = false;
+            block.activity.getStageScale = jest.fn().mockReturnValue(1);
+            block.activity.trashcan = {
+                hide: jest.fn(),
+                isVisible: true,
+                overTrashcan: jest.fn(() => {
+                    order.push("query-trash");
+                    return false;
+                })
+            };
+            mockBlocks.longPressTimeout = null;
+            mockBlocks.syncDragGroupSpatialGrid = jest.fn(() => order.push("sync-grid"));
+            mockBlocks.blockMoved = jest.fn(() => order.push("dock"));
+            mockBlocks.adjustDocks = jest.fn(() => order.push("adjust"));
+
+            block._mouseoutCallback({ stageX: 100, stageY: 100 }, true, false, false, true, true);
+
+            expect(order).toEqual(["restore", "sync-grid", "query-trash", "dock", "adjust"]);
+        });
+
+        it("does not reconcile a clean grid", () => {
+            const block = new Block(mockProtoBlock, mockBlocks);
+            block.blockIndex = 0;
+            block._setDragGroupTrashHoverScale = jest.fn();
+            block.hasValueDrivenLabel = jest.fn().mockReturnValue(false);
+            block.activity.logo.runningLilypond = false;
+            block.activity.trashcan = { hide: jest.fn() };
+            mockBlocks.longPressTimeout = null;
+            mockBlocks.syncDragGroupSpatialGrid = jest.fn();
+
+            block._mouseoutCallback({}, false, false, false, true, false);
+
+            expect(mockBlocks.syncDragGroupSpatialGrid).not.toHaveBeenCalled();
+        });
+    });
+
     describe("dispose()", () => {
         it("should clean up connections, DOM nodes, containers, bitmaps, and parent pointers", () => {
             const block = new Block(mockProtoBlock, mockBlocks);

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -918,25 +918,26 @@ describe("Block Foundation", () => {
             mockBlocks.clearCachedDragGroup = jest.fn();
             mockBlocks.invalidateTopBlockCache = jest.fn();
             mockBlocks.unhighlight = jest.fn();
+            mockBlocks.syncDragGroupSpatialGrid = jest.fn();
 
             block.activity.getStageScale = jest.fn().mockReturnValue(1);
             block.activity.blocksContainer = { y: 0 };
             block.activity.scrollBlockContainer = false;
             block.activity.trashcan = {
                 show: jest.fn(),
+                hide: jest.fn(),
                 overTrashcan: jest.fn().mockReturnValue(false),
                 startHighlightAnimation: jest.fn(),
                 stopHighlightAnimation: jest.fn()
             };
 
             block._loadEventHandlers();
+            global.docById.mockReturnValue({ style: {} });
             return { block, handlers };
         };
 
         it("defers cached drag-group updates and marks the release dirty", () => {
-            const { block, handlers } = makeEventBlock();
-            const mouseoutSpy = jest.spyOn(block, "_mouseoutCallback").mockImplementation(() => {});
-            global.docById.mockReturnValue({ style: {} });
+            const { handlers } = makeEventBlock();
 
             handlers.mousedown({ stageX: 100, stageY: 100 });
 
@@ -949,18 +950,12 @@ describe("Block Foundation", () => {
 
             expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(0, 10, 0, true);
             expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(1, 10, 0, true);
-            expect(mouseoutSpy).toHaveBeenCalledWith(
-                expect.anything(),
-                false,
-                false,
-                false,
-                true,
-                true
-            );
+            expect(mockBlocks.syncDragGroupSpatialGrid).toHaveBeenCalledTimes(1);
         });
 
         it("defers drag-group updates when the cached group is unavailable", () => {
             const { handlers } = makeEventBlock();
+            handlers.mousedown({ stageX: 100, stageY: 100 });
             mockBlocks._cachedDragGroup = null;
             mockBlocks.dragGroup = [0, 1];
             mockBlocks.findDragGroup = jest.fn();
@@ -977,19 +972,12 @@ describe("Block Foundation", () => {
         });
 
         it("reports a clean grid when release follows no coordinate movement", () => {
-            const { block, handlers } = makeEventBlock();
-            const mouseoutSpy = jest.spyOn(block, "_mouseoutCallback").mockImplementation(() => {});
+            const { handlers } = makeEventBlock();
 
+            handlers.mousedown({ stageX: 100, stageY: 100 });
             handlers.pressup({ stageX: 100, stageY: 100 });
 
-            expect(mouseoutSpy).toHaveBeenCalledWith(
-                expect.anything(),
-                false,
-                false,
-                false,
-                true,
-                false
-            );
+            expect(mockBlocks.syncDragGroupSpatialGrid).not.toHaveBeenCalled();
         });
 
         it("reconciles the grid after restoring trash-hover positions and before docking", () => {

--- a/js/__tests__/block.test.js
+++ b/js/__tests__/block.test.js
@@ -946,6 +946,9 @@ describe("Block Foundation", () => {
                 stageY: 100,
                 nativeEvent: { preventDefault: jest.fn() }
             });
+
+            expect(mockBlocks.syncDragGroupSpatialGrid).not.toHaveBeenCalled();
+
             handlers.pressup({ stageX: 110, stageY: 100 });
 
             expect(mockBlocks.moveBlockRelativeBatched).toHaveBeenCalledWith(0, 10, 0, true);

--- a/js/activity/__tests__/block-drag-controller.test.js
+++ b/js/activity/__tests__/block-drag-controller.test.js
@@ -312,12 +312,19 @@ describe("BlockDragController", () => {
             ];
             for (const [dx, dy] of deltas) {
                 for (const blk of blocks._cachedDragGroup) {
-                    blocks.moveBlockRelativeBatched(blk, dx, dy);
+                    blocks.moveBlockRelativeBatched(blk, dx, dy, true);
                 }
             }
 
             expect(blockList[0].container).toEqual({ x: 106, y: 103 });
             expect(blockList[1].container).toEqual({ x: 106, y: 123 });
+            expect(blocks._updateSpatialGrid).not.toHaveBeenCalled();
+
+            blocks.syncDragGroupSpatialGrid();
+
+            expect(blocks._updateSpatialGrid).toHaveBeenCalledTimes(2);
+            expect(blocks._updateSpatialGrid).toHaveBeenNthCalledWith(1, 0);
+            expect(blocks._updateSpatialGrid).toHaveBeenNthCalledWith(2, 1);
         });
 
         it("moveBlockRelative schedules a checkBounds pass and updates the spatial grid", () => {
@@ -827,6 +834,7 @@ describe("BlockDragController", () => {
             ["findDragGroup", [0]],
             ["cacheDragGroup", [0]],
             ["clearCachedDragGroup", []],
+            ["syncDragGroupSpatialGrid", []],
             ["moveBlockRelative", [0, 1, 2]],
             ["moveBlockRelativeBatched", [0, 1, 2]],
             ["moveStackRelative", [0, 1, 2]]

--- a/js/activity/block-drag-controller.js
+++ b/js/activity/block-drag-controller.js
@@ -110,6 +110,20 @@ class BlockDragController {
     }
 
     /**
+     * Reconcile spatial-grid positions after a drag that deferred updates.
+     * @public
+     * @returns {void}
+     */
+    syncDragGroupSpatialGrid() {
+        const blocks = this.blocks;
+        const dragGroup = blocks._cachedDragGroup ?? blocks.dragGroup;
+
+        for (const blk of dragGroup) {
+            blocks._updateSpatialGrid(blk);
+        }
+    }
+
+    /**
      * Given a block, find all the blocks connected to it.
      * @param - blk - block
      * @private
@@ -196,10 +210,11 @@ class BlockDragController {
      * @param - blk - block index
      * @param - dx - delta x
      * @param - dy - delta y
+     * @param {boolean} deferSpatialGrid - defer spatial-grid updates until drag release
      * @public
      * @returns {void}
      */
-    moveBlockRelativeBatched(blk, dx, dy) {
+    moveBlockRelativeBatched(blk, dx, dy, deferSpatialGrid = false) {
         const blocks = this.blocks;
         blocks.inLongPress = false;
         blocks.isBlockMoving = true;
@@ -207,7 +222,9 @@ class BlockDragController {
         if (myBlock.container) {
             myBlock.container.x += dx;
             myBlock.container.y += dy;
-            blocks._updateSpatialGrid(blk);
+            if (!deferSpatialGrid) {
+                blocks._updateSpatialGrid(blk);
+            }
         }
     }
 
@@ -1023,6 +1040,7 @@ const setupBlockDragController = blocks => {
     blocks.findDragGroup = (...args) => controller.findDragGroup(...args);
     blocks.cacheDragGroup = (...args) => controller.cacheDragGroup(...args);
     blocks.clearCachedDragGroup = (...args) => controller.clearCachedDragGroup(...args);
+    blocks.syncDragGroupSpatialGrid = (...args) => controller.syncDragGroupSpatialGrid(...args);
     blocks.moveBlockRelative = (...args) => controller.moveBlockRelative(...args);
     blocks.moveBlockRelativeBatched = (...args) => controller.moveBlockRelativeBatched(...args);
     blocks.moveStackRelative = (...args) => controller.moveStackRelative(...args);

--- a/js/block.js
+++ b/js/block.js
@@ -3135,6 +3135,7 @@ class Block {
         // This avoids redundant O(N) findDragGroup and O(D) rest2 chain walks
         // on every mouse move event (which fires 60+ times per second).
         let _dragHasRest2 = false;
+        let _dragSpatialGridDirty = false;
 
         /**
          * Handles the click event on the block container.
@@ -3258,6 +3259,7 @@ class Block {
             // Reset any stale hover-scaling state from prior drags.
             this._trashHoverGroupState = null;
             this._dragPointerDown = true;
+            _dragSpatialGridDirty = false;
 
             // Track time for detecting long pause...
             that.blocks.mouseDownTime = new Date().getTime();
@@ -3452,7 +3454,8 @@ class Block {
             }
 
             // Move the dragged block itself (batched — no checkBounds).
-            that.blocks.moveBlockRelativeBatched(thisBlock, dx, dy);
+            that.blocks.moveBlockRelativeBatched(thisBlock, dx, dy, true);
+            _dragSpatialGridDirty ||= dx !== 0 || dy !== 0;
 
             // If we are over the trash, warn the user.
             const overTrash = that.activity.trashcan.overTrashcan(
@@ -3476,7 +3479,7 @@ class Block {
                 for (let b = 0; b < cachedGroup.length; b++) {
                     const blk = cachedGroup[b];
                     if (blk !== thisBlock) {
-                        that.blocks.moveBlockRelativeBatched(blk, dx, dy);
+                        that.blocks.moveBlockRelativeBatched(blk, dx, dy, true);
                     }
                 }
             } else {
@@ -3486,7 +3489,7 @@ class Block {
                     for (let b = 0; b < that.blocks.dragGroup.length; b++) {
                         const blk = that.blocks.dragGroup[b];
                         if (b !== 0) {
-                            that.blocks.moveBlockRelativeBatched(blk, dx, dy);
+                            that.blocks.moveBlockRelativeBatched(blk, dx, dy, true);
                         }
                     }
                 }
@@ -3548,7 +3551,7 @@ class Block {
             that._dragPointerDown = false;
 
             if (!that.blocks.getLongPressStatus()) {
-                that._mouseoutCallback(event, moved, haveClick, false, true);
+                that._mouseoutCallback(event, moved, haveClick, false, true, _dragSpatialGridDirty);
             } else {
                 clearTimeout(that.blocks.longPressTimeout);
                 that.blocks.longPressTimeout = null;
@@ -3563,6 +3566,7 @@ class Block {
 
             // Clear cached drag state.
             _dragHasRest2 = false;
+            _dragSpatialGridDirty = false;
             moved = false;
             that._announced = false;
         });
@@ -3601,10 +3605,18 @@ class Block {
      * @param {boolean} haveClick - Indicates if a click event occurred.
      * @param {boolean} hideDOM - Indicates whether to hide DOM elements.
      * @param {boolean} dragEnded - Indicates whether this callback is from drag release.
+     * @param {boolean} spatialGridDirty - Indicates whether grid reconciliation was deferred.
      * Sets cursor style to default.
      * @returns {void}
      */
-    _mouseoutCallback(event, moved, haveClick, hideDOM, dragEnded = false) {
+    _mouseoutCallback(
+        event,
+        moved,
+        haveClick,
+        hideDOM,
+        dragEnded = false,
+        spatialGridDirty = false
+    ) {
         const thisBlock = this.blockIndex;
         if (!this.activity.logo.runningLilypond) {
             document.body.style.cursor = "default";
@@ -3613,6 +3625,10 @@ class Block {
         // Restore drag scaling only when drag interaction actually ends.
         if (dragEnded) {
             this._setDragGroupTrashHoverScale(false, 0, 0, true);
+        }
+
+        if (spatialGridDirty) {
+            this.blocks.syncDragGroupSpatialGrid();
         }
 
         // Always hide the trash when there is no block selected.


### PR DESCRIPTION
## Description

This PR reduces unnecessary spatial-grid updates while dragging connected block stacks.

Previously, every block in a connected stack updated its spatial-grid position on every `pressmove` event. However, the spatial grid is only needed when resolving nearby blocks for docking after the drag.

This change defers those updates during the drag and synchronizes the dragged blocks once before drop and docking logic runs.

Block movement and rendering during the drag remain unchanged.

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## What Changed

- Added an option to `moveBlockRelativeBatched()` to defer spatial-grid updates.
- Connected blocks continue to move normally during `pressmove`, but their spatial-grid updates are deferred.
- The dragged group is synchronized once when the drag ends, before docking logic uses the grid.
- Synchronization only happens if block coordinates actually changed.
- Existing non-drag callers continue updating the spatial grid immediately.

## Performance

Tested in Chrome using a deterministic stack of **300 connected blocks**, dragged **240px across 180 movement events**.

Three fresh runs were performed before and after the change. Values below are median-of-three.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Spatial-grid updates | 54,299 | 599 | 98.9% fewer |
| Spatial-grid time | 56.4 ms | 0.9 ms | 98.4% less |
| Total `pressmove` time | 90.1 ms | 18.8 ms | 79.1% less |
| Median `pressmove` | 0.4 ms | 0.1 ms | 75% less |
| p95 `pressmove` | 0.8 ms | 0.2 ms | 75% less |
| Frames over 16.7 ms | 0 | 0 | No regression |
| Estimated dropped frames | 0 | 0 | No regression |

Dragging was already smooth on the tested machine. This optimization reduces unnecessary main-thread work rather than fixing an observed frame-rate issue.

## Testing

Verified:

- Connected-stack dragging and docking
- Single-block dragging
- Short movements below the drag threshold
- Clicks without movement
- Trash hover and trash drops
- Dragging with and without a nearby docking target
- Non-drag block movement continues to update the grid immediately
- Spatial-grid synchronization happens before drop/docking logic

Automated verification:

- Focused tests: 61 passed
- Full test suite: 8,371 tests passed across 224 suites
- Lint passed
- Prettier passed
- `git diff --check` passed

## Files Changed

- `js/block.js`
- `js/activity/block-drag-controller.js`
- `js/activity/__tests__/block-drag-controller.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block dragging so the positioning of connected blocks remains accurate throughout movement and after release.
  * Deferred spatial updates during grouped dragging to improve responsiveness, then synchronized positions when dragging ends.
  * Improved behavior when dragging blocks over the trash area or docking them after movement.

* **Tests**
  * Added coverage for cached and uncached drag groups, release-time synchronization, deferred updates, and restoration before docking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->