### PR TITLE
docs: remove redundant lint and Prettier requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,7 +68,6 @@ Please complete the sections below to help us review your changes efficiently.
 - [ ] I have added/updated tests that prove the effectiveness of these changes.
 - [ ] I have updated the documentation to reflect these changes, if applicable.
 - [ ] I have followed the project's coding style guidelines.
-- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
 - [ ] I have addressed the code review feedback from the previous submission, if applicable.
 - [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ See [DevContainer README.md](./.devcontainer/README.md) for details.
 
 1. Clone and install: `git clone https://github.com/sugarlabs/musicblocks.git && npm install`
 2. Run locally: `npm run dev`
-3. Before pushing: `npm run lint && npx prettier --check . && npm test`
+3. Before pushing: `npm test`
 
 For writing tests, see [Docs/TESTING.md](./Docs/TESTING.md).
 


### PR DESCRIPTION
## Description

Removes the manual lint and Prettier requirement from the PR checklist and README.md.

Lint and Prettier are automatically applied through pre-checks, so asking contributors to run them manually is redundant.

## Category

- [x] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change

## Changes Made

- Removed the manual lint and Prettier requirement from the PR checklist.
- Kept `npm test` in the README for local testing.

## Steps to Reproduce

Not applicable.

## Visual Changes

Not applicable.

## Testing Performed

Not applicable. Documentation-only change.

## Checklist

- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

Lint and Prettier continue to run automatically through pre-checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Developer Quick Start instructions to run the test suite before pushing changes.
  - Removed linting and formatting checks from the pull request checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->