### PR TITLE
fix: resolve viewport culling for zoom and viewport edges

### DIFF
--- a/js/__tests__/block-constants.test.js
+++ b/js/__tests__/block-constants.test.js
@@ -27,7 +27,8 @@ describe("block-constants", () => {
             "LONGSTACK",
             "SPATIAL_GRID_CELL_SIZE",
             "CAMERAVALUE",
-            "VIDEOVALUE"
+            "VIDEOVALUE",
+            "VIEWPORT_CULL_PADDING"
         ];
         expect(Object.keys(constants).sort()).toEqual(expectedKeys.sort());
     });
@@ -38,5 +39,6 @@ describe("block-constants", () => {
         expect(global.SPATIAL_GRID_CELL_SIZE).toBeUndefined();
         expect(global.CAMERAVALUE).toBeUndefined();
         expect(global.VIDEOVALUE).toBeUndefined();
+        expect(global.VIEWPORT_CULL_PADDING).toBeUndefined();
     });
 });

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -169,10 +169,10 @@ describe("Viewport Culling", () => {
 
     it("should mark blocks outside the viewport as not visible", () => {
         blocks.blockList = [
-            { trash: false, container: { x: -200, y: 100 }, width: 50, height: 30 },
-            { trash: false, container: { x: 900, y: 100 }, width: 50, height: 30 },
-            { trash: false, container: { x: 100, y: -100 }, width: 50, height: 30 },
-            { trash: false, container: { x: 100, y: 700 }, width: 50, height: 30 }
+            { trash: false, container: { x: -300, y: 100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 1100, y: 100 }, width: 50, height: 30 },
+            { trash: false, container: { x: 100, y: -300 }, width: 50, height: 30 },
+            { trash: false, container: { x: 100, y: 900 }, width: 50, height: 30 }
         ];
 
         blocks._updateViewportCulling();
@@ -183,23 +183,158 @@ describe("Viewport Culling", () => {
         expect(blocks.blockList[3]._viewportVisible).toBe(false);
     });
 
-    it("should handle scrolled viewport offset", () => {
-        mockActivity.blocksContainer.x = -200;
-        mockActivity.blocksContainer.y = -100;
-
+    it("should keep blocks within the 150px screen-space padding visible (prevent edge pop-in)", () => {
+        // Canvas: 800x600, scale: 1.0, padding: 150px
+        // Padded viewport: X in [-150, 950], Y in [-150, 750]
         blocks.blockList = [
-            { trash: false, container: { x: 0, y: 0 }, width: 50, height: 30 },
-            { trash: false, container: { x: 300, y: 200 }, width: 50, height: 30 },
-            { trash: false, container: { x: 1000, y: 800 }, width: 50, height: 30 }
+            // Block positioned just outside screen (x: 850) but within 150px padding (850 < 950)
+            { trash: false, container: { x: 850, y: 100 }, width: 50, height: 30 },
+            // Block positioned just outside screen on left (x: -100, width: 50, right edge = -50 > -150)
+            { trash: false, container: { x: -100, y: 100 }, width: 50, height: 30 },
+            // Block strictly beyond the 150px padding boundary (x: 951 > 950)
+            { trash: false, container: { x: 951, y: 100 }, width: 50, height: 30 }
         ];
 
         blocks._updateViewportCulling();
 
-        // vp rect = (200, 100) to (1000, 700)
-        // Block at (0,0) with w=50,h=30: (0+50) <= 200 → off-screen left
+        expect(blocks.blockList[0]._viewportVisible).toBe(true);
+        expect(blocks.blockList[1]._viewportVisible).toBe(true);
+        expect(blocks.blockList[2]._viewportVisible).toBe(false);
+    });
+
+    it("should handle scrolled viewport offset with padding", () => {
+        mockActivity.blocksContainer.x = -200;
+        mockActivity.blocksContainer.y = -100;
+
+        // Container offset: (-200, -100), canvas: 800x600, padding: 150
+        // Padded world viewport: X in [50, 1150], Y in [-50, 850]
+        blocks.blockList = [
+            // Right edge at -50 + 50 = 0 <= 50 -> off-screen left beyond padding
+            { trash: false, container: { x: -50, y: 0 }, width: 50, height: 30 },
+            // Inside padded viewport (300, 200)
+            { trash: false, container: { x: 300, y: 200 }, width: 50, height: 30 },
+            // Right edge at 1200 > 1150 and left edge at 1200 >= 1150 -> off-screen right beyond padding
+            { trash: false, container: { x: 1200, y: 800 }, width: 50, height: 30 }
+        ];
+
+        blocks._updateViewportCulling();
+
         expect(blocks.blockList[0]._viewportVisible).toBe(false);
         expect(blocks.blockList[1]._viewportVisible).toBe(true);
         expect(blocks.blockList[2]._viewportVisible).toBe(false);
+    });
+
+    describe("Deterministic Zoom & Scale-Aware Viewport AABB Geometry", () => {
+        // Canvas: 800 x 600, Container: (0, 0), Screen padding: 150px
+        it("should correctly calculate AABB visibility at scale = 0.5 (zoomed out)", () => {
+            mockActivity.blocksContainer.scaleX = 0.5;
+            mockActivity.blocksContainer.scaleY = 0.5;
+            // Screen padding 150px / 0.5 = 300 world units
+            // World viewport: X in [-300, 1900], Y in [-300, 1500]
+            const inside = {
+                trash: false,
+                container: { x: 400, y: 300 },
+                width: 50,
+                height: 30
+            };
+            // Block B: x = 1880, width = 50 -> [1880, 1930] overlaps X <= 1900 boundary
+            const edgeOverlap = {
+                trash: false,
+                container: { x: 1880, y: 500 },
+                width: 50,
+                height: 30
+            };
+            // Block C: x = 1901, width = 50 -> strictly outside (left edge 1901 > 1900)
+            const outside = {
+                trash: false,
+                container: { x: 1901, y: 500 },
+                width: 50,
+                height: 30
+            };
+
+            blocks.blockList = [inside, edgeOverlap, outside];
+            blocks._updateViewportCulling();
+
+            expect(inside._viewportVisible).toBe(true);
+            expect(edgeOverlap._viewportVisible).toBe(true);
+            expect(outside._viewportVisible).toBe(false);
+        });
+
+        it("should correctly calculate AABB visibility at scale = 1.0 (default)", () => {
+            mockActivity.blocksContainer.scaleX = 1.0;
+            mockActivity.blocksContainer.scaleY = 1.0;
+            // Screen padding 150px / 1.0 = 150 world units
+            // World viewport: X in [-150, 950], Y in [-150, 750]
+            const inside = {
+                trash: false,
+                container: { x: 400, y: 300 },
+                width: 50,
+                height: 30
+            };
+            // Block B: x = 940, width = 50 -> [940, 990] overlaps X <= 950 boundary
+            const edgeOverlap = {
+                trash: false,
+                container: { x: 940, y: 300 },
+                width: 50,
+                height: 30
+            };
+            // Block C: x = 951, width = 50 -> strictly outside (left edge 951 > 950)
+            const outside = {
+                trash: false,
+                container: { x: 951, y: 300 },
+                width: 50,
+                height: 30
+            };
+
+            blocks.blockList = [inside, edgeOverlap, outside];
+            blocks._updateViewportCulling();
+
+            expect(inside._viewportVisible).toBe(true);
+            expect(edgeOverlap._viewportVisible).toBe(true);
+            expect(outside._viewportVisible).toBe(false);
+        });
+
+        it("should correctly calculate AABB visibility at scale = 2.0 (zoomed in)", () => {
+            mockActivity.blocksContainer.scaleX = 2.0;
+            mockActivity.blocksContainer.scaleY = 2.0;
+            // Screen padding 150px / 2.0 = 75 world units
+            // World viewport: X in [-75, 475], Y in [-75, 375]
+            const inside = {
+                trash: false,
+                container: { x: 200, y: 150 },
+                width: 50,
+                height: 30
+            };
+            // Block B: x = 470, width = 50 -> [470, 520] overlaps X <= 475 boundary
+            const edgeOverlap = {
+                trash: false,
+                container: { x: 470, y: 150 },
+                width: 50,
+                height: 30
+            };
+            // Block C: x = 476, width = 50 -> strictly outside (left edge 476 > 475)
+            const outside = {
+                trash: false,
+                container: { x: 476, y: 150 },
+                width: 50,
+                height: 30
+            };
+            // Block D: at (1000, 700) - would be visible at scale 0.5, but culled at scale 2.0
+            const farOutside = {
+                trash: false,
+                container: { x: 1000, y: 700 },
+                width: 50,
+                height: 30
+            };
+
+            blocks.blockList = [inside, edgeOverlap, outside, farOutside];
+            blocks._updateViewportCulling();
+
+            expect(inside._viewportVisible).toBe(true);
+            expect(edgeOverlap._viewportVisible).toBe(true);
+            expect(outside._viewportVisible).toBe(false);
+            expect(farOutside._viewportVisible).toBe(false);
+        });
     });
 
     it("should refresh a stale highlight cache when a block re-enters the viewport", () => {

--- a/js/activity.js
+++ b/js/activity.js
@@ -576,9 +576,11 @@ class Activity {
          * 3. GIF animations are playing
          * This eliminates unnecessary 60fps updates when idle.
          */
-        // Track last container position to avoid per-frame culling recompute.
+        // Track last container position and scale to avoid per-frame culling recompute.
         this._lastCullContainerX = undefined;
         this._lastCullContainerY = undefined;
+        this._lastCullScaleX = undefined;
+        this._lastCullScaleY = undefined;
 
         this._startRenderLoop = () => {
             if (this._renderLoopRunning) return;
@@ -595,16 +597,20 @@ class Activity {
 
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
                         try {
-                            // Recompute culling when container moved.
+                            // Recompute culling when container moved or scaled.
                             if (
                                 this.blocks &&
                                 this.blocksContainer &&
                                 (this._lastCullContainerX !== this.blocksContainer.x ||
-                                    this._lastCullContainerY !== this.blocksContainer.y)
+                                    this._lastCullContainerY !== this.blocksContainer.y ||
+                                    this._lastCullScaleX !== this.blocksContainer.scaleX ||
+                                    this._lastCullScaleY !== this.blocksContainer.scaleY)
                             ) {
                                 this.blocks._updateViewportCulling();
                                 this._lastCullContainerX = this.blocksContainer.x;
                                 this._lastCullContainerY = this.blocksContainer.y;
+                                this._lastCullScaleX = this.blocksContainer.scaleX;
+                                this._lastCullScaleY = this.blocksContainer.scaleY;
                             }
 
                             this.stage.update();
@@ -1636,6 +1642,8 @@ class Activity {
             // Viewport size changed — recompute culling on next render frame.
             this._lastCullContainerX = undefined;
             this._lastCullContainerY = undefined;
+            this._lastCullScaleX = undefined;
+            this._lastCullScaleY = undefined;
 
             // Firefox large canvas warning
             const isFirefox = navigator.userAgent.includes("Firefox");

--- a/js/block-constants.js
+++ b/js/block-constants.js
@@ -12,7 +12,7 @@
 /*
    exported
    MINIMUMDOCKDISTANCE, LONGSTACK, SPATIAL_GRID_CELL_SIZE,
-   CAMERAVALUE, VIDEOVALUE
+   CAMERAVALUE, VIDEOVALUE, VIEWPORT_CULL_PADDING
  */
 
 /**
@@ -35,12 +35,20 @@ const SPATIAL_GRID_CELL_SIZE = 50;
 const CAMERAVALUE = "##__CAMERA__##";
 const VIDEOVALUE = "##__VIDEO__##";
 
+/**
+ * Viewport culling buffer in screen-space pixels.
+ * Blocks within this margin outside the visible screen stay rendered,
+ * preventing visual pop-in during panning, dragging, and fast zooming.
+ */
+const VIEWPORT_CULL_PADDING = 150;
+
 const blockConstants = {
     MINIMUMDOCKDISTANCE,
     LONGSTACK,
     SPATIAL_GRID_CELL_SIZE,
     CAMERAVALUE,
-    VIDEOVALUE
+    VIDEOVALUE,
+    VIEWPORT_CULL_PADDING
 };
 
 if (typeof module !== "undefined" && module.exports) {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -27,7 +27,7 @@
     setOctaveRatio, splitScaleDegree, splitSolfege, updateTemperaments,
     docById, define, BlocksDependencies, deepClone, pubsub,
     MINIMUMDOCKDISTANCE, LONGSTACK, SPATIAL_GRID_CELL_SIZE,
-    CAMERAVALUE, VIDEOVALUE, setupBlockDragController
+    CAMERAVALUE, VIDEOVALUE, VIEWPORT_CULL_PADDING, setupBlockDragController
 */
 
 /* global showZoomOverlay */
@@ -38,7 +38,7 @@
         createjs
    - js/block-constants.js
         MINIMUMDOCKDISTANCE, LONGSTACK, SPATIAL_GRID_CELL_SIZE,
-        CAMERAVALUE, VIDEOVALUE
+        CAMERAVALUE, VIDEOVALUE, VIEWPORT_CULL_PADDING
    - js/block.js
         Block
    - js/activity/block-drag-controller.js
@@ -7015,11 +7015,16 @@ class Blocks {
             const container = this.activity.blocksContainer;
             if (!container) return;
 
-            // Viewport rect in container-space
-            const vpLeft = -container.x;
-            const vpTop = -container.y;
-            const vpRight = vpLeft + canvas.width;
-            const vpBottom = vpTop + canvas.height;
+            // Viewport rect in container-space with screen-space padding converted to container units
+            const scaleX = container.scaleX || 1;
+            const scaleY = container.scaleY || 1;
+            const paddingX = VIEWPORT_CULL_PADDING / scaleX;
+            const paddingY = VIEWPORT_CULL_PADDING / scaleY;
+
+            const vpLeft = -container.x / scaleX - paddingX;
+            const vpTop = -container.y / scaleY - paddingY;
+            const vpRight = (-container.x + canvas.width) / scaleX + paddingX;
+            const vpBottom = (-container.y + canvas.height) / scaleY + paddingY;
 
             for (let i = 0; i < this.blockList.length; i++) {
                 const block = this.blockList[i];


### PR DESCRIPTION

## Description

This PR addresses some problems regarding the viewport culling in the workspace, especially the zoom and pan operations of the canvas.

The previous culling algorithm was based on calculating the viewport directly from the size of the canvas, meaning that it used the scale 1.0x. This caused blocks close to the edges of the workspace to be culled when zooming out. Simultaneously, zooming in could lead to remote blocks being flagged as visible.

This PR improves the scalability of the culling operations and introduces a tiny buffer for smooth panning.

**Fixes:** #

**Blocks not disappearing when zooming out**

   The viewport boundaries take into consideration the `scaleX` and `scaleY`, hence, the visible world area calculation becomes accurate at all zoom levels.

2. **Unnecessary blocks rendering when zooming in**

   Blocks that are located outside the viewport after it has been magnified can be correctly culled rather than still showing them as visible.

3. **Sudden block appearance at the edge while panning**

   There is a buffer size of `150px` in screen space which causes blocks to render a little earlier before they get to the visible space.

4. **Culling not being recalculated after zoom change without panning**

   The rendering loop had checks on changes to `container.x` and `container.y`, but there were no checks on the container scale. It now checks the changes to `scaleX` and `scaleY`.

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] UI/UX — Changes to the user interface or user experience
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`js/block-constants.js`**:
  - Added `VIEWPORT_CULL_PADDING = 150` (specified in screen-space pixels).
  - Preserved previous CommonJS, RequireJS AMD, and browser `window` global exports.
- **`js/blocks.js`**:
  - Modified `_updateViewportCulling()` to convert screen padding into container coordinates (`paddingX = VIEWPORT_CULL_PADDING / scaleX`, `paddingY = VIEWPORT_CULL_PADDING / scaleY`).
  - Fixed viewport rectangle dimensions calculation using `scaleX` and `scaleY`:
    ```javascript
    const vpLeft = -container.x / scaleX - paddingX;
    const vpTop = -container.y / scaleY - paddingY;
    const vpRight = (-container.x + canvas.width) / scaleX + paddingX;
    const vpBottom = (-container.y + canvas.height) / scaleY + paddingY;
    ```
  - Preserved previous AABB collision detection and drag group override implementation.
- **`js/activity.js`**:
  - Added `_lastCullScaleX` and `_lastCullScaleY`.
  - Modified `renderLoop()` to recalculate culling when container position or scale change is detected.
  - Reset culling scale values after canvas resizing.
- **`js/__tests__/blocks.test.js`**:
  - Modified existing tests considering new padding of 150px.
  - Added deterministic AABB tests suites for `0.5x`, `1.0x`, and `2.0x` scales

## Steps to Reproduce

1. Open Music Blocks with a project having several stacks spread out across the canvas.
2. Zoom out to `0.5x` using the zoom-out control.
3. Observe blocks positioned on the outer right or bottom edge: previously, they would disappear completely from view despite being well within the browser window.
4. Pan a block stack slowly across the canvas edge: previously, blocks violently popped into and out of existence right on the border line.

## Sanity Checks
1] Check 1: Real-Time Browser Rendering Benchmark (FPS & stage.update())

<img width="1243" height="324" alt="image" src="https://github.com/user-attachments/assets/15fb4eb8-69c9-4947-b2a9-f194b1af772a" />


2] Check 2: Zoom Invariance Proof

<img width="1282" height="240" alt="image" src="https://github.com/user-attachments/assets/b1f49b05-d854-402f-9079-5f7d2779e26e" />



<img width="763" height="147" alt="image" src="https://github.com/user-attachments/assets/a5b41c9b-4512-402b-bc4e-06e6d648a322" />



## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved viewport rendering to account for zoom level and scrolling.
  * Blocks near the viewport edge remain visible with a 150-pixel screen-space buffer.
  * Visibility updates now respond when the canvas scale changes, keeping displayed content accurate across zoom levels.
  * Blocks that overlap the padded viewport boundary remain available as expected, while content far outside the visible area continues to be excluded for smoother rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->