### PR TITLE
refactor(styles): remove forced !important body styling and inline styles to fix page cascade

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -742,8 +742,7 @@ img.icon:hover {
 }
 
 body {
-    background-color: #92b5c8 !important;
-    /*  2.5B 7/4 */
+    background-color: var(--color-bg-primary);
     padding: 0;
     margin: 0;
     font-family: sans-serif;

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
         </script>
     </head>
 
-    <body id="body" data-title="index" style="background: #f9f9f9">
+    <body id="body" data-title="index">
         <!-- Fallback for browsers that don't support preload -->
         <noscript> JavaScript is required to view this page. </noscript>
         <header>

--- a/js/__tests__/page-cascade.test.js
+++ b/js/__tests__/page-cascade.test.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Utkarsh Anand
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..", "..");
+const activitiesCss = fs.readFileSync(path.join(ROOT, "css", "activities.css"), "utf8");
+const indexHtml = fs.readFileSync(path.join(ROOT, "index.html"), "utf8");
+
+/**
+ * Isolates the top-level `body { ... }` rule in activities.css (the one with
+ * no class/id qualifier), as opposed to `body.dark`, `body.samples-shown`,
+ * etc. Mirrors the light parsing approach used in themes-contrast.test.js.
+ */
+const getBaseBodyRule = css => {
+    const match = css.match(/(?:^|\n)body\s*\{([^}]*)\}/);
+    if (!match) {
+        throw new Error("no base `body { ... }` rule found in activities.css");
+    }
+    return match[1];
+};
+
+describe("page background cascade (issue: Fix Page Cascade)", () => {
+    const baseBodyRule = getBaseBodyRule(activitiesCss);
+
+    test("base body rule no longer forces a hard-coded !important background", () => {
+        expect(baseBodyRule).not.toMatch(/!important/);
+        expect(baseBodyRule).not.toMatch(/#92b5c8/i);
+    });
+
+    test("base body rule sources its background from the design-token system", () => {
+        expect(baseBodyRule).toMatch(/background-color:\s*var\(--color-bg-primary\)/);
+    });
+
+    test("index.html no longer hard-codes a body background inline style", () => {
+        const bodyTagMatch = indexHtml.match(/<body\b[^>]*>/);
+        expect(bodyTagMatch).not.toBeNull();
+        expect(bodyTagMatch[0]).not.toMatch(/style\s*=\s*["'][^"']*background/i);
+    });
+});


### PR DESCRIPTION
## Description

The base `body` rule in `css/activities.css` set a hard-coded background-color with `!important`, which unconditionally beat the non-`!important` `body.dark`/`body.highcontrast` rules in `css/darkmode.css` regardless of selector specificity — so dark/high-contrast mode never actually painted their background. `index.html` also set an inline `style="background: #f9f9f9"` on `<body>`, which by itself would have out-specified those same rules even without `!important`.

## Related Issue

**Fixes:** #8512

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `css/activities.css`: removed the `!important` and the hard-coded `#92b5c8`; the base `body` rule now sources its background from the existing `var(--color-bg-primary)` design token.
- `index.html`: removed the inline background style from `<body>` so the class-based dark/high-contrast rules can win the cascade normally.
- `js/__tests__/page-cascade.test.js`: new regression test asserting the base body rule has no `!important`/hard-coded hex and that `<body>` has no inline background style.

---

## Testing Performed

- `npx jest js/__tests__/page-cascade.test.js` — 3/3 passing.
- `npx prettier --check css/activities.css index.html` — no issues.
- Manually verified light/dark/high-contrast body background now switches correctly.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

There's another open PR (#8515) addressing the same issue. I left a review comment there flagging that its branch predates the fix for #8392 on master and would revert it if merged as-is. Opening this in parallel so there's a clean, rebase-free option ready either way — happy to close this one if #8515 gets updated first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated page backgrounds to consistently use the primary theme color.
  - Removed the conflicting inline document background styling.

- **Tests**
  - Added coverage to verify background styles follow the intended theme cascade and avoid outdated hard-coded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->