### PR TITLE
fix(activity): show the Stop button when a Start block is clicked

### DIFF
--- a/js/__tests__/activity_toolbar_integration.test.js
+++ b/js/__tests__/activity_toolbar_integration.test.js
@@ -189,4 +189,25 @@ describe("Activity Toolbar Integration", () => {
             expect(activity.toolbar.resetStop).toHaveBeenCalled();
         });
     });
+
+    describe("onRunTurtle", () => {
+        // Logo calls onRunTurtle() from runLogoCommands(), which is the one
+        // point every way of starting a project passes through -- including a
+        // click on a Start block, which never goes near the toolbar handlers.
+        test("shows the stop button when execution starts", () => {
+            activity.onRunTurtle();
+
+            expect(activity.toolbar.highlightStop).toHaveBeenCalledWith("red");
+        });
+
+        test("is the mirror image of onStopTurtle", () => {
+            activity.onRunTurtle();
+            expect(activity.toolbar.highlightStop).toHaveBeenCalledTimes(1);
+            expect(activity.toolbar.resetStop).not.toHaveBeenCalled();
+
+            activity.onStopTurtle();
+            expect(activity.toolbar.resetStop).toHaveBeenCalledTimes(1);
+            expect(activity.toolbar.highlightStop).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1288,6 +1288,59 @@ describe("Logo runLogoCommands", () => {
         });
     });
 
+    describe("the Stop button is shown however a project is started", () => {
+        // walterbender asked how #8494 was tested, given the many ways a run
+        // can begin. These drive runLogoCommands the way each of those ways
+        // does, and assert the activity callback that lights the Stop button
+        // actually fires -- rather than calling onRunTurtle() directly, which
+        // would prove only that the handler works when something calls it.
+        const startWith = (startHere, blockList) => {
+            logo._restoreConnections = jest.fn();
+            logo.runFromBlock = jest.fn();
+            logo.blockList = blockList;
+            logo.runLogoCommands(startHere, null);
+            return mockActivity.onRunTurtle;
+        };
+
+        test("clicking a single Start block", () => {
+            // block.js -> logo.runLogoCommands(topBlock), the path a click takes.
+            const onRun = startWith(0, [
+                { name: "start", value: 0, trash: false, connections: [] }
+            ]);
+            expect(onRun).toHaveBeenCalled();
+        });
+
+        test("a project holding several Start blocks", () => {
+            // The case in the screenshot: more than one stack, started together.
+            const onRun = startWith(null, [
+                { name: "start", value: 0, trash: false, connections: [] },
+                { name: "start", value: 1, trash: false, connections: [] },
+                { name: "start", value: 2, trash: false, connections: [] }
+            ]);
+            expect(onRun).toHaveBeenCalled();
+        });
+
+        test("the toolbar play button, with no block singled out", () => {
+            // toolbar-controller.js -> runLogoCommands(null, env).
+            const onRun = startWith(null, [
+                { name: "start", value: 0, trash: false, connections: [] }
+            ]);
+            expect(onRun).toHaveBeenCalled();
+        });
+
+        test("an action stack rather than a Start block", () => {
+            const onRun = startWith(0, [
+                { name: "action", value: 0, trash: false, connections: [] }
+            ]);
+            expect(onRun).toHaveBeenCalled();
+        });
+
+        test("a project with no blocks at all", () => {
+            const onRun = startWith(null, []);
+            expect(onRun).toHaveBeenCalled();
+        });
+    });
+
     test("executes startHere path", () => {
         logo._restoreConnections = jest.fn();
         logo.runFromBlock = jest.fn();

--- a/js/activity.js
+++ b/js/activity.js
@@ -2110,6 +2110,15 @@ class Activity {
          * When turtle starts running change stop button to running state
          */
         this.onRunTurtle = () => {
+            // Logo calls this from runLogoCommands(), so it covers every way a
+            // project can start -- the toolbar buttons and a click on a Start
+            // block alike. The toolbar handlers highlight the stop button
+            // themselves before delegating, so this is what makes the button
+            // appear for the paths that never touch the toolbar. Calling it
+            // twice on those paths is harmless: highlightStop() only assigns
+            // display and color.
+            this.toolbar.highlightStop(window.platformColor.stopIconcolor);
+
             // TODO: plugin support
         };
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -2112,11 +2112,12 @@ class Activity {
         this.onRunTurtle = () => {
             // Logo calls this from runLogoCommands(), so it covers every way a
             // project can start -- the toolbar buttons and a click on a Start
-            // block alike. The toolbar handlers highlight the stop button
-            // themselves before delegating, so this is what makes the button
-            // appear for the paths that never touch the toolbar. Calling it
-            // twice on those paths is harmless: highlightStop() only assigns
-            // display and color.
+            // block alike. The toolbar handlers highlight the stop button too,
+            // but not all of them do it up front: _doFastButton highlights
+            // after runFast(), and _doStepButton only when runStep() reports
+            // "started". This is what makes the button appear for the paths
+            // that never touch the toolbar at all. Where both run, the second
+            // call is harmless: highlightStop() only assigns display and color.
             this.toolbar.highlightStop(window.platformColor.stopIconcolor);
 
             // TODO: plugin support


### PR DESCRIPTION
Fixes #8217.

Running a project by clicking a Start block leaves the Stop button hidden, so
there is no way to stop it.

### Root cause

Showing and hiding the button are handled asymmetrically.

Hiding is central: Logo calls `activity.onStopTurtle()` when a run ends
(`js/logo.js:1317`), and that handler calls `toolbar.resetStop()`, which sets
`display` to `"none"`.

Showing is not. It lives in the toolbar button handlers — `_doFastButton` at
`js/activity.js:895` and `_doStepButton` at `js/activity.js:945` — so only a run
started from the toolbar ever calls `highlightStop()`. A Start-block click goes
`js/block.js` → `logo.runLogoCommands()`, never touching those handlers, so the
button stays hidden from the previous run's `resetStop()`.

### The counterpart hook already exists

Logo calls `activity.onRunTurtle()` from `runLogoCommands()` (`js/logo.js:1616`)
— the single point every start path passes through — but the handler was an
empty stub holding only a `// TODO: plugin support` comment.
`js/logo.js:1688-1692` even calls it a second time with the comment *"Launching
status/oscilloscope block would have hidden the Stop Button so show it again"*,
documenting a contract the stub does not honour.

So this PR implements the stub: `onRunTurtle()` now calls
`toolbar.highlightStop()`, mirroring `onStopTurtle()`'s `toolbar.resetStop()`.
That puts show and hide back in the same place and fixes every non-toolbar start
path at once. The toolbar paths call `highlightStop()` a second time, which is
harmless — it only assigns `display` and `color`.

### Why not the approach in #8223

The earlier attempt at this issue (closed for inactivity) added a
`highlightStop()` call after each of the six `runLogoCommands()` call sites in
`js/block.js`. That leaves the same asymmetry in place and misses every other
caller of `runLogoCommands`, including `js/blocks.js` and `js/SaveInterface.js`.

### Testing

Adds a `describe("onRunTurtle")` block to
`js/__tests__/activity_toolbar_integration.test.js`, alongside the existing
`describe("onStopTurtle")`, asserting the button is shown on start and that the
two handlers stay mirror images. Both fail against the unpatched file.

```
Before: 8819 passed, 231 suites
After:  8821 passed, 231 suites
Reverting activity.js with the tests kept: 2 failed, 7 passed
```

ESLint clean.

One caveat: this was diagnosed and tested at the unit level, so the end-to-end
repro from the issue is still worth a manual check before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The Stop button now consistently highlights when project execution begins, including projects started from Start blocks, the toolbar, action stacks, or empty projects.
  - Start and stop actions now provide consistent toolbar state transitions.
  - Screen reader announcements for messages and errors are now handled consistently.

- **Tests**
  - Added coverage for execution-state updates across all supported project-start scenarios.
  - Added coverage for performance-tracker URL validation and Stop-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n