### PR TITLE
fix(midi): compare numeric indices when linking imported blocks

### DIFF
--- a/js/__tests__/midi.test.js
+++ b/js/__tests__/midi.test.js
@@ -310,4 +310,106 @@ describe("transcribeMidi", () => {
         const restBlocks = loadedBlocks.filter(block => block[1] === "rest2");
         expect(restBlocks.length).toBeGreaterThan(0);
     });
+
+    // Regression tests for the `for...in` string-key comparisons in
+    // transcribeMidi(). `for (const i in sched)` yields string keys, so the
+    // strict comparisons `i === 0`, `i === sched.length - 1`, `na === 0` and
+    // `na === notes.length - 1` are never true. Those flags decide which block
+    // each newnote and each trailing pitch docks to, so the emitted graph ends
+    // up with connections that the target block does not reciprocate.
+    const blockName = block => (Array.isArray(block[1]) ? block[1][0] : block[1]);
+
+    /**
+     * Mirrors the integrity check Blocks.adjustDocks() performs: for every
+     * non-null connection A -> B, block B must list A among its own
+     * connections. adjustDocks() logs "Did not find match for ..." and aborts
+     * the rest of that block's docks when this does not hold.
+     */
+    const findUnreciprocatedConnections = blocks => {
+        const byIndex = new Map(blocks.map(block => [block[0], block]));
+        const broken = [];
+        blocks.forEach(block => {
+            const [index, , , , connections] = block;
+            (connections || []).forEach((target, dock) => {
+                if (target === null || target === undefined) return;
+                const other = byIndex.get(target);
+                if (other === undefined) {
+                    broken.push(
+                        `${blockName(block)}(${index}).connections[${dock}] -> missing block ${target}`
+                    );
+                    return;
+                }
+                if (!(other[4] || []).includes(index)) {
+                    broken.push(
+                        `${blockName(block)}(${index}).connections[${dock}] -> ` +
+                            `${blockName(other)}(${target}), which does not connect back`
+                    );
+                }
+            });
+        });
+        return broken;
+    };
+
+    it("should emit a block graph whose connections are all reciprocated", async () => {
+        await transcribeMidi(mockMidi);
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+
+        expect(findUnreciprocatedConnections(loadedBlocks)).toEqual([]);
+    });
+
+    it("should dock the first note of an action to the action, not to its name text", async () => {
+        const singleNoteMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [{ name: "C4", midi: 60, time: 0, duration: 0.5 }]
+                }
+            ]
+        };
+
+        await transcribeMidi(singleNoteMidi);
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+
+        const actionBlock = loadedBlocks.find(block => blockName(block) === "action");
+        expect(actionBlock).toBeDefined();
+
+        // connections[1] is the action's name text, connections[2] its first child.
+        const nameText = loadedBlocks.find(block => block[0] === actionBlock[4][1]);
+        const firstChild = loadedBlocks.find(block => block[0] === actionBlock[4][2]);
+        expect(blockName(nameText)).toBe("text");
+        expect(blockName(firstChild)).toBe("newnote");
+
+        // The child has to point back at the action block.
+        expect(firstChild[4][0]).toBe(actionBlock[0]);
+        expect(firstChild[4][0]).not.toBe(nameText[0]);
+    });
+
+    it("should end the last pitch of a note rather than chaining it to the hidden block", async () => {
+        const chordMidi = {
+            header: mockMidi.header,
+            tracks: [
+                {
+                    instrument: { name: "acoustic grand piano", percussion: false },
+                    channel: 0,
+                    notes: [
+                        { name: "C4", midi: 60, time: 0, duration: 0.5 },
+                        { name: "E4", midi: 64, time: 0, duration: 0.5 }
+                    ]
+                }
+            ]
+        };
+
+        await transcribeMidi(chordMidi);
+        const loadedBlocks = loadNewBlocksSpy.mock.calls[0][0];
+
+        const pitchBlocks = loadedBlocks.filter(block => blockName(block) === "pitch");
+        expect(pitchBlocks).toHaveLength(2);
+
+        // connections[3] is the pitch's "next" dock. Only the last pitch of the
+        // chord ends the stack.
+        expect(pitchBlocks[0][4][3]).toBe(pitchBlocks[1][0]);
+        expect(pitchBlocks[1][4][3]).toBeNull();
+    });
 });

--- a/js/midi.js
+++ b/js/midi.js
@@ -184,7 +184,10 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
             shortestNoteDenominator = Math.max(shortestNoteDenominator, temp[1]);
         }
 
-        for (const i in sched) {
+        // Indexed loop, not `for...in`: `for...in` yields string keys, so the
+        // `i === 0` and `i === sched.length - 1` comparisons below would never
+        // be true and every note would be treated as neither first nor last.
+        for (let i = 0; i < sched.length; i++) {
             if (stopProcessing) break; // Exit inner loop if flag is set
             const { notes, start, end } = sched[i];
             const duration = end - start;
@@ -212,7 +215,9 @@ const transcribeMidi = async (midi, maxNoteBlocks) => {
                     );
                     x += 2;
                 } else {
-                    for (const na in notes) {
+                    // Indexed loop for the same reason as the `sched` loop above:
+                    // `na` has to be a number for these comparisons to hold.
+                    for (let na = 0; na < notes.length; na++) {
                         const name = notes[na].name;
                         const first = na === 0;
                         const last = na === notes.length - 1;


### PR DESCRIPTION
MIDI import produces a block graph whose connections are not reciprocated, so
`Blocks.adjustDocks()` aborts on them and logs `Did not find match for ...`. The
imported note stacks are left at the `0,0` coordinates the importer wrote instead
of being laid out under their action block, and dragging a pitch pulls the
following hidden spacer out of its note clamp.

`transcribeMidi()` walks `sched` and each note's `notes` with `for...in`, which
yields string keys. Four flags compare those keys against numbers:

```
i === 0                    "0" === 0    -> always false
i === sched.length - 1     "2" === 2    -> always false
na === 0                                -> always false
na === notes.length - 1                 -> always false
```

`first` and `last` decide which block each newnote and each trailing pitch docks
to, so both are always taken to be neither first nor last: the first `newnote` of
every action docks to the action's **name text** block rather than the action
itself, and the last `pitch` of every note docks its "next" to the note's
`hidden` spacer rather than ending the stack.

This is a regression from #7614, which replaced non-null `==` with `===` across
seven files. `i == 0` and `na == 0` were correct with loose equality precisely
because `for...in` keys are strings; making them strict without changing the
loops turned every comparison false. Nothing caught it because the MIDI tests
assert block counts and note values, never the connection graph.

I fixed it at the loops rather than at the four comparisons, so the flags cannot
drift back if a fifth one is added later.

The new tests include a reciprocity check that mirrors the integrity check
`adjustDocks()` itself performs. On the existing three-track fixture it reports
11 unreciprocated connections before the fix and none after. 8822 tests pass
across 231 suites; reverting only `js/midi.js` fails exactly the three added
tests.

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n
