### PR TITLE
fix(turtle-painter): stop the canvas colour being converted twice

### DIFF
--- a/js/__tests__/turtle-painter-infinity.bug.test.js
+++ b/js/__tests__/turtle-painter-infinity.bug.test.js
@@ -9,6 +9,7 @@ global.NANERRORMSG = "Not a number.";
 global.getcolor = jest.fn(() => [50, 100, "rgba(255,0,49,1)"]);
 global.getMunsellColor = jest.fn(() => "rgba(128,64,32,1)");
 global.hex2rgb = jest.fn(() => "rgba(255,0,49,1)");
+global.isValidHex = require("../utils/utils-logic.js").isValidHex;
 
 const createMockTurtle = () => ({
     turtles: {

--- a/js/__tests__/turtle-painter.test.js
+++ b/js/__tests__/turtle-painter.test.js
@@ -141,7 +141,10 @@ describe("Painter Class", () => {
         });
 
         test("should initialize canvas color and alpha", () => {
-            expect(painter._canvasColor).toBe("rgba(255,0,49,1)");
+            // Hex, not rgba: _processColor() converts _canvasColor on every
+            // stroke, so storing a pre-converted rgba string here made the
+            // default pen color come out black.
+            expect(painter._canvasColor).toBe("#ff0031");
             expect(painter._canvasAlpha).toBe(1.0);
         });
 
@@ -1301,5 +1304,107 @@ describe("Additional Robustness & Missing Coverage Tests", () => {
         painter._hollowState = true;
         painter._arc(0, 0, 0, 0, 100, 200, 10, 0, Math.PI, false, false);
         expect(mockTurtle.ctx.lineCap).toBe("round");
+    });
+});
+
+describe("Canvas color representation (regression: turtle colors lost on Run)", () => {
+    // The mocks at the top of this file stub getMunsellColor() and hex2rgb()
+    // with constant return values, which hides any format mismatch between the
+    // code that writes _canvasColor and the code that reads it. These tests
+    // deliberately restore the real implementations.
+    const realUtils = require("../utils/utils-logic.js");
+    let painter;
+    let mockTurtle;
+    let savedHex2rgb;
+    let savedGetMunsellColor;
+
+    // The real getMunsellColor(20, 50, 100) from js/utils/munsell.js.
+    const MUNSELL_HEX = "#b06d00";
+
+    beforeEach(() => {
+        savedHex2rgb = global.hex2rgb;
+        savedGetMunsellColor = global.getMunsellColor;
+        global.hex2rgb = realUtils.hex2rgb;
+        global.getMunsellColor = jest.fn(() => MUNSELL_HEX);
+
+        setupRafMock();
+        mockTurtle = createMockTurtle();
+        painter = new Painter(mockTurtle);
+    });
+
+    afterEach(() => {
+        global.hex2rgb = savedHex2rgb;
+        global.getMunsellColor = savedGetMunsellColor;
+        teardownRafMock();
+        jest.clearAllMocks();
+    });
+
+    test("the default pen color draws as red, not black", () => {
+        painter._processColor();
+
+        expect(mockTurtle.ctx.strokeStyle).toBe("rgba(255,0,49,1)");
+    });
+
+    test("drawing after doClear keeps the turtle's color instead of going black", () => {
+        // This is the Run path: the toolbar clears every turtle before running,
+        // and every stroke afterwards came out black.
+        painter.turtles.c1ctx = { beginPath: jest.fn(), clearRect: jest.fn() };
+        painter.doClear(true, false, false);
+
+        painter._processColor();
+
+        expect(mockTurtle.ctx.strokeStyle).toBe("rgba(176,109,0,1)");
+        expect(mockTurtle.ctx.strokeStyle).not.toBe("rgba(0,0,0,1)");
+        expect(mockTurtle.ctx.fillStyle).toBe("rgba(176,109,0,1)");
+    });
+
+    test("doClear leaves _canvasColor in the same hex form the doSet* methods use", () => {
+        painter.turtles.c1ctx = { beginPath: jest.fn(), clearRect: jest.fn() };
+        painter.doClear(true, false, false);
+
+        expect(painter._canvasColor).toBe(MUNSELL_HEX);
+    });
+
+    test("_processColor applies the pen alpha to a hex canvas color", () => {
+        painter._canvasColor = MUNSELL_HEX;
+        painter._canvasAlpha = 0.5;
+
+        painter._processColor();
+
+        expect(mockTurtle.ctx.strokeStyle).toBe("rgba(176,109,0,0.5)");
+    });
+
+    test("_processColor tolerates an rgba canvas color and still applies the alpha", () => {
+        painter._canvasColor = "rgba(176,109,0,1)";
+        painter._canvasAlpha = 0.25;
+
+        painter._processColor();
+
+        expect(mockTurtle.ctx.strokeStyle).toBe("rgba(176,109,0,0.25)");
+    });
+
+    test("closeSVG emits a well-formed rgb() color from a hex canvas color", () => {
+        painter._canvasColor = MUNSELL_HEX;
+        painter._canvasAlpha = 1;
+        painter._svgPath = true;
+        painter._fillState = true;
+        painter.svgOutput = "M 0,0 ";
+
+        painter.closeSVG();
+
+        expect(painter.svgOutput).toContain("fill:rgb(176,109,0);");
+        expect(painter.svgOutput).toContain("stroke:rgb(176,109,0);");
+    });
+
+    test("closeSVG still handles an rgba canvas color", () => {
+        painter._canvasColor = "rgba(176,109,0,1)";
+        painter._canvasAlpha = 1;
+        painter._svgPath = true;
+        painter._fillState = false;
+        painter.svgOutput = "M 0,0 ";
+
+        painter.closeSVG();
+
+        expect(painter.svgOutput).toContain("stroke:rgb(176,109,0);");
     });
 });

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -16,8 +16,8 @@
  */
 
 /*
-   global _, getMunsellColor, getcolor, hex2rgb, STROKECOLORS, FILLCOLORS,
-   TURTLESVG, WRAP, clampNumber
+   global _, getMunsellColor, getcolor, hex2rgb, isValidHex, STROKECOLORS,
+   FILLCOLORS, TURTLESVG, WRAP, clampNumber
  */
 
 /*
@@ -27,7 +27,7 @@
    - js/utils/munsell.js
         getMunsellColor, getcolor
    - js/utils/utils.js
-        hex2rgb
+        hex2rgb, isValidHex
    - js/artwork.js
         STROKECOLORS, FILLCOLORS, TURTLESVG
    - js/toolbar.js
@@ -95,7 +95,9 @@ class Painter {
         this.cp2x = 100;
         this.cp2y = 100;
 
-        this._canvasColor = "rgba(255,0,49,1)"; // '#ff0031';
+        // Kept as a Munsell hex string: _processColor() converts it on every
+        // stroke, and converting an already-converted rgba string yields black.
+        this._canvasColor = "#ff0031";
         this._canvasAlpha = 1.0;
         this._fillState = false;
         this._hollowState = false;
@@ -775,7 +777,13 @@ class Painter {
      * @private
      */
     _processColor() {
-        const color = hex2rgb(this._canvasColor, this._canvasAlpha);
+        // _canvasColor is normally a Munsell hex string. Tolerate an
+        // already-converted "rgba(...)" string as well: hex2rgb() fails closed
+        // to black on anything that is not hex, so without this guard a single
+        // stray rgba write turns every later stroke black with no error.
+        const color = isValidHex(this._canvasColor)
+            ? hex2rgb(this._canvasColor, this._canvasAlpha)
+            : this._canvasColor.replace(/,[\d.]+\)$/, `,${this._canvasAlpha})`);
         this.turtle.ctx.strokeStyle = color;
         this.turtle.ctx.fillStyle = color;
     }
