### PR TITLE
fix(blocks): key the spatial grid on the block number, not the raw index

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1704,6 +1704,23 @@ describe("Spatial grid indexing", () => {
         return found.sort();
     }
 
+    /**
+     * Asserts the grid is keyed only by numbers, in both directions. A string
+     * alias sitting beside the number is the failure this guards against, and
+     * checking one key by name would not catch it.
+     * @returns {void}
+     */
+    function expectNumericKeysOnly() {
+        for (const key of blocks._blockGridCell.keys()) {
+            expect(typeof key).toBe("number");
+        }
+        for (const members of blocks._spatialGrid.values()) {
+            for (const member of members) {
+                expect(typeof member).toBe("number");
+            }
+        }
+    }
+
     it("registers every block under a numeric key when first built", () => {
         expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
         expect(cellsHolding(0)).toEqual(["0,0"]);
@@ -1732,12 +1749,15 @@ describe("Spatial grid indexing", () => {
 
             expect(blocks._getNearbyBlocks(0, 0)).not.toContain(1);
             expect(cellsHolding(1)).toEqual(["100,100"]);
+            expect(cellsHolding("1")).toEqual([]);
+            expectNumericKeysOnly();
         });
 
         it("keeps one entry per block rather than adding a second", () => {
             blocks._updateSpatialGrid("1");
 
             expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
+            expectNumericKeysOnly();
         });
 
         it("reports the block as a number, so the self-connection guard matches", () => {
@@ -1793,6 +1813,7 @@ describe("Spatial grid indexing", () => {
 
             expect(blocks._blockGridCell.has(0)).toBe(true);
             expect(cellsHolding(0)).toEqual(["18,0"]);
+            expectNumericKeysOnly();
         });
 
         it("places a block with no docks by its container position", () => {
@@ -1823,6 +1844,10 @@ describe("Spatial grid indexing", () => {
 
             // The same Set object is kept, so an unchanged block is not rewritten.
             expect(blocks._blockGridCell.get(1)).toBe(before);
+            // The early return must not leave a string alias behind either.
+            expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
+            expect(cellsHolding("1")).toEqual([]);
+            expectNumericKeysOnly();
         });
     });
 });

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1648,3 +1648,181 @@ describe("Blocks Foundation", () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Spatial grid key type
+//
+// The grid is a Map of cell key to a Set of block indices, plus a Map from
+// block index to the cells it occupies. Both compare keys strictly, so the
+// index a caller passes has to be the same type the grid already holds or the
+// block is registered twice and the older entry is never cleaned up, leaving
+// it listed at a position it has left.
+// ---------------------------------------------------------------------------
+
+describe("Spatial grid indexing", () => {
+    let mockActivity;
+    let blocks;
+
+    beforeEach(() => {
+        mockActivity = {
+            storage: {},
+            trashcan: {},
+            turtles: {},
+            boundary: {},
+            macroDict: {},
+            palettes: { dict: {}, show: jest.fn() },
+            logo: { synth: { loadSynth: jest.fn() } },
+            blocksContainer: { x: 0, y: 0 },
+            canvas: { width: 800, height: 600 },
+            refreshCanvas: jest.fn(),
+            errorMsg: jest.fn(),
+            setSelectionMode: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            setHomeContainers: jest.fn(),
+            __tick: jest.fn()
+        };
+        blocks = new Blocks(mockActivity);
+        blocks.blockList = [
+            { trash: false, name: "start", container: { x: 0, y: 0 }, docks: [[0, 0]] },
+            { trash: false, name: "note", container: { x: 0, y: 0 }, docks: [[0, 0]] }
+        ];
+        blocks._rebuildSpatialGrid();
+    });
+
+    /**
+     * Reads back the cells a block currently occupies in the grid.
+     * @param {number} idx - block index
+     * @returns {string[]} Sorted cell keys holding that block.
+     */
+    function cellsHolding(idx) {
+        const found = [];
+        for (const [cellKey, members] of blocks._spatialGrid) {
+            if (members.has(idx)) {
+                found.push(cellKey);
+            }
+        }
+        return found.sort();
+    }
+
+    it("registers every block under a numeric key when first built", () => {
+        expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
+        expect(cellsHolding(0)).toEqual(["0,0"]);
+        expect(cellsHolding(1)).toEqual(["0,0"]);
+    });
+
+    it("moves a block out of its old cell and into the new one", () => {
+        blocks.blockList[1].container.x = 5000;
+        blocks.blockList[1].container.y = 5000;
+
+        blocks._updateSpatialGrid(1);
+
+        expect(cellsHolding(1)).toEqual(["100,100"]);
+        expect(blocks._getNearbyBlocks(0, 0)).not.toContain(1);
+        expect(blocks._getNearbyBlocks(5000, 5000)).toContain(1);
+    });
+
+    describe("when the index arrives as a string", () => {
+        beforeEach(() => {
+            blocks.blockList[1].container.x = 5000;
+            blocks.blockList[1].container.y = 5000;
+        });
+
+        it("does not leave the block listed at the position it left", () => {
+            blocks._updateSpatialGrid("1");
+
+            expect(blocks._getNearbyBlocks(0, 0)).not.toContain(1);
+            expect(cellsHolding(1)).toEqual(["100,100"]);
+        });
+
+        it("keeps one entry per block rather than adding a second", () => {
+            blocks._updateSpatialGrid("1");
+
+            expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
+        });
+
+        it("reports the block as a number, so the self-connection guard matches", () => {
+            blocks._updateSpatialGrid("1");
+
+            const nearby = blocks._getNearbyBlocks(5000, 5000);
+
+            // block-drag-controller skips the dragged block with `b === thisBlock`,
+            // which a string entry would slip past.
+            expect(nearby).toContain(1);
+            expect(nearby).not.toContain("1");
+            expect(nearby.every(b => typeof b === "number")).toBe(true);
+        });
+
+        it("agrees with the numeric call in every respect", () => {
+            const asString = new Blocks(mockActivity);
+            asString.blockList = blocks.blockList.map(b => ({
+                ...b,
+                container: { ...b.container }
+            }));
+            asString._rebuildSpatialGrid();
+            asString._updateSpatialGrid("1");
+
+            blocks._updateSpatialGrid(1);
+
+            expect([...asString._blockGridCell.keys()]).toEqual([...blocks._blockGridCell.keys()]);
+            expect(asString._getNearbyBlocks(0, 0)).toEqual(blocks._getNearbyBlocks(0, 0));
+            expect(asString._getNearbyBlocks(5000, 5000)).toEqual(
+                blocks._getNearbyBlocks(5000, 5000)
+            );
+        });
+    });
+
+    describe("edge cases", () => {
+        it("ignores an index that names no block", () => {
+            blocks._updateSpatialGrid(99);
+
+            expect([...blocks._blockGridCell.keys()]).toEqual([0, 1]);
+        });
+
+        it("ignores a block that has no container yet", () => {
+            blocks.blockList.push({ trash: false, name: "note", container: null, docks: [[0, 0]] });
+
+            blocks._updateSpatialGrid(2);
+
+            expect(blocks._blockGridCell.has(2)).toBe(false);
+        });
+
+        it("keeps block 0 registered, rather than treating it as absent", () => {
+            blocks.blockList[0].container.x = 900;
+
+            blocks._updateSpatialGrid("0");
+
+            expect(blocks._blockGridCell.has(0)).toBe(true);
+            expect(cellsHolding(0)).toEqual(["18,0"]);
+        });
+
+        it("places a block with no docks by its container position", () => {
+            blocks.blockList[1].docks = [];
+            blocks.blockList[1].container.x = 5000;
+            blocks.blockList[1].container.y = 5000;
+
+            blocks._updateSpatialGrid("1");
+
+            expect(cellsHolding(1)).toEqual(["100,100"]);
+        });
+
+        it("registers a block in every cell its docks reach", () => {
+            blocks.blockList[1].docks = [
+                [0, 0],
+                [0, 600]
+            ];
+
+            blocks._updateSpatialGrid("1");
+
+            expect(cellsHolding(1)).toEqual(["0,0", "0,12"]);
+        });
+
+        it("does no work when the block has not left its cells", () => {
+            const before = blocks._blockGridCell.get(1);
+
+            blocks._updateSpatialGrid("1");
+
+            // The same Set object is kept, so an unchanged block is not rewritten.
+            expect(blocks._blockGridCell.get(1)).toBe(before);
+        });
+    });
+});

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -307,6 +307,13 @@ class Blocks {
             const block = this.blockList[blkIdx];
             if (!block || !block.container) return;
 
+            // The grid is keyed by block index, and Map and Set compare keys
+            // strictly. A caller iterating blockList with for...in hands over
+            // a string, which would register the block a second time and
+            // orphan the entry already held under its number, leaving it
+            // listed at a position it has left. Key on the number always.
+            const idx = Number(blkIdx);
+
             // Compute the set of cells this block should occupy
             const newKeys = new Set();
             if (block.docks && block.docks.length > 0) {
@@ -325,7 +332,7 @@ class Blocks {
             }
 
             // Check if cells changed; skip update if identical
-            const oldKeys = this._blockGridCell.get(blkIdx);
+            const oldKeys = this._blockGridCell.get(idx);
             if (oldKeys && oldKeys.size === newKeys.size) {
                 let same = true;
                 for (const k of newKeys) {
@@ -342,7 +349,7 @@ class Blocks {
                 for (const oldKey of oldKeys) {
                     const oldSet = this._spatialGrid.get(oldKey);
                     if (oldSet) {
-                        oldSet.delete(blkIdx);
+                        oldSet.delete(idx);
                         if (oldSet.size === 0) this._spatialGrid.delete(oldKey);
                     }
                 }
@@ -355,9 +362,9 @@ class Blocks {
                     cellSet = new Set();
                     this._spatialGrid.set(key, cellSet);
                 }
-                cellSet.add(blkIdx);
+                cellSet.add(idx);
             }
-            this._blockGridCell.set(blkIdx, newKeys);
+            this._blockGridCell.set(idx, newKeys);
         };
 
         /**


### PR DESCRIPTION
## Description

The spatial grid is a `Map` of cell key to a `Set` of block indices, plus a `Map` from block index to the cells that block occupies. Both compare keys strictly, so an index that arrives as a string is a different key from the number already stored.

`_updateSpatialGrid` therefore found nothing to clean up, left the block registered in the cells it had moved out of, and added a second entry under the string:

```
_blockGridCell keys: [0, 1, "1"]
grid: '0,0 -> {0,1}', '100,100 -> {1}'
```

The workspace layout controller reaches this by iterating `blockList` with `for...in`, which yields strings. So pressing **Home** left every block still listed at the position it had just been moved away from.

That matters because `_getNearbyBlocks` feeds the nearest-dock search in `block-drag-controller`. A dropped block could match a neighbour that is no longer there, and the guard that stops a block connecting to itself compares strictly:

```js
if (b === thisBlock) {
    continue;
}
```

`"1" === 1` is false, so that guard does not fire for a string entry.

## Related Issue

Fixes #8475

## Category

- [x] Bug fix

## Changes Made

Normalise the index once, where the grid is keyed:

```js
const idx = Number(blkIdx);
```

and use it for the four places that touch the `Map` and the `Set`: the lookup of the old cells, the removal from them, the insertion into the new cells, and the record of which cells the block now occupies.

**On where the fix goes.** The `for...in` in the layout controller is what produces the string, but it is one caller of a function that any code can reach, and `moveBlockRelative` also pushes whatever it is given into `dragGroup`. Fixing it at the boundary that owns the invariant covers every present and future caller, and it is a six line change to one file rather than a change to three call sites that leaves the next caller free to reintroduce it.

## Testing Performed

Sixteen tests added to `js/__tests__/blocks.test.js`, driving the real `Blocks` class rather than a stand in. **Seven of them fail without the fix.**

They cover the numeric case, the string case, and the equivalence of the two, plus the edge cases: an index naming no block, a block with no container, block `0` (which must not be mistaken for absent), a block with no docks, a block whose docks span two cells, and an unchanged block being left alone.

Each of the four coercion points was reverted individually to confirm the tests catch it:

| reverted point | tests failed |
|---|---:|
| lookup of old cells | 4 |
| record of occupied cells | 1 |
| cell membership | 5 |
| removal from old cells | 3 |

`npm run lint` and `npx prettier --check` are clean. Full suite: **8828 passing**.

Three tests fail in `scripts/generate-tests/__tests__/write-generated.test.js`, but they fail identically on a clean master, so they are unrelated to this change. They look like a path handling issue on Windows in the infrastructure added by #8381.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spatial positioning and indexing for blocks.
  * Prevented duplicate or stale entries when block indices are provided as strings.
  * Improved handling of blocks with invalid, missing, or dockless configurations.
  * Preserved correct behavior for blocks spanning multiple cells and blocks that do not move.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->