### PR TITLE
fix(blocks): normalise the block index used as a spatial-grid key

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -384,6 +384,49 @@ describe("Viewport Culling", () => {
     });
 });
 
+describe("_updateSpatialGrid index normalisation", () => {
+    // The grid keys a Map and Sets by the block index, and those compare with
+    // SameValueZero, so "1" and 1 are distinct. Callers iterating blockList
+    // with `for...in` pass strings. See #8475.
+    const build = () => {
+        const blocks = new Blocks({
+            palettes: { dict: {} },
+            refreshCanvas: jest.fn(),
+            trashcan: { stopHighlightAnimation: jest.fn() }
+        });
+        blocks.blockList = [
+            {
+                name: "start",
+                trash: false,
+                docks: [[0, 0]],
+                container: { x: 10, y: 10 },
+                width: 20,
+                height: 20
+            }
+        ];
+        return blocks;
+    };
+
+    it('keys the grid the same way whether given 0 or "0"', () => {
+        const numeric = build();
+        numeric._updateSpatialGrid(0);
+        const viaNumber = [...numeric._blockGridCell.keys()];
+
+        const stringy = build();
+        stringy._updateSpatialGrid("0");
+        const viaString = [...stringy._blockGridCell.keys()];
+
+        expect(viaString).toEqual(viaNumber);
+    });
+
+    it("does not register the same block twice when called both ways", () => {
+        const blocks = build();
+        blocks._updateSpatialGrid(0);
+        blocks._updateSpatialGrid("0");
+        expect(blocks._blockGridCell.size).toBe(1);
+    });
+});
+
 describe("Blocks Foundation", () => {
     let mockActivity;
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -307,6 +307,18 @@ class Blocks {
             const block = this.blockList[blkIdx];
             if (!block || !block.container) return;
 
+            // The grid keys a Map and a set of Sets by this index, and those
+            // compare with SameValueZero, so "1" and 1 are different keys.
+            // Callers that iterate blockList with `for...in` hand over string
+            // keys -- workspace-layout-controller does at three sites -- which
+            // registered the block a second time and left the entry under its
+            // numeric key behind, so it kept matching at a position it had
+            // left. Normalise here, where the invariant lives, so it holds for
+            // every caller rather than only the ones known today.
+            if (typeof blkIdx === "string" && blkIdx !== "" && !isNaN(blkIdx)) {
+                blkIdx = Number(blkIdx);
+            }
+
             // Compute the set of cells this block should occupy
             const newKeys = new Set();
             if (block.docks && block.docks.length > 0) {


### PR DESCRIPTION
Fixes #8475.

`_updateSpatialGrid` keys `_blockGridCell` and the `_spatialGrid` cell Sets by
the block index, and Map/Set compare with SameValueZero — so `"1"` and `1` are
two different keys. `workspace-layout-controller.js` iterates the block list with
`for...in` at three sites and forwards those string keys through
`moveBlockRelative`. The lookup for the old cells misses, the block is never
removed from the cells it just left, and a second registration appears under the
string, leaving it matchable at a position it has moved away from.

I normalised inside `_updateSpatialGrid` rather than at the three loops, for two
reasons.

The grid owns this invariant, so fixing it there holds for any future caller
rather than only the three that exist today.

And the loop-level fix breaks five existing tests: the workspace-layout suite
models `blockList` as a plain object with letter keys rather than an array, so
`Number("a")` is `NaN` and the loops skip everything. Production `blockList` is an
array (`_rebuildSpatialGrid` iterates it by `.length`), so the coercion was
correct for production and wrong for the fixture — but normalising at the grid
avoids the question entirely.

Happy to do the loops as well if you would rather the callers pass the right
type, though that wants the fixture updating in the same PR.

620 tests pass across the blocks and activity suites; reverting only the
normalisation fails the two added tests.

---

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n