### PR TITLE
fix: replace unreachable try/catch with isNaN check in toInteger()

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -40,13 +40,13 @@ function setupNumberBlocks(activity) {
      */
     const toInteger = (logo, value, blk) => {
         if (typeof value === "string") {
-            try {
-                return parseInt(value, 10);
-            } catch (e) {
+            const result = parseInt(value, 10);
+            if (isNaN(result)) {
                 logo.stopTurtle = true;
                 activity.errorMsg(NANERRORMSG, blk);
                 return null;
             }
+            return result;
         }
         return value;
     };


### PR DESCRIPTION
## Description

This PR fixes a bug in the `toInteger()` helper function where a try/catch block was attempting to catch exceptions from `parseInt()`, which never throws. This caused non-numeric strings to silently convert to `NaN` and propagate through arithmetic operations without displaying error messages to users.

**What changed:**
- Replaced the unreachable try/catch block with an explicit `isNaN()` check after calling `parseInt()`
- Now properly detects invalid numeric input and stops execution with an error message

**Impact:**
- Users now receive proper feedback when providing invalid input to arithmetic blocks (Modulo, Power, Shift, Remainder, etc.)
- Prevents silent corruption of calculations with `NaN` values
- Improves debugging experience for end users

## Related Issue

<!-- Add issue number here -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Lint check passed (`npm run lint`)
- [x] Code formatting verified (`npx prettier --check js/blocks/NumberBlocks.js`)
- [x] All tests passed (`npm test` - 8819 tests passed)

## Affected Components

The fix affects the `toInteger()` helper function in `js/blocks/NumberBlocks.js`, which is used by:
- `ModBlock` (Modulo operation)
- `PowerBlock` (Exponentiation)
- `ShiftBlock` (Bit shift)
- `RemainderBlock` (Remainder operation)
- `calculateBothArgs()` (shared binary operation helper)
- Conditional comparison blocks

All these operations now properly handle invalid string input.

## Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore
- [ ] UI/UX
- [ ] i18n

## Related Issue

Fixes #8513