### PR TITLE
fix(musickeyboard): give padded keys a voice on a single-note keyboard

### DIFF
--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -924,6 +924,41 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         );
         expect(g4Item).toBeDefined();
     });
+
+    test("gives every padded key a voice when the keyboard holds a single note", () => {
+        const keyboard = new MusicKeyboard(mockActivity);
+        // A keyboard built from exactly one pitch block: G4 (sol 4).
+        keyboard.noteNames = ["sol"];
+        keyboard.octaves = [4];
+        keyboard._rowBlocks = [44];
+        keyboard.instruments = ["guitar"];
+
+        mockActivity.blocks = {
+            blockList: {
+                44: { name: "pitch", connections: [null, 45, 46, null] },
+                45: { value: "sol" },
+                46: { value: 4 }
+            },
+            adjustDocks: jest.fn(),
+            clampBlocksToCheck: [],
+            adjustExpandableClampBlock: jest.fn(),
+            sendStackToTrash: jest.fn()
+        };
+
+        keyboard.init();
+
+        // The keys generated above the single note used to be created without a
+        // voice, which made them silent and threw when they were pressed.
+        const voiceless = keyboard.displayLayout.filter(item => item.voice === undefined);
+        expect(voiceless).toEqual([]);
+
+        // The padded keys should carry the voice of the note they were built from.
+        const c5Item = keyboard.displayLayout.find(
+            item => item.noteName === "C" && item.noteOctave === 5
+        );
+        expect(c5Item).toBeDefined();
+        expect(c5Item.voice).toBe("guitar");
+    });
 });
 
 describe("MusicKeyboard core logic", () => {

--- a/js/widgets/__tests__/musickeyboard.test.js
+++ b/js/widgets/__tests__/musickeyboard.test.js
@@ -948,9 +948,10 @@ describe("MusicKeyboard widgetWindow.onclose & event cleanup", () => {
         keyboard.init();
 
         // The keys generated above the single note used to be created without a
-        // voice, which made them silent and threw when they were pressed.
-        const voiceless = keyboard.displayLayout.filter(item => item.voice === undefined);
-        expect(voiceless).toEqual([]);
+        // voice, which made them silent and threw when they were pressed. Every
+        // key in the padded octave should carry the source note's voice.
+        expect(keyboard.displayLayout).toHaveLength(13);
+        expect(keyboard.displayLayout.every(item => item.voice === "guitar")).toBe(true);
 
         // The padded keys should carry the voice of the note they were built from.
         const c5Item = keyboard.displayLayout.find(

--- a/js/widgets/musickeyboard.js
+++ b/js/widgets/musickeyboard.js
@@ -1314,7 +1314,12 @@ function MusicKeyboard(activity) {
         // Fill in any gaps
         let lastOctave = obj[1];
         let thisOctave;
-        let lastVoice;
+        // Seed the voice from the first note, the same way the left-hand
+        // padding above does. The loop below is what normally keeps this up to
+        // date, but it starts at index 1, so with a single-note keyboard it
+        // never runs and the padding added after the last note would otherwise
+        // be left without a voice.
+        let lastVoice = noteList[0].voice;
         for (let i = 1; i < noteList.length; i++) {
             if (noteList[i].noteName === "drum") {
                 drumList.push(noteList[i]);


### PR DESCRIPTION
- [x] Bug Fix

## What's wrong

If a Music Keyboard contains only **one** pitch block, most of the keys it draws don't work. They look and highlight like normal keys, but pressing them plays nothing and throws an error in the console.

The widget always pads the keyboard out to a full octave around the notes you gave it. Those padded keys are supposed to inherit the voice of the note they were built from — and the ones *below* the note do. The ones *above* it end up with no voice at all, so the synth is asked to load an instrument called `undefined`.

```
Error in trigger: TypeError: sourceName is undefined
    loadSynth    js/utils/synthutils.js:1803
    trigger      js/utils/synthutils.js:2340
    __startNote  js/widgets/musickeyboard.js:693
```

The error is swallowed by the `catch` in `trigger()`, so nothing appears on screen — the key just stays silent, which makes it look like the keyboard is broken rather than the note.

## Steps to reproduce

1. Open Music Blocks and leave the default **Start** block on the canvas (the widget needs it — it's what creates the turtle).
2. From the **Widgets** palette, click **music keyboard**. It drops a standalone stack containing five pitch blocks: `sol4, fa4, mi4, re4, do4`.
3. Click that stack to run it. The keyboard opens and **every key works** — this is the healthy case worth checking first.
4. Now drag the **`mi` pitch block** out to the trash. It takes the blocks below it with it, leaving a single pitch block, `sol` / `4`.
5. Click the stack again to reopen the keyboard.
6. Open the browser console and press the keys.

**Before this change:** `C4` `D4` `E4` `F4` `G4` play normally, but **`G♯4` `A4` `A♯4` `B4` `C5`** are silent and each one logs the `TypeError` above.

**After this change:** all thirteen keys play, and the console stays clean.

It's easier to see if you press the widget's play button once first, so the browser lets audio start — otherwise every key is silent for an unrelated reason and it's hard to tell the two apart.

## The cause

`fillChromaticGaps()` in `js/widgets/musickeyboard.js` pads the sorted note list out to a full octave.

The left-hand padding reads the voice straight off the first note:

```js
newList.push({
    ...
    voice: noteList[0].voice
});
```

The right-hand padding instead uses `lastVoice`, which is declared empty and only assigned inside this loop:

```js
let lastVoice;
for (let i = 1; i < noteList.length; i++) {
    ...
    lastVoice = noteList[i].voice;
```

The loop starts at index 1, so when there's only one note it never runs at all. `lastVoice` is still `undefined` by the time the trailing keys are appended, and each of them gets `voice: undefined`.

That's also why the bug disappears as soon as you add a second pitch block — the loop runs once and `lastVoice` gets a real value.

## The fix

Seed `lastVoice` from the first note, so the right-hand padding starts from the same place the left-hand padding already does. One line, and it matches the existing behaviour rather than introducing a new rule.

Worth noting that the widget's own `onclose` handler already guards with `if (layoutItem.voice)` before stopping a sound, so the possibility of a missing voice was known about on the teardown path — it just wasn't handled where the keys are played.

### before: 

https://github.com/user-attachments/assets/8d91f0a3-3609-48d5-a294-c3c2ce9fa9d1

### after:

https://github.com/user-attachments/assets/ec6a406c-77cc-42da-9fb6-70a0007824ff




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed padded keyboard layouts so generated keys consistently retain the original note’s voice, including single-note keyboards and end-of-range padding.
  * Ensured single-note keyboard layouts generate the expected 13-key chromatic range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->