### PR TITLE
fix(pitchstaircase): clamp the dissected frequency to the audible range

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -38,6 +38,9 @@ global.normalizeNoteAccidentals = jest.fn(n => n);
 global.Singer = { masterVolume: [50] };
 global.last = arr => arr[arr.length - 1];
 global.clampNumber = require("../../utils/utils-logic.js").clampNumber;
+// Audible range, the same bounds frequencyToPitch clamps to.
+global.A0 = 27.5;
+global.C10 = 16744.04;
 
 window.innerWidth = 1200;
 window.btoa = jest.fn(s => s);
@@ -448,6 +451,21 @@ describe("PitchStaircase Widget", () => {
             expect(psc.Stairs[0][2]).toBeCloseTo(330);
             expect(psc._history).toContain(0);
             expect(psc._makeStairs).toHaveBeenCalled();
+        });
+
+        test("keeps the dissected frequency inside the audible range", () => {
+            // ratio1 > ratio2 makes the divisor < 1, so each dissect multiplies
+            // rather than divides. Repeating it used to run away past 1e11 Hz.
+            psc._musicRatio1 = { value: "3" };
+            psc._musicRatio2 = { value: "2" };
+            psc.Stairs = [["G", "", 392.0, 1, 1, 392.0, 4]];
+
+            for (let i = 0; i < 50; i++) {
+                const top = psc.Stairs[0][2];
+                psc._dissectStair(makeEvent(top));
+                expect(psc.Stairs[0][2]).toBeLessThanOrEqual(global.C10);
+                expect(psc.Stairs[0][2]).toBeGreaterThanOrEqual(global.A0);
+            }
         });
 
         test("sanitises invalid ratio inputs to their defaults", () => {

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -16,7 +16,7 @@
    global
 
    platformColor, _, SYNTHSVG, frequencyToPitch, DEFAULTVOICE,
-   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last, clampNumber
+   normalizeNoteAccidentals, PREVIEWVOLUME, Singer, last, clampNumber, A0, C10
  */
 
 /*
@@ -287,7 +287,13 @@ class PitchStaircase {
             return;
         }
 
-        const newFrequency = parseFloat(frequency) / inputNum;
+        // Dissecting divides by ratio2/ratio1, so entering the ratio the other
+        // way round (ratio1 > ratio2) makes the divisor less than 1 and every
+        // click multiplies the frequency instead. `frequencyToPitch` already
+        // clamps to [A0, C10], but the raw value stored on the stair, drawn in
+        // its label and handed to the synth was not, so it ran away unbounded.
+        // Clamp to the same range the pitch conversion uses.
+        const newFrequency = clampNumber(parseFloat(frequency) / inputNum, A0, C10);
         const obj = frequencyToPitch(newFrequency);
         let foundStep = false;
         let repeatStep = false;


### PR DESCRIPTION
Fixes #8338.

`_dissectStair` divides the stair's frequency by `ratio2 / ratio1`, so entering
the ratio the other way round — 3 and 2 rather than 2 and 3 — makes the divisor
less than 1 and every click multiplies the frequency instead. Nothing bounds the
result:

```
clicks   unclamped Hz    clamped Hz
     5      2.9768e+3       2976.75
    10      2.2605e+4      16744.04
    20      1.3035e+6      16744.04
    50      2.4995e+11     16744.04
```

The runaway value is stored on the stair, rendered into its label, handed to
`synth.trigger` and baked into the Hertz blocks on export, so it corrupts a saved
project as well as the display and the audio.

Rather than pick a new limit, this reuses the one already in the codebase:
`frequencyToPitch` clamps its input to `[A0, C10]`, which is why pitch-name
conversion never broke while the raw frequency did. `clampNumber` is already
imported in this file and used a few lines above for the stair width.

One note on test setup: `A0` and `C10` were not among the globals stubbed in
`pitchstaircase.test.js`, so I added them next to the existing `clampNumber` and
`frequencyToPitch` stubs.

59 tests pass; reverting only the widget fails the single added test.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented pitch staircase frequencies from exceeding the supported range during repeated stair dissection.
  - Improved stability of pitch conversion, display, and sound generation when repeatedly modifying staircases.
  - Added regression coverage to help ensure frequencies remain within the supported A0–C10 range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n