### PR TITLE
docs: correct doubled words in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -516,7 +516,7 @@ Feel free. But, please don't spam :p.
    any satisfactory answer, then ask it in a comment. If it is a general
    question about Music Blocks, please use the new
    [discussions](https://github.com/sugarlabs/musicblocks/discussions)
-   tab on top the the repository, or the _Sugar-dev Devel
+   tab on top of the repository, or the _Sugar-dev Devel
    <[sugar-devel@lists.sugarlabs.org](mailto:sugar-devel@lists.sugarlabs.org)>_
    mailing list. We also have a
    [matrix channel](https://matrix.to/#/#music-blocks:matrix.org).

--- a/Docs/documentation-es/README.md
+++ b/Docs/documentation-es/README.md
@@ -354,7 +354,7 @@ blocks, individual note blocks, or the *Tuplet* block.
 
 The *Rhythm* block is used to specify a series of notes of the same
 duration (e.g., three quarter notes or seven eighth notes). The number
-of notes is the top argument; the bottom argument is the the note
+of notes is the top argument; the bottom argument is the note
 duration, e.g., `1/1` for a whole note, `1/2` for a half note, `1/4`
 for a quarter note, etc. (Recall that in traditional Western notation
 all note values are (1) in powers of two, and are (2) in relation to

--- a/Docs/documentation/README.md
+++ b/Docs/documentation/README.md
@@ -686,7 +686,7 @@ LIVE](https://musicblocks.sugarlabs.org/index.html?id=1732180386380311&run=True)
 
 The _Rhythm_ block is used to specify a series of notes of the same
 duration (e.g., three quarter notes or seven eighth notes). The number
-of notes is the top argument; the bottom argument is the the note
+of notes is the top argument; the bottom argument is the note
 duration, e.g., `1/1` for a whole note, `1/2` for a half note, `1/4`
 for a quarter note, etc. (Recall that in traditional Western notation
 all note values are (1) in powers of two, and are (2) in relation to

--- a/Docs/documentation/index.html
+++ b/Docs/documentation/index.html
@@ -289,7 +289,7 @@ blocks, individual note blocks, or the <em>Tuplet</em> block.</p>
 <p><img src="../guide/matrix6.svg" alt="matrix6.svg" title="Rhythm block"></p>
 <p>The <em>Rhythm</em> block is used to specify a series of notes of the same
 duration (e.g., three quarter notes or seven eighth notes). The number
-of notes is the top argument; the bottom argument is the the note
+of notes is the top argument; the bottom argument is the note
 duration, e.g., <code>1/1</code> for a whole note, <code>1/2</code> for a half note, <code>1/4</code>
 for a quarter note, etc. (Recall that in traditional Western notation
 all note values are (1) in powers of two, and are (2) in relation to

--- a/Docs/guide/03-programming-with-music.html
+++ b/Docs/guide/03-programming-with-music.html
@@ -344,7 +344,7 @@
 	  <h4><a name="SET-KEY">3.2.5 Set Key</a></h4>
 	  <p>The <em>Set key</em> block is used to change both the mode and key of the
 	    current scale. (The current scale is used to define the mapping of
-	    Solfege [when set Movable Do = True] to notes and also the number of half steps take by the the
+	    Solfege [when set Movable Do = True] to notes and also the number of half steps take by the
 	    <em>Scalar step</em> block.) For example, by setting the key to C Major, the
 	    scale is defined by starting at C (or Do) and applying the pattern of half
 	    steps defined by a Major mode. In this case, the pattern of steps

--- a/Docs/guide/README.md
+++ b/Docs/guide/README.md
@@ -507,7 +507,7 @@ used to bump the `Mi 4` note up by one octave and then to bump the
 
 The *Set key* block is used to change both the mode and key of the
 current scale. (The current scale is used to define the mapping of
-Solfege [when set Movable Do = True] to notes and also the number of half steps take by the the
+Solfege [when set Movable Do = True] to notes and also the number of half steps take by the
 *Scalar step* block.) For example, by setting the key to C Major, the
 scale is defined by starting at C (or Do) and applying the pattern of half
 steps defined by a Major mode. In this case, the pattern of steps

--- a/js/README.md
+++ b/js/README.md
@@ -250,7 +250,7 @@ Note: Trailing arguments can be neglected in both functions, if not needed.
 * For arg blocks value is set by using a `return` statement.
 
 * In case of flow blocks, return value should be in the form
-  `[childFlow, childFlowCount]` or `[]` if if there is no child
+  `[childFlow, childFlowCount]` or `[]` if there is no child
   flow. (A child flow is, for example, the internal flow of a clamp,
   e.g. what is repeated in a repeat block.)
 


### PR DESCRIPTION
## Description

Doubled words in the documentation: "the the" in the English and Spanish
user manuals and in the programming guide, "on top the the repository" ->
"on top of the repository" in the contributing guide, and "if if there is
no child" in the js/ developer README.

## Related Issue

**Fixes:** none - no open issue for these; the fixes are self-contained.

---

## Category

- [ ] Bug Fix
- [ ] Feature
- [ ] UI/UX
- [ ] Performance
- [ ] Tests
- [x] Documentation - Updates to docs, comments, or README
- [ ] Chore / Refactor
- [ ] CI/CD

---

## Changes Made

Seven files, one word each: CONTRIBUTING.md, Docs/documentation/README.md,
Docs/documentation-es/README.md, Docs/guide/README.md, js/README.md, and
the two committed HTML renderings that carry the same sentences
(Docs/documentation/index.html and
Docs/guide/03-programming-with-music.html) so the Markdown and HTML stay
in step.

---

## Testing Performed

None needed - no JavaScript, CSS or configuration is touched, so there is
no runtime behaviour to exercise.

---

## Checklist

- [x] I have tested these changes locally and they work as expected. (Docs render unchanged apart from the corrected words.)
- [ ] I have added/updated tests that prove the effectiveness of these changes. (Not applicable.)
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run npm run lint and npx prettier --check . with no errors. (No source files changed; I did not run the JS toolchain for a docs-only edit.)
- [x] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

The commit carries a Signed-off-by line for the DCO check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected grammar and duplicated words across contributor guidance and user documentation.
  - Improved descriptions for Rhythm blocks, Set Key instructions, and flow-block return values.
  - Updated English and Spanish documentation for clearer reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->