### PR TITLE
fix(blocks): use a numeric block index in renameDos

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -384,6 +384,48 @@ describe("Viewport Culling", () => {
     });
 });
 
+describe("renameDos", () => {
+    // for...in yields string keys; both comparisons in the loop are strict
+    // against numbers, so a string key matched neither. See #8477.
+    const makeBlock = (name, value, connections) => ({
+        name,
+        value,
+        connections,
+        trash: false,
+        text: { text: value },
+        container: { updateCache: jest.fn() }
+    });
+
+    const build = () => {
+        const blocks = new Blocks({
+            palettes: { dict: {} },
+            refreshCanvas: jest.fn(),
+            trashcan: { stopHighlightAnimation: jest.fn() }
+        });
+        // 0: the onbeatdo parent, holding the action name in slot 2
+        // 1: filler so slot 2 is a distinct index
+        // 2: the text block carrying the action name
+        blocks.blockList = [
+            makeBlock("onbeatdo", "unused", [null, 1, 2]),
+            makeBlock("text", "filler", [0]),
+            makeBlock("text", "oldAction", [0])
+        ];
+        return blocks;
+    };
+
+    it("renames the action name held in an onbeatdo slot", () => {
+        const blocks = build();
+        blocks.renameDos("oldAction", "newAction");
+        expect(blocks.blockList[2].value).toBe("newAction");
+    });
+
+    it("honours skipBlock", () => {
+        const blocks = build();
+        blocks.renameDos("oldAction", "newAction", 2);
+        expect(blocks.blockList[2].value).toBe("oldAction");
+    });
+});
+
 describe("Blocks Foundation", () => {
     let mockActivity;
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -3493,7 +3493,12 @@ class Blocks {
 
             /** Update the blocks, do->oldName should be do->newName */
             /** Named dos are modified in a separate function below. */
-            for (const blk in this.blockList) {
+            for (const blkKey in this.blockList) {
+                // `for...in` yields string keys. Both comparisons below are
+                // strict against numbers -- `connections` holds numeric block
+                // indices, and `skipBlock` is passed one -- so a string key
+                // silently matched neither.
+                const blk = Number(blkKey);
                 if (blk === skipBlock) {
                     continue;
                 }


### PR DESCRIPTION
Fixes #8477.

`renameDos` walks the block list with `for...in`, which yields string keys, and
two comparisons in the loop body are strict against numbers:

- `blkParent.connections.indexOf(blk)` searches an array of numeric block indices
  for `"2"`, so it returns `-1` and the `!== 2` guard is always true — `onbeatdo`
  and `listen`, which hold the action name in slot 2, were never renamed.
- `blk === skipBlock` compares a string to the block number passed at
  `js/blocks.js:1343`, so the skip argument had no effect.

Coerced the key once at the top of the loop.

Two tests added, for the rename and for `skipBlock`. Worth being straight about
the second: only the first fails without the fix. With the bug present nothing is
renamed at all, so the skip test passes trivially — it is a guard for later
rather than a demonstration now.

203 tests pass across the blocks, connection-validator and block-drag-controller
suites.

---

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n