### PR TITLE
fix(keyboard): scroll the open palette with the arrow keys instead of throwing

### DIFF
--- a/js/__tests__/palette.test.js
+++ b/js/__tests__/palette.test.js
@@ -1542,6 +1542,27 @@ describe("Palettes Class", () => {
             expect(insertedMarkup).toContain("overflow-x: hidden");
         });
 
+        test("scrollEvent scrolls the open block list and scrollDiff mirrors it", () => {
+            const paletteItems = { scrollTop: 0 };
+            global.docById = jest.fn(id => (id === "PaletteBody_items" ? paletteItems : null));
+            palettes.add("test");
+            const palette = palettes.dict.test;
+
+            palette.scrollEvent(-20, 1); // arrow down: list moves up
+            expect(paletteItems.scrollTop).toBe(20);
+            expect(palette.scrollDiff).toBe(-20);
+
+            palette.scrollEvent(-palette.scrollDiff, 1); // home: back to the top
+            expect(paletteItems.scrollTop).toBe(0);
+        });
+
+        test("scrollEvent is a no-op when no palette menu is open", () => {
+            global.docById = jest.fn(() => null);
+            palettes.add("test");
+            expect(() => palettes.dict.test.scrollEvent(-20, 1)).not.toThrow();
+            expect(palettes.dict.test.scrollDiff).toBe(0);
+        });
+
         test("_showMenuItems renders a basic block", () => {
             const paletteList = document.createElement("table");
 

--- a/js/activity/__tests__/keyboard-controller.test.js
+++ b/js/activity/__tests__/keyboard-controller.test.js
@@ -504,16 +504,18 @@ describe("KeyboardController", () => {
             expect(rhythm.scrollEvent).toHaveBeenCalledWith(-20, 1);
         });
 
-        it("does not throw on the arrows when the stored palette name has no entry", () => {
+        it("falls back to scrolling the canvas when the stored palette name has no entry", () => {
             const activity = makeActivity();
             activity.palettes.dict = {};
             activity.palettes.activePalette = "rhythm";
+            activity.blocksContainer.y = 0;
             const controller = createController(activity);
 
-            expect(() => controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }))).not.toThrow();
-            expect(() =>
-                controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }))
-            ).not.toThrow();
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            expect(activity.blocksContainer.y).toBe(20);
+
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }));
+            expect(activity.blocksContainer.y).toBe(0);
         });
 
         it("scrolls the palette menu home when the mouse is over the palette", () => {

--- a/js/activity/__tests__/keyboard-controller.test.js
+++ b/js/activity/__tests__/keyboard-controller.test.js
@@ -490,17 +490,30 @@ describe("KeyboardController", () => {
     describe("palette scrolling", () => {
         it("scrolls the active palette on the up/down arrows when no block is active", () => {
             const activity = makeActivity();
-            activity.palettes.activePalette = {
-                scrollEvent: jest.fn(),
-                scrollDiff: 40
-            };
+            // Palettes.showPalette stores the open palette's *name*; the
+            // controller has to look the object up in palettes.dict.
+            const rhythm = { scrollEvent: jest.fn(), scrollDiff: 40 };
+            activity.palettes.dict = { rhythm };
+            activity.palettes.activePalette = "rhythm";
             const controller = createController(activity);
 
             controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
-            expect(activity.palettes.activePalette.scrollEvent).toHaveBeenCalledWith(20, 1);
+            expect(rhythm.scrollEvent).toHaveBeenCalledWith(20, 1);
 
             controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }));
-            expect(activity.palettes.activePalette.scrollEvent).toHaveBeenCalledWith(-20, 1);
+            expect(rhythm.scrollEvent).toHaveBeenCalledWith(-20, 1);
+        });
+
+        it("does not throw on the arrows when the stored palette name has no entry", () => {
+            const activity = makeActivity();
+            activity.palettes.dict = {};
+            activity.palettes.activePalette = "rhythm";
+            const controller = createController(activity);
+
+            expect(() => controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }))).not.toThrow();
+            expect(() =>
+                controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }))
+            ).not.toThrow();
         });
 
         it("scrolls the palette menu home when the mouse is over the palette", () => {
@@ -517,6 +530,18 @@ describe("KeyboardController", () => {
     });
 
     describe("stage scrolling", () => {
+        it("scrolls the open palette back to the top on HOME", () => {
+            const activity = makeActivity();
+            activity.palettes.mouseOver = false;
+            const rhythm = { scrollEvent: jest.fn(), scrollDiff: -120 };
+            activity.palettes.dict = { rhythm };
+            activity.palettes.activePalette = "rhythm";
+            const controller = createController(activity);
+
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.HOME }));
+            expect(rhythm.scrollEvent).toHaveBeenCalledWith(120, 1);
+        });
+
         it("jumps to the bottom of the page on END", () => {
             const activity = makeActivity();
             const controller = createController(activity);

--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -316,6 +316,14 @@ class KeyboardController {
                     activity._doFastButton();
                 }
             } else if (!disableKeys) {
+                // palettes.activePalette holds the open palette's *name*
+                // (see Palettes.showPalette); resolve it to the object.
+                const activePalette =
+                    activity.palettes.activePalette !== null &&
+                    activity.palettes.dict &&
+                    activity.palettes.dict[activity.palettes.activePalette]
+                        ? activity.palettes.dict[activity.palettes.activePalette]
+                        : null;
                 switch (event.keyCode) {
                     case END:
                         activity.textMsg("END " + _("Jumping to the bottom of the page."));
@@ -350,8 +358,8 @@ class KeyboardController {
                                 );
                                 activity.blocks.blockMoved(activity.blocks.activeBlock);
                                 activity.blocks.adjustDocks(activity.blocks.activeBlock, true);
-                            } else if (activity.palettes.activePalette !== null) {
-                                activity.palettes.activePalette.scrollEvent(STANDARDBLOCKHEIGHT, 1);
+                            } else if (activePalette !== null) {
+                                activePalette.scrollEvent(STANDARDBLOCKHEIGHT, 1);
                             } else {
                                 activity.blocksContainer.y += 20;
                             }
@@ -371,11 +379,8 @@ class KeyboardController {
                                 );
                                 activity.blocks.blockMoved(activity.blocks.activeBlock);
                                 activity.blocks.adjustDocks(activity.blocks.activeBlock, true);
-                            } else if (activity.palettes.activePalette !== null) {
-                                activity.palettes.activePalette.scrollEvent(
-                                    -STANDARDBLOCKHEIGHT,
-                                    1
-                                );
+                            } else if (activePalette !== null) {
+                                activePalette.scrollEvent(-STANDARDBLOCKHEIGHT, 1);
                             } else {
                                 activity.blocksContainer.y -= 20;
                             }
@@ -422,11 +427,8 @@ class KeyboardController {
                             const dy = Math.max(55 - activity.palettes.buttons["rhythm"].y, 0);
                             activity.palettes.menuScrollEvent(1, dy);
                             activity.palettes.hidePaletteIconCircles();
-                        } else if (activity.palettes.activePalette !== null) {
-                            activity.palettes.activePalette.scrollEvent(
-                                -activity.palettes.activePalette.scrollDiff,
-                                1
-                            );
+                        } else if (activePalette !== null) {
+                            activePalette.scrollEvent(-activePalette.scrollDiff, 1);
                         } else {
                             // Bring all the blocks "home".
                             activity.workspaceLayoutController._findBlocks();

--- a/js/palette.js
+++ b/js/palette.js
@@ -1520,6 +1520,33 @@ class Palette {
         this._hideMenuItems();
     }
 
+    /**
+     * Vertical scroll offset of the open block list, negative when scrolled
+     * down. Kept in the sign convention of the pre-HTML palette so the
+     * keyboard controller's Home handler (which passes -scrollDiff) still
+     * scrolls back to the top.
+     * @returns {number}
+     */
+    get scrollDiff() {
+        const items = docById("PaletteBody_items");
+        return items ? -items.scrollTop : 0;
+    }
+
+    /**
+     * Scroll the open block list. A positive direction moves the list down
+     * (revealing blocks above), a negative one moves it up.
+     * @param {number} direction - signed pixel amount
+     * @param {number} scrollSpeed - multiplier
+     * @returns {void}
+     */
+    scrollEvent(direction, scrollSpeed) {
+        const items = docById("PaletteBody_items");
+        if (!items) {
+            return;
+        }
+        items.scrollTop -= direction * scrollSpeed;
+    }
+
     showMenu(createHeader) {
         const palDiv = docById("palette");
         palDiv.childNodes[0].style.borderRight = "0";


### PR DESCRIPTION
- [x] Bug Fix

## What's wrong

With a palette open and no block selected, the up and down arrow keys and Home are supposed to scroll the palette's block list. Instead every press throws an uncaught error and nothing scrolls:

```
Uncaught TypeError: activity.palettes.activePalette.scrollEvent is not a function
    at KeyboardController.__keyPressed (js/activity/keyboard-controller.js:375)   ← ArrowDown
    at KeyboardController.__keyPressed (js/activity/keyboard-controller.js:354)   ← ArrowUp
    at KeyboardController.__keyPressed (js/activity/keyboard-controller.js:426)   ← Home
    at KeyboardController._handleKeyDown (js/activity/keyboard-controller.js:34)
```

It only shows up when the palette was opened by the app rather than by a mouse click, because a click leaves keyboard focus on the palette column, whose own handler takes the arrow keys first. Renaming an action block is the everyday way to get there: `block.js` force-opens the Action palette after the rename so the new block is visible, and focus stays on the page.

## Steps to reproduce

1. Open Music Blocks, open the browser console and close the blue hint banner (keyboard shortcuts are ignored while it is showing).
2. Load `examples/chopsticks.html`, or drag an **action** block from the Action palette onto the canvas.
3. Click the name label on the action block, type a new name such as `chorus`, and press **Enter**. The Action palette opens on its own.
4. Move the mouse off the block onto empty canvas, without clicking.
5. Press **↓**.

**Before this change:** the `TypeError` above, once per key press. ↑ and Home do the same.

**After this change:** the open block list scrolls one block height per press, and Home scrolls it back to the top.

Step 4 matters. After Enter the renamed label is still the active block, so the arrows would nudge it instead. Leaving the block fires its `mouseout`, which clears `activeBlock` (`js/block.js:3533`) but not `activePalette`, and that is the state the scroll branch runs in.

## The cause

Two halves of the 2020 palette rewrite never met.

`Palettes.showPalette()` stores the open palette's **name**:

```js
this.dict[name].showMenu(true);
this.activePalette = name; // used to delete plugins
```

The keyboard controller still treats `activePalette` as a `Palette` **object**, calling `.scrollEvent()` on it and reading `.scrollDiff`. And `Palette.scrollEvent` itself was removed in 56a21fb52 when the canvas palette was replaced by the HTML one, so even with an object there would be nothing to call.

CI never caught it because the existing unit test mocks `activePalette` as `{ scrollEvent: jest.fn() }`, which is the shape the controller expects rather than the one the app produces.

## The fix

`js/palette.js` gets `scrollEvent(direction, scrollSpeed)` and a `scrollDiff` getter back on `Palette`, implemented against the HTML list (`#PaletteBody_items.scrollTop`). They keep the old sign convention, so the controller's Home handler, which passes `-scrollDiff`, lands on the top of the list as before.

`js/activity/keyboard-controller.js` resolves the palette object once, `palettes.dict[palettes.activePalette]`, and uses it at the three call sites. If the name has no entry it falls through to the canvas-scroll branch instead of throwing.

### before:

https://github.com/user-attachments/assets/f32dc1e1-c226-4645-89d5-3440eb83bb2d



### after:

https://github.com/user-attachments/assets/1d555e7c-a771-46ca-9eab-0aa1674ec316




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved keyboard navigation for palette lists, including reliable Up, Down, and Home key scrolling.
  - Palette scrolling now maintains the correct position while navigating and can return to the top of the list.
  - Added safer handling when no palette is open or the selected palette is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->