### PR TITLE
chore: remove debug console statements from turtle.js

### DIFF
--- a/js/turtle.js
+++ b/js/turtle.js
@@ -135,17 +135,7 @@ class Turtle {
                 that.container.updateCache();
                 that.activity.refreshCanvas();
             },
-            onRetry: attempt => {
-                console.debug(
-                    "Turtle container for " +
-                        that.name +
-                        " not yet ready (attempt " +
-                        (attempt + 1) +
-                        "/" +
-                        MAX_RETRIES +
-                        ")"
-                );
-            },
+            onRetry: attempt => {},
             maxRetries: MAX_RETRIES,
             initialDelay: INITIAL_DELAY,
             errorMessage:


### PR DESCRIPTION
## Description

Removed the debug `console.debug()` statement from `js/turtle.js` as part of the cleanup requested in issue #5464.

The change removes unnecessary debug output during turtle container retry attempts while keeping the existing retry behavior unchanged.

## Related Issue

**Part of:** #5464

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] Performance — Improves performance
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] CI/CD — Changes to CI/CD workflows and automation
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] i18n — Internationalization and localization changes

---

## Changes Made

- Removed the debug `console.debug()` statement from `js/turtle.js`.
- Removed unnecessary console output produced during turtle container retry attempts.
- Kept the existing `console.warn()` statement because it reports a GIF animation failure.
- Ran Prettier on `js/turtle.js`.
- No functional retry behavior was changed.

---

## Steps to Reproduce

Not applicable. This is a maintenance cleanup that removes debug output without changing the intended application behavior.

## Visual Changes

None.

---

## Testing Performed

- `npx eslint js/turtle.js` — passed
- `npm run lint` — passed
- `npm test -- --runInBand` — passed
- 231 test suites passed
- 8,896 tests passed
- `git diff --check` — passed
- `npx prettier --check .` was checked; it reports existing formatting issues elsewhere in the repository, so no unrelated files were modified.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This PR only removes a debug `console.debug()` statement from `js/turtle.js`. The existing `console.warn()` for GIF animation failures has been intentionally preserved.

No functional behavior was intentionally changed.