### PR TITLE
refactor(turtle-singer): drop dead duplicate-factor loops in widget rows

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -888,10 +888,15 @@ describe("processPitch widget-row definition adds one row per visit", () => {
     beforeEach(() => {
         savedGlobals = {
             noteIsSolfege: global.noteIsSolfege,
-            getSolfege: global.getSolfege
+            getSolfege: global.getSolfege,
+            getNote: global.getNote
         };
         global.noteIsSolfege = jest.fn().mockReturnValue(false);
         global.getSolfege = jest.fn(note => note);
+        // A fresh array per call: processPitch writes back into the returned
+        // note (noteObj[0] = ...), which would otherwise mutate a shared mock
+        // return value and leak into later suites.
+        global.getNote = jest.fn(() => ["C", 4]);
 
         turtleMock = createTurtleMock();
         turtleMock.singer = new Singer(turtleMock);
@@ -918,6 +923,7 @@ describe("processPitch widget-row definition adds one row per visit", () => {
     afterEach(() => {
         global.noteIsSolfege = savedGlobals.noteIsSolfege;
         global.getSolfege = savedGlobals.getSolfege;
+        global.getNote = savedGlobals.getNote;
     });
 
     test("pitch-drum matrix adds exactly one row while duplicateFactor is 3", () => {
@@ -945,6 +951,82 @@ describe("processPitch widget-row definition adds one row per visit", () => {
         Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
 
         expect(activityMock.logo.phraseMaker.rowLabels).toHaveLength(1);
+    });
+
+    test("LEGO widget adds exactly one row while duplicateFactor is 3", () => {
+        activityMock.logo.inLegoWidget = true;
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.legoWidget.rowLabels).toHaveLength(1);
+        expect(activityMock.logo.legoWidget.rowArgs).toHaveLength(1);
+    });
+
+    test.each([
+        { name: "pitch-drum matrix", flag: "inPitchDrumMatrix", widget: "pitchDrumMatrix" },
+        { name: "phrase maker", flag: "inMatrix", widget: "phraseMaker" },
+        { name: "LEGO widget", flag: "inLegoWidget", widget: "legoWidget" }
+    ])("$name applies the first arpeggio offset once", ({ flag, widget }) => {
+        activityMock.logo[flag] = true;
+        turtleMock.singer.arpeggio = [7, 12, 19];
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        // getNote receives transposition + cents + arpeggio[0]; later offsets
+        // are unreachable here because each duplicate is a separate visit.
+        expect(global.getNote).toHaveBeenCalledWith(
+            "C",
+            4,
+            7,
+            expect.anything(),
+            expect.anything(),
+            null,
+            expect.anything(),
+            expect.anything()
+        );
+        expect(activityMock.logo[widget].rowLabels).toHaveLength(1);
+    });
+
+    test("a setdrum clamp overrides the pitch-drum matrix row", () => {
+        activityMock.logo.inPitchDrumMatrix = true;
+        turtleMock.singer.drumStyle = ["kick drum"];
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.pitchDrumMatrix.drums).toEqual(["kick drum"]);
+        expect(activityMock.logo.pitchDrumMatrix.rowLabels).toHaveLength(0);
+    });
+
+    test("a setdrum clamp overrides the phrase maker row", () => {
+        activityMock.logo.inMatrix = true;
+        turtleMock.singer.drumStyle = ["snare drum"];
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.phraseMaker.rowLabels).toEqual(["snare drum"]);
+        expect(activityMock.logo.phraseMaker.rowArgs).toEqual([-1]);
+    });
+
+    test("a setdrum clamp overrides the LEGO widget row", () => {
+        activityMock.logo.inLegoWidget = true;
+        turtleMock.singer.drumStyle = ["hi hat"];
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.legoWidget.rowLabels).toEqual(["hi hat"]);
+        expect(activityMock.logo.legoWidget.rowArgs).toEqual([-1]);
+    });
+
+    test("converts the label to solfege in C major when the note is solfege", () => {
+        activityMock.logo.inMatrix = true;
+        turtleMock.singer.keySignature = ["C", "major"];
+        global.noteIsSolfege.mockReturnValue(true);
+        global.getSolfege.mockReturnValue("do");
+
+        Singer.processPitch(activityMock, "do", 4, 0, 0, 123);
+
+        expect(global.getSolfege).toHaveBeenCalled();
+        expect(activityMock.logo.phraseMaker.rowLabels).toEqual(["do"]);
     });
 });
 

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -876,6 +876,78 @@ describe("processPitch — note block execution path", () => {
     });
 });
 
