### PR TITLE
fix(musicutils): parse multi-digit and negative octaves

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -925,6 +925,17 @@ describe("noteToObj", () => {
         expect(noteToObj("C")).toEqual(["C", 4]);
         expect(noteToObj("Bb")).toEqual(["Bb", 4]);
     });
+    it("should parse octaves of more than one digit", () => {
+        expect(noteToObj("C10")).toEqual(["C", 10]);
+        expect(noteToObj("Gb12")).toEqual(["Gb", 12]);
+    });
+    it("should parse negative octaves", () => {
+        expect(noteToObj("A-1")).toEqual(["A", -1]);
+        expect(noteToObj("Gb-2")).toEqual(["Gb", -2]);
+    });
+    it("should parse octave zero", () => {
+        expect(noteToObj("C0")).toEqual(["C", 0]);
+    });
 });
 
 describe("frequencyToPitch", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4052,13 +4052,15 @@ const getTemperamentName = name => {
  * @returns {Array} An array containing the note, octave, and cents.
  */
 const noteToObj = note => {
-    let octave = parseInt(note.slice(note.length - 1), 10);
-    if (isNaN(octave)) {
-        octave = 4;
-    } else {
-        note = note.slice(0, note.length - 1);
+    // Take the whole trailing number rather than just the final character, so
+    // that octaves outside 0-9 survive: "C10" is C in octave 10, not "C1" in
+    // octave 0, and "A-1" is A in octave -1, not "A-" in octave 1. A leading
+    // minus only counts as a sign when digits follow it.
+    const match = /^(.*?)(-?\d+)$/.exec(note);
+    if (match === null) {
+        return [note, 4];
     }
-    return [note, octave];
+    return [match[1], parseInt(match[2], 10)];
 };
 
 /**


### PR DESCRIPTION
Fixes #8479.

`noteToObj` read the octave with `note.slice(note.length - 1)`, which takes a
single character, so any octave that is not one digit gets split in the wrong
place and the remainder is left in the pitch name:

```
noteToObj("C10")   ->  ["C1", 0]     wanted ["C", 10]
noteToObj("A-1")   ->  ["A-", 1]     wanted ["A", -1]
noteToObj("Gb12")  ->  ["Gb1", 2]    wanted ["Gb", 12]
```

The pitch name is the more damaging half. `"C1"` and `"A-"` are not note names,
so whatever consumes the result is looking up something that cannot match — the
wrong octave number is the visible symptom, but the corrupted name is why it
fails rather than merely sounding wrong.

This matches the whole trailing number instead of the last character. A leading
minus counts as a sign only when digits follow it, so a name with no octave still
falls through to the default of 4.

573 tests in `musicutils.test.js` pass. Reverting only the function fails two of
the three tests added — `"C0"` already worked, because a single zero is one
character, so that one is a regression guard rather than a demonstration.

### On the other locations in the issue

The report says the same line appears in three places. I found one site with that
expression; the others have the same class of bug by different means:

- `PitchBlocks.js:553` uses `"12345678".includes(lastChar)`, which additionally
  cannot recognise octave 0 or 9
- `EnsembleBlocks.js:697` and `:739` repeat the single-character assumption in
  two places, not one

So four sites, in three different shapes. I have deliberately not touched them
here — they want a single shared parse helper rather than three more one-line
patches, and that seems worth agreeing on first. Happy to do it in a follow-up if
you would like.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Note parsing now correctly supports multi-digit and negative octaves, such as `C10` and `A-1`.
  * Notes without an octave continue to default to octave 4.

* **Tests**
  * Added coverage for zero, multi-digit, and negative octave values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n