### PR TITLE
fix(widgets): scope pitchstaircase maximization to widget body

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -563,9 +563,16 @@ describe("PitchStaircase Widget", () => {
         let buttons;
         let widgetWindow;
         let wfbElement;
+        let widgetBodyElement;
+        const originalWindowFor = window.widgetWindows.windowFor;
+
+        afterEach(() => {
+            window.widgetWindows.windowFor = originalWindowFor;
+        });
 
         beforeEach(() => {
             buttons = {};
+            widgetBodyElement = { append: jest.fn(), style: {} };
             widgetWindow = {
                 clear: jest.fn(),
                 show: jest.fn(),
@@ -580,11 +587,12 @@ describe("PitchStaircase Widget", () => {
                 }),
                 addInputButton: jest.fn(value => ({ value, addEventListener: jest.fn() })),
                 addDivider: jest.fn(),
-                getWidgetBody: jest.fn(() => ({ append: jest.fn(), style: {} })),
+                getWidgetBody: jest.fn(() => widgetBodyElement),
                 destroy: jest.fn(),
                 onclose: null,
                 onmaximize: null,
-                _maximized: false
+                _maximized: false,
+                isMaximized: jest.fn(() => widgetWindow._maximized)
             };
             window.widgetWindows.windowFor = jest.fn(() => widgetWindow);
 
@@ -618,12 +626,12 @@ describe("PitchStaircase Widget", () => {
             expect(psc._undo).toHaveBeenCalled();
         });
 
-        test("Clear button repeatedly undoes until exhausted", () => {
-            psc._undo = jest
-                .fn()
-                .mockReturnValueOnce(true)
-                .mockReturnValueOnce(true)
-                .mockReturnValue(false);
+        test("Clear button calls _undo until false", () => {
+            let count = 0;
+            psc._undo = jest.fn(() => {
+                count++;
+                return count < 3;
+            });
             buttons["Clear"].onclick();
             expect(psc._undo).toHaveBeenCalledTimes(3);
         });
@@ -670,11 +678,32 @@ describe("PitchStaircase Widget", () => {
         test("onmaximize grows the widget body when maximized", () => {
             widgetWindow._maximized = true;
             widgetWindow.onmaximize();
-            expect(wfbElement.style.maxHeight).toBe(16 * PitchStaircase.BUTTONSIZE + "px");
+            expect(widgetBodyElement.style.maxHeight).toBe(16 * PitchStaircase.BUTTONSIZE + "px");
 
             widgetWindow._maximized = false;
             widgetWindow.onmaximize();
-            expect(wfbElement.style.maxHeight).toBe(10 * PitchStaircase.BUTTONSIZE + "px");
+            expect(widgetBodyElement.style.maxHeight).toBe(10 * PitchStaircase.BUTTONSIZE + "px");
+        });
+
+        test("onmaximize scopes to getWidgetBody and does not mutate foreign document elements", () => {
+            const foreignWfb = { style: { maxHeight: "50px" } };
+            jest.spyOn(document, "getElementsByClassName").mockReturnValue([foreignWfb]);
+
+            widgetWindow._maximized = true;
+            widgetWindow.onmaximize();
+
+            // Foreign element was untouched
+            expect(foreignWfb.style.maxHeight).toBe("50px");
+            // Own widget body was updated
+            expect(widgetBodyElement.style.maxHeight).toBe(16 * PitchStaircase.BUTTONSIZE + "px");
+        });
+
+        test("onmaximize safely exits if widgetBody or style is missing", () => {
+            widgetWindow.getWidgetBody = jest.fn(() => null);
+            expect(() => widgetWindow.onmaximize()).not.toThrow();
+
+            widgetWindow.getWidgetBody = jest.fn(() => ({}));
+            expect(() => widgetWindow.onmaximize()).not.toThrow();
         });
     });
 

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -853,7 +853,7 @@ class PitchStaircase {
                     }, 1000);
                 }
             };
-        const wfbWidget = document.getElementsByClassName("wfbWidget")[0];
+        const wfbWidget = widgetWindow.getWidgetBody();
         if (wfbWidget && wfbWidget.style) {
             wfbWidget.style.maxHeight = 10 * PitchStaircase.BUTTONSIZE + "px";
             wfbWidget.style.overflowY = "scroll";
@@ -880,10 +880,17 @@ class PitchStaircase {
         activity.textMsg(_("Click on a note to create a new step."), 3000);
 
         widgetWindow.onmaximize = () => {
-            if (widgetWindow._maximized) {
-                wfbWidget.style.maxHeight = 16 * PitchStaircase.BUTTONSIZE + "px";
-            } else {
-                wfbWidget.style.maxHeight = 10 * PitchStaircase.BUTTONSIZE + "px";
+            const body = widgetWindow.getWidgetBody();
+            if (body && body.style) {
+                const isMax =
+                    typeof widgetWindow.isMaximized === "function"
+                        ? widgetWindow.isMaximized()
+                        : widgetWindow._maximized;
+                if (isMax) {
+                    body.style.maxHeight = 16 * PitchStaircase.BUTTONSIZE + "px";
+                } else {
+                    body.style.maxHeight = 10 * PitchStaircase.BUTTONSIZE + "px";
+                }
             }
         };
     }


### PR DESCRIPTION


## Description

In `js/widgets/pitchstaircase.js`, `PitchStaircase.init()` previously retrieved its container element with `document.getElementsByClassName("wfbWidget")[0]`. When multiple widgets are open in the DOM (e.g. Music Keyboard or Help dialog), maximizing or restoring the Pitch Staircase window incorrectly mutated the `maxHeight` and `overflowY` styling of the *first* widget found in the document rather than its own container. Additionally, `widgetWindow.onmaximize` accessed `wfbWidget.style` directly without null checks, throwing an unhandled `TypeError` if `.wfbWidget` was unmounted.
This PR scopes the container directly to `widgetWindow.getWidgetBody()`, adds defensive null checks in `onmaximize`, uses `widgetWindow.isMaximized()`, and introduces thorough unit tests to prevent regression and mock leakage.


### Visible Impact & Root Cause:

- The help window's `.wfbWidget` is pre-mounted in the DOM at page load. As a result, `document.getElementsByClassName("wfbWidget")[0]` immediately targeted the help window container rather than the Pitch Staircase container.
- Consequently, on `master`, the Pitch Staircase body never received its intended `maxHeight` and `overflowY` styling upon maximizing, leaving its scroll container broken.


## Related Issue

**Fixes:** #8484

**Fixes:** #

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation
---

## Changes Made

- In `js/widgets/pitchstaircase.js`:
  - Replaced `document.getElementsByClassName("wfbWidget")[0]` with `widgetWindow.getWidgetBody()`.
  - Added defensive guards checking `body && body.style` before styling inside `widgetWindow.onmaximize`.
  - Used `widgetWindow.isMaximized()` API with fallback to `widgetWindow._maximized`.
- In `js/widgets/__tests__/pitchstaircase.test.js`:
  - Updated existing `onmaximize` tests to verify `widgetBodyElement.style.maxHeight`.
  - Added a test verifying that `onmaximize` scopes to `getWidgetBody()` and does NOT mutate foreign `document.getElementsByClassName("wfbWidget")` elements.
  - Added a test verifying `onmaximize` safely exits if `widgetBody` or `style` is missing/null.
  - Added `afterEach` restoring `window.widgetWindows.windowFor` to prevent mock leakage across describe blocks.

---

## Steps to Reproduce

1. Open Music Blocks (`http://127.0.0.1:3000`).
2. Open another widget first (e.g. Music Keyboard or Help dialog).
3. Drag and run a `pitch staircase` block to open the Pitch Staircase window.
4. Click the **Maximize** button (`⤢`) on Pitch Staircase.
5. Notice that without this fix, the first widget in the DOM has its `maxHeight` mutated instead of Pitch Staircase.

## Visual Changes

### Before
<img width="1917" height="911" alt="Screenshot 2026-09-05 105517" src="https://github.com/user-attachments/assets/252de417-3e67-48e8-a979-8bdacfe6c356" />




### After
<img width="1917" height="905" alt="Screenshot 2026-09-04 124946" src="https://github.com/user-attachments/assets/967e3499-f92c-4c79-a6f4-0bfeff1bc750" />




---

## Testing Performed

- `npm test -- js/widgets/__tests__/pitchstaircase.test.js` (All 60 tests passed)
- `npx prettier --check js/widgets/pitchstaircase.js js/widgets/__tests__/pitchstaircase.test.js` (Passed)
- `npm run lint` (Passed with 0 errors, 0 warnings)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PitchStaircase widget behavior when maximizing and restoring its display.
  - Ensured sizing changes apply only to the correct widget body.
  - Added safer handling when widget body or style information is unavailable.
  - Clear-button behavior now reliably supports undo actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->