### PR TITLE
fix(toolbar): stop the mode switch shifting the save menu handlers

### DIFF
--- a/js/__tests__/save-icons-wiring.test.js
+++ b/js/__tests__/save-icons-wiring.test.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * MusicBlocks v3.7.1
+ * Copyright (C) 2026 Rakshit Yadav
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Toolbar.renderSaveIcons() takes its handlers positionally, so a call site
+// that passes the wrong number of arguments silently shifts every handler
+// after the extra one onto the wrong menu item. That is invisible to a unit
+// test that mocks the call site, so the arity is checked against the source.
+
+const fs = require("fs");
+const path = require("path");
+
+const read = rel => fs.readFileSync(path.join(__dirname, "..", "..", rel), "utf8");
+
+/** Names of the parameters renderSaveIcons() declares, in order. */
+const declaredParams = source => {
+    const start = source.indexOf("renderSaveIcons(");
+    expect(start).toBeGreaterThan(-1);
+    const open = source.indexOf("(", start);
+    const close = source.indexOf(")", open);
+    return source
+        .slice(open + 1, close)
+        .split(",")
+        .map(p => p.trim())
+        .filter(Boolean);
+};
+
+/** Every renderSaveIcons(...) call in `source`, as arrays of argument text. */
+const callArguments = source => {
+    const calls = [];
+    const re = /renderSaveIcons\(/g;
+    let m;
+    while ((m = re.exec(source)) !== null) {
+        const open = m.index + m[0].length - 1;
+        // A declaration, not a call: its body follows the closing paren.
+        let depth = 0;
+        let end = -1;
+        for (let i = open; i < source.length; i++) {
+            if (source[i] === "(") depth += 1;
+            else if (source[i] === ")") {
+                depth -= 1;
+                if (depth === 0) {
+                    end = i;
+                    break;
+                }
+            }
+        }
+        if (end === -1) continue;
+        if (/^\s*\{/.test(source.slice(end + 1))) continue;
+
+        const inner = source.slice(open + 1, end);
+        const args = [];
+        let buf = "";
+        let d = 0;
+        for (const ch of inner) {
+            if (ch === "(" || ch === "[" || ch === "{") d += 1;
+            if (ch === ")" || ch === "]" || ch === "}") d -= 1;
+            if (ch === "," && d === 0) {
+                args.push(buf.trim());
+                buf = "";
+            } else {
+                buf += ch;
+            }
+        }
+        if (buf.trim()) args.push(buf.trim());
+        calls.push({ line: source.slice(0, m.index).split("\n").length, args });
+    }
+    return calls;
+};
+
+describe("renderSaveIcons call sites", () => {
+    const toolbarSource = read("js/toolbar-ui.js");
+    const params = declaredParams(toolbarSource);
+
+    it("declares the handlers the save menu needs", () => {
+        expect(params).toEqual([
+            "html_onclick",
+            "doSVG_onclick",
+            "svg_onclick",
+            "midi_onclick",
+            "png_onclick",
+            "wave_onclick",
+            "ly_onclick",
+            "abc_onclick",
+            "mxml_onclick",
+            "blockartworksvg_onclick",
+            "blockartworkpng_onclick"
+        ]);
+    });
+
+    it.each(["js/activity.js", "js/toolbar-ui.js"])(
+        "%s passes one argument per declared parameter",
+        file => {
+            const calls = callArguments(read(file));
+            expect(calls.length).toBeGreaterThan(0);
+            for (const call of calls) {
+                expect({ file, line: call.line, count: call.args.length }).toEqual({
+                    file,
+                    line: call.line,
+                    count: params.length
+                });
+            }
+        }
+    );
+
+    it("passes the block artwork handlers last at every call site", () => {
+        for (const file of ["js/activity.js", "js/toolbar-ui.js"]) {
+            for (const call of callArguments(read(file))) {
+                expect(
+                    `${file}:${call.line} -> ${call.args[params.indexOf("abc_onclick")]}`
+                ).toMatch(/saveAbc/);
+                expect(
+                    `${file}:${call.line} -> ${call.args[params.indexOf("mxml_onclick")]}`
+                ).toMatch(/saveMxml/);
+                expect(
+                    `${file}:${call.line} -> ${call.args[params.indexOf("blockartworksvg_onclick")]}`
+                ).toMatch(/saveBlockArtwork\b/);
+                expect(
+                    `${file}:${call.line} -> ${call.args[params.indexOf("blockartworkpng_onclick")]}`
+                ).toMatch(/saveBlockArtworkPNG/);
+            }
+        }
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -1000,7 +1000,6 @@ class Activity {
                 activity.save.savePNG.bind(activity.save),
                 activity.save.saveWAV.bind(activity.save),
                 activity.save.saveLilypond.bind(activity.save),
-                activity.save.afterSaveLilypondLY.bind(activity.save),
                 activity.save.saveAbc.bind(activity.save),
                 activity.save.saveMxml.bind(activity.save),
                 activity.save.saveBlockArtwork.bind(activity.save),


### PR DESCRIPTION
- [x] Bug Fix
- [x] Tests

## What's wrong

Switch between Beginner and Advanced mode, then open the Save menu, and four of the items save the wrong thing. Asking for the block artwork as SVG downloads a MusicXML `.xml` file instead. A fifth item, block artwork as PNG, becomes unreachable, because nothing is wired to it any more.

The menu is fine on a fresh page load. It only breaks once you use the mode toggle, which is why it is easy to miss.

Every save handler is shifted onto the item one place below it:

| Save menu item | should run | actually runs after a mode switch |
| --- | --- | --- |
| Save as ABC | `saveAbc` | `saveLilypond` |
| Save as MusicXML | `saveMxml` | `saveAbc` |
| Save block artwork as SVG | `saveBlockArtwork` | `saveMxml` |
| Save block artwork as PNG | `saveBlockArtworkPNG` | `saveBlockArtwork` |
| (nothing) | | `saveBlockArtworkPNG` never runs |

## Steps to reproduce

1. Open Music Blocks. It starts in Beginner mode.
2. Open the hamburger menu and click **Advanced** to switch modes.
3. Click the **Save** button in the toolbar.
4. Click **Save block artwork as SVG** and accept the filename.

**Before this change:** the downloaded file is MusicXML, not the block artwork. Same story for the neighbouring items: ABC gives you Lilypond and MusicXML gives you ABC.

**After this change:** every item saves what it says it saves.

To confirm it is the mode toggle and not the exporters, reload the page while already in Advanced mode and do not touch the toggle. The same four items are correct. Here is what I measured, recording the extension each item asked `save.download()` for:

| Save menu item | expected | fresh load, no toggle | after using the toggle |
| --- | --- | --- | --- |
| Save as ABC | `abc` | `abc` | `ly` |
| Save as MusicXML | `xml` | `xml` | `abc` |
| Save block artwork as SVG | `svg` | `svg` | `xml` |
| Save block artwork as PNG | `png` | `png` | `svg` |

## The cause

`Toolbar.renderSaveIcons()` in `js/toolbar-ui.js` takes its eleven handlers positionally:

```js
renderSaveIcons(
    html_onclick, doSVG_onclick, svg_onclick, midi_onclick, png_onclick,
    wave_onclick, ly_onclick, abc_onclick, mxml_onclick,
    blockartworksvg_onclick, blockartworkpng_onclick
) {
```

There are three call sites. Two of them pass eleven arguments and line up correctly. The third, inside `doSwitchMode` in `js/activity.js`, passes twelve:

```js
activity.save.saveLilypond.bind(activity.save),
activity.save.afterSaveLilypondLY.bind(activity.save),   // extra
activity.save.saveAbc.bind(activity.save),
```

`afterSaveLilypondLY` is not a save handler at all. It is a helper that `saveLilypond` calls internally once it has the Lilypond text. Slotting it in at position eight pushes `saveAbc` into the `mxml_onclick` slot, `saveMxml` into the block artwork SVG slot, and so on down the list, and drops `saveBlockArtworkPNG` off the end.

`doSwitchMode` is the Beginner and Advanced toggle handler, so the wiring is correct until the first time you switch modes, and wrong from then on.

## Changes Made

Removed the stray twelfth argument from the `renderSaveIcons` call in `doSwitchMode`, so all three call sites pass the same eleven handlers.

## Testing Performed

There is already a test at `js/__tests__/toolbar.test.js` that checks all eleven positions map to the right save method, and it passes on master. It exercises `renderModeSelectIcon` in `js/toolbar-ui.js` and mocks the mode switch callback as a bare `jest.fn()`, so the real `doSwitchMode` never runs and the mismatch stays invisible to it.

Added `js/__tests__/save-icons-wiring.test.js`, which reads the source and checks the invariant the positional API depends on: every `renderSaveIcons(...)` call site passes exactly one argument per declared parameter, and the last four arguments are the ABC, MusicXML and two block artwork handlers. Two of its four tests fail on master and all four pass with this change.

Also ran the whole suite, 8835 jest tests and all Cypress specs pass, and `npm run lint` and `npx prettier --check` are clean.

In the running app I checked all nine Save menu items in both paths, fresh load and after using the toggle, by recording the extension each one requested. That is the table above.

## Related Issue

No open issue for this one. I found it while testing the toolbar and keyboard paths.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**.




https://github.com/user-attachments/assets/1633b33b-4298-4476-856e-8533436e0c53

