### PR TITLE
fix(musicutils): align numberToPitchSharp octave with A0 baseline

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -1381,6 +1381,35 @@ describe("numberToPitchSharp", () => {
         expect(numberToPitchSharp(1)).toEqual(["A♯", 0]);
         expect(numberToPitchSharp(2)).toEqual(["B", 0]);
     });
+    it("round-trips all 12 pitch classes through pitchToNumber", () => {
+        const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+        for (const name of names) {
+            const pn = pitchToNumber(name, 4, "C major");
+            expect(numberToPitchSharp(pn)).toEqual([name.replace("#", SHARP), 4]);
+        }
+    });
+    it("round-trips natural notes across octaves, including negative octaves", () => {
+        for (let oct = -1; oct <= 6; oct++) {
+            expect(numberToPitchSharp(pitchToNumber("C", oct, "C major"))).toEqual(["C", oct]);
+            expect(numberToPitchSharp(pitchToNumber("A", oct, "C major"))).toEqual(["A", oct]);
+        }
+    });
+    it("round-trips through pitchToNumber in non-12-EDO and meantone temperaments", () => {
+        for (const edo of ["equal19", "equal31", "1/3 comma meantone", "1/4 comma meantone"]) {
+            expect(numberToPitchSharp(pitchToNumber("C", 4, "C major", edo), edo)).toEqual([
+                "C",
+                4
+            ]);
+            expect(numberToPitchSharp(pitchToNumber("A", 4, "C major", edo), edo)).toEqual([
+                "A",
+                4
+            ]);
+            expect(numberToPitchSharp(pitchToNumber("D", 4, "C major", edo), edo)).toEqual([
+                "D",
+                4
+            ]);
+        }
+    });
 });
 
 describe("getNumber", () => {

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -4889,29 +4889,32 @@ const numberToPitchSharp = (i, temperament) => {
                 i += 12;
                 n += 1;
             }
-            const octave = Math.floor(i / 12) - n;
+            const octave = Math.floor((i + PITCHES2.indexOf("A")) / 12) - n;
             const nameIndex = Math.round(((i % 12) / 12) * 12);
             return [PITCHES2[(nameIndex + PITCHES2.indexOf("A")) % 12], octave];
         } else {
-            const octave = Math.floor(i / 12);
+            const octave = Math.floor((i + PITCHES2.indexOf("A")) / 12);
             const nameIndex = Math.round(((i % 12) / 12) * 12);
             return [PITCHES2[(nameIndex + PITCHES2.indexOf("A")) % 12], octave];
         }
     }
-    const t = TEMPERAMENT[temperament];
-    const edoNames = t && t.noteLabels ? t.noteLabels : generateNoteNames(currentEDO);
+    const edoNames = generateNoteNames(currentEDO);
+    let aIndex = edoNames.indexOf("A");
+    if (aIndex === -1) {
+        aIndex = Math.round((9 / 12) * currentEDO);
+    }
     if (i < 0) {
         let n = 0;
         while (i < 0) {
             i += currentEDO;
             n += 1;
         }
-        const octave = Math.floor(i / currentEDO) - n;
-        const nameIndex = i % currentEDO;
+        const octave = Math.floor((i + aIndex) / currentEDO) - n;
+        const nameIndex = (i + aIndex) % currentEDO;
         return [edoNames[nameIndex], octave];
     } else {
-        const octave = Math.floor(i / currentEDO);
-        const nameIndex = i % currentEDO;
+        const octave = Math.floor((i + aIndex) / currentEDO);
+        const nameIndex = (i + aIndex) % currentEDO;
         return [edoNames[nameIndex], octave];
     }
 };


### PR DESCRIPTION
## Description

Corrects an issue with octave calculations in `numberToPitchSharp()`. For the Music Blocks, pitch number 0 corresponds to **A0**, while octaves shift by **C** (`A0, A#0, B0` -> `C1`). `numberToPitchSharp()` calculated `octave = Math.floor(i / 12)`, missing the A-offset; thus, 9 out of 12 pitch classes (from C to G#) were off by one octave.
This pull request introduces `PITCHES2.indexOf("A")` into octave calculations and makes the calculations consistent for non-12


## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- **`js/utils/musicutils.js`**:
  - `octave = Math.floor((i + PITCHES2.indexOf("A")) / 12)` in 12-EDO branch.
  - Used `generateNoteNames(currentEDO)` and added `aIndex` baseline offset in non-12-EDO branch.
- **`js/utils/__tests__/musicutils.test.js`**:
  - Added tests for 12-EDO round-trip, negative octaves, and non-12-EDO / meantone temperaments.

## Steps to Reproduce

run this in terminal -- 

node -e "
global._ = s => s;
global.window = { btoa: s => Buffer.from(s).toString('base64') };

const { pitchToNumber, numberToPitchSharp } = require('./js/utils/musicutils.js');

const pitchNumber = pitchToNumber('C', 4, 'C major');
const result = numberToPitchSharp(pitchNumber);

console.log('C4 -> Pitch Number:', pitchNumber);
console.log('numberToPitchSharp:', result);
"
## Visual Changes
### Before

<img width="643" height="351" alt="image" src="https://github.com/user-attachments/assets/c7df92a9-9a65-4307-9043-e5ecec9c3b62" />


### After

<img width="460" height="351" alt="image" src="https://github.com/user-attachments/assets/d3d44342-23ee-42a3-b723-07c82b85ceb3" />


## Testing Performed

<img width="829" height="157" alt="image" src="https://github.com/user-attachments/assets/592e977c-482d-4f0d-bc98-5df9998029f2" />



## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

caller getNoteFromInterval (js/utils/musicutils.js:5021) looks at note names and did previously ignore the returned octave, so changing it will prevent silent corruptions of any direct consumers and future callers of numberToPitchSharp."
This fix is purely surgical in nature and involves changes to js/utils/musicutils.js and its test file.

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pitch-to-note conversion across 12-tone, equal, non-12-tone, and meantone temperaments.
  - Corrected octave and note positioning, including negative octaves and temperaments without an A reference note.
  - Improved consistency when converting between numeric pitches and note names.

- **Tests**
  - Added coverage for all 12 pitch classes, natural notes across octaves, negative octaves, and multiple temperament systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->