### PR TITLE
test: add test case for chord block connection hierarchy in _savePhrase

### DIFF
--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -2009,8 +2009,9 @@ describe("LegoWidget Eye Dropper Listener Safety", () => {
 });
 
 describe("_savePhrase chord block connection hierarchy", () => {
+    const originalUnderscore = global._;
     afterEach(() => {
-        delete global._;
+        global._ = originalUnderscore;
     });
 
     it("correctly chains sequential pitch blocks for a chord", () => {

--- a/js/widgets/__tests__/legobricks.test.js
+++ b/js/widgets/__tests__/legobricks.test.js
@@ -2007,3 +2007,67 @@ describe("LegoWidget Eye Dropper Listener Safety", () => {
         });
     });
 });
+
+describe("_savePhrase chord block connection hierarchy", () => {
+    afterEach(() => {
+        delete global._;
+    });
+
+    it("correctly chains sequential pitch blocks for a chord", () => {
+        const legoWidget = new LegoWidget();
+
+        global._ = val => val;
+
+        legoWidget.colorData = [{ color: "red" }];
+        legoWidget._collectNotesToPlay = jest.fn();
+        legoWidget._notesToPlay = [
+            {
+                noteValue: 1,
+                pitches: [
+                    { solfege: "do", octave: 4 },
+                    { solfege: "mi", octave: 4 },
+                    { solfege: "sol", octave: 4 }
+                ],
+                isRest: false
+            }
+        ];
+
+        let generatedStack = null;
+
+        legoWidget.activity = {
+            textMsg: jest.fn(),
+            refreshCanvas: jest.fn(),
+            blocks: {
+                palettes: { dict: {} },
+                loadNewBlocks: jest.fn(stack => {
+                    generatedStack = stack;
+                })
+            }
+        };
+
+        legoWidget._savePhrase();
+
+        expect(legoWidget.activity.blocks.loadNewBlocks).toHaveBeenCalled();
+        expect(generatedStack).toBeDefined();
+
+        const pitchBlocks = generatedStack.filter(block => block[1] === "pitch");
+
+        expect(pitchBlocks).toHaveLength(3);
+
+        const vspaceBlock = generatedStack.find(block => block[1] === "vspace");
+
+        const firstPitchId = pitchBlocks[0][0];
+        const secondPitchId = pitchBlocks[1][0];
+        const thirdPitchId = pitchBlocks[2][0];
+
+        // vspace → first pitch → second pitch → third pitch
+        expect(pitchBlocks[0][4][0]).toBe(vspaceBlock[0]);
+        expect(pitchBlocks[0][4][3]).toBe(secondPitchId);
+
+        expect(pitchBlocks[1][4][0]).toBe(firstPitchId);
+        expect(pitchBlocks[1][4][3]).toBe(thirdPitchId);
+
+        expect(pitchBlocks[2][4][0]).toBe(secondPitchId);
+        expect(pitchBlocks[2][4][3]).toBeNull();
+    });
+});


### PR DESCRIPTION
## Description

Added a regression test for `_savePhrase()` to verify the connection hierarchy generated for chord pitch blocks. The test creates a three-note chord and checks that the pitch blocks are correctly chained, with the first pitch connected to the vspace block, the second pitch connected to the first pitch, and the third pitch connected to the second pitch, with no further connections.

---

## Category

- [x] Tests — Adds or updates test coverage

---

## Testing Performed

The test was run with the existing Jest test suite and passed successfully, confirming that the chord pitch blocks maintain the expected sequential connection hierarchy.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for saving three-note chords.
  * Verified that generated pitch blocks connect sequentially and load correctly into the activity stack.
  * Confirmed that saved chord structures preserve their intended connections, supporting reliable playback and editing of multi-note musical phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->