### PR TITLE
refactor: use the shared announceToScreenReader for aria-live announcements

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -2243,23 +2243,6 @@ class Activity {
          * @param {string|HTMLElement|DocumentFragment} msg - The message to display.
          * @param {number} [duration=60000] - Duration in milliseconds before message disappears.
          */
-        /**
-         * Ensures a visually hidden aria-live region exists for screen reader announcements.
-         * @returns {HTMLElement} The live region element.
-         */
-        const __ensureA11yLiveRegion = () => {
-            let region = document.getElementById("mbA11yLiveRegion");
-            if (region) return region;
-            region = document.createElement("div");
-            region.id = "mbA11yLiveRegion";
-            region.setAttribute("role", "status");
-            region.setAttribute("aria-live", "polite");
-            region.setAttribute("aria-atomic", "true");
-            region.style.cssText =
-                "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
-            document.body.appendChild(region);
-            return region;
-        };
         this.textMsg = (msg, duration = AlertController.MSG_TIMEOUT) => {
             if (this.msgText === null) {
                 // The container may not be ready yet, so do nothing.
@@ -2269,9 +2252,10 @@ class Activity {
             const showMsg = () => {
                 this.alertRenderer.showTextMsg(msg);
             };
-            // Announce to screen readers via aria-live region
+            // textMsg() also accepts an HTMLElement or a DocumentFragment, and
+            // announcing one of those would read out "[object HTMLDivElement]".
             if (msg && typeof msg === "string") {
-                __ensureA11yLiveRegion().textContent = msg;
+                announceToScreenReader(msg);
             }
 
             const hideMsg = () => {
@@ -2298,9 +2282,10 @@ class Activity {
                 return;
             }
 
-            // Announce errors to screen readers via aria-live region
+            // textMsg() also accepts an HTMLElement or a DocumentFragment, and
+            // announcing one of those would read out "[object HTMLDivElement]".
             if (msg && typeof msg === "string") {
-                __ensureA11yLiveRegion().textContent = msg;
+                announceToScreenReader(msg);
             }
 
             const showMsg = () => {

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -27,7 +27,8 @@
     setOctaveRatio, splitScaleDegree, splitSolfege, updateTemperaments,
     docById, define, BlocksDependencies, deepClone, pubsub,
     MINIMUMDOCKDISTANCE, LONGSTACK, SPATIAL_GRID_CELL_SIZE,
-    CAMERAVALUE, VIDEOVALUE, setupBlockDragController
+    CAMERAVALUE, VIDEOVALUE, setupBlockDragController,
+    announceToScreenReader
 */
 
 /* global showZoomOverlay */
@@ -6939,20 +6940,7 @@ class Blocks {
             const blockLabel =
                 (myBlock.protoblock.staticLabels && myBlock.protoblock.staticLabels[0]) ||
                 myBlock.name;
-            const liveRegion =
-                document.getElementById("mbA11yLiveRegion") ||
-                (() => {
-                    const r = document.createElement("div");
-                    r.id = "mbA11yLiveRegion";
-                    r.setAttribute("role", "status");
-                    r.setAttribute("aria-live", "polite");
-                    r.setAttribute("aria-atomic", "true");
-                    r.style.cssText =
-                        "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;";
-                    document.body.appendChild(r);
-                    return r;
-                })();
-            liveRegion.textContent = blockLabel + " " + _("block sent to trash");
+            announceToScreenReader(blockLabel + " " + _("block sent to trash"));
 
             /** Adjust the stack from which we just deleted blocks. */
             if (parentBlock !== null) {


### PR DESCRIPTION
### Why

`utils.js` already has `announceToScreenReader()`, which creates the shared `#mbA11yLiveRegion` and writes a message into it. Two other files had grown their own copies of the same thing:

- `activity.js` — a private `__ensureA11yLiveRegion()` used by `textMsg()` and `errorMsg()`
- `blocks.js` — the region built inline as an IIFE, when announcing a block sent to trash

All three create the same element with the same `id`, `role`, `aria-live`, `aria-atomic` and off-screen `cssText`. The copies were not doing anything the shared helper does not, and three implementations of one live region is a drift risk — a fix to the announcement behaviour in one would silently miss the other two.

This points both call sites at the shared helper. Net **-27 lines**, no behaviour change.

### Notes

`activity.js` keeps its `typeof msg === "string"` check rather than pushing it down into the shared helper, since `textMsg()` also accepts an `HTMLElement` or a `DocumentFragment` and announcing one of those would read out `"[object HTMLDivElement]"`. That constraint is specific to this caller, so it seemed wrong to impose it on everyone.

`announceToScreenReader` is called as a bare identifier, which is how `block.js`, `piemenus.js` and `block-drag-controller.js` already call it. `utils.js` attaches it to `window` deliberately for that, with a comment noting callers have previously hit `ReferenceError` when relying on script load order.

### Testing

`npx jest` — **231 suites, 8896 tests passing**, unchanged from master. `eslint --max-warnings 0` clean on both files.

### How this PR started, since the history is public

I first wrote this as an *extraction*, moving `activity.js`'s helper into a new `js/activity/a11y-live-region.js` with its own tests, aiming at `activity.js`'s 0% coverage. Cypress caught it immediately: `SyntaxError: Identifier 'announceToScreenReader' has already been declared`, 19 of 19 specs failing. The name was already taken by `utils.js`, which is how I found the duplication. A new module was the wrong answer — deleting two copies is the right one.

Worth flagging that Jest was perfectly happy with the broken version; only the browser run caught it.

### Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [x] Chore / Refactor
- [ ] UI/UX
- [ ] i18n

### AI

I used Claude Code for this change and this description. The test counts and the Cypress failure above are from actual runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen reader announcements for activity messages, errors, and block deletion updates.
  - Standardized announcements across the interface using a shared accessibility mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->