### PR TITLE
fix: temperament retuning when starting pitch changes

### DIFF
--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -520,6 +520,7 @@ function setupIntervalsActions(activity) {
          * @returns {void}
          */
         static setTemperament(temperament, pitch, octave) {
+            const previousStartingPitch = activity.logo.synth.startingPitch;
             activity.logo.synth.inTemperament = temperament;
             activity.logo._userTemperament = temperament;
             activity.logo.synth.startingPitch = pitch + "" + octave;
@@ -529,7 +530,8 @@ function setupIntervalsActions(activity) {
 
             if (
                 activity.logo.temperamentSelected[len - 1] !==
-                activity.logo.temperamentSelected[len - 2]
+                    activity.logo.temperamentSelected[len - 2] ||
+                (len > 1 && activity.logo.synth.startingPitch !== previousStartingPitch)
             ) {
                 activity.logo.synth.changeInTemperament = true;
             }

--- a/js/turtleactions/__tests__/IntervalsActions.test.js
+++ b/js/turtleactions/__tests__/IntervalsActions.test.js
@@ -1104,6 +1104,27 @@ describe("setupIntervalsActions", () => {
         expect(logo.synth.changeInTemperament).toBe(true);
     });
 
+    test.each([
+        ["A", 4],
+        ["C", 5]
+    ])("setTemperament flags a starting-pitch change to %s%s", (pitch, octave) => {
+        Singer.IntervalsActions.setTemperament("just intonation", "C", 4);
+        logo.synth.changeInTemperament = false;
+
+        Singer.IntervalsActions.setTemperament("just intonation", pitch, octave);
+
+        expect(logo.synth.changeInTemperament).toBe(true);
+    });
+
+    test("setTemperament does not flag an unchanged temperament and starting pitch", () => {
+        Singer.IntervalsActions.setTemperament("just intonation", "C", 4);
+        logo.synth.changeInTemperament = false;
+
+        Singer.IntervalsActions.setTemperament("just intonation", "C", 4);
+
+        expect(logo.synth.changeInTemperament).toBe(false);
+    });
+
     test("setTemperament does not flag a change on the very first call when the temperament is unset", () => {
         Singer.IntervalsActions.setTemperament(undefined, "C", 4);
         expect(logo.synth.changeInTemperament).toBe(false);


### PR DESCRIPTION
## Description

This PR fixes an issue where changing the starting pitch of the same temperament did not update the tuning used for note playback.

The temperament frequency table depends on both the selected temperament and its starting pitch. However, Music Blocks only marked the table for rebuilding when the temperament itself changed.

For example:

- `5-limit Just Intonation, C4` → `D4` plays at `297 Hz`
- Change to `5-limit Just Intonation, A4`
- The starting pitch updates to `A4`, but the old C4-based frequency table was reused
- `D4` incorrectly continued playing at `297 Hz`

The temperament change check now also considers the starting pitch. This ensures the frequency table is rebuilt when the pitch or octave changes, even when the temperament remains the same.

## Steps to Reproduce

1. Add a **Set temperament** block with:
   - Temperament: `5-limit Just Intonation`
   - Pitch: `C`
   - Octave: `4`
2. Play `D4`.
3. Add another **Set temperament** block with:
   - Temperament: `5-limit Just Intonation`
   - Pitch: `A`
   - Octave: `4`
4. Play `D4` again.

### Before

Both notes use the old C4-based tuning:

- First `D4`: `297 Hz`
- Second `D4`: `297 Hz` (Wrong)

### After

The second temperament block rebuilds the frequency table using the new starting pitch:

- First `D4`: `297 Hz`
- Second `D4`: `293.33 Hz` (Correct)

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates docs, comments, or README
- [ ] Chore / Refactor — Maintenance or cleanup
- [ ] CI/CD — Changes workflows or automation

## Testing

- [x] Same temperament + different starting pitch rebuilds the frequency table
- [x] Same temperament + different octave triggers a rebuild
- [x] Same temperament + same starting pitch does not trigger an unnecessary rebuild
- [x] Different temperament still triggers a rebuild
- [x] Verified real note playback uses the rebuilt frequency table
- [x] Existing relevant tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Temperament changes are now detected when either the selected temperament or starting pitch changes.
  - Reapplying the same temperament and starting pitch no longer incorrectly indicates a change.

- **Tests**
  - Added coverage for starting-pitch changes and unchanged temperament settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->