### PR TITLE
chore: remove dead rhythmruler case label in block.js collapse switch (Related to #8456)

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -1780,13 +1780,6 @@ class Block {
                             platformColor.blockText
                         );
                         break;
-                    case "rhythmruler":
-                        that.collapseText = new createjs.Text(
-                            _("ruler"),
-                            fontSize + "px Sans",
-                            platformColor.blockText
-                        );
-                        break;
                     case "timbre":
                         that.collapseText = new createjs.Text(
                             _("timbre"),


### PR DESCRIPTION
## Description

`js/block.js`'s `__processHighlightCollapseBitmap` has a `switch (that.name)` for setting collapse-block label text. It contains a `case "rhythmruler":` that is dead code — the actual registered block name is `"rhythmruler2"`, and a correct `case "rhythmruler2":` already exists later in the same switch. The dead entry never causes wrong output, just clutter.

PR #8429 fixed the real bug in `project-manager.js`; this cleans up the leftover dead case in `block.js`.

Related to #8456, #2017

## Changes Made

- `js/block.js`: removed unreachable `case "rhythmruler":` block (7 lines) from the collapse-label switch. The correct `case "rhythmruler2":` already handles this block.

## Category
- [x] Chore / Refactor

## Testing Performed

- `npm run lint` — clean
- `npx prettier --check js/block.js` — clean
- `npm test` — 226 suites, 8485 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the localized “ruler” label from the collapsed Rhythmruler block display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->