### PR TITLE
fix(themes): fix unreadable text in status matrix and pitch staircase cells

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -2346,6 +2346,7 @@ table {
 .pitch-staircase-btn,
 .pitch-staircase-step {
     background-color: var(--color-selector-bg);
+    color: var(--color-selector-text);
     transition: background-color 0.2s ease;
 }
 

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -28,6 +28,7 @@
     /* Selector / Widget Colors */
     --color-selector-bg: #8cc6ff;
     --color-selector-selected: #1a8cff;
+    --color-selector-text: #000000;
     --color-label-bg: #a0a0a0;
 
     --color-success: #10b981;
@@ -129,6 +130,7 @@ body.dark {
 
     --color-selector-bg: #64b5f6;
     --color-selector-selected: #1e88e5;
+    --color-selector-text: #000000;
     --color-label-bg: #bdbdbd;
 
     /* Adjusted state backgrounds for dark mode */
@@ -170,6 +172,7 @@ body.highcontrast {
 
     --color-selector-bg: #00ffff;
     --color-selector-selected: #00cccc;
+    --color-selector-text: #000000;
     --color-label-bg: #ffffff;
 
     --color-success: #00ff00;

--- a/js/widgets/status.js
+++ b/js/widgets/status.js
@@ -184,12 +184,14 @@ class StatusMatrix {
                     : "";
 
             const selectorBg = "var(--color-selector-bg)";
+            const selectorText = "var(--color-selector-text)";
             cell.textContent = "\u00A0";
             const b = document.createElement("b");
             b.textContent = str;
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
             cell.style.backgroundColor = selectorBg;
+            cell.style.color = selectorText;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
@@ -197,6 +199,7 @@ class StatusMatrix {
                 }
                 cell = row.insertCell();
                 cell.style.backgroundColor = selectorBg;
+                cell.style.color = selectorText;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";
@@ -207,6 +210,7 @@ class StatusMatrix {
 
         if (_THIS_IS_MUSIC_BLOCKS_) {
             const selectorBg = "var(--color-selector-bg)";
+            const selectorText = "var(--color-selector-text)";
             const row = header.insertRow();
             cell = row.insertCell();
             cell.style.fontSize =
@@ -219,6 +223,7 @@ class StatusMatrix {
             cell.appendChild(b);
             cell.style.height = Math.floor(MATRIXBUTTONHEIGHT * this._cellScale) + "px";
             cell.style.backgroundColor = selectorBg;
+            cell.style.color = selectorText;
             cell.style.paddingLeft = "10px";
             for (const turtle of this.activity.turtles.turtleList) {
                 if (turtle.inTrash) {
@@ -226,6 +231,7 @@ class StatusMatrix {
                 }
                 cell = row.insertCell();
                 cell.style.backgroundColor = selectorBg;
+                cell.style.color = selectorText;
                 cell.style.fontSize =
                     Math.floor(this._cellScale * StatusMatrix.FONTSCALEFACTOR) * 0.9 + "%";
                 cell.textContent = "";


### PR DESCRIPTION
- [x] Bug Fix

The Status Matrix and Pitch Staircase CSS token migration in #8394 moved their cell backgrounds to `--color-selector-bg`/`--color-selector-selected` but never set a matching text color. The cells kept the ambient widget text color (light gray/white in dark and high contrast), which lands at roughly 1.2:1 to 2.5:1 contrast against the light blue/cyan cell background, well under the 4.5:1 WCAG AA minimum. In the Status widget this makes labels like "Pitch converter" and "Beat count" nearly invisible, and the Pitch Staircase frequency/note readout is similarly unreadable.

## Steps to reproduce
1. Switch the app to the dark theme or high contrast theme (hamburger menu, top right).
2. Drag out the "status" block from the Widgets palette, or the "pitch staircase" block from Pitch, and run it.
3. Open the widget window. In dark theme the row labels blend into the blue background; in high contrast theme the white text on cyan is almost unreadable.

Adds a `--color-selector-text` token (black across all three themes, since the selector backgrounds are uniformly light) and applies it:
- inline in `status.js`, since those cells never carried the `status-matrix-cell` class the existing windows.css rule was written against
- in `activities.css` on `.pitch-staircase-btn`/`.pitch-staircase-step`, which do use their class

Verified in the running app across light, dark, and high contrast themes; `js/__tests__/themes-contrast.test.js` and the full suite pass.