### PR TITLE
fix(blocks): let boolean docks bridge to anyin/anyout like every other type

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1767,6 +1767,60 @@ describe("Blocks Foundation", () => {
             expect(blocks.blockList[1].connections[0]).toBe(0);
         });
 
+        it("snaps a booleanout block (e.g. And/Or/Not) onto an anyin dock, like Switch/Case (#8463)", async () => {
+            blocks.blockList = [
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 0,
+                    docks: [
+                        [0, 0, "in"],
+                        [0, 20, "anyin"]
+                    ],
+                    connections: [null, null],
+                    name: "switch"
+                }),
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 15,
+                    docks: [[0, 0, "booleanout"]],
+                    connections: [null],
+                    name: "and"
+                })
+            ];
+
+            await blocks.blockMoved(1);
+
+            expect(blocks.blockList[1].connections[0]).toBe(0);
+            expect(blocks.blockList[0].connections[1]).toBe(1);
+        });
+
+        it("snaps an anyout block (e.g. namedbox) onto a booleanin dock, like If/While (#8463)", async () => {
+            blocks.blockList = [
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 0,
+                    docks: [
+                        [0, 0, "in"],
+                        [0, 20, "booleanin"]
+                    ],
+                    connections: [null, null],
+                    name: "if"
+                }),
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 15,
+                    docks: [[0, 0, "anyout"]],
+                    connections: [null],
+                    name: "namedbox"
+                })
+            ];
+
+            await blocks.blockMoved(1);
+
+            expect(blocks.blockList[1].connections[0]).toBe(0);
+            expect(blocks.blockList[0].connections[1]).toBe(1);
+        });
+
         it("exposes the same BlockDragController instance to every delegated method", () => {
             expect(blocks.blockDragController).toBeDefined();
             expect(blocks.findDragGroup).not.toBe(blocks.blockDragController.findDragGroup);

--- a/js/__tests__/connection-validator.test.js
+++ b/js/__tests__/connection-validator.test.js
@@ -65,6 +65,38 @@ describe("ConnectionValidator.testConnectionType — returns false for unsupport
     });
 });
 
