### PR TITLE
fix(sensors): modernize enter key detection and add null guards (#7021)

### DIFF
--- a/js/blocks/SensorsBlocks.js
+++ b/js/blocks/SensorsBlocks.js
@@ -89,37 +89,46 @@ function setupSensorsBlocks(activity) {
             inputElem.style.mozUserSelect = "text";
             inputElem.style.msUserSelect = "text";
 
-            docById("labelDiv").replaceChildren(inputElem);
+            const labelDiv = docById("labelDiv");
+            if (labelDiv) {
+                labelDiv.replaceChildren(inputElem);
+            }
             const cblk = activity.blocks.blockList[blk].connections[1];
-            if (cblk !== null) {
+            if (cblk !== null && activity.blocks.blockList[cblk]) {
                 inputElem.placeholder = activity.blocks.blockList[cblk].value;
             }
-            inputElem.style.left = activity.turtles.getTurtle(turtle).container.x + "px";
-            inputElem.style.top = activity.turtles.getTurtle(turtle).container.y + "px";
+            const turtleObj = activity.turtles.getTurtle(turtle);
+            if (turtleObj && turtleObj.container) {
+                inputElem.style.left = turtleObj.container.x + "px";
+                inputElem.style.top = turtleObj.container.y + "px";
+            }
             inputElem.focus();
 
-            docById("labelDiv").classList.add("hasKeyboard");
+            if (labelDiv) {
+                labelDiv.classList.add("hasKeyboard");
+            }
 
             // Add a handler to continue the flow after the input.
             function __keyPressed(event) {
-                if (event.keyCode === 13) {
+                if (event.key === "Enter" || event.keyCode === 13) {
                     // RETURN
-                    const inputElem = docById("textLabel");
                     const value = inputElem.value;
                     if (isNaN(value)) {
                         logo.inputValues[turtle] = value;
                     } else {
-                        logo.inputValues[turtle] = Number(value);
+                        logo.inputValues[turtle] = parseFloat(value);
                     }
-
                     inputElem.blur();
                     inputElem.style.display = "none";
                     logo.clearTurtleRun(turtle);
-                    docById("labelDiv").classList.remove("hasKeyboard");
+                    const currentLabelDiv = docById("labelDiv");
+                    if (currentLabelDiv) {
+                        currentLabelDiv.classList.remove("hasKeyboard");
+                    }
                 }
             }
 
-            docById("textLabel").addEventListener("keypress", __keyPressed);
+            inputElem.addEventListener("keypress", __keyPressed);
         }
     }
     /**

--- a/js/blocks/__tests__/SensorsBlocks.test.js
+++ b/js/blocks/__tests__/SensorsBlocks.test.js
@@ -395,7 +395,100 @@ describe("setupSensorsBlocks", () => {
             expect(labelDiv.replaceChildren).toHaveBeenCalled();
             expect(labelDiv.innerHTML).toContain('input id="textLabel"');
             expect(activity.turtles.ithTurtle(turtleIndex).doWait).toHaveBeenCalledWith(120);
-            // Note: we are not simulating the keypress event.
+            expect(labelDiv.classList.add).toHaveBeenCalledWith("hasKeyboard");
+        });
+
+        it("should ignore non-Enter keys and keep listener active for subsequent Enter", () => {
+            const inputBlock = DummyFlowBlock.createdBlocks["input"];
+            activity.turtles.ithTurtle(turtleIndex).doWait = jest.fn();
+            activity.blocks.blockList["blkInput"] = { connections: [null, null] };
+            inputBlock.flow([], logo, turtleIndex, "blkInput");
+            const labelDiv = docById("labelDiv");
+            const inputElem = labelDiv.children[0];
+
+            inputElem.value = "test";
+            inputElem.dispatchEvent(new KeyboardEvent("keypress", { key: "a", bubbles: true }));
+
+            expect(logo.clearTurtleRun).not.toHaveBeenCalled();
+            expect(labelDiv.classList.remove).not.toHaveBeenCalledWith("hasKeyboard");
+            expect(logo.inputValues[turtleIndex]).toBeUndefined();
+
+            // Dispatch Enter after non-Enter key to verify listener remained active
+            inputElem.dispatchEvent(new KeyboardEvent("keypress", { key: "Enter", bubbles: true }));
+
+            expect(logo.inputValues[turtleIndex]).toBe("test");
+            expect(logo.clearTurtleRun).toHaveBeenCalledWith(turtleIndex);
+            expect(labelDiv.classList.remove).toHaveBeenCalledWith("hasKeyboard");
+        });
+
+        it("should handle Enter key (event.key === 'Enter') with string value", () => {
+            const inputBlock = DummyFlowBlock.createdBlocks["input"];
+            activity.turtles.ithTurtle(turtleIndex).doWait = jest.fn();
+            activity.blocks.blockList["blkInput"] = { connections: [null, null] };
+            inputBlock.flow([], logo, turtleIndex, "blkInput");
+            const labelDiv = docById("labelDiv");
+            const inputElem = labelDiv.children[0];
+
+            inputElem.value = "Hello MusicBlocks";
+            inputElem.dispatchEvent(new KeyboardEvent("keypress", { key: "Enter", bubbles: true }));
+
+            expect(logo.inputValues[turtleIndex]).toBe("Hello MusicBlocks");
+            expect(inputElem.style.display).toBe("none");
+            expect(logo.clearTurtleRun).toHaveBeenCalledWith(turtleIndex);
+            expect(labelDiv.classList.remove).toHaveBeenCalledWith("hasKeyboard");
+        });
+
+        it("should handle Enter key with numeric value and convert with parseFloat", () => {
+            const inputBlock = DummyFlowBlock.createdBlocks["input"];
+            activity.turtles.ithTurtle(turtleIndex).doWait = jest.fn();
+            activity.blocks.blockList["blkInput"] = { connections: [null, null] };
+            inputBlock.flow([], logo, turtleIndex, "blkInput");
+            const labelDiv = docById("labelDiv");
+            const inputElem = labelDiv.children[0];
+
+            inputElem.value = "123.45";
+            inputElem.dispatchEvent(new KeyboardEvent("keypress", { key: "Enter", bubbles: true }));
+
+            expect(logo.inputValues[turtleIndex]).toBe(123.45);
+            expect(typeof logo.inputValues[turtleIndex]).toBe("number");
+        });
+
+        it("should support legacy event.keyCode === 13 fallback on keypress", () => {
+            const inputBlock = DummyFlowBlock.createdBlocks["input"];
+            activity.turtles.ithTurtle(turtleIndex).doWait = jest.fn();
+            activity.blocks.blockList["blkInput"] = { connections: [null, null] };
+            inputBlock.flow([], logo, turtleIndex, "blkInput");
+            const labelDiv = docById("labelDiv");
+            const inputElem = labelDiv.children[0];
+
+            inputElem.value = "99";
+            inputElem.dispatchEvent(new KeyboardEvent("keypress", { keyCode: 13, bubbles: true }));
+
+            expect(logo.inputValues[turtleIndex]).toBe(99);
+            expect(logo.clearTurtleRun).toHaveBeenCalledWith(turtleIndex);
+        });
+
+        it("should handle missing labelDiv or turtle container defensively without throwing", () => {
+            const inputBlock = DummyFlowBlock.createdBlocks["input"];
+            activity.turtles.ithTurtle(turtleIndex).doWait = jest.fn();
+            activity.blocks.blockList["blkInput"] = { connections: [null, "missingCblk"] };
+
+            // Temporarily remove labelDiv
+            const savedLabelDiv = documentElements.labelDiv;
+            delete documentElements.labelDiv;
+
+            // Temporarily mock turtle without container
+            const turtle = activity.turtles.getTurtle(turtleIndex);
+            const originalContainer = turtle.container;
+            turtle.container = null;
+
+            expect(() => {
+                inputBlock.flow([], logo, turtleIndex, "blkInput");
+            }).not.toThrow();
+
+            // Restore
+            turtle.container = originalContainer;
+            documentElements.labelDiv = savedLabelDiv;
         });
     });
 


### PR DESCRIPTION
## Description

Resolves #7021 by modernizing keyboard event handling and adding defensive null guards in `InputBlock.flow()` (`js/blocks/SensorsBlocks.js`).

Previously, `InputBlock.flow()` re-queried `docById("textLabel")` redundantly inside the `__keyPressed` handler even though the closure already held a reference to `inputElem`. The handler also relied solely on the deprecated `event.keyCode === 13` property and lacked null guards for DOM elements and turtle objects that may not exist during edge-case lifecycle states.

## Related Issue

Part of  #7021

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

1. **Modernized Keyboard Event Detection**:
   - Replaced deprecated `event.keyCode === 13` checks with the standard `event.key === "Enter"` (with `event.keyCode === 13` retained as a legacy fallback).
2. **Direct Element Reference**:
   - Handled element operations directly through the lexical `inputElem` instance created in `flow()` instead of redundant `docById("textLabel")` queries inside the `__keyPressed` callback. The listener is now bound to `inputElem` directly rather than re-querying the DOM.
3. **Defensive Null Guards**:
   - Added checks for `labelDiv`, `cblk`, and `turtleObj.container` to prevent unhandled `TypeError` exceptions if invoked during unusual lifecycle states.
4. **Numeric Conversion**:
   - Switched from `Number()` to `parseFloat()` for numeric input conversion, consistent with rest of codebase.
5. **Unit Test Coverage**:
   - Expanded `js/blocks/__tests__/SensorsBlocks.test.js` with 6 new focused tests verifying:
     - Form setup and `hasKeyboard` class application.
     - Ignoring non-Enter keystrokes while keeping the listener active for subsequent Enter.
     - Handling `event.key === "Enter"` with string and numeric values.
     - Handling legacy `event.keyCode === 13` fallback.
     - Defensive behavior when `labelDiv` or turtle container is missing.

---

## Testing Performed

- `npm test -- js/blocks/__tests__/SensorsBlocks.test.js` (35/35 passing)
- `npm run lint` (0 errors, 0 warnings across the repository)
- `npx prettier --check js/blocks/SensorsBlocks.js js/blocks/__tests__/SensorsBlocks.test.js` (Passed)
- `npm test` (Full test suite: all passing)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).