### PR TITLE
fix: scope pitchstaircase to widget body

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -588,8 +588,8 @@ describe("PitchStaircase Widget", () => {
             };
             window.widgetWindows.windowFor = jest.fn(() => widgetWindow);
 
-            wfbElement = { style: {} };
-            jest.spyOn(document, "getElementsByClassName").mockReturnValue([wfbElement]);
+            wfbElement = { style: {}, append: jest.fn() };
+            widgetWindow.getWidgetBody = jest.fn(() => wfbElement);
 
             mockActivity = {
                 logo: { synth: { setMasterVolume: jest.fn(), stop: jest.fn() } },

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -853,7 +853,7 @@ class PitchStaircase {
                     }, 1000);
                 }
             };
-        const wfbWidget = document.getElementsByClassName("wfbWidget")[0];
+        const wfbWidget = widgetWindow.getWidgetBody();
         if (wfbWidget && wfbWidget.style) {
             wfbWidget.style.maxHeight = 10 * PitchStaircase.BUTTONSIZE + "px";
             wfbWidget.style.overflowY = "scroll";


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes an unassigned bug in the Pitch Staircase widget where its elements were appending themselves to the first widget they found on the screen using a global DOM query (`document.getElementsByClassName("wfbWidget")[0]`). If another widget was opened before the Pitch Staircase, elements might render inside the wrong widget's body.

This correctly scopes the append target to the Pitch Staircase's own widget body using `widgetWindow.getWidgetBody()`, preventing the elements from bleeding into or rendering inside other open widgets. This addresses the exact same class of bug as Issue #8484, but found specifically within the Pitch Staircase widget.

## Related Issue

**Fixes:** #
**Related to:** #8484

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Replaced the global `document.getElementsByClassName("wfbWidget")[0]` query with the properly scoped `widgetWindow.getWidgetBody()` in `js/widgets/pitchstaircase.js`.
- Updated the `PitchStaircase` unit tests in `js/widgets/__tests__/pitchstaircase.test.js` to correctly mock `widgetWindow.getWidgetBody()` instead of overriding the global `document.getElementsByClassName` function.

---

## Steps to Reproduce

1. Open the Music Blocks app.
2. Open another widget (e.g., Music Keyboard or Phrase Maker) first so it becomes the first `.wfbWidget` in the DOM.
3. Open the Pitch Staircase widget.
4. Without this fix, the Pitch Staircase UI might mistakenly attempt to append itself to the DOM of the previously opened widget.

## Visual Changes

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- Validated that the Pitch Staircase renders correctly inside its own scoped widget body.
- Adjusted and successfully ran all existing tests related to `PitchStaircase` (`npm test js/widgets/__tests__/pitchstaircase.test.js`).
- Passed global linting and formatting tests (`npm run lint` and `npx prettier --check .`).

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This was discovered during a code audit for similar issues related to `#8484` (which fixed the exact same global querying pattern inside the Music Keyboard widget).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget initialization to target the correct widget body, supporting more reliable behavior when multiple widgets are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->