+describe("ConnectionValidator.testConnectionType — boolean docks bridge to anyin/anyout (#8463)", () => {
+    // These are hardcoded rather than derived from ALLOWED_CONNECTIONS itself,
+    // unlike the tests above: a derived assertion would trivially keep
+    // passing even if these specific pairs were removed again, since it only
+    // ever checks whatever happens to be in the set. Every other dock family
+    // (number, text, media, file, solfege, scaledegree, note) already bridges
+    // to anyin/anyout in both directions; boolean is a value type like any of
+    // those and should be no different, so a Boolean block can be docked into
+    // a generic "any" socket (e.g. Switch/Case) and a generic "any" value can
+    // be docked into a booleanin socket (e.g. a namedbox into If/While).
+    it("allows a booleanout block to dock into an anyin socket", () => {
+        expect(ConnectionValidator.testConnectionType("booleanout", "anyin")).toBe(true);
+        expect(ConnectionValidator.testConnectionType("anyin", "booleanout")).toBe(true);
+    });
+
+    it("allows an anyout block to dock into a booleanin socket", () => {
+        expect(ConnectionValidator.testConnectionType("anyout", "booleanin")).toBe(true);
+        expect(ConnectionValidator.testConnectionType("booleanin", "anyout")).toBe(true);
+    });
+
+    it("still allows booleanout to dock directly into booleanin", () => {
+        expect(ConnectionValidator.testConnectionType("booleanout", "booleanin")).toBe(true);
+        expect(ConnectionValidator.testConnectionType("booleanin", "booleanout")).toBe(true);
+    });
+
+    it("does not let boolean docks bridge into unrelated in/out types", () => {
+        expect(ConnectionValidator.testConnectionType("booleanout", "numberin")).toBe(false);
+        expect(ConnectionValidator.testConnectionType("booleanin", "numberout")).toBe(false);
+        expect(ConnectionValidator.testConnectionType("booleanout", "textin")).toBe(false);
+    });
+});
+
 describe("ConnectionValidator.testConnectionType — edge cases", () => {
     it("is case-sensitive", () => {
         const [type1, type2] = ALLOWED_PAIRS[0];

--- a/js/connection-validator.js
+++ b/js/connection-validator.js
@@ -32,6 +32,8 @@ const ALLOWED_CONNECTIONS = new Set([
     "anyout:textin",
     "booleanout:booleanin",
     "booleanin:booleanout",
+    "booleanin:anyout",
+    "anyout:booleanin",
     "mediain:mediaout",
     "mediaout:mediain",
     "mediain:textout",
@@ -74,6 +76,7 @@ const ALLOWED_CONNECTIONS = new Set([
     "anyin:solfegeout",
     "anyin:scaledegreeout",
     "anyin:noteout",
+    "anyin:booleanout",
     "textout:anyin",
     "mediaout:anyin",
     "numberout:anyin",
@@ -81,7 +84,8 @@ const ALLOWED_CONNECTIONS = new Set([
     "fileout:anyin",
     "solfegeout:anyin",
     "scaledegreeout:anyin",
-    "noteout:anyin"
+    "noteout:anyin",
+    "booleanout:anyin"
 ]);
 
 /**


### PR DESCRIPTION
## Description

Boolean-producing and boolean-consuming blocks can't be docked into the generic anyin/anyout sockets, even though every other value type can. This breaks dragging a Boolean block (And/Or/Not/comparison) into Switch or Case, and dragging a namedbox holding a boolean into If/While/Until/Wait For. Full writeup with reproduction steps is in the linked issue.

## Related Issue

**Fixes:** #8463

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

---

## Changes Made

`ConnectionValidator.ALLOWED_CONNECTIONS` in `js/connection-validator.js` gives every other output family (number, text, media, file, solfege, scaledegree, note) an explicit pairing with anyin/anyout, in both directions. booleanout/booleanin only paired with each other. Nothing in the interpreter treats booleans specially in a way that would justify leaving them out, SwitchBlock/CaseBlock's flow() in `js/blocks/FlowBlocks.js` is a plain equality check that already works with any value, and namedbox (outType: "anyout") is explicitly meant to hold any value. It was a straightforward omission in the table.

Added the four missing pairs to ALLOWED_CONNECTIONS, following the exact pattern already used for every other family:

```
anyin:booleanout
booleanout:anyin
anyout:booleanin
booleanin:anyout
```

No changes to block definitions or interpreter logic were needed, they already handle booleans correctly once the connection is allowed.

## Steps to Reproduce

1. Drag out a Switch block (Flow palette) and an And or Or block (Boolean palette).
2. Try to snap the boolean block into the Switch block's argument socket. It won't connect.
3. Same result with Case, and with If/While/Until/Wait For when trying to feed them a namedbox holding a boolean.

## Testing Performed

- `js/__tests__/connection-validator.test.js`: added explicit assertions for the four pairs. These are hardcoded rather than derived from ALLOWED_CONNECTIONS like the rest of that file's tests, since a derived assertion would trivially keep passing even if these pairs were removed again. Also added a negative test confirming boolean docks still don't bridge into unrelated types (number/text).
- `js/__tests__/blocks.test.js`: added two tests in the "real, compatible dock" describe block that exercise actual dock-snapping through `blocks.blockMoved()` with the real ConnectionValidator, one modeling a booleanout block snapping into an anyin socket (Switch/Case), one modeling an anyout block snapping into a booleanin socket (namedbox into If/While).
- Ran the full Jest suite locally: 8806 passing. 3 failures are in `scripts/generate-tests/__tests__/write-generated.test.js`, a Windows-only EPERM on `fs.symlinkSync` (a local permissions limitation unrelated to this change and to any file touched here), not something this PR introduced.
- `eslint --max-warnings=0` and `npx prettier --check` both pass clean on the changed files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Impact: Switch/Case can now branch on a boolean condition via drag-and-drop, and a boolean value stored in a named box can be tested by If/While/Until/Wait For, both previously silent, unexplained failures for a block that just wouldn't snap. No behavior changes for any already-working connection type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection validation for boolean sockets and generic input/output sockets.
  - Boolean connections now remain supported while invalid connections to number or text sockets are rejected.
  - Improved reliability of block-loading and drag-and-drop behavior during repeated or overlapping operations.

- **Tests**
  - Added coverage for boolean socket compatibility and overlapping block loads.
  - Improved test cleanup and reduced reliance on fixed timing delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->