### PR TITLE
perf(turtle-singer): remove discarded per-note ratio computation

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -1122,6 +1122,71 @@ describe("processNote — delayedNotes reset on zero-duration tied notes (#8176)
     });
 });
 
+describe("processNote playback path avoids discarded ratio computation", () => {
+    let turtleMock;
+    let activityMock;
+    let savedGlobals;
+
+    beforeEach(() => {
+        savedGlobals = {
+            rationalToFraction: global.rationalToFraction,
+            getOctaveRatio: global.getOctaveRatio
+        };
+        global.rationalToFraction = jest.fn(() => [3, 2]);
+        global.getOctaveRatio = jest.fn(() => 2);
+
+        const blk = "mockBlk";
+        turtleMock = createTurtleMock();
+        turtleMock.singer = new Singer(turtleMock);
+        turtleMock.blink = jest.fn();
+        turtleMock.singer.inNoteBlock = [blk];
+        turtleMock.singer.notePitches = { [blk]: ["C"] };
+        turtleMock.singer.noteOctaves = { [blk]: [4] };
+        turtleMock.singer.noteCents = { [blk]: [0] };
+        turtleMock.singer.noteHertz = { [blk]: [0] };
+        turtleMock.singer.noteDrums = { [blk]: [] };
+        turtleMock.singer.noteBeatValues = { [blk]: [1] };
+        turtleMock.singer.keySignature = "C major";
+        turtleMock.singer.suppressOutput = true;
+        turtleMock.singer.justCounting = [];
+        turtleMock.singer.oscList = { [blk]: [] };
+
+        activityMock = createActivityMock(turtleMock);
+        activityMock.errorMsg = jest.fn();
+        Object.assign(activityMock.logo, {
+            runningLilypond: false,
+            runningMxml: false,
+            runningAbc: false,
+            runningMIDI: false,
+            specialArgs: [],
+            dispatchTurtleSignals: jest.fn()
+        });
+        Object.assign(activityMock.logo.synth, {
+            inTemperament: "equal",
+            changeInTemperament: false,
+            startingPitch: "A0",
+            getFrequency: jest.fn(() => [261.63]),
+            getCustomFrequency: jest.fn(() => [261.63])
+        });
+        activityMock.stage = { update: jest.fn() };
+    });
+
+    afterEach(() => {
+        global.rationalToFraction = savedGlobals.rationalToFraction;
+        global.getOctaveRatio = savedGlobals.getOctaveRatio;
+    });
+
+    test("does not build per-note frequency ratios during playback", () => {
+        Singer.processNote(activityMock, 4, false, "mockBlk", 0, jest.fn());
+
+        // Sanity: the pitched-note path actually ran.
+        expect(global.getNote).toHaveBeenCalled();
+        // The ratio/fraction results were never consumed anywhere, so the
+        // hot per-note path must not pay for computing them.
+        expect(global.rationalToFraction).not.toHaveBeenCalled();
+    });
+});
+
 describe("scalarDistance edge cases", () => {
     let turtleMock;
     let activityMock;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -24,7 +24,7 @@
     temperamentHasRatios, isEquallyTempered,
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
-   noteToFrequency, getTemperament, getOctaveRatio, rationalToFraction,
+   noteToFrequency, getTemperament,
    SEMITONES, normalizeNoteAccidentals, parseNoteString, getCurrentEDO,
    keySignatureToMode, getSavedCustomModes,
    clampNumber
@@ -37,10 +37,10 @@
     js/utils/musicutils.js
         frequencyToPitch, pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp, getStepSizeDown,
         numberToPitch, pitchToNumber, noteIsSolfege, getSolfege, SOLFEGENAMES1,
-        SOLFEGECONVERSIONTABLE, getInterval, noteToFrequency, getTemperament, getOctaveRatio,
+        SOLFEGECONVERSIONTABLE, getInterval, noteToFrequency, getTemperament,
         getCurrentEDO, isEquallyTempered
     js/utils/utils.js
-        rationalSum, _, rationalToFraction
+        rationalSum, _
     js/utils/synthutils.js
         instrumentsEffects, instrumentsFilters
  */
@@ -2267,43 +2267,6 @@ class Singer {
                                 );
                                 activity.logo.updateNotation(chordNotes, d, turtle, -1, chordDrums);
                             }
-                        }
-                    }
-
-                    const notesFrequency = isCustomTemperament(activity.logo.synth.inTemperament)
-                        ? activity.logo.synth.getCustomFrequency(notes)
-                        : activity.logo.synth.getFrequency(
-                              notes,
-                              activity.logo.synth.changeInTemperament
-                          );
-                    const startingPitch = activity.logo.synth.startingPitch;
-                    const startPitchParsed = parseNoteString(startingPitch);
-                    const frequency = getCachedPitchToFrequency(
-                        startPitchParsed[0],
-                        startPitchParsed[1],
-                        0,
-                        null,
-                        activity.logo.synth.inTemperament
-                    );
-                    const pitchNumber = getTemperament(
-                        activity.logo.synth.inTemperament
-                    ).pitchNumber;
-                    const ratio = [];
-                    const number = [];
-                    const numerator = [];
-                    const denominator = [];
-
-                    for (let k = 0; k < notesFrequency.length; k++) {
-                        if (notesFrequency[k] !== undefined) {
-                            ratio[k] = notesFrequency[k] / frequency;
-                            number[k] = (
-                                pitchNumber *
-                                (Math.log10(ratio[k]) / Math.log10(getOctaveRatio()))
-                            ).toFixed(0);
-                            // Cache rationalToFraction result to avoid duplicate calls
-                            const fraction = rationalToFraction(ratio[k]);
-                            numerator[k] = fraction[0];
-                            denominator[k] = fraction[1];
                         }
                     }
 