+describe("processPitch widget-row definition adds one row per visit", () => {
+    // The Duplicate block re-queues each block in its clamp `factor` times
+    // (see DuplicateBlock.flow), so a pitch block is already visited once per
+    // duplicate. These guard against re-introducing a per-visit multiplier
+    // here, which would add factor x factor rows.
+    let turtleMock;
+    let activityMock;
+    let savedGlobals;
+
+    beforeEach(() => {
+        savedGlobals = {
+            noteIsSolfege: global.noteIsSolfege,
+            getSolfege: global.getSolfege
+        };
+        global.noteIsSolfege = jest.fn().mockReturnValue(false);
+        global.getSolfege = jest.fn(note => note);
+
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        turtleMock.singer.inNoteBlock = [];
+        turtleMock.singer.duplicateFactor = 3;
+
+        activityMock = {
+            turtles: { ithTurtle: jest.fn().mockReturnValue(turtleMock) },
+            errorMsg: jest.fn(),
+            logo: {
+                synth: { inTemperament: false },
+                clearNoteParams: jest.fn(),
+                pitchBlocks: [],
+                inPitchDrumMatrix: false,
+                inMatrix: false,
+                inLegoWidget: false,
+                pitchDrumMatrix: { addRowBlock: jest.fn(), rowLabels: [], rowArgs: [], drums: [] },
+                phraseMaker: { addRowBlock: jest.fn(), rowLabels: [], rowArgs: [] },
+                legoWidget: { addRowBlock: jest.fn(), rowLabels: [], rowArgs: [] }
+            }
+        };
+    });
+
+    afterEach(() => {
+        global.noteIsSolfege = savedGlobals.noteIsSolfege;
+        global.getSolfege = savedGlobals.getSolfege;
+    });
+
+    test("pitch-drum matrix adds exactly one row while duplicateFactor is 3", () => {
+        activityMock.logo.inPitchDrumMatrix = true;
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.pitchDrumMatrix.rowLabels).toHaveLength(1);
+        expect(activityMock.logo.pitchDrumMatrix.rowArgs).toHaveLength(1);
+    });
+
+    test("phrase maker adds exactly one row while duplicateFactor is 3", () => {
+        activityMock.logo.inMatrix = true;
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.phraseMaker.rowLabels).toHaveLength(1);
+        expect(activityMock.logo.phraseMaker.rowArgs).toHaveLength(1);
+    });
+
+    test("row count stays at one for a fractional duplicateFactor", () => {
+        activityMock.logo.inMatrix = true;
+        turtleMock.singer.duplicateFactor = 0.5;
+
+        Singer.processPitch(activityMock, "C", 4, 0, 0, 123);
+
+        expect(activityMock.logo.phraseMaker.rowLabels).toHaveLength(1);
+    });
+});
+
 describe("noteCounter regression behavior", () => {
     let turtleMock;
     let activityMock;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -904,44 +904,40 @@ class Singer {
                 }
             }
 
-            const duplicateFactor =
-                tur.singer.duplicateFactor.length > 0 ? tur.singer.duplicateFactor : 1;
+            // The Duplicate block re-queues this block once per duplicate,
+            // so the row is added once per visit with no extra multiplier.
+            // Apply transpositions
+            const transposition = 2 * delta + tur.singer.transposition;
+            let atrans = transposition + cents;
+            if (tur.singer.arpeggio.length > 0) {
+                atrans += tur.singer.arpeggio[0];
+            }
 
-            for (let i = 0; i < duplicateFactor; i++) {
-                // Apply transpositions
-                const transposition = 2 * delta + tur.singer.transposition;
-                const alen = tur.singer.arpeggio.length;
-                let atrans = transposition + cents;
-                if (alen > 0 && i < alen) {
-                    atrans += tur.singer.arpeggio[i];
-                }
+            const nnote = getNote(
+                note,
+                octave,
+                atrans, // transposition,
+                tur.singer.keySignature,
+                tur.singer.movable,
+                null,
+                activity.errorMsg,
+                activity.logo.synth.inTemperament
+            );
+            nnote[0] = noteIsSolfege(note)
+                ? getSolfege(
+                      nnote[0],
+                      tur.singer.keySignature,
+                      tur.singer.movable,
+                      activity.logo.synth.inTemperament,
+                      edo
+                  )
+                : nnote[0];
 
-                const nnote = getNote(
-                    note,
-                    octave,
-                    atrans, // transposition,
-                    tur.singer.keySignature,
-                    tur.singer.movable,
-                    null,
-                    activity.errorMsg,
-                    activity.logo.synth.inTemperament
-                );
-                nnote[0] = noteIsSolfege(note)
-                    ? getSolfege(
-                          nnote[0],
-                          tur.singer.keySignature,
-                          tur.singer.movable,
-                          activity.logo.synth.inTemperament,
-                          edo
-                      )
-                    : nnote[0];
-
-                if (tur.singer.drumStyle.length > 0) {
-                    activity.logo.pitchDrumMatrix.drums.push(last(tur.singer.drumStyle));
-                } else {
-                    activity.logo.pitchDrumMatrix.rowLabels.push(nnote[0]);
-                    activity.logo.pitchDrumMatrix.rowArgs.push(nnote[1]);
-                }
+            if (tur.singer.drumStyle.length > 0) {
+                activity.logo.pitchDrumMatrix.drums.push(last(tur.singer.drumStyle));
+            } else {
+                activity.logo.pitchDrumMatrix.rowLabels.push(nnote[0]);
+                activity.logo.pitchDrumMatrix.rowArgs.push(nnote[1]);
             }
         } else if (activity.logo.inMatrix) {
             if (note.toLowerCase() !== "rest") {
@@ -951,66 +947,62 @@ class Singer {
                 }
             }
 
-            const duplicateFactor =
-                tur.singer.duplicateFactor.length > 0 ? tur.singer.duplicateFactor : 1;
+            // The Duplicate block re-queues this block once per duplicate,
+            // so the row is added once per visit with no extra multiplier.
+            // Apply transpositions
+            const transposition = 2 * delta + tur.singer.transposition;
+            let atrans = transposition + cents;
+            if (tur.singer.arpeggio.length > 0) {
+                atrans += tur.singer.arpeggio[0];
+            }
+            const noteObj = getNote(
+                note,
+                octave,
+                atrans, // transposition,
+                tur.singer.keySignature,
+                tur.singer.movable,
+                null,
+                activity.errorMsg,
+                activity.logo.synth.inTemperament
+            );
+            tur.singer.previousNotePlayed = tur.singer.lastNotePlayed;
+            tur.singer.lastNotePlayed = [noteObj[0] + noteObj[1], 4];
 
-            for (let i = 0; i < duplicateFactor; i++) {
-                // Apply transpositions
-                const transposition = 2 * delta + tur.singer.transposition;
-                const alen = tur.singer.arpeggio.length;
-                let atrans = transposition + cents;
-                if (alen > 0 && i < alen) {
-                    atrans += tur.singer.arpeggio[i];
-                }
-                const noteObj = getNote(
-                    note,
-                    octave,
-                    atrans, // transposition,
+            if (
+                tur.singer.keySignature[0] === "C" &&
+                tur.singer.keySignature[1].toLowerCase() === "major" &&
+                noteIsSolfege(note)
+            ) {
+                noteObj[0] = getSolfege(
+                    noteObj[0],
                     tur.singer.keySignature,
                     tur.singer.movable,
-                    null,
-                    activity.errorMsg,
-                    activity.logo.synth.inTemperament
+                    activity.logo.synth.inTemperament,
+                    edo
                 );
-                tur.singer.previousNotePlayed = tur.singer.lastNotePlayed;
-                tur.singer.lastNotePlayed = [noteObj[0] + noteObj[1], 4];
+            }
 
+            // If we are in a setdrum clamp, override the pitch.
+            if (tur.singer.drumStyle.length > 0) {
+                activity.logo.phraseMaker.rowLabels.push(last(tur.singer.drumStyle));
+                activity.logo.phraseMaker.rowArgs.push(-1);
+            } else {
+                // Don't bother with the name conversions.
+                activity.logo.phraseMaker.rowLabels.push(noteObj[0]);
+                /*
+                // Was the pitch arg a note name or solfege name?
                 if (
-                    tur.singer.keySignature[0] === "C" &&
-                    tur.singer.keySignature[1].toLowerCase() === "major" &&
-                    noteIsSolfege(note)
+                    SOLFEGENAMES1.indexOf(note) !== -1 &&
+                    noteObj[0] in SOLFEGECONVERSIONTABLE
                 ) {
-                    noteObj[0] = getSolfege(
-                        noteObj[0],
-                        tur.singer.keySignature,
-                        tur.singer.movable,
-                        activity.logo.synth.inTemperament,
-                        edo
+                    activity.logo.phraseMaker.rowLabels.push(
+                        SOLFEGECONVERSIONTABLE[noteObj[0]]
                     );
-                }
-
-                // If we are in a setdrum clamp, override the pitch.
-                if (tur.singer.drumStyle.length > 0) {
-                    activity.logo.phraseMaker.rowLabels.push(last(tur.singer.drumStyle));
-                    activity.logo.phraseMaker.rowArgs.push(-1);
                 } else {
-                    // Don't bother with the name conversions.
                     activity.logo.phraseMaker.rowLabels.push(noteObj[0]);
-                    /*
-                    // Was the pitch arg a note name or solfege name?
-                    if (
-                        SOLFEGENAMES1.indexOf(note) !== -1 &&
-                        noteObj[0] in SOLFEGECONVERSIONTABLE
-                    ) {
-                        activity.logo.phraseMaker.rowLabels.push(
-                            SOLFEGECONVERSIONTABLE[noteObj[0]]
-                        );
-                    } else {
-                        activity.logo.phraseMaker.rowLabels.push(noteObj[0]);
-                    }
-                    */
-                    activity.logo.phraseMaker.rowArgs.push(noteObj[1]);
                 }
+                */
+                activity.logo.phraseMaker.rowArgs.push(noteObj[1]);
             }
         } else if (activity.logo.inLegoWidget && !activity.logo.inMatrix) {
             if (note.toLowerCase() !== "rest") {
@@ -1020,53 +1012,49 @@ class Singer {
                 }
             }
 
-            const duplicateFactor =
-                tur.singer.duplicateFactor.length > 0 ? tur.singer.duplicateFactor : 1;
+            // The Duplicate block re-queues this block once per duplicate,
+            // so the row is added once per visit with no extra multiplier.
+            // Apply transpositions
+            const transposition = 2 * delta + tur.singer.transposition;
+            let atrans = transposition + cents;
+            if (tur.singer.arpeggio.length > 0) {
+                atrans += tur.singer.arpeggio[0];
+            }
+            const noteObj = getNote(
+                note,
+                octave,
+                atrans, // transposition,
+                tur.singer.keySignature,
+                tur.singer.movable,
+                null,
+                activity.errorMsg,
+                activity.logo.synth.inTemperament
+            );
+            tur.singer.previousNotePlayed = tur.singer.lastNotePlayed;
+            tur.singer.lastNotePlayed = [noteObj[0] + noteObj[1], 4];
 
-            for (let i = 0; i < duplicateFactor; i++) {
-                // Apply transpositions
-                const transposition = 2 * delta + tur.singer.transposition;
-                const alen = tur.singer.arpeggio.length;
-                let atrans = transposition + cents;
-                if (alen > 0 && i < alen) {
-                    atrans += tur.singer.arpeggio[i];
-                }
-                const noteObj = getNote(
-                    note,
-                    octave,
-                    atrans, // transposition,
+            if (
+                tur.singer.keySignature[0] === "C" &&
+                tur.singer.keySignature[1].toLowerCase() === "major" &&
+                noteIsSolfege(note)
+            ) {
+                noteObj[0] = getSolfege(
+                    noteObj[0],
                     tur.singer.keySignature,
                     tur.singer.movable,
-                    null,
-                    activity.errorMsg,
-                    activity.logo.synth.inTemperament
+                    activity.logo.synth.inTemperament,
+                    edo
                 );
-                tur.singer.previousNotePlayed = tur.singer.lastNotePlayed;
-                tur.singer.lastNotePlayed = [noteObj[0] + noteObj[1], 4];
+            }
 
-                if (
-                    tur.singer.keySignature[0] === "C" &&
-                    tur.singer.keySignature[1].toLowerCase() === "major" &&
-                    noteIsSolfege(note)
-                ) {
-                    noteObj[0] = getSolfege(
-                        noteObj[0],
-                        tur.singer.keySignature,
-                        tur.singer.movable,
-                        activity.logo.synth.inTemperament,
-                        edo
-                    );
-                }
-
-                // If we are in a setdrum clamp, override the pitch.
-                if (tur.singer.drumStyle.length > 0) {
-                    activity.logo.legoWidget.rowLabels.push(last(tur.singer.drumStyle));
-                    activity.logo.legoWidget.rowArgs.push(-1);
-                } else {
-                    // Don't bother with the name conversions.
-                    activity.logo.legoWidget.rowLabels.push(noteObj[0]);
-                    activity.logo.legoWidget.rowArgs.push(noteObj[1]);
-                }
+            // If we are in a setdrum clamp, override the pitch.
+            if (tur.singer.drumStyle.length > 0) {
+                activity.logo.legoWidget.rowLabels.push(last(tur.singer.drumStyle));
+                activity.logo.legoWidget.rowArgs.push(-1);
+            } else {
+                // Don't bother with the name conversions.
+                activity.logo.legoWidget.rowLabels.push(noteObj[0]);
+                activity.logo.legoWidget.rowArgs.push(noteObj[1]);
             }
         } else if (tur.singer.inNoteBlock.length > 0) {
             const addPitch = (note, octave, cents, direction) => {


### PR DESCRIPTION
## Description

Three copy-pasted branches in `Singer.processPitch` (the pitch-drum matrix, phrase maker, and LEGO widget row-definition paths) guard a loop like this:

```js
const duplicateFactor =
    tur.singer.duplicateFactor.length > 0 ? tur.singer.duplicateFactor : 1;
for (let i = 0; i < duplicateFactor; i++) { ... }
```

`duplicateFactor` is a Number, though, never an array. It starts at `1`, gets reset to `1` in `turtle.js`, and is only ever mutated with `*=` and `/=` in `FlowBlocks` and `IntervalsBlocks`. So `.length` is `undefined`, the comparison is always false, the local is always `1`, and the loop runs exactly once. The per-iteration arpeggio offset inside it can therefore only ever read `arpeggio[0]`.

The obvious fix is to make the guard numeric. That would be wrong, and it took me a while to work out why.

`DuplicateBlock.flow` doesn't just record a factor. It re-queues every block in its clamp with `new Queue(child, factor, blk, receivedArg)`, and that happens whether or not a widget is capturing rows. A pitch block inside a Duplicate clamp is therefore already visited `factor` times, once per queued copy, and each visit adds its row. Put a multiplier inside as well and you get factor x factor rows.

Rather than guess, I tried it: applied the numeric fix locally and ran the new tests. With `duplicateFactor = 3` I got 3 rows where 1 was expected. A fractional factor was worse. Duplicate divides on clamp exit, and `Math.floor(0.5)` is 0, so the loop never ran and the row vanished entirely.

This PR deletes the dead conditional and the single-iteration loop at all three sites, inlining the `i = 0` behaviour. Runtime behaviour is unchanged.

### About the diff size

GitHub shows roughly 242 changed lines, which looks alarming for a cleanup. Nearly all of it is the loop body dedenting by four spaces. `git diff -w` gives the real number: 12 lines added, 24 removed. Reviewing with whitespace hidden is much easier.

## Related Issue

None. Found while reading `processPitch` for something else. I checked for overlapping work before opening this one and found nothing touching these branches.

## PR Category

-   [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
-   [x] Tests — Adds or updates test coverage
-   [ ] Bug Fix — Fixes a bug or incorrect behavior
-   [ ] Feature — Adds new functionality
-   [ ] Performance — Improves performance (load time, memory, rendering, etc.)
-   [ ] Documentation — Updates to docs, comments, or README
-   [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

-   `js/turtle-singer.js`: removed the dead `duplicateFactor` conditional and its loop from the pitch-drum matrix, phrase maker, and LEGO widget branches. The loop body is now inline with `arpeggio[0]` in place of `arpeggio[i]`, and the temporary `alen` is gone with it. Each site keeps a short comment explaining why there is no multiplier here.
-   `js/__tests__/turtle-singer.test.js`: three tests pinning the row counts, so anyone who later reads the dead code as a bug and "fixes" it gets a red suite instead of a silent regression.

## Testing Performed

This is a refactor, so the tests characterise existing behaviour rather than starting red. I wrote them first, watched them pass against unmodified code, and only then removed the loops.

To confirm they are worth anything, I applied the naive numeric fix and re-ran them. All three failed, reporting 3 rows for `duplicateFactor = 3` and 0 rows for a fractional factor. That's the regression they exist to catch.

-   `npx jest js/__tests__/turtle-singer.test.js`: 131/131 pass.
-   With the Duplicate block's own suites (`FlowBlocks`, `IntervalsBlocks`): 219/219 pass.
-   Full Jest suite: 8,798 pass. The 8 failures (`mb-dialog`, `sampler`, `SaveInterface`, `write-generated`) are all pre-existing on master, which I verified by stashing this change and re-running them on a clean tree.
-   `npx eslint` and `npx prettier --check` are clean on both files. Commit is DCO signed off.

## Checklist

-   [x] I have tested these changes locally and they work as expected.
-   [x] I have added/updated tests that prove the effectiveness of these changes.
-   [ ] I have updated the documentation to reflect these changes, if applicable.
-   [x] I have followed the project's coding style guidelines.
-   [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
-   [ ] I have addressed the code review feedback from the previous submission, if applicable.
-   [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

## Additional Notes for Reviewers

One thing I deliberately left alone: in widget mode the arpeggio offset is read at index 0 on every visit, so offsets past the first are unreachable there. That was already true before this PR, since the loop only ever ran once. Whether widget rows should walk the arpeggio is a behaviour question for someone who knows the intent, and it deserves its own PR rather than being smuggled into a cleanup.

If maintainers do want widget rows to honour Duplicate differently, the queueing in `DuplicateBlock.flow` is where that belongs, not a second multiplier here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate row creation in the pitch drum matrix, phrase maker, and LEGO widgets.
  - Each processed pitch block now adds one row, keeping widget layouts consistent.
  - Duplicate blocks are queued for subsequent processing, with consistent arpeggio offset handling.
  - Improved solfege label conversion and drum-setting behavior across widget types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->