### PR TITLE
fix: consolidate play and stop into single toggle button #8451

### DIFF
--- a/js/toolbar-ui.js
+++ b/js/toolbar-ui.js
@@ -2400,6 +2400,10 @@ class ToolbarUI {
      */
     highlightStop(color) {
         const stopBtn = document.getElementById("stop");
+        const playBtn = document.getElementById("play");
+        if (playBtn) {
+            playBtn.style.display = "none";
+        }
         if (stopBtn) {
             stopBtn.style.display = "inline-block";
             stopBtn.style.color = color;
@@ -2417,9 +2421,13 @@ class ToolbarUI {
             this._dimTimeout = null;
         }
         const stopBtn = document.getElementById("stop");
+        const playBtn = document.getElementById("play");
         if (stopBtn) {
             stopBtn.style.display = "none";
             stopBtn.style.color = "white";
+        }
+        if (playBtn) {
+            playBtn.style.display = "inline-block";
         }
     }
 


### PR DESCRIPTION
## PR Category
- [x] UI/UX

## Description
Consolidates the main toolbar's Play (▶) and Stop (⏹) buttons into a single state-based toggle control. The button displays the Play icon while idle and toggles to the Stop icon while execution is running, returning to Play when playback finishes naturally or is stopped.

## Changes Made
- Updated `highlightStop()` in `js/toolbar-ui.js` to hide the `#play` button while `#stop` is active.
- Updated `resetStop()` in `js/toolbar-ui.js` to restore the `#play` button when execution stops or completes.
- Added/updated unit tests in `js/__tests__/toolbar-ui.test.js` to verify `#play` and `#stop` display toggling.

## How It Was Tested
1. Executed unit tests: `npm test`
2. Verified code style and formatting: `npm run lint` and `npx prettier --check .`
3. Manual testing in browser (`http://127.0.0.1:3000`):
   - Clicked Play $\rightarrow$ icon toggled to Stop during playback.
   - Clicked Stop $\rightarrow$ playback stopped and icon toggled back to Play.
   - Natural project completion $\rightarrow$ automatically toggled back to Play.
   - Keyboard shortcuts (`Space` / `Alt+Enter`) $\rightarrow$ toggled play/stop state correctly.

## Screenshots
<img width="1920" height="855" alt="image" src="https://github.com/user-attachments/assets/47ee015a-b319-4ff3-a92f-e66672779912" />
<img width="1920" height="864" alt="image" src="https://github.com/user-attachments/assets/8ee64ea3-f627-42af-bd86-bd87f683d8da" />
