### PR TITLE
fix: parse the debug and performance query parameters instead of substring matching

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1229,6 +1229,65 @@ describe("Logo runLogoCommands", () => {
         jest.restoreAllMocks();
     });
 
+    describe("performance mode detection from the URL", () => {
+        // window.location cannot be reassigned in this jsdom, so drive the query
+        // string through history.replaceState, which jsdom does support.
+        const withSearch = (search, fn) => {
+            const before = window.location.search;
+            window.history.replaceState({}, "", search || "/");
+            try {
+                fn();
+            } finally {
+                window.history.replaceState({}, "", before || "/");
+            }
+        };
+
+        const trackerRequestedFor = search => {
+            const requirejsSpy = jest.fn();
+            const originalRequirejs = global.requirejs;
+            const savedTracker = global.performanceTracker;
+            global.requirejs = requirejsSpy;
+            // The lazy-load branch only runs when the tracker is not yet loaded,
+            // which is the situation this URL check exists to decide.
+            delete global.performanceTracker;
+            logo._restoreConnections = jest.fn();
+            logo.runFromBlock = jest.fn();
+            logo.blockList = [];
+            try {
+                withSearch(search, () => logo.runLogoCommands(null, null));
+            } finally {
+                global.requirejs = originalRequirejs;
+                global.performanceTracker = savedTracker;
+            }
+            return requirejsSpy.mock.calls.some(
+                call => Array.isArray(call[0]) && call[0].includes("utils/performanceTracker")
+            );
+        };
+
+        test("loads the tracker for ?performance=true", () => {
+            expect(trackerRequestedFor("?performance=true")).toBe(true);
+        });
+
+        test("loads the tracker when the parameter is not first", () => {
+            expect(trackerRequestedFor("?a=1&performance=true")).toBe(true);
+        });
+
+        test("ignores a parameter that merely ends in performance=true", () => {
+            // A substring search matches "?noperformance=true", which asks for
+            // no such thing.
+            expect(trackerRequestedFor("?noperformance=true")).toBe(false);
+        });
+
+        test("ignores a value that merely starts with true", () => {
+            expect(trackerRequestedFor("?performance=truex")).toBe(false);
+        });
+
+        test("ignores performance=false and an absent parameter", () => {
+            expect(trackerRequestedFor("?performance=false")).toBe(false);
+            expect(trackerRequestedFor("")).toBe(false);
+        });
+    });
+
     test("executes startHere path", () => {
         logo._restoreConnections = jest.fn();
         logo.runFromBlock = jest.fn();

--- a/js/logo.js
+++ b/js/logo.js
@@ -51,6 +51,28 @@ const getPerformanceTracker = () =>
     typeof performanceTracker === "undefined" ? null : performanceTracker;
 
 /**
+ * Whether performance profiling was asked for in the URL.
+ *
+ * Parses the query string rather than searching it for a substring, so that
+ * `?noperformance=true`, `?x=performance=true` and `?performance=truex` are not
+ * mistaken for `?performance=true`. `URLSearchParams` is guarded because it is
+ * absent in very old browsers, where the answer should be "not asked for"
+ * rather than a thrown error inside runLogoCommands.
+ *
+ * @returns {boolean}
+ */
+const _performanceRequestedInURL = () => {
+    if (typeof window === "undefined" || !window.location || !window.location.search) {
+        return false;
+    }
+    try {
+        return new URLSearchParams(window.location.search).get("performance") === "true";
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
  * @class
  * @classdesc Queue entry for managing running blocks.
  */
@@ -1391,8 +1413,7 @@ class Logo {
     runLogoCommands(startHere, env) {
         const performanceModeEnabled =
             typeof window !== "undefined" &&
-            (window.DEBUG_PERFORMANCE === true ||
-                (window.location && window.location.search.includes("performance=true")));
+            (window.DEBUG_PERFORMANCE === true || _performanceRequestedInURL());
 
         if (
             performanceModeEnabled &&

--- a/js/utils/__tests__/debugLog.urlparam.test.js
+++ b/js/utils/__tests__/debugLog.urlparam.test.js
@@ -1,0 +1,66 @@
+/**
+ * debugLog's ?debug=true handling, tested away from localhost.
+ *
+ * The module enables logging on localhost regardless of the URL, and jsdom
+ * runs at localhost by default, so a test for the URL branch would pass no
+ * matter what the URL said. This file runs at a non-local origin, which is
+ * the only place the query parameter decides anything.
+ *
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://musicblocks.sugarlabs.org/"}
+ */
+
+describe("debugLog ?debug= handling away from localhost", () => {
+    let originalConsoleLog;
+    let mockConsoleLog;
+
+    beforeEach(() => {
+        jest.resetModules();
+        if (typeof localStorage !== "undefined") localStorage.clear();
+        originalConsoleLog = console.log;
+        mockConsoleLog = jest.fn();
+        console.log = mockConsoleLog;
+        window.history.pushState({}, "", "/");
+    });
+
+    afterEach(() => {
+        console.log = originalConsoleLog;
+    });
+
+    const debugLogFor = search => {
+        window.history.pushState({}, "", search || "/");
+        jest.resetModules();
+        return require("../debugLog");
+    };
+
+    it("is not localhost, so the URL is what decides", () => {
+        expect(["localhost", "127.0.0.1"]).not.toContain(window.location.hostname);
+    });
+
+    it("logs for ?debug=true", () => {
+        debugLogFor("/?debug=true")("hello");
+        expect(mockConsoleLog).toHaveBeenCalledWith("[MB]", "hello");
+    });
+
+    it("logs when debug=true is not the first parameter", () => {
+        debugLogFor("/?a=1&debug=true&b=2")("hello");
+        expect(mockConsoleLog).toHaveBeenCalledWith("[MB]", "hello");
+    });
+
+    it("stays silent for ?nodebug=true", () => {
+        // A substring match reads this as a request for debug logging.
+        debugLogFor("/?nodebug=true")("hello");
+        expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it("stays silent for ?debug=truex", () => {
+        debugLogFor("/?debug=truex")("hello");
+        expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it("stays silent for ?debug=false and with no parameter", () => {
+        debugLogFor("/?debug=false")("hello");
+        debugLogFor("/")("hello");
+        expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+});

--- a/js/utils/debugLog.js
+++ b/js/utils/debugLog.js
@@ -53,12 +53,13 @@ const debugLog = (() => {
         }
 
         // 2. URL parameter: ?debug=true
-        if (
-            typeof window !== "undefined" &&
-            window.location &&
-            window.location.search.includes("debug=true")
-        ) {
-            return console.log.bind(console, "[MB]");
+        // Parsed rather than substring-matched, so that "?nodebug=true" and
+        // "?debug=truex" are not mistaken for it.
+        if (typeof window !== "undefined" && window.location && window.location.search) {
+            const params = new URLSearchParams(window.location.search);
+            if (params.get("debug") === "true") {
+                return console.log.bind(console, "[MB]");
+            }
         }
 
         // 3. Auto-enable for local development (no flag set).


### PR DESCRIPTION
### Problem

Two places read a query parameter by searching the raw query string for a substring:

```js
js/logo.js:1395            window.location.search.includes("performance=true")
js/utils/debugLog.js:59    window.location.search.includes("debug=true")
```

So URLs that never asked for either feature switch it on:

| URL | current | should be |
|---|---|---|
| `?performance=true` / `?debug=true` | enabled | enabled |
| `?noperformance=true` / `?nodebug=true` | **enabled** | not enabled |
| `?performance=truex` / `?debug=truex` | **enabled** | not enabled |
| `?x=performance=true` | **enabled** | not enabled |

In both cases the comment directly above already names the parameter — `?performance=true`, `?debug=true` — so the substring match was not the intent.

The cost is small but real: `logo.js` lazy-loads `performanceTracker` and pays its overhead on a page that did not ask, and `debugLog` starts writing to the console in production.

### Fix

Parse with `URLSearchParams` and compare the value. `logo.js`'s call is guarded, because `URLSearchParams` is absent in very old browsers and the right answer there is "not requested" rather than an exception thrown inside `runLogoCommands`.

`performanceTracker.js` already has exactly this logic, correctly parsed, in `isPerformanceModeEnabled()` at line 119 — but it is **dead code**: never called, never exported. `logo.js` cannot use it, because this check is what decides whether that module is loaded at all, so at that moment it does not exist. Flagging it since it is presumably meant to be the single source of truth; happy to remove it or wire it up in a follow-up, whichever you prefer.

### Tests

Eleven tests across the two files. Reverting **only** the source and keeping the tests fails exactly the false-positive cases and leaves the genuine ones passing:

```
logo.js reverted:
  ✓ loads the tracker for ?performance=true
  ✕ ignores a parameter that merely ends in performance=true
  ✕ ignores a value that merely starts with true

debugLog.js reverted:
  ✓ logs for ?debug=true
  ✕ stays silent for ?nodebug=true
  ✕ stays silent for ?debug=truex
```

Full suite: **232 suites, 8907 tests passing**. `eslint --max-warnings 0` clean.

Two notes on method, since both nearly produced worthless tests:

- The `logo.js` tests first set the query string by replacing `window.location`. That silently does nothing in this jsdom, so the branch never ran and **every test passed, including the ones written to fail**. `history.replaceState` is what works.
- `debugLog` also enables logging on localhost regardless of the URL, and jsdom runs at localhost, so URL tests there pass whatever the URL says. The new file runs at `https://musicblocks.sugarlabs.org/` and asserts it is not localhost before asserting anything else.

### Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n

### AI

I used Claude Code for this change and this description. The URL behaviour table, the revert results and the suite counts are from running the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance-mode detection from URL parameters to recognize only valid `performance=true` values.
  - Prevented malformed, false, or missing parameters from incorrectly enabling performance profiling.
  - Added safeguards for environments without URL parameter support.
  - Improved debug logging controls to activate only when the URL contains an exact `debug=true` parameter.
  - Prevented unrelated URL text, false values, or missing parameters from enabling debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->