### PR TITLE
test(cypress): stabilize meter and pitch staircase widget E2E teardown and navigation

### DIFF
--- a/cypress/e2e/meter-widget.cy.js
+++ b/cypress/e2e/meter-widget.cy.js
@@ -45,7 +45,7 @@ describe("Meter widget", () => {
         // auto-save from re-triggering the widget on subsequent test runs.
         cy.visit("http://127.0.0.1:3000");
         cy.clearLocalStorage();
-        cy.visit("http://127.0.0.1:3000");
+        cy.reload();
         cy.waitForAppReady();
 
         // Dismiss the first-run "Take a Tour" guide if it appears, so that
@@ -53,7 +53,25 @@ describe("Meter widget", () => {
         cy.get("body").then($body => {
             const closeButtons = $body.find(".windowFrame .wftButton.close");
             if (closeButtons.length) {
-                cy.wrap(closeButtons).click({ multiple: true, force: true });
+                cy.wrap(closeButtons).each($btn => {
+                    cy.wrap($btn).click({ force: true });
+                });
+            }
+        });
+    });
+
+    afterEach(() => {
+        // Stop audio playback and close any open widget windows to prevent
+        // active loops from interrupting the next test's page initialization.
+        cy.get("body").then($body => {
+            if ($body.find("#stop").length) {
+                cy.get("#stop").click({ force: true });
+            }
+            const closeButtons = $body.find(".windowFrame .wftButton.close");
+            if (closeButtons.length) {
+                cy.wrap(closeButtons).each($btn => {
+                    cy.wrap($btn).click({ force: true });
+                });
             }
         });
     });

--- a/cypress/e2e/pitch-staircase-widget.cy.js
+++ b/cypress/e2e/pitch-staircase-widget.cy.js
@@ -37,7 +37,7 @@ describe("Pitch Staircase widget", () => {
         // auto-save from re-triggering the widget on subsequent test runs.
         cy.visit("http://127.0.0.1:3000");
         cy.clearLocalStorage();
-        cy.visit("http://127.0.0.1:3000");
+        cy.reload();
         cy.waitForAppReady();
 
         // Dismiss the first-run "Take a Tour" guide if it appears, so that
@@ -45,7 +45,18 @@ describe("Pitch Staircase widget", () => {
         cy.get("body").then($body => {
             const closeButtons = $body.find(".windowFrame .wftButton.close");
             if (closeButtons.length) {
-                cy.wrap(closeButtons).click({ multiple: true, force: true });
+                cy.wrap(closeButtons).each($btn => {
+                    cy.wrap($btn).click({ force: true });
+                });
+            }
+        });
+    });
+
+    afterEach(() => {
+        // Stop audio playback cleanly before the next test loads.
+        cy.get("body").then($body => {
+            if ($body.find("#stop").length) {
+                cy.get("#stop").click({ force: true });
             }
         });
     });
@@ -103,7 +114,9 @@ describe("Pitch Staircase widget", () => {
         // PitchStaircase.init() wires widgetWindow.onclose to clear all
         // timeouts, stop synth audio, and call widgetWindow.destroy() -
         // which removes the .windowFrame from the DOM.
-        cy.get('[aria-label="pitch staircase"] [role="button"][aria-label="Close window"]').click();
+        cy.get('[aria-label="pitch staircase"] [role="button"][aria-label="Close window"]').click({
+            force: true
+        });
 
         // The window frame should be fully destroyed.
         cy.get('[aria-label="pitch staircase"]').should("not.exist");


### PR DESCRIPTION
## Description
This PR stabilizes the flaky Cypress end-to-end tests in `meter-widget.cy.js` and `pitch-staircase-widget.cy.js`.

### Root Cause
1. **RequireJS Aborted Script Error / Loading Timeout**:
   Tests were performing a rapid duplicate `cy.visit('/') -> cy.clearLocalStorage() -> cy.visit('/')`. In headless CI environments, the second visit would abort in-flight asynchronous RequireJS module requests from the first visit. This triggered an unhandled window `Script error` and an error alert from `js/loader.js:588` (`Failed to initialize Music Blocks core. Please refresh the page`), leaving `#loading-image-container` visible and timing out after 60,000ms.
2. **Unstopped Playback Across Tests**:
   Previous tests clicked `#play` without stopping before completing, leaking active audio/turtle intervals into subsequent test executions.
3. **Detached Element Race Condition**:
   Closing the pitch staircase title bar window occasionally failed when the widget element detached during asynchronous animation cleanup.

## Category
<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Tests — Adds or updates test coverage


### Changes Made
- **[meter-widget.cy.js](cypress/e2e/meter-widget.cy.js)**:
  - Replaced the rapid duplicate `cy.visit('/')` sequence with `cy.reload()` after clearing local storage.
  - Added an `afterEach()` cleanup hook to stop playback (`#stop`) and dismiss any open widget dialogs.
- **[pitch-staircase-widget.cy.js](cypress/e2e/pitch-staircase-widget.cy.js)**:
  - Replaced the rapid duplicate `cy.visit('/')` with `cy.reload()` after clearing local storage.
  - Added an `afterEach()` cleanup hook to ensure playback is stopped.
  - Added `{ force: true }` when clicking the window close button to prevent test failures due to detached DOM elements.

---

## How Has This Been Tested?
- [x] Ran both test suites locally using Cypress:
  ```bash
  npx cypress run --spec "cypress/e2e/meter-widget.cy.js"
  npx cypress run --spec "cypress/e2e/pitch-staircase-widget.cy.js"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage for the Meter and Pitch Staircase widgets.
  - Added more reliable application readiness checks and first-run tour handling.
  - Improved test cleanup by stopping playback and closing remaining widget windows after each test.
  - Strengthened widget close-button validation to better reflect user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->