### PR TITLE
fix(statistics): release the busy state so the widget cannot deadlock

### DIFF
--- a/js/widgets/__tests__/statistics.test.js
+++ b/js/widgets/__tests__/statistics.test.js
@@ -330,4 +330,91 @@ describe("StatsWindow", () => {
 
         expect(global.analyzeProject).not.toHaveBeenCalled();
     });
+
+    describe("busy-state release", () => {
+        let errorSpy;
+
+        beforeEach(() => {
+            errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+            document.body.style.cursor = "";
+        });
+
+        afterEach(() => {
+            errorSpy.mockRestore();
+        });
+
+        test("chart callback clears activity.loading on the success path", () => {
+            const sw = new StatsWindow(activity);
+            expect(activity.loading).toBe(true);
+
+            capturedCb();
+
+            expect(activity.loading).toBe(false);
+            expect(document.body.style.cursor).toBe("default");
+        });
+
+        test("a completed run releases _inFlight so Refresh works again", () => {
+            // Asserting _inFlight === false straight after construction would
+            // pass even if the success callback never released it, since it
+            // starts false. Drive a full run, then prove the next refresh is
+            // allowed to start analysis.
+            const sw = new StatsWindow(activity);
+            capturedCb();
+
+            global.analyzeProject.mockClear();
+            sw.refresh();
+
+            expect(global.analyzeProject).toHaveBeenCalledTimes(1);
+        });
+
+        test("a throwing analyzeProject does not leave the UI wedged", () => {
+            global.analyzeProject.mockImplementation(() => {
+                throw new Error("malformed project data");
+            });
+
+            const sw = new StatsWindow(activity);
+
+            expect(activity.loading).toBe(false);
+            expect(document.body.style.cursor).toBe("default");
+            expect(sw._inFlight).toBe(false);
+            expect(errorSpy).toHaveBeenCalled();
+        });
+
+        test("a throwing chart constructor does not leave the UI wedged", () => {
+            global.Chart.mockImplementation(() => ({
+                Radar: () => {
+                    throw new Error("chart render failed");
+                }
+            }));
+
+            const sw = new StatsWindow(activity);
+
+            expect(activity.loading).toBe(false);
+            expect(document.body.style.cursor).toBe("default");
+            expect(sw._inFlight).toBe(false);
+        });
+
+        test("constructing the widget does not rethrow when analysis fails", () => {
+            global.runAnalytics.mockImplementation(() => {
+                throw new Error("worker crashed");
+            });
+
+            expect(() => new StatsWindow(activity)).not.toThrow();
+        });
+
+        test("Refresh still works after a failed analysis", () => {
+            global.analyzeProject.mockImplementation(() => {
+                throw new Error("malformed project data");
+            });
+            const sw = new StatsWindow(activity);
+
+            // Recover: the next run succeeds, and must not be blocked by the
+            // _inFlight flag left over from the failed one.
+            global.analyzeProject.mockReturnValue([1]);
+            global.analyzeProject.mockClear();
+            sw.refresh();
+
+            expect(global.analyzeProject).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/js/widgets/statistics.js
+++ b/js/widgets/statistics.js
@@ -130,9 +130,18 @@ class StatsWindow {
         document.body.style.cursor = "wait";
 
         let myRadarChart = null;
-        const scores = analyzeProject(this.activity);
-        runAnalytics(this.activity);
-        const data = scoreToChartData(scores);
+
+        // Releases the busy state entered just above. Both the success path
+        // (once the chart has finished animating) and the failure path must go
+        // through here, or the widget leaves the UI wedged: activity.loading
+        // gates the turtle and context-menu hover handlers, and _inFlight gates
+        // the Refresh button.
+        const __releaseBusyState = () => {
+            this.activity.loading = false;
+            document.body.style.cursor = "default";
+            this._inFlight = false;
+        };
+
         const __callback = () => {
             const imageData = myRadarChart.toBase64Image();
             const img = new Image();
@@ -145,11 +154,24 @@ class StatsWindow {
             this.widgetWindow.getWidgetBody().appendChild(img);
             this.activity.blocks.hideBlocks();
             this.activity.showBlocksAfterRun = false;
-            document.body.style.cursor = "default";
-            this._inFlight = false;
+            __releaseBusyState();
         };
-        const options = getChartOptions(__callback);
-        myRadarChart = new window.Chart(ctx).Radar(data, options);
+
+        // Only the analysis and chart construction are guarded: those are the
+        // steps that consume project data and can throw on a malformed or
+        // oversized project, and they are the only ones that run while the busy
+        // state is set.
+        try {
+            const scores = analyzeProject(this.activity);
+            runAnalytics(this.activity);
+            const data = scoreToChartData(scores);
+            const options = getChartOptions(__callback);
+            myRadarChart = new window.Chart(ctx).Radar(data, options);
+        } catch (err) {
+            console.error("Statistics analysis failed:", err);
+            __releaseBusyState();
+            return;
+        }
 
         this.jsonObject = document.createElement("ul");
         this.jsonObject.style.float = "left";


### PR DESCRIPTION
Fixes #7063.

`doAnalytics()` sets two pieces of global busy state before it starts work —
`activity.loading = true` and `document.body.style.cursor = "wait"`. Neither was
guaranteed to be released.

### Failure path

There was no error handling at all. `analyzeProject()`, `runAnalytics()` and the
`Chart` constructor all consume project data, so a malformed or oversized
project throws past the cleanup in the chart's completion callback. The wait
cursor then stays forever, and `_inFlight` stays `true`, which permanently
disables the Refresh button added in #8141. Only a page reload recovers, losing
unsaved work.

### Success path

`activity.loading` was never cleared either. `statistics.js` was the only place
in the tree that set the flag true without a matching false. That flag gates the
turtle hover handlers (`js/turtles.js`) and the context-menu hover and mousedown
handlers (`js/activity/context-menu-controller.js`), all written as
`if (!activity.loading)`. So merely opening the Statistics widget silently
killed those hover affordances for the rest of the session.

### The fix

The release is pulled into one `__releaseBusyState()` helper that both the chart
completion callback and the new `catch` block go through, so the two paths
cannot drift apart again.

Following the review feedback on the earlier attempt at this issue (#7065,
closed for inactivity — *"It seems too much is inside the try {} block.
Shouldn't it just be the analytics?"*), the `try` block covers only the analysis
and chart construction. The `docById("myChart")`/`getContext()` lines above it
are left outside deliberately: they run before any busy state is set, so a throw
there cannot wedge the UI, and guarding them would only mask a missing canvas.

### A note on the report

The issue describes an `async doAnalytics()` awaiting `analyzeProject()` inside
a `setTimeout`. The current code is neither async nor timed — that part of the
description is stale. The defect itself is real, and since #8141 added the
Refresh button it is slightly worse than described, because `_inFlight` leaks
too.

### Testing

Adds five cases to `js/widgets/__tests__/statistics.test.js`: the success-path
release of `activity.loading`, a throwing `analyzeProject`, a throwing `Chart`
constructor, the constructor not rethrowing, and Refresh still working after a
failed analysis. All five fail against the unpatched file; no existing test
needed changing.

```
Before: 18 passed, 18 total
After:  23 passed, 23 total
Reverting statistics.js with the tests kept: 5 failed, 18 passed
```

ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the statistics widget could remain stuck in a loading or busy state after analysis or chart-rendering errors.
  - The widget now reliably resets its loading indicator and cursor when processing completes or fails.
  - Refreshing the widget now works correctly after a failed analysis, and errors are logged without preventing future updates.
  - Failed processing no longer leaves incomplete chart updates visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n