### PR TITLE
fix(utils): use timers for readiness polling and timeout

### DIFF
--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -139,8 +139,83 @@ const {
     makeKeyboardAccessible,
     CameraManager,
     announceToScreenReader,
+    waitForReadiness,
     _
 } = require("../utils.js");
+
+describe("waitForReadiness()", () => {
+    let elements;
+    let getElementByIdSpy;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        elements = {};
+        global.createjs = { Stage: jest.fn() };
+        global.Howler = {};
+        global.jQuery = {};
+        getElementByIdSpy = jest
+            .spyOn(document, "getElementById")
+            .mockImplementation(id => elements[id] || null);
+        global.requestAnimationFrame = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        delete global.createjs;
+        delete global.Howler;
+        delete global.jQuery;
+        delete global.requestAnimationFrame;
+        getElementByIdSpy.mockRestore();
+    });
+
+    it("polls at checkInterval and does not use requestAnimationFrame", () => {
+        const callback = jest.fn();
+        waitForReadiness(callback, { minWait: 0, checkInterval: 100, maxWait: 1000 });
+
+        jest.advanceTimersByTime(99);
+        expect(callback).not.toHaveBeenCalled();
+        expect(getElementByIdSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(getElementByIdSpy).toHaveBeenCalledTimes(3);
+        expect(callback).not.toHaveBeenCalled();
+        expect(global.requestAnimationFrame).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(99);
+        expect(getElementByIdSpy).toHaveBeenCalledTimes(3);
+
+        jest.advanceTimersByTime(1);
+        expect(getElementByIdSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("enforces maxWait independently of requestAnimationFrame", () => {
+        const callback = jest.fn();
+        waitForReadiness(callback, { minWait: 0, checkInterval: 1000, maxWait: 250 });
+
+        jest.advanceTimersByTime(250);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(global.requestAnimationFrame).not.toHaveBeenCalled();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it("calls the callback once and clears both timers when ready", () => {
+        elements.myCanvas = {};
+        elements.loader = {};
+        elements.toolbars = {};
+        const callback = jest.fn();
+
+        waitForReadiness(callback, { minWait: 100, checkInterval: 100, maxWait: 500 });
+        jest.advanceTimersByTime(100);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(jest.getTimerCount()).toBe(0);
+
+        jest.advanceTimersByTime(500);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+});
 
 describe("makeKeyboardAccessible()", () => {
     test("adds button semantics and activates on Enter and Space", () => {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -180,18 +180,21 @@ let format = (str, data) => {
 
 /**
  * Wait for critical dependencies to be ready before calling callback.
- * Uses polling with exponential backoff and maximum timeout.
+ * Uses timer-based polling and a separate maximum timeout.
  * This replaces the arbitrary 5-second delay for Firefox with actual readiness checks.
  *
  * @param {Function} callback - The function to call when ready
  * @param {Object} options - Configuration options
  * @param {number} options.maxWait - Maximum wait time in ms (default: 10000)
  * @param {number} options.minWait - Minimum wait time in ms (default: 500)
- * @param {number} options.checkInterval - Initial check interval in ms (default: 100)
+ * @param {number} options.checkInterval - Check interval in ms (default: 100)
  */
 function waitForReadiness(callback, options = {}) {
     const { maxWait = 10000, minWait = 500, checkInterval = 100 } = options;
     const startTime = Date.now();
+    let pollTimerId = null;
+    let timeoutId = null;
+    let completed = false;
 
     /**
      * Check if critical dependencies and DOM elements are ready
@@ -215,29 +218,42 @@ function waitForReadiness(callback, options = {}) {
     /**
      * Polling function that checks readiness and calls callback when ready
      */
+    const complete = timedOut => {
+        if (completed) return;
+
+        completed = true;
+        clearTimeout(pollTimerId);
+        clearTimeout(timeoutId);
+
+        if (timedOut) {
+            // Timeout - initialize anyway as fallback
+            console.warn(
+                `[Firefox] Initialization timed out after ${maxWait}ms, proceeding anyway`
+            );
+        }
+
+        callback();
+    };
+
     const check = () => {
+        if (completed) return;
+
         const elapsed = Date.now() - startTime;
 
         if (elapsed >= minWait && isReady()) {
             // Ready! Initialize the app
 
             console.log(`[Firefox] Initialized in ${elapsed}ms (readiness-based)`);
-            callback();
-        } else if (elapsed >= maxWait) {
-            // Timeout - initialize anyway as fallback
-
-            console.warn(
-                `[Firefox] Initialization timed out after ${maxWait}ms, proceeding anyway`
-            );
-            callback();
+            complete(false);
         } else {
-            // Not ready yet, check again on next animation frame
-            requestAnimationFrame(check);
+            // Not ready yet, check again after the configured interval
+            pollTimerId = setTimeout(check, checkInterval);
         }
     };
 
-    // Start the readiness check loop
-    requestAnimationFrame(check);
+    // Start polling and timeout independently so timeout does not depend on RAF.
+    pollTimerId = setTimeout(check, checkInterval);
+    timeoutId = setTimeout(() => complete(true), maxWait);
 }
 
 // docByClass(), docByTagName(), docById(), docByName(), docBySelector()
@@ -1302,6 +1318,7 @@ if (typeof module !== "undefined" && module.exports) {
         processRawPluginData,
         preparePluginExports,
         processMacroData,
+        waitForReadiness,
         updatePluginObj,
         announceToScreenReader,
         doUseCamera,


### PR DESCRIPTION
## Description

Fix Firefox startup readiness polling so it respects the configured `checkInterval` and does not depend on `requestAnimationFrame()` for timeout handling.

Previously, readiness was checked on every animation frame, with `maxWait` evaluated only inside the RAF callback. This could cause unnecessary readiness checks and potentially delay startup indefinitely when RAF was paused or throttled, such as in a background tab.

## Related Issue

**Fixes:** :  no issue linked

## Category

* [x] Bug Fix
* [x] Performance
* [x] Tests

## Changes Made

* Replaced RAF-based readiness polling with `setTimeout()` using the configured `checkInterval`.
* Added an independent maximum-wait timer using `maxWait`.
* Added a completion guard to ensure the callback executes exactly once.
* Cleared both timers when readiness succeeds or the timeout is reached.
* Exported `waitForReadiness()` for direct unit testing.
* Added focused Jest coverage for:

  * Configured polling intervals
  * Independence from `requestAnimationFrame()`
  * Maximum-timeout fallback
  * Exactly-once callback execution
  * Timer cleanup

The existing Firefox startup caller and callback ordering remain unchanged.

## Steps to Reproduce

1. Open Music Blocks in Firefox.
2. Start the application while critical dependencies are delayed or the tab is backgrounded.
3. Observe readiness polling and startup fallback behavior.
4. Previously, polling occurred on every animation frame and timeout handling depended on RAF callbacks.

## Visual Changes

Not applicable. This change only affects startup scheduling and readiness polling.

## Testing Performed

- Focused Tests : js/utils/__tests__/utils.test.js with 167 passed tests
- Ran overall test : npm test ( 2 unrelated tests fails which has already pr raised to solve  it )
- checked all lint, prettier,

### Manual Firefox Verification

1. Run `npm run serve:dev`.
2. Open `http://127.0.0.1:3000` in Firefox.
3. Hard-refresh the page.
4. Confirm the loader disappears.
5. Confirm the toolbars, palettes, and canvas are usable.
6. Check the browser console for startup errors.

## Checklist

* [x] I have added or updated tests that prove the effectiveness of these changes.
* [x] I have followed the project coding style guidelines.
* [x] I have run linting and formatting checks.
* [x] I have tested these changes locally in Firefox.
* [x] I have updated the documentation, if applicable.
* [x] I have addressed previous code review feedback, if applicable.
* [x] I have enabled **Allow edits from maintainers**.

## Additional Notes

The readiness callback performs application initialization and does not require a paint-frame callback. Rendering synchronization remains handled separately by the Activity render loop.

The independent timeout may still be delayed by browser timer throttling in fully suspended tabs, but it is no longer coupled to RAF availability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readiness detection by using reliable timer-based polling.
  - Ensured readiness callbacks run only once, whether readiness is detected or the maximum wait time is reached.
  - Added proper cleanup for polling and timeout timers.
- **Tests**
  - Expanded automated coverage for polling intervals, timeout handling, callback execution, and timer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->