### PR TITLE
fix: cancel stale trash signal timers

### DIFF
--- a/js/__tests__/activity_trashsignal.test.js
+++ b/js/__tests__/activity_trashsignal.test.js
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Sugar Labs
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the The GNU Affero General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
+
+const { loadActivitySandbox } = require("./helpers/activity-vm-sandbox");
+
+const makeActivity = (clearTimeoutImplementation = timerId => global.clearTimeout(timerId)) => {
+    const clearTimeoutSpy = jest.fn(clearTimeoutImplementation);
+    const { Activity } = loadActivitySandbox({
+        overrides: {
+            clearTimeout: clearTimeoutSpy,
+            closeWidgets: jest.fn()
+        }
+    });
+    const activity = new Activity();
+    activity.blocksContainer = { x: 100, y: 200 };
+    activity.palettes = { dict: {} };
+    activity.refreshCanvas = jest.fn();
+    activity.stage = { dispatchEvent: jest.fn() };
+    activity.blocks = {
+        palettes: { dict: {} },
+        blockList: [],
+        trashStacks: [],
+        trashPreviews: {},
+        blockArt: {},
+        blockCollapseArt: {},
+        _beginDeferCheckBounds: jest.fn(),
+        _endDeferCheckBounds: jest.fn(),
+        captureStackPreview: jest.fn(() => null),
+        deleteActionBlock: jest.fn(),
+        moveBlockRelative: jest.fn()
+    };
+    activity.saveLocally = jest.fn();
+    activity.clearTimeoutSpy = clearTimeoutSpy;
+    return activity;
+};
+
+const addActionBlocks = (activity, count) => {
+    for (let i = 0; i < count; i++) {
+        activity.blocks.blockList.push({
+            name: "action",
+            trash: false,
+            connections: [null, null],
+            hide: jest.fn(),
+            container: { uncache: jest.fn() }
+        });
+    }
+};
+
+describe("Activity trash signal scheduling", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test("dispatches trashsignal after the no-action delay", () => {
+        const activity = makeActivity();
+
+        activity.sendAllToTrash(false, true, false);
+
+        expect(activity.stage.dispatchEvent).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(0);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledTimes(1);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledWith("trashsignal");
+    });
+
+    test("cancels an obsolete timer when a newer operation starts", () => {
+        const activity = makeActivity();
+        addActionBlocks(activity, 25);
+
+        activity.sendAllToTrash(false, true, false);
+        activity.sendAllToTrash(false, true, false);
+
+        expect(activity.clearTimeoutSpy).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(0);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(2500);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test("ignores an obsolete callback when timer cancellation is too late", () => {
+        const activity = makeActivity(() => {});
+        addActionBlocks(activity, 25);
+
+        activity.sendAllToTrash(false, true, false);
+        activity.sendAllToTrash(false, true, false);
+
+        jest.advanceTimersByTime(2500);
+        expect(activity.clearTimeoutSpy).toHaveBeenCalledTimes(1);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test("preserves the 100 milliseconds per action block delay", () => {
+        const activity = makeActivity();
+        addActionBlocks(activity, 25);
+
+        activity.sendAllToTrash(false, true, false);
+
+        jest.advanceTimersByTime(2499);
+        expect(activity.stage.dispatchEvent).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(activity.stage.dispatchEvent).toHaveBeenCalledTimes(1);
+        expect(activity.blocks.deleteActionBlock).toHaveBeenCalledTimes(25);
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -350,6 +350,11 @@ class Activity {
         // Interval ID for the loading animation (to allow cleanup)
         this.loadAnimationIntervalId = null;
 
+        // Own the deferred trash signal so a newer trash/load operation can
+        // cancel an obsolete signal.
+        this._trashSignalTimer = null;
+        this._trashSignalGeneration = 0;
+
         // Initialize GIF animator
         if (typeof GIFAnimator !== "undefined") {
             this.gifAnimator = new GIFAnimator();
@@ -1930,6 +1935,12 @@ class Activity {
          * @param {boolean} closeAllWidgets  {if true close all open widgets}
          */
         this.sendAllToTrash = (addStartBlock, doNotSave, closeAllWidgets = true) => {
+            if (this._trashSignalTimer !== null) {
+                clearTimeout(this._trashSignalTimer);
+                this._trashSignalTimer = null;
+            }
+            const trashSignalGeneration = ++this._trashSignalGeneration;
+
             // Return to home position after loading new blocks.
             this.blocksContainer.x = 0;
             this.blocksContainer.y = 0;
@@ -2026,7 +2037,11 @@ class Activity {
             // Wait for palette to clear (#891)
             // We really need to signal when each palette item is deleted
             const that = this;
-            setTimeout(() => {
+            this._trashSignalTimer = setTimeout(() => {
+                if (trashSignalGeneration !== that._trashSignalGeneration) {
+                    return;
+                }
+                that._trashSignalTimer = null;
                 that.stage.dispatchEvent("trashsignal");
             }, 100 * actionBlockCounter); // 1000
 


### PR DESCRIPTION
## Description

Prevent stale delayed `trashsignal` events from affecting newer trash or project-loading operations.

`Activity.sendAllToTrash()` previously created a raw `setTimeout()` without retaining its timer ID. If another trash or load operation began before the timeout fired, the old timer could dispatch `trashsignal` into listeners belonging to the newer operation.

## Related Issue

**Fixes:** : no issue found

## Category

- [x] Bug Fix
- [ ] Feature
- [ ] UI/UX
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] Chore/Refactor
- [ ] CI/CD

## Changes Made

- Added Activity-owned state for the pending trash signal timer.
- Added a generation counter for trash signal operations.
- Cancelled the previous timer before starting a new `sendAllToTrash()` operation.
- Stored the current timeout ID.
- Ignored callbacks belonging to stale generations.
- Cleared the stored timer ID before dispatching `trashsignal`.
- Preserved the existing `100 * actionBlockCounter` delay.
- Added focused fake-timer tests for cancellation, generation protection, immediate dispatch, and large action counters.

## Steps to Reproduce

1. Start a trash or project-loading operation that uses `sendAllToTrash()`.
2. Start another trash or project-loading operation before the first delayed signal fires.
3. The previous implementation could dispatch the first operation’s stale `trashsignal` into listeners belonging to the newer operation.
4. The updated implementation cancels and invalidates the previous operation’s timer.

## Visual Changes

Not applicable.

## Testing Performed

- Focused Jest tests:
  - `activity_trashsignal.test.js`
  - `activity-projectmanager-integration.test.js`
  - `project-manager.test.js`
- Result: 3 suites passed, 123 tests passed.
- `npm run lint`
- `npx prettier --check js/activity.js js/__tests__/activity_trashsignal.test.js`
- Full Jest suite was run.
- The full suite had two unrelated failures in `scripts/generate-tests/__tests__/write-generated.test.js` concerning generated-test path validation.

## Checklist

- [x] Tested locally
- [x] Added or updated tests
- [ ] Updated documentation, if applicable
- [x] Followed the project coding style
- [x] Ran lint and Prettier checks
- [ ] Addressed review feedback, if applicable
- [ ] Enabled “Allow edits from maintainers”



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity trash-signal scheduling to prevent obsolete delayed signals from being dispatched.
  * Ensured repeated trash actions cancel pending timers and ignore stale callbacks.
  * Preserved the existing 100-millisecond delay per action block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->