### PR TITLE
fix(munsell): read rgba() candidates in searchColors

### DIFF
--- a/js/utils/__tests__/munsell.test.js
+++ b/js/utils/__tests__/munsell.test.js
@@ -97,7 +97,10 @@ describe("munsell", () => {
         it("should identify a close match for a RGB value", () => {
             const color = searchColors(100, 150, 200);
             const nearestColor = getcolor(color);
-            expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
+            // getcolor() yields "#rrggbb" for only 20 of the 100 candidates and
+            // "rgba(...)" for the rest, so accept both. This previously matched
+            // hex alone, which held only while those other 80 were unreachable.
+            expect(nearestColor[2]).toMatch(/^(#[0-9a-fA-F]{6}|rgba\(\d+, \d+, \d+, \d+\.?\d*\))$/);
         });
     });
 });
@@ -197,5 +200,39 @@ describe("getMunsellColor edge cases", () => {
     it("should handle chroma at boundary 0", () => {
         const color = getMunsellColor(50, 50, 0);
         expect(color).toBeDefined();
+    });
+});
+
+describe("searchColors", () => {
+    const rgbOf = color =>
+        color.charAt(0) === "#"
+            ? [
+                  parseInt(color.substr(1, 2), 16),
+                  parseInt(color.substr(3, 2), 16),
+                  parseInt(color.substr(5, 2), 16)
+              ]
+            : color
+                  .match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/)
+                  .slice(1)
+                  .map(Number);
+
+    it("should find every candidate when asked for that candidate's own colour", () => {
+        // getcolor() returns "#rrggbb" for only 20 of the 100 candidates and
+        // "rgba(...)" for the rest. Parsing every one as hex gave NaN
+        // distances for those 80, and NaN < distance is false, so they could
+        // never be returned -- not even for their own colour.
+        for (let i = 0; i < 100; i++) {
+            const [r, g, b] = rgbOf(String(getcolor(i)[2]));
+            expect(searchColors(r, g, b)).toBe(i);
+        }
+    });
+
+    it("should be able to return more than the 20 hex-valued candidates", () => {
+        const reachable = new Set();
+        for (let i = 0; i < 100; i++) {
+            const [r, g, b] = rgbOf(String(getcolor(i)[2]));
+            reachable.add(searchColors(r, g, b));
+        }
+        expect(reachable.size).toBe(100);
     });
 });

--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -6833,14 +6833,37 @@ let getcolor = color => {
  * @param {number} b - Intensity of blue.
  * @returns {number} The color value of the nearest match.
  */
+/**
+ * Extract [r, g, b] from either of the two forms `interpColor` produces.
+ * It returns "#rrggbb" only when the interpolation parameter lands exactly on
+ * 0 or 1, and "rgba(r, g, b, a)" for every value in between.
+ * @param {string} color
+ * @returns {number[]} the red, green and blue components
+ */
+const colorToRGB = color => {
+    if (color.charAt(0) === "#") {
+        return [
+            parseInt(color.substr(1, 2), 16),
+            parseInt(color.substr(3, 2), 16),
+            parseInt(color.substr(5, 2), 16)
+        ];
+    }
+    const parts = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    return parts === null
+        ? [0, 0, 0]
+        : [parseInt(parts[1], 10), parseInt(parts[2], 10), parseInt(parts[3], 10)];
+};
+
 let searchColors = (r, g, b) => {
     let nearestColor = -1;
     let distance = 10000000;
     for (let i = 0; i < 100; i++) {
         const color = getcolor(i);
-        const r1 = parseInt(color[2].substr(1, 2), 16);
-        const g1 = parseInt(color[2].substr(3, 2), 16);
-        const b1 = parseInt(color[2].substr(5, 2), 16);
+        // Parse both forms. Reading every candidate as hex made the 80 that
+        // interpolate to "rgba(...)" yield NaN distances, and `NaN < distance`
+        // is false, so they could never be chosen -- a candidate could not even
+        // find itself.
+        const [r1, g1, b1] = colorToRGB(color[2]);
         const distSquared = (r1 - r) * (r1 - r) + (g1 - g) * (g1 - g) + (b1 - b) * (b1 - b);
         if (distSquared < distance) {
             distance = distSquared;


### PR DESCRIPTION
Fixes #8422.

`getcolor(i)[2]` comes from `interpColor`, which returns `"#rrggbb"` only when
the interpolation parameter lands exactly on 0 or 1, and `"rgba(r, g, b, a)"` for
every value in between. Of the 100 candidates `searchColors` walks, 20 are hex
and 80 are rgba.

`searchColors` parsed all of them as hex. For an rgba string `substr(1, 2)` reads
`"gb"`, so the components come back `NaN`, the squared distance is `NaN`, and
`NaN < distance` is false — those 80 candidates could never be returned.
Measured before the change:

```
candidates that do not find themselves:          80 of 100
distinct indices searchColors can ever return:   20
```

After: all 100 find themselves, and all 100 are reachable. Parsing is split into
a `colorToRGB` helper that handles both forms.

### One existing test had to change

`should identify a close match for a RGB value` asserted the nearest colour
matched `/^#[0-9a-fA-F]{6}$/`. That only held while the 80 rgba candidates were
unreachable — the assertion encoded the bug. With the fix,
`searchColors(100, 150, 200)` returns candidate 57, whose colour is an rgba
string.

The assertion now accepts either form, using the same regex this file already
applies to `getMunsellColor` a few tests further down, so it follows the file's
own existing convention rather than something invented to make a failure go away.

`js/utils/__tests__`: 1409 tests pass across 23 suites. Reverting only
`munsell.js` fails the two added tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved color searching for results represented in either hexadecimal or `rgba(...)` formats.
  - Interpolated color candidates now participate correctly in nearest-color matching.
  - Added safer handling for invalid color values to prevent incorrect search results.
  - Improved coverage across the full color candidate set, helping ensure every available candidate can be searched reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n