### PR TITLE
fix(musicutils): honour an octave passed as a numeric string

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -2645,6 +2645,18 @@ describe("calcOctave", () => {
     it("should be able to handle default case", () => {
         expect(calcOctave(4, "default", ["do"], "do")).toBe(4);
     });
+
+    it("should honour an octave passed as a numeric string", () => {
+        // Text blocks reach calcOctave with a string; the requested octave
+        // must not be replaced by the computed one.
+        expect(calcOctave(4, "7", null, "C")).toBe(7);
+        expect(calcOctave(4, "2", ["C"], "C")).toBe(2);
+    });
+
+    it("should clamp a numeric string to the same 1-9 range as a number", () => {
+        expect(calcOctave(4, "12", null, "C")).toBe(9);
+        expect(calcOctave(4, "0", null, "C")).toBe(1);
+    });
 });
 
 describe("calcOctaveInterval", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -7957,17 +7957,24 @@ const calcOctave = (currentOctave, arg, lastNotePlayed, currentNote, temperament
         case _("previous"):
         case "previous":
             return Math.max(changedCurrent - 1, 1);
-        default:
-            try {
-                if (changedCurrent) {
-                    return changedCurrent;
-                } else {
-                    return Math.floor(Number(arg));
-                }
-            } catch (e) {
-                // console.debug("cannot convert " + arg + " to a number");
-                return currentOctave;
+        default: {
+            // An octave can arrive here as a string: `calculateValueWithOctave`
+            // in NumberBlocks.js forwards a block value to this function
+            // precisely when that value is a string, so a text block holding
+            // "5" lands in this branch. `changedCurrent` is assigned in every
+            // branch above and is non-zero for any real octave, so testing it
+            // first made the conversion unreachable and silently replaced the
+            // requested octave with the computed one.
+            //
+            // Clamp to 1-9 to match the numeric branch at the top of this
+            // function. Anything that is not a number -- "default", an empty
+            // string, null -- still falls back to the computed octave.
+            const requested = Math.floor(Number(arg));
+            if (arg !== "" && arg !== null && !isNaN(requested)) {
+                return Math.max(1, Math.min(requested, 9));
             }
+            return changedCurrent;
+        }
     }
 };
 


### PR DESCRIPTION
Fixes #8423.

`calcOctave`'s default branch tested `if (changedCurrent)` before converting the
argument. `changedCurrent` is assigned in every branch of the chain above it and
is non-zero for any real octave, so `Math.floor(Number(arg))` was unreachable and
a requested octave was silently replaced by the computed one.

This is reachable from the UI: `calculateValueWithOctave` in `NumberBlocks.js`
forwards a block value to `calcOctave` precisely *because* that value is a
string, so a text block holding "5" lands in this branch.

Fixed by converting first and falling back to the computed octave only when the
argument is not a number, clamped to 1-9 to match the numeric branch at the top
of the function — so `"12"` and `12` now agree.

### One correction to the report

The issue's own first example does not demonstrate the bug:

```
calcOctave(4, "5", null, "C")   // reported 4, expected 5
```

Executed, that already returned **5** before this change — by coincidence, since
the computed octave for G against C at octave 4 happens to be 5. A reviewer
trying the reported example would reasonably conclude the bug was not real. The
clean demonstration is:

```
calcOctave(4, "7", null, "C")   // returns 5, the argument is ignored
```

which is what the added tests use.

`musicutils.test.js`: 572 pass. Reverting only the function fails the two added
tests.

Note: #8479 also touches `musicutils.js`, so whichever of the two merges second
may want a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved octave handling for numeric text values.
  - Octaves are now limited to the supported range of 1–9.
  - Empty, null, or invalid values fall back to the calculated octave.

- **Tests**
  - Added coverage for numeric-string octave inputs and range limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n