### PR TITLE
fix: cross platform path resolution and symlink handling in test generator

### DIFF
--- a/scripts/generate-tests/__tests__/write-generated.test.js
+++ b/scripts/generate-tests/__tests__/write-generated.test.js
@@ -170,7 +170,15 @@ describe("safeWrite", () => {
         const outside = fs.mkdtempSync(path.join(os.tmpdir(), "mb-outside-"));
         try {
             fs.mkdirSync(path.join(sandbox, "js", "utils"), { recursive: true });
-            fs.symlinkSync(outside, path.join(sandbox, "js", "utils", "__tests__"), "dir");
+            try {
+                fs.symlinkSync(outside, path.join(sandbox, "js", "utils", "__tests__"), "dir");
+            } catch (err) {
+                if (err.code === "EPERM" || err.code === "EACCES") {
+                    // windows without developer mode or elevated privileges cannot create symlinks
+                    return;
+                }
+                throw err;
+            }
             expect(() =>
                 safeWrite(validSource, { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
             ).toThrow(/real path resolves outside the repository/);

--- a/scripts/generate-tests/__tests__/write-generated.test.js
+++ b/scripts/generate-tests/__tests__/write-generated.test.js
@@ -40,6 +40,22 @@ const FIXTURES = path.join(__dirname, "fixtures", "generated");
 const validSource = fs.readFileSync(path.join(FIXTURES, "valid-utils-logic.txt"), "utf8");
 const utilsLogicPlan = () => extractFile("js/utils/utils-logic.js");
 
+// Probe symlink support synchronously to use it.skip when unsupported (e.g. Windows without Dev Mode), avoiding false passes.
+const symlinkSupported = (() => {
+    const probe = fs.mkdtempSync(path.join(os.tmpdir(), "mb-symlink-probe-"));
+    try {
+        fs.symlinkSync(probe, path.join(probe, "link"), "dir");
+        return true;
+    } catch (err) {
+        if (err.code === "EPERM" || err.code === "EACCES") {
+            return false;
+        }
+        throw err;
+    } finally {
+        fs.rmSync(probe, { recursive: true, force: true });
+    }
+})();
+
 let sandbox;
 beforeEach(() => {
     sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "mb-write-generated-"));
@@ -166,35 +182,30 @@ describe("safeWrite", () => {
         ).toThrow(/repo-relative/);
     });
 
-    it("refuses to write through a __tests__ symlink that escapes the repo", () => {
-        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "mb-outside-"));
-        try {
-            fs.mkdirSync(path.join(sandbox, "js", "utils"), { recursive: true });
+    (symlinkSupported ? it : it.skip)(
+        "refuses to write through a __tests__ symlink that escapes the repo",
+        () => {
+            const outside = fs.mkdtempSync(path.join(os.tmpdir(), "mb-outside-"));
             try {
+                fs.mkdirSync(path.join(sandbox, "js", "utils"), { recursive: true });
                 fs.symlinkSync(outside, path.join(sandbox, "js", "utils", "__tests__"), "dir");
-            } catch (err) {
-                if (err.code === "EPERM" || err.code === "EACCES") {
-                    // windows without developer mode or elevated privileges cannot create symlinks
-                    return;
-                }
-                throw err;
+                expect(() =>
+                    safeWrite(validSource, { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
+                ).toThrow(/real path resolves outside the repository/);
+                // even a dry run refuses it
+                expect(() =>
+                    safeWrite(validSource, {
+                        modulePath: "js/utils/utils-logic.js",
+                        cwd: sandbox,
+                        dryRun: true
+                    })
+                ).toThrow(/real path resolves outside the repository/);
+                expect(fs.readdirSync(outside)).toEqual([]);
+            } finally {
+                fs.rmSync(outside, { recursive: true, force: true });
             }
-            expect(() =>
-                safeWrite(validSource, { modulePath: "js/utils/utils-logic.js", cwd: sandbox })
-            ).toThrow(/real path resolves outside the repository/);
-            // even a dry run refuses it
-            expect(() =>
-                safeWrite(validSource, {
-                    modulePath: "js/utils/utils-logic.js",
-                    cwd: sandbox,
-                    dryRun: true
-                })
-            ).toThrow(/real path resolves outside the repository/);
-            expect(fs.readdirSync(outside)).toEqual([]);
-        } finally {
-            fs.rmSync(outside, { recursive: true, force: true });
         }
-    });
+    );
 });
 
 describe("writeGeneratedTest: validate-then-write", () => {

--- a/scripts/generate-tests/write-generated.js
+++ b/scripts/generate-tests/write-generated.js
@@ -121,8 +121,9 @@ function assertSafeTestPath(candidatePath, root) {
     if (!posix.split("/").includes("__tests__")) {
         throw new Error(`refusing to write outside a __tests__/ directory: "${candidatePath}"`);
     }
-    const absolute = path.resolve(root, candidatePath);
-    const contained = absolute === root || absolute.startsWith(root + path.sep);
+    const resolvedRoot = path.resolve(root);
+    const absolute = path.resolve(resolvedRoot, candidatePath);
+    const contained = absolute === resolvedRoot || absolute.startsWith(resolvedRoot + path.sep);
     if (!contained) {
         throw new Error(`refusing to write outside the repository: "${candidatePath}"`);
     }


### PR DESCRIPTION

## Description

The test generation validation utilities and test suite (`scripts/generate-tests/`) were introduced in #8381. While the suite executes successfully in Linux CI environments, running `npm test` locally on Windows encounters test failures due to platform-specific path resolution and symlink permission constraints. 

This pull request addresses those platform differences to ensure tests run smoothly and reliably across all operating systems.

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

## Changes Made

- **`write-generated.js`**: Resolved `root` with `path.resolve(root)` before checking `absolute.startsWith(resolvedRoot + path.sep)` to ensure consistent root containment checks across platforms with drive letters.
* `write-generated.test.js`: Probed symlink support synchronously and conditionally registered the symlink-escape test as `it.skip` when unsupported (e.g. Windows without Developer Mode), avoiding false-positive test passes.

---

## Steps to Reproduce

1. Run `npm test` on a Windows machine in a standard terminal.
2. Notice "refusing to write outside the repository" and "EPERM: operation not permitted, symlink" errors causing the test suite to fail.

---

## Testing Performed

- Ran `npm test`

Before:
<img width="978" height="697" alt="image" src="https://github.com/user-attachments/assets/dadf7977-22a5-4f1c-b579-368ef75f6f19" />
<img width="990" height="467" alt="image" src="https://github.com/user-attachments/assets/2d3fb6d4-9fa9-4790-a31d-bf298eed98df" />


After:
Windows require developer mode to create symlinks, without it fs.symlinkSync() throws EPERM. If symlinks are not supported, Jest marks the test as skipped instead of passing it.
<img width="512" height="130" alt="image" src="https://github.com/user-attachments/assets/43e6b43f-5381-418f-8a69-f3171d3f1c00" />


---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against generated test paths escaping the repository directory.
  * Updated symlink-related test handling for environments that restrict symlink creation, while preserving validation in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->