### PR TITLE
fix(musicutils): normalise the mode name when choosing sharps or flats

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1825,6 +1825,51 @@ describe("buildScale", () => {
             [2, 2, 1, 2, 2, 2, 1]
         ]); // Default C major scale
     });
+
+    // The sharp/flat preference tables are keyed on "<key> major" / "<key> minor",
+    // so the mode has to be mapped onto its major/minor equivalent before the
+    // lookup. Without that, every mode name the mode pie menu offers misses the
+    // table and the scale is spelled with the wrong accidental.
+    const modalCases = [
+        // E natural minor and E minor are the same key and must agree.
+        { keySignature: "E natural minor", expected: ["E", "F♯", "G", "A", "B", "C", "D", "E"] },
+        { keySignature: "E aeolian", expected: ["E", "F♯", "G", "A", "B", "C", "D", "E"] },
+        { keySignature: "B natural minor", expected: ["B", "C♯", "D", "E", "F♯", "G", "A", "B"] },
+        { keySignature: "G ionian", expected: ["G", "A", "B", "C", "D", "E", "F♯", "G"] },
+        { keySignature: "C lydian", expected: ["C", "D", "E", "F♯", "G", "A", "B", "C"] },
+        { keySignature: "A dorian", expected: ["A", "B", "C", "D", "E", "F♯", "G", "A"] },
+        { keySignature: "B phrygian", expected: ["B", "C", "D", "E", "F♯", "G", "A", "B"] },
+        { keySignature: "D mixolydian", expected: ["D", "E", "F♯", "G", "A", "B", "C", "D"] }
+    ];
+
+    modalCases.forEach(({ keySignature, expected }) => {
+        it(`should spell ${keySignature} with the accidental of its relative key`, () => {
+            expect(buildScale(keySignature)[0]).toEqual(expected);
+        });
+    });
+
+    it("should spell a mode the same way as its major/minor synonym", () => {
+        expect(buildScale("E natural minor")[0]).toEqual(buildScale("E minor")[0]);
+        expect(buildScale("E aeolian")[0]).toEqual(buildScale("E minor")[0]);
+        expect(buildScale("C ionian")[0]).toEqual(buildScale("C major")[0]);
+    });
+
+    it("should not repeat a letter name in a seven-note modal scale", () => {
+        modalCases.forEach(({ keySignature }) => {
+            const letters = buildScale(keySignature)[0]
+                .slice(0, 7)
+                .map(note => note[0]);
+            expect(new Set(letters).size).toBe(7);
+        });
+    });
+
+    it("should agree with getSharpFlatPreference for modal key signatures", () => {
+        // getSharpFlatPreference already normalises through modeMapper; buildScale
+        // must not contradict it.
+        expect(getSharpFlatPreference("E natural minor")).toBe("sharp");
+        expect(buildScale("E natural minor")[0]).toContain("F♯");
+        expect(buildScale("E natural minor")[0]).not.toContain("G♭");
+    });
 });
 
 describe("scalePatternToEDO", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -6563,15 +6563,24 @@ const buildScale = (keySignature, edo) => {
 
     const halfSteps = getModePattern(obj[1], currentEDO);
 
+    // SHARPPREFERENCE and FLATPREFERENCE are keyed only on "<key> major" and
+    // "<key> minor", but keySignatureToMode() returns the raw mode name --
+    // "natural minor", "aeolian", "lydian", "dorian" and so on. Map the mode
+    // onto its major/minor equivalent first, exactly as getSharpFlatPreference()
+    // does, otherwise the lookup misses for every mode the pie menu offers and
+    // the scale falls through to the wrong spelling.
+    const preferenceMode = modeMapper(obj[0], obj[1]);
+    const preferenceKey = preferenceMode[0] + " " + preferenceMode[1];
+
     let thisScale;
     if (NOTESFLAT.includes(myKeySignature)) {
-        if (SHARPPREFERENCE.includes(obj[0].toLowerCase() + " " + obj[1])) {
+        if (SHARPPREFERENCE.includes(preferenceKey)) {
             thisScale = NOTESSHARP;
         } else {
             thisScale = NOTESFLAT;
         }
     } else {
-        if (FLATPREFERENCE.includes(obj[0].toLowerCase() + " " + obj[1])) {
+        if (FLATPREFERENCE.includes(preferenceKey)) {
             thisScale = NOTESFLAT;
         } else {
             thisScale = NOTESSHARP;


### PR DESCRIPTION
Choosing E and "natural minor" spells the scale `E G♭ G A B C D`. The letter G
appears twice, and the same key entered as "E minor" spells it correctly as
`E F♯ G A B C D`.

`buildScale()` picks between `NOTESSHARP` and `NOTESFLAT` by looking the key
signature up in `SHARPPREFERENCE` / `FLATPREFERENCE`. Those tables are keyed only
on `"<key> major"` and `"<key> minor"`, but `keySignatureToMode()` returns the raw
mode name, and for minor keys it canonicalises to `"natural minor"` — even the
`Em` shorthand comes back as `["E", "natural minor"]`. So the lookup string is
`"e natural minor"`, which is in neither table, and the scale falls through to the
flat spelling.

`getSharpFlatPreference()`, 1900 lines earlier in the same file, already solves
this: it runs `keySignatureToMode()` through `modeMapper()` first, so
`"E natural minor"` becomes `"e minor"` and resolves to sharp. `buildScale()`
skips that step, so the two functions contradict each other for the same key
signature. This adds the missing `modeMapper()` call.

The affected mode names are precisely the ones the mode pie menu offers —
ionian, dorian, phrygian, lydian, mixolydian, locrian, aeolian and natural minor
— and plain "minor" is not in that menu at all, so the normal UI route to E minor
is the broken one. Pitches sound right; it is the spelling that is wrong, which
is what the staff, the solfege wheel and the Lilypond export all read from.

One thing I left alone on purpose: `modeMapper()` has no case for harmonic or
melodic minor, which are instead listed explicitly in `FLATPREFERENCE` for the
six flat keys. `E harmonic minor` is therefore still mis-spelled. Fixing that
means deciding whether `modeMapper` or the preference tables should own that
mapping — happy to do it either way if you have a preference, but I did not want
to guess.

Verified: 8830 tests pass across 231 suites, and no existing test changed
behaviour. Reverting only `musicutils.js` fails exactly the eleven added tests.

### Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n
