### PR TITLE
fix(connection-validator): bridge boolean docks to the any sockets

### DIFF
--- a/js/__tests__/connection-validator.test.js
+++ b/js/__tests__/connection-validator.test.js
@@ -65,6 +65,38 @@ describe("ConnectionValidator.testConnectionType — returns false for unsupport
     });
 });
 
+describe("ConnectionValidator.testConnectionType — boolean bridges to the any sockets", () => {
+    // Boolean was the only value type with no pairing to anyin/anyout, so a
+    // boolean could not be docked into Switch/Case (argTypes: ["anyin"]) and a
+    // named box could not be docked into if/while. See #8463.
+    it.each([
+        ["booleanout", "anyin"],
+        ["anyin", "booleanout"],
+        ["booleanin", "anyout"],
+        ["anyout", "booleanin"]
+    ])("allows %s -> %s", (type1, type2) => {
+        expect(ConnectionValidator.testConnectionType(type1, type2)).toBe(true);
+    });
+
+    it("still pairs boolean with itself", () => {
+        expect(ConnectionValidator.testConnectionType("booleanout", "booleanin")).toBe(true);
+        expect(ConnectionValidator.testConnectionType("booleanin", "booleanout")).toBe(true);
+    });
+
+    it("gives boolean the same any-bridge that number, text and solfege have", () => {
+        for (const base of ["number", "text", "solfege", "boolean"]) {
+            for (const pair of [
+                `${base}in:anyout`,
+                `anyout:${base}in`,
+                `anyin:${base}out`,
+                `${base}out:anyin`
+            ]) {
+                expect(ConnectionValidator.ALLOWED_CONNECTIONS.has(pair)).toBe(true);
+            }
+        }
+    });
+});
+
 describe("ConnectionValidator.testConnectionType — edge cases", () => {
     it("is case-sensitive", () => {
         const [type1, type2] = ALLOWED_PAIRS[0];

--- a/js/connection-validator.js
+++ b/js/connection-validator.js
@@ -32,6 +32,15 @@ const ALLOWED_CONNECTIONS = new Set([
     "anyout:textin",
     "booleanout:booleanin",
     "booleanin:booleanout",
+    // Boolean was the only value type with no bridge to the generic "any"
+    // sockets. Both directions are needed: a boolean output has to dock into
+    // the anyin of Switch/Case, and an any output such as a named box has to
+    // dock into the boolean input of if/while. number, text and solfege
+    // already carry all four of these pairings.
+    "booleanin:anyout",
+    "anyout:booleanin",
+    "anyin:booleanout",
+    "booleanout:anyin",
     "mediain:mediaout",
     "mediaout:mediain",
     "mediain:textout",


### PR DESCRIPTION
Fixes #8463.

Boolean is the only value type in `ALLOWED_CONNECTIONS` with no pairing to the
generic any sockets. Auditing the table by base type:

```
type          in:anyout  anyout:in  anyin:out  out:anyin
number          yes        yes        yes        yes
text            yes        yes        yes        yes
solfege         yes        yes        yes        yes
file            no         no         yes        yes
media           no         no         yes        yes
note            no         no         yes        yes
scaledegree     no         no         yes        yes
grid            no         no         no         yes
pitch           no         no         no         yes
boolean         no         no         no         no
```

Small correction to the report: the bridge is not uniform across the other types
— there are three tiers. Boolean is alone at zero, which is the part that holds.

This adds all four pairings rather than the two-entry form the middle tier uses,
because the two broken workflows need opposite directions: Switch/Case declare
`argTypes: ["anyin"]` so a boolean *output* must dock into an anyin, while a
named box has an any *output* that must dock into the boolean input of if/while.
That is the same set number, text and solfege already carry. Happy to narrow it
to just `booleanout:anyin` / `anyin:booleanout` if you would rather not open the
input side.

Tests cover the four pairings, that boolean still pairs with itself, and a
completeness check that boolean matches number/text/solfege. That last one is
what would have caught this when the any bridge was added for the other types —
the existing suite derives its cases from the live Set, so it could not.

211 tests pass across connection-validator, blocks and block-drag-controller;
reverting only the table fails the five added assertions.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Boolean connections can now link with generic `any` input and output sockets.
  - Boolean sockets support self-pairing and consistent compatibility with other supported socket types.

- **Tests**
  - Added coverage for boolean-to-generic connections, self-pairing, and compatibility parity across number, text, and solfege sockets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n