### PR TITLE
feat(pitchslider): add Shift + Arrow key shortcuts for live octave navigation

### DIFF
--- a/js/widgets/__tests__/pitchslider.test.js
+++ b/js/widgets/__tests__/pitchslider.test.js
@@ -539,13 +539,28 @@ describe("PitchSlider Widget", () => {
             expect(mockOscillator.triggerAttackRelease).toHaveBeenCalledWith(440, "4n");
         });
 
-        test("slider registers mousedown event listener", () => {
+        test("slider registers mousedown and pointerdown event listeners", () => {
             expect(slider.sliders[0]).toBeDefined();
             expect(slider.sliders[0].addEventListener).toHaveBeenCalledWith(
                 "mousedown",
                 expect.any(Function)
             );
+            expect(slider.sliders[0].addEventListener).toHaveBeenCalledWith(
+                "pointerdown",
+                expect.any(Function)
+            );
         });
+
+        test("pointerdown event sets activeSlider to slider id", () => {
+            const pointerdownCall = slider.sliders[0].addEventListener.mock.calls.find(
+                call => call[0] === "pointerdown"
+            );
+            const pointerdownHandler = pointerdownCall[1];
+            slider.activeSlider = null;
+            pointerdownHandler();
+            expect(slider.activeSlider).toBe("0");
+        });
+
         test("mousedown event sets activeSlider to slider id", () => {
             const mousedownCall = slider.sliders[0].addEventListener.mock.calls.find(
                 call => call[0] === "mousedown"
@@ -554,6 +569,96 @@ describe("PitchSlider Widget", () => {
             slider.activeSlider = null;
             mousedownHandler();
             expect(slider.activeSlider).toBe("0");
+        });
+
+        test("Shift + ArrowUp keydown steps frequency up by an octave", () => {
+            slider.sliders[0].value = "440";
+            slider.sliders[0].min = "220";
+            slider.sliders[0].max = "1760";
+            slider.activeSlider = "0";
+
+            const keydownCall = document.addEventListener.mock.calls.find(
+                call => call[0] === "keydown"
+            );
+            const keyHandler = keydownCall[1];
+
+            const event = {
+                key: "ArrowUp",
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            keyHandler(event);
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(parseFloat(slider.sliders[0].value)).toBeCloseTo(880, 1);
+        });
+
+        test("Shift + ArrowDown keydown steps frequency down by an octave", () => {
+            slider.sliders[0].value = "880";
+            slider.sliders[0].min = "220";
+            slider.sliders[0].max = "1760";
+            slider.activeSlider = "0";
+
+            const keydownCall = document.addEventListener.mock.calls.find(
+                call => call[0] === "keydown"
+            );
+            const keyHandler = keydownCall[1];
+
+            const event = {
+                key: "ArrowDown",
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            keyHandler(event);
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(parseFloat(slider.sliders[0].value)).toBeCloseTo(440, 1);
+        });
+
+        test("slider oninput from keyboard plays preview via triggerAttackRelease without drone", () => {
+            const rangeSlider = slider.sliders[0];
+            rangeSlider.value = "500";
+            rangeSlider._fromKeyboard = true;
+            rangeSlider.oninput();
+            rangeSlider._fromKeyboard = false;
+
+            expect(mockOscillator.triggerAttackRelease).toHaveBeenCalledWith(500, "4n");
+            expect(mockOscillator.triggerAttack).not.toHaveBeenCalled();
+        });
+
+        test("arrow key navigation plays preview note without endless drone", () => {
+            const rangeSlider = slider.sliders[0];
+            rangeSlider.value = "440";
+            slider.frequencies[0] = 440;
+            slider.activeSlider = "0";
+
+            // When event is dispatched in browser, oninput runs
+            rangeSlider.dispatchEvent = jest.fn(() => {
+                if (typeof rangeSlider.oninput === "function") {
+                    rangeSlider.oninput();
+                }
+            });
+
+            const keydownCall = document.addEventListener.mock.calls.find(
+                call => call[0] === "keydown"
+            );
+            const keyHandler = keydownCall[1];
+
+            const event = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            keyHandler(event);
+
+            const expected = 440 * Math.pow(2, 1 / 12);
+            expect(mockOscillator.triggerAttackRelease).toHaveBeenCalledWith(expected, "4n");
+            expect(mockOscillator.triggerAttack).not.toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/pitchslider.js
+++ b/js/widgets/pitchslider.js
@@ -94,22 +94,29 @@ class PitchSlider {
                     const max = parseFloat(slider.max);
                     const currentValue = parseFloat(slider.value);
 
+                    const stepRatio = event.shiftKey ? Math.pow(semitone, edo) : semitone;
+
                     if (event.key === "ArrowUp" || event.key === "ArrowRight") {
-                        // Move up by a semitone
-                        slider.value = this._stepFrequency(currentValue, "up", semitone, min, max);
+                        // Move up by a semitone or an octave if Shift is pressed
+                        slider.value = this._stepFrequency(currentValue, "up", stepRatio, min, max);
                     } else if (event.key === "ArrowDown" || event.key === "ArrowLeft") {
-                        // Move down by a semitone
+                        // Move down by a semitone or an octave if Shift is pressed
                         slider.value = this._stepFrequency(
                             currentValue,
                             "down",
-                            semitone,
+                            stepRatio,
                             min,
                             max
                         );
                     }
 
-                    const inputEvent = new Event("input", { bubbles: true });
-                    slider.dispatchEvent(inputEvent);
+                    slider._fromKeyboard = true;
+                    try {
+                        const inputEvent = new Event("input", { bubbles: true });
+                        slider.dispatchEvent(inputEvent);
+                    } finally {
+                        slider._fromKeyboard = false;
+                    }
                 }
 
                 return false;
@@ -138,6 +145,9 @@ class PitchSlider {
                 this.activeSlider = id;
             }
 
+            slider.addEventListener("pointerdown", () => {
+                this.activeSlider = id;
+            });
             slider.addEventListener("mousedown", () => {
                 this.activeSlider = id;
             });
@@ -158,6 +168,11 @@ class PitchSlider {
             };
 
             slider.oninput = () => {
+                if (slider._fromKeyboard) {
+                    changeFreq();
+                    oscillators[id].triggerAttackRelease(this.frequencies[id], "4n");
+                    return;
+                }
                 oscillators[id].triggerAttack(this.frequencies[id]);
                 changeFreq();
             };


### PR DESCRIPTION
- [x] Feature

## Description
Extends `Shift + ArrowUp` / `Shift + ArrowRight` (octave up) and `Shift + ArrowDown` / `Shift + ArrowLeft` (octave down) live octave navigation shortcuts to the `PitchSlider` widget (`js/widgets/pitchslider.js`), aligning shortcut consistency with the `MusicKeyboard` widget.

Also registers a `pointerdown` listener alongside `mousedown` to ensure `activeSlider` registration works uniformly across touchscreens, tablets, and mouse devices.

Closes #8491

## Changes Made
- Added `Shift + Arrow` octave stepping logic in `js/widgets/pitchslider.js`.
- Registered `pointerdown` event listener on `PitchSlider` sliders.
- Added comprehensive unit tests in `js/widgets/__tests__/pitchslider.test.js`.

## Testing Performed
- Ran `npx jest js/widgets/__tests__/pitchslider.test.js` — All 70 unit tests pass cleanly.
- Verified Prettier formatting and ESLint checks (0 errors).

## Checklist
- [x] I have read the project documentation and contribution guidelines.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shift+Arrow keyboard controls now adjust pitch by one octave.
  - Keyboard pitch changes provide a short preview sound.
  - Sliders become active when pressed or touched, improving interaction with multiple sliders.

- **Bug Fixes**
  - Prevented keyboard interactions from starting a continuous sustained sound.
  - Improved pitch updates triggered through keyboard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->