### PR TITLE
fix(highcontrast): consume design tokens for trash view styling

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -94,31 +94,35 @@ body.highcontrast {
     color: var(--fg) !important;
 }
 
-/* Trash view colors for dark mode consuming design system tokens */
-.dark .trash-view {
+/* Trash view colors for dark and high-contrast modes consuming design system tokens */
+.dark .trash-view,
+.highcontrast .trash-view {
     background-color: var(--color-bg-secondary) !important;
     color: var(--color-text-primary) !important;
     border: 2px solid var(--color-border-primary) !important;
 }
 
-.dark .button-container {
+.dark .button-container,
+.highcontrast .button-container {
     background-color: var(--color-bg-tertiary) !important;
     border-bottom: 1px solid var(--color-border-primary) !important;
 }
 
-.dark .trash-item.hover {
+.dark .trash-item.hover,
+.highcontrast .trash-item.hover {
     background-color: var(--color-brand-primary-hover) !important;
     color: var(--color-text-inverse) !important;
 }
 
-.dark .trash-item.selected {
+.dark .trash-item.selected,
+.highcontrast .trash-item.selected {
     background-color: var(--color-brand-primary) !important;
     color: var(--color-text-inverse) !important;
 }
 
-
-/* Improve block icon visibility in dark mode */
-.dark .trash-item-icon {
+/* Improve block icon visibility in dark and high-contrast modes */
+.dark .trash-item-icon,
+.highcontrast .trash-item-icon {
     background-color: rgba(255, 255, 255, 0.855);
     border-radius: 3px;
     padding: 2px;


### PR DESCRIPTION
## Description
In PR #8288, `.dark .trash-view` was updated to consume CSS design tokens for dark mode. However, High-Contrast mode (`body.highcontrast`) was not styled, causing the trash view modal to fall back to the default hardcoded `background-color: white; color: black;`.

When a visually impaired user switches to High-Contrast mode (where the entire canvas and UI turn `#000000` with high-contrast text), opening the trash panel showed a stark white popup that violated WCAG AAA contrast standards and caused text to become unreadable on hover.

This PR extends the token-based styling in `css/darkmode.css` to `.highcontrast`:
- Sets `.highcontrast .trash-view` to use `var(--color-bg-secondary)` (`#000000`), `var(--color-text-primary)` (`#ffffff`), and `var(--color-border-primary)` (`#ffffff`).
- Sets `.highcontrast .button-container` to use `var(--color-bg-tertiary)` and `var(--color-border-primary)`.
- Sets `.highcontrast .trash-item.hover` and `.selected` to consume high-contrast brand tokens (`#ffffff` / `#ffff00`) with inverted text.
- Ensures `.trash-item-icon` maintains visibility against black backgrounds.

## Related PRs
- Follow-up to #8288
## Category
- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] UI/UX — Changes to the user interface or user experience

## Here are screenshot:
### Before
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/9023478f-8165-49d1-9542-4c2acc42f5b7" />


### After 
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/587c9375-2746-477a-9966-ca5d2572597f" />



## Changes Made
- [MODIFY] `css/darkmode.css`: Add `.highcontrast` selectors alongside `.dark` for `.trash-view`, `.button-container`, `.trash-item`, and `.trash-item-icon`.

## Testing & Verification
- Tested locally in Light, Dark, and High-Contrast modes.
- Verified 23/23 tests pass: `node ./node_modules/jest/bin/jest.js js/activity/__tests__/trash-controller.test.js`.
- Verified pre-commit hooks passed `lint-staged`, `prettier`, and `commitlint` with DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Trash view, button, hover, selected-item, and icon styling for improved consistency in dark and high-contrast modes.
  * Aligned high-contrast colors and icon visibility with the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->