@@ -788,8 +796,13 @@ class Painter {
             // For the SVG output, we need to replace rgba() with
             // rgb();fill-opacity:1 and rgb();stroke-opacity:1
 
-            let svgColor = this._canvasColor.replace(/rgba/g, "rgb");
-            svgColor = svgColor.substr(0, this._canvasColor.length - 4) + ");";
+            // The opacity travels separately in fill-opacity/stroke-opacity
+            // below, so the color itself is emitted as rgb(...) with the alpha
+            // channel dropped. Accepts either representation of _canvasColor.
+            const rgba = isValidHex(this._canvasColor)
+                ? hex2rgb(this._canvasColor)
+                : this._canvasColor;
+            const svgColor = rgba.replace("rgba(", "rgb(").replace(/,[\d.]+\)$/, ");");
 
             this._svgOutput += '" style="stroke-linecap:round;fill:';
             this._svgOutput += this._fillState
@@ -1396,7 +1409,10 @@ class Painter {
         this._fillState = false;
         this._hollowState = false;
 
-        this._canvasColor = hex2rgb(getMunsellColor(this.color, this.value, this.chroma));
+        // Store the hex string, exactly as doSetColor/doSetChroma/doSetValue/
+        // doSetHue do. Pre-converting to rgba here made _processColor() convert
+        // it a second time, which yields black for every stroke after a clear.
+        this._canvasColor = getMunsellColor(this.color, this.value, this.chroma);
 
         this._svgOutput = "";
         this._svgPath = false;


### PR DESCRIPTION
Fixes #8492.

Pressing Run draws every stroke in black while printing `color` or `shade`
still reports the right numbers. The turtle attributes are not actually lost —
the cached canvas color is being converted twice.

### Root cause

`_canvasColor` is written in two incompatible formats. `doSetColor`,
`doSetChroma`, `doSetValue`, `doSetHue` and `Turtles.createArtwork` all store a
Munsell hex string, but `doClear` and the constructor default stored an
already-converted `rgba(...)` string. `_processColor()` then runs `hex2rgb()` on
whatever it finds, and `hex2rgb()` fails closed:

```
hex2rgb("#ff0031")          -> "rgba(255,0,49,1)"
hex2rgb("rgba(255,0,49,1)") -> "rgba(0,0,0,1)"
```

So any turtle whose `_canvasColor` last came from `doClear` paints black. That
is exactly the Run path: the toolbar's `_clearAllTurtles()` calls
`doClear(true, true, true)` on every turtle before running, whereas clicking a
Start block goes straight to `runLogoCommands()` and never calls `doClear` —
which is why the same project looks right from the Start block and black from
Run. The getter blocks read `painter.color`/`painter.value`, not the cached
string, so print keeps reporting correct values.

This is a regression from #8054, which made `_processColor()` a pure function.
The previous version normalised in place and was therefore idempotent:

```js
if (this._canvasColor[0] === "#") {
    this._canvasColor = hex2rgb(this._canvasColor.split("#")[1]);
}
```

### A second defect from the same cause

That in-place normalisation was also what kept `closeSVG()` working, since it
expects an rgba string and slices the alpha channel off by string length. With
it gone, `closeSVG()` receives a hex string on the `doSetColor` path and emits
garbage — `"#ff0031"` becomes the color literal `"#ff);"`. SVG export is
affected too.

### The fix

Hex becomes the single stored representation: it is what five of the six write
sites already use, and it lets `_processColor()` stay the one place that applies
`_canvasAlpha`. `doClear()` now stores the hex exactly as the `doSet*` methods
do, and the constructor default becomes `"#ff0031"` (the value its own trailing
comment already named). Both readers additionally accept an rgba string,
following the same `isValidHex()` guard `js/blocks/SensorsBlocks.js` already
uses for this field, so a future stray write degrades instead of silently
painting everything black.

### Deliberately not addressed

Whether Run should reset turtle position and pen at all.
`doClear(true, true, true)` also zeroes `x`/`y` and resets shade to
`DEFAULTVALUE` and color to `index * 10`, and nothing re-applies the Start
block's saved attributes at Run time. Whether that reset is wanted is a design
question, so this PR only restores the color that was being computed wrongly —
happy to follow up on the reset separately.

### One correction to the report

Shade is not reset to 0. `doClear` sets `value` to `DEFAULTVALUE` (50) and
`color` to `index * 10`, never 0. The black strokes come from the double
conversion above, not from a zeroed shade — which is consistent with print
still showing non-zero values.

### Testing

Adds seven cases to `js/__tests__/turtle-painter.test.js`. The existing mocks in
that file stub `hex2rgb()` and `getMunsellColor()` with constant return values,
which is why no test caught this; the new block restores the real `hex2rgb()`
and a hex-returning `getMunsellColor()`.

Five of the seven fail against the unpatched file, along with the constructor
assertion below. The other two — "_processColor applies the pen alpha to a hex
canvas color" and "closeSVG still handles an rgba canvas color" — pass both
before and after; they are guards proving this change does not break the paths
that already worked, not demonstrations of the bug.

One existing test is relaxed: "should initialize canvas color and alpha"
asserted `_canvasColor === "rgba(255,0,49,1)"`, which encoded the defect. It now
asserts `"#ff0031"`. `js/__tests__/turtle-painter-infinity.bug.test.js` gains a
one-line `isValidHex` stub; it does not load `utils-logic`, unlike the other
painter suites.

```
Before: 8819 passed, 231 suites
After:  8826 passed, 231 suites
Reverting turtle-painter.js with the tests kept: 6 failed, 123 passed
```

ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed canvas color handling for hexadecimal and RGBA values, preventing colors from unexpectedly rendering as black.
  - Improved SVG color output by preserving hexadecimal colors and applying transparency correctly.
  - Fixed clearing behavior so turtle colors remain consistent afterward.
  - Updated the default canvas color representation for more reliable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n