### PR TITLE
fix(blocks): index renameDos numerically so its block comparisons match

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -384,6 +384,269 @@ describe("Viewport Culling", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// renameDos
+//
+// Called when an action is renamed, to carry the new name onto every block
+// that refers to it. Two of its checks compare the loop index against block
+// numbers: the skipBlock guard, and the slot check that only renames the
+// action-name argument of an onbeatdo or listen block. Both need the index to
+// be a number.
+// ---------------------------------------------------------------------------
+
+describe("renameDos", () => {
+    let blocks;
+
+    beforeEach(() => {
+        const mockActivity = {
+            storage: {},
+            trashcan: {},
+            turtles: {},
+            boundary: {},
+            macroDict: {},
+            palettes: { dict: {}, show: jest.fn() },
+            logo: { synth: { loadSynth: jest.fn() } },
+            blocksContainer: { x: 0, y: 0 },
+            canvas: { width: 800, height: 600 },
+            refreshCanvas: jest.fn(),
+            errorMsg: jest.fn(),
+            setSelectionMode: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            setHomeContainers: jest.fn(),
+            __tick: jest.fn()
+        };
+        blocks = new Blocks(mockActivity);
+    });
+
+    /**
+     * Builds a text block holding a value, as the action-name argument is.
+     * @param {string} value - the name the block carries
+     * @param {number} parent - index of the block it hangs from
+     * @returns {Object} A text block shaped the way renameDos expects.
+     */
+    function textBlock(value, parent) {
+        return {
+            name: "text",
+            value,
+            trash: false,
+            connections: [parent],
+            text: { text: value },
+            container: { updateCache: jest.fn() }
+        };
+    }
+
+    /**
+     * Builds a parent block. Connections hold block numbers, matching the
+     * real blockList, because the slot check searches them with indexOf.
+     * @param {string} name - block name, such as "do" or "onbeatdo"
+     * @param {Array} connections - [parent, ...arguments]
+     * @returns {Object} A parent block.
+     */
+    function parentBlock(name, connections) {
+        return {
+            name,
+            value: null,
+            trash: false,
+            connections,
+            text: { text: "" },
+            container: { updateCache: jest.fn() }
+        };
+    }
+
+    describe("blocks that carry an action name", () => {
+        it("renames the argument of a plain do block", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", 0)];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("newAction");
+            expect(blocks.blockList[1].text.text).toBe("newAction");
+            expect(blocks.blockList[1].container.updateCache).toHaveBeenCalled();
+        });
+
+        it.each(["do", "calc", "doArg", "calcArg", "action"])(
+            "renames the argument of a %s block",
+            name => {
+                blocks.blockList = [parentBlock(name, [null, 1]), textBlock("myAction", 0)];
+
+                blocks.renameDos("myAction", "newAction");
+
+                expect(blocks.blockList[1].value).toBe("newAction");
+            }
+        );
+
+        it("leaves a block naming a different action alone", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("otherAction", 0)];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("otherAction");
+        });
+
+        it("leaves a block whose parent refers to nothing alone", () => {
+            blocks.blockList = [parentBlock("repeat", [null, 1]), textBlock("myAction", 0)];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+        });
+    });
+
+    // onbeatdo and listen take two arguments. The first is the beat or the
+    // event name, the second is the action to run, so only slot 2 is renamed.
+    describe("onbeatdo and listen, which rename only their slot 2 argument", () => {
+        it.each(["onbeatdo", "listen"])("renames the action name of a %s block", name => {
+            blocks.blockList = [
+                parentBlock(name, [null, 1, 2]),
+                textBlock("4", 0),
+                textBlock("myAction", 0)
+            ];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[2].value).toBe("newAction");
+            expect(blocks.blockList[2].text.text).toBe("newAction");
+        });
+
+        it.each(["onbeatdo", "listen"])("leaves the slot 1 argument of a %s block alone", name => {
+            // Slot 1 is the beat or the event name, which is not an action
+            // and must keep its value even when it reads the same.
+            blocks.blockList = [
+                parentBlock(name, [null, 1, 2]),
+                textBlock("myAction", 0),
+                textBlock("somethingElse", 0)
+            ];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[2].value).toBe("somethingElse");
+        });
+
+        it("renames slot 2 and leaves slot 1 alone when both name the action", () => {
+            blocks.blockList = [
+                parentBlock("onbeatdo", [null, 1, 2]),
+                textBlock("myAction", 0),
+                textBlock("myAction", 0)
+            ];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[2].value).toBe("newAction");
+        });
+    });
+
+    describe("skipBlock", () => {
+        it("leaves the block it is asked to skip untouched", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", 0)];
+
+            blocks.renameDos("myAction", "newAction", 1);
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[1].text.text).toBe("myAction");
+            expect(blocks.blockList[1].container.updateCache).not.toHaveBeenCalled();
+        });
+
+        it("renames the others while skipping the one named", () => {
+            blocks.blockList = [
+                parentBlock("do", [null, 1]),
+                textBlock("myAction", 0),
+                parentBlock("do", [null, 3]),
+                textBlock("myAction", 2)
+            ];
+
+            blocks.renameDos("myAction", "newAction", 1);
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[3].value).toBe("newAction");
+        });
+
+        it("skips block 0 when asked, rather than treating it as absent", () => {
+            // Block 0 is falsy as an index, so a guard written as a truth test
+            // rather than a comparison would fail to skip it.
+            blocks.blockList = [textBlock("myAction", 1), parentBlock("do", [null, 0])];
+
+            blocks.renameDos("myAction", "newAction", 0);
+
+            expect(blocks.blockList[0].value).toBe("myAction");
+        });
+
+        it("renames everything when no block is named", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", 0)];
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("newAction");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("does nothing when the name is unchanged", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", 0)];
+
+            blocks.renameDos("myAction", "myAction");
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[1].container.updateCache).not.toHaveBeenCalled();
+        });
+
+        it("handles an empty block list", () => {
+            blocks.blockList = [];
+
+            expect(() => blocks.renameDos("myAction", "newAction")).not.toThrow();
+        });
+
+        it("leaves trashed blocks alone", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", 0)];
+            blocks.blockList[1].trash = true;
+
+            blocks.renameDos("myAction", "newAction");
+
+            expect(blocks.blockList[1].value).toBe("myAction");
+        });
+
+        it("skips a block whose parent connection is null", () => {
+            blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", null)];
+
+            expect(() => blocks.renameDos("myAction", "newAction")).not.toThrow();
+            expect(blocks.blockList[1].value).toBe("myAction");
+        });
+
+        it("renames every referring block across a larger workspace", () => {
+            blocks.blockList = [
+                parentBlock("do", [null, 1]),
+                textBlock("myAction", 0),
+                parentBlock("onbeatdo", [null, 3, 4]),
+                textBlock("4", 2),
+                textBlock("myAction", 2),
+                parentBlock("listen", [null, 6, 7]),
+                textBlock("event", 5),
+                textBlock("myAction", 5),
+                parentBlock("repeat", [null, 9]),
+                textBlock("myAction", 8)
+            ];
+
+            blocks.renameDos("myAction", "newAction");
+
+            // Everything that names the action through a do, onbeatdo or
+            // listen is renamed; the repeat argument is not an action name.
+            expect(blocks.blockList.map(b => b.value)).toEqual([
+                null,
+                "newAction",
+                null,
+                "4",
+                "newAction",
+                null,
+                "event",
+                "newAction",
+                null,
+                "myAction"
+            ]);
+        });
+    });
+});
+
 describe("Blocks Foundation", () => {
     let mockActivity;
 

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -591,10 +591,14 @@ describe("renameDos", () => {
             expect(blocks.blockList[1].container.updateCache).not.toHaveBeenCalled();
         });
 
-        it("handles an empty block list", () => {
+        it("leaves an empty block list empty", () => {
             blocks.blockList = [];
 
-            expect(() => blocks.renameDos("myAction", "newAction")).not.toThrow();
+            blocks.renameDos("myAction", "newAction");
+
+            // A throw would fail the test on its own, so the postcondition is
+            // what is asserted: nothing was added to the list.
+            expect(blocks.blockList).toEqual([]);
         });
 
         it("leaves trashed blocks alone", () => {
@@ -609,8 +613,11 @@ describe("renameDos", () => {
         it("skips a block whose parent connection is null", () => {
             blocks.blockList = [parentBlock("do", [null, 1]), textBlock("myAction", null)];
 
-            expect(() => blocks.renameDos("myAction", "newAction")).not.toThrow();
+            blocks.renameDos("myAction", "newAction");
+
             expect(blocks.blockList[1].value).toBe("myAction");
+            expect(blocks.blockList[1].text.text).toBe("myAction");
+            expect(blocks.blockList[1].container.updateCache).not.toHaveBeenCalled();
         });
 
         it("renames every referring block across a larger workspace", () => {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3493,7 +3493,11 @@ class Blocks {
 
             /** Update the blocks, do->oldName should be do->newName */
             /** Named dos are modified in a separate function below. */
-            for (const blk in this.blockList) {
+            // Indexed numerically. Both the skipBlock check below and the
+            // connections.indexOf slot check further down compare against
+            // block numbers, and for...in would hand them a string, which is
+            // never strictly equal to the number it is matched against.
+            for (let blk = 0; blk < this.blockList.length; blk++) {
                 if (blk === skipBlock) {
                     continue;
                 }


### PR DESCRIPTION
## Description

`renameDos` walks the block list with `for...in`, which yields **string** keys, and two of its checks compare that index against block **numbers**.

**The slot check.** `onbeatdo` and `listen` take two arguments: the beat or event name, then the action to run. Only the second should be renamed, so the loop guards on the connection slot:

```js
if (
    (blkParent.name === "onbeatdo" || blkParent.name === "listen") &&
    blkParent.connections.indexOf(blk) !== 2
) {
    continue;
}
```

`connections` holds block numbers and `indexOf` compares strictly, so searching for `"2"` in `[null, 1, 2]` returns `-1` rather than `2`. `-1 !== 2` is always true, so it always continued and the action-name argument was **never renamed**. Renaming an action left every `on strong beat` and `listen` block pointing at a name that no longer existed, while every plain `do` block updated correctly.

**The skip guard.**

```js
if (blk === skipBlock) {
    continue;
}
```

A string is never strictly equal to the number that `js/blocks.js:1343` passes, so the block it asks to leave alone was renamed anyway.

Both follow from the one loop.

## Related Issue

Fixes #8477

## Category

- [x] Bug fix

## Changes Made

Index the loop numerically:

```js
for (let blk = 0; blk < this.blockList.length; blk++) {
```

with a comment recording why the index type matters here. That is the whole behaviour change; both comparisons then work as written.

`renameNameddos` below uses the same iteration style but only ever uses the index to look a block up, so it is left alone.

## Testing Performed

Twenty-six tests added, driving the real `Blocks` class. **Seven fail without the fix.**

They cover the blocks that carry an action name, `onbeatdo` and `listen` renaming slot 2 while leaving slot 1 alone (including the case where both slots hold the same text, which is what separates a working slot check from one that renames indiscriminately), `skipBlock` including block `0` (falsy as an index, so a guard written as a truth test rather than a comparison would fail it), and the edge cases: an unchanged name, an empty block list, trashed blocks, a null parent connection, and a larger workspace where a `repeat` argument must be left alone.

`npm run lint` and `npx prettier --check` are clean. Full suite: **8850 passing**.

Three tests fail in `scripts/generate-tests/__tests__/write-generated.test.js`, but they fail identically on a clean master, so they are unrelated. They look like path handling on Windows in the infrastructure added by #8381.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action-name renaming reliability by preserving correct block indices during processing.
  * Ensured blocks with missing parent connections retain their values, text, and cached state.
  * Preserved expected behavior when processing empty block lists and skipped blocks.

* **Tests**
  * Expanded coverage for empty lists, null parent connections, unchanged names, and larger workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->