### PR DESCRIPTION
## Description

Deep inside `Singer.processNote`, in the branch that plays actual pitches, there's a block that runs once for every note played:

```js
const notesFrequency = isCustomTemperament(...) ? getCustomFrequency(notes) : getFrequency(notes, ...);
const startPitchParsed = parseNoteString(startingPitch);
const frequency = getCachedPitchToFrequency(...);
const pitchNumber = getTemperament(...).pitchNumber;
const ratio = [], number = [], numerator = [], denominator = [];
for (let k = 0; k < notesFrequency.length; k++) {
    ratio[k] = notesFrequency[k] / frequency;
    number[k] = (pitchNumber * (Math.log10(ratio[k]) / Math.log10(getOctaveRatio()))).toFixed(0);
    const fraction = rationalToFraction(ratio[k]);
    numerator[k] = fraction[0];
    denominator[k] = fraction[1];
}
```

Nothing reads any of it. I grepped every one of the nine computed values across the file: `notesFrequency`, `frequency`, `pitchNumber`, `ratio`, `number`, `numerator`, `denominator`, `startingPitch`, `startPitchParsed`. All references sit inside the block itself. The results are built, then dropped.

The cost is not trivial. `rationalToFraction` runs a bounded search that can take thousands of iterations for irrational inputs, and equal-temperament ratios (powers of 2^(1/12)) are exactly that. This sits in the hottest audio path in the app, once per chord note, per note played, and contributes nothing. A telling detail: the block was recently touched to cache the `rationalToFraction` result "to avoid duplicate calls". Someone optimised code whose output goes nowhere. That's the kind of trap dead code sets.

This PR deletes the block and removes `getOctaveRatio` / `rationalToFraction` from the file's globals comments (those were their last references here).

### The one non-obvious question: the temperament flag

The deleted block called `getFrequency(notes, changeInTemperament)`, and when that flag is set, `_getFrequency` triggers `temperamentChanged()`, which rebuilds the note-frequency table and clears the flag. So deleting the block removes one consumer of that flag. I traced whether that matters:

- For any temperament where the table is actually used (non-equal, non-custom), `needsFreqConversion()` in `Synth._performNotes` is true, so the play path calls `_getFrequency(notes, this.changeInTemperament)` itself and handles the change.
- For equal/EDO temperaments, `temperamentChanged` short-circuits: it resets the flag and returns without building anything. A stale flag there has no observable effect, and the next conversion-needing call resets it anyway.

So the flag consumption the block performed was either duplicated by the play path exactly when it mattered, or a no-op. Happy to walk through it in review if anything looks off.

## Related Issue

**Fixes:** none. Found through code inspection while auditing per-note work in `processNote`. No open PR or issue touches this block.

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [x] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/turtle-singer.js`: deleted the discarded ratio computation (about 36 lines) from the pitched-note branch of `processNote`; dropped `getOctaveRatio` and `rationalToFraction` from the globals comments since nothing in the file uses them any more.
- `js/__tests__/turtle-singer.test.js`: new test that drives `processNote` through the full pitched playback path and asserts `rationalToFraction` is never called, with a sanity check that the pitched path actually ran.

---

## Steps to Reproduce

Not applicable. No behaviour changes; the deleted values never left the function.

---

## Testing Performed

Proper red/green this time: the test was written first and failed against the old code, catching exactly one `rationalToFraction` call with ratio 0.5946 (261.63/440, the C4-over-A4 ratio the dead block computed). After the deletion it passes.

- `npx jest js/__tests__/turtle-singer.test.js`: 129/129 pass.
- With the neighbouring `logo` and `synthutils` suites: all pass.
- Full Jest suite: 8,812 pass. The 8 failures (`sampler`, `SaveInterface`, `mb-dialog`, `write-generated`) are pre-existing. I stashed this change and ran those four suites on a clean tree: identical 8 failures, byte for byte the same counts.
- `npx eslint` and `npx prettier --check` clean on both files. Commit is DCO signed off.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

If this table was meant to feed something (a ratio display, notation, debugging), that consumer never landed, and git history carries the block through several refactors with no reader ever added. Should someone want it later, reintroducing it next to its actual consumer would be the right shape, ideally behind a flag so plain playback doesn't pay for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pitched-note playback by removing unnecessary per-note ratio calculations.
  - Prevented related ratio-processing errors during note playback.

- **Tests**
  - Added regression coverage to verify pitched notes play without invoking obsolete ratio calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->