### PR TITLE
test(cypress): add E2E initialization and rendering coverage for Oscilloscope widget

### DIFF
--- a/cypress/e2e/widgets/OscilloscopeInitialization.cy.js
+++ b/cypress/e2e/widgets/OscilloscopeInitialization.cy.js
@@ -1,0 +1,65 @@
+// cypress/e2e/widgets/OscilloscopeInitialization.cy.js
+describe("Oscilloscope Widget Initialization", () => {
+    beforeEach(() => {
+        cy.visit("/");
+        cy.waitForAppReady();
+    });
+
+    it("initializes cleanly and renders the canvas", () => {
+        cy.window().then(win => {
+            const activity = win.ActivityContext.getActivity();
+
+            // Prepare minimal deterministic Oscilloscope dependencies
+            activity.logo.oscilloscopeTurtles = [
+                {
+                    inTrash: false,
+                    running: false,
+                    painter: { _canvasColor: "#ff0000" }
+                }
+            ];
+
+            // Safely stub the method on the existing object instead of overwriting activity.turtles
+            cy.stub(activity.turtles, "getIndexOfTurtle").returns(0);
+
+            // The global instruments object might already exist, so we populate it safely
+            win.instruments = win.instruments || {};
+            win.instruments[0] = {
+                mockSynth: { connect: cy.stub() }
+            };
+
+            return new Cypress.Promise((resolve, reject) => {
+                win.require(
+                    ["widgets/oscilloscope"],
+                    () => {
+                        try {
+                            const Oscilloscope = win.eval(
+                                'typeof Oscilloscope !== "undefined" ? Oscilloscope : null'
+                            );
+                            if (!Oscilloscope) {
+                                throw new Error("Oscilloscope class not found after require");
+                            }
+
+                            const widget = new Oscilloscope(activity);
+
+                            expect(widget.widgetWindow).to.exist;
+
+                            const canvas = win.document.querySelector(".oscilloscopeCanvas");
+                            expect(canvas).to.exist;
+                            expect(canvas.width).to.be.greaterThan(0);
+                            expect(canvas.height).to.be.greaterThan(0);
+
+                            widget.close();
+
+                            expect(win.document.querySelector(".oscilloscopeCanvas")).to.not.exist;
+
+                            resolve();
+                        } catch (err) {
+                            reject(err);
+                        }
+                    },
+                    reject
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Description
Introduces programmatic E2E testing for the Oscilloscope widget.
Previously, the Oscilloscope widget (`js/widgets/oscilloscope.js`) lacked programmatic initialization coverage. Because it relies heavily on the Web Audio API (Tone.js) and active turtle data to render its visualizer, it was vulnerable to silent initialization crashes. This PR adds a defensive Cypress E2E smoke test that ensures the widget can be instantiated, generates its core UI window, mounts its `canvas` elements, and cleanly destroys itself upon closing.

### Category
- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

### Changes Made
- **E2E Initialization Test (`OscilloscopeInitialization.cy.js`)**: Added a Cypress test that programmaticly loads and initializes the Oscilloscope widget via RequireJS.
- **Safe Turtle Mocking**: Uses `cy.stub(activity.turtles, "getIndexOfTurtle")` to provide minimal required turtle indexes without overwriting the entire `activity.turtles` instance, avoiding hidden lifecycle side-effects.
- **Global Instrument Mocking**: Pre-initializes a minimal `win.instruments[0]` object mimicking a connected synth, ensuring that the widget's internal audio routing logic (`reconnectSynthsToAnalyser`) executes natively without crashing.
- **Repository Conventions**: Implements the test without relying on the `win.module` workaround, natively evaluating the class block using `win.eval('Oscilloscope')` to match the exact mechanism used by `MeterWidgetInitialization.cy.js`.

### Steps to Reproduce
1. Check out this branch.
2. Run the specific Cypress test using `npx cypress run --spec cypress/e2e/widgets/OscilloscopeInitialization.cy.js`.
3. **Expected:** The test initializes the Oscilloscope, asserts the canvas dimensions are greater than 0, cleanly triggers `widget.close()`, asserts the canvas is removed from the DOM, and passes successfully.

### Testing Performed
- `npx cypress run --spec cypress/e2e/widgets/OscilloscopeInitialization.cy.js` (1 passing)
- `npm run test` (Full Jest suite passes with 0 related regressions)

### Checklist
- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled "Allow edits from maintainers" (required for auto-rebase; affects PR branch only).

### Summary by CodeRabbit
**Tests**
- Added E2E coverage for programmatic initialization and DOM rendering of the Oscilloscope widget.
- Implemented defensive mocking for global `instruments` and `activity.turtles` to ensure the audio routing logic can be tested in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for Oscilloscope widget initialization, including creation, canvas sizing, closing, and canvas removal.

- **Chores**
  - Updated several underlying package versions and dependency resolution overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->