### PR TITLE
fix(mxml): use the closed-form dot multiplier for note duration

### DIFF
--- a/js/__tests__/mxml.test.js
+++ b/js/__tests__/mxml.test.js
@@ -156,7 +156,7 @@ describe("saveMxmlOutput", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    0: [[["C"], 4, 1]]
+                    0: [[["C4"], 4, 1]]
                 }
             }
         };
@@ -165,13 +165,15 @@ describe("saveMxmlOutput", () => {
 
         // Quarter note (32 / 4 = 8 divisions) with one dot: 8 * 1.5 = 12.
         expect(output).toContain("<duration>12</duration>");
+        expect(output).toContain("<step>C</step>");
+        expect(output).toContain("<octave>4</octave>");
     });
 
     it("should compute duration correctly for a double-dotted note (base * 1.75, not base * 2.25)", () => {
         const logo = {
             notation: {
                 notationStaging: {
-                    0: [[["C"], 4, 2]]
+                    0: [[["C4"], 4, 2]]
                 }
             }
         };
@@ -193,8 +195,8 @@ describe("saveMxmlOutput", () => {
             notation: {
                 notationStaging: {
                     0: [
-                        [["C"], 4, 2],
-                        [["D"], 4, 2]
+                        [["C4"], 4, 2],
+                        [["D4"], 4, 2]
                     ]
                 }
             }

--- a/js/__tests__/mxml.test.js
+++ b/js/__tests__/mxml.test.js
@@ -151,4 +151,58 @@ describe("saveMxmlOutput", () => {
         expect(output).toContain('<tie type="start"/>');
         expect(output).toContain('<tie type="stop"/>');
     });
+
+    it("should compute duration correctly for a single-dotted note (base * 1.5)", () => {
+        const logo = {
+            notation: {
+                notationStaging: {
+                    0: [[["C"], 4, 1]]
+                }
+            }
+        };
+
+        const output = saveMxmlOutput(logo);
+
+        // Quarter note (32 / 4 = 8 divisions) with one dot: 8 * 1.5 = 12.
+        expect(output).toContain("<duration>12</duration>");
+    });
+
+    it("should compute duration correctly for a double-dotted note (base * 1.75, not base * 2.25)", () => {
+        const logo = {
+            notation: {
+                notationStaging: {
+                    0: [[["C"], 4, 2]]
+                }
+            }
+        };
+
+        const output = saveMxmlOutput(logo);
+
+        // Quarter note (32 / 4 = 8 divisions) with two dots: 8 * 1.75 = 14.
+        // A naive loop that multiplies by 1.5 per dot instead yields 8 * 2.25 = 18.
+        expect(output).toContain("<duration>14</duration>");
+        expect(output).not.toContain("<duration>18</duration>");
+    });
+
+    it("should account for double-dotted duration when deciding measure breaks", () => {
+        // Two double-dotted quarter notes at 14 divisions each total 28, which
+        // fits in one 32-division measure. With the old, inflated duration (18
+        // each, 36 total), the second note would overflow the measure and force
+        // a premature break into a second measure.
+        const logo = {
+            notation: {
+                notationStaging: {
+                    0: [
+                        [["C"], 4, 2],
+                        [["D"], 4, 2]
+                    ]
+                }
+            }
+        };
+
+        const output = saveMxmlOutput(logo);
+        const measureCount = (output.match(/<measure /g) || []).length;
+
+        expect(measureCount).toBe(1);
+    });
 });

--- a/js/mxml.js
+++ b/js/mxml.js
@@ -139,8 +139,10 @@ saveMxmlOutput = logo => {
 
             let isChordNote = false;
             for (const p of obj[0]) {
-                let dur = 32 / obj[1];
-                for (let j = 0; j < obj[2]; j++) dur += dur / 2;
+                // obj[2] is the dot count; 2 - 1/2^dotCount is the same multiplier
+                // durationToNoteValue() (musicutils.js) uses to derive it, so this stays
+                // consistent with how the dot count was assigned in the first place.
+                const dur = (32 / obj[1]) * (2 - 1 / Math.pow(2, obj[2]));
 
                 if (divisionsLeft < dur && !isChordNote) {
                     if (openedMeasureTag) {


### PR DESCRIPTION
## Description

`saveMxmlOutput` (MusicXML export) computes the wrong `<duration>` for double-dotted notes, and the same wrong value can misplace measure breaks for the rest of that voice.

## Related Issue

**Fixes:** #8532

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

`js/mxml.js`:

```js
let dur = 32 / obj[1];
for (let j = 0; j < obj[2]; j++) dur += dur / 2;
```

`obj[2]` is the note's dot count, coming straight from `durationToNoteValue()` (`js/utils/musicutils.js`). That function derives the dot count using the multiplier `2 - 1/2^dotCount` — 1.5x for one dot, 1.75x for two. The export code instead multiplies the running `dur` by 1.5 on every iteration, so:

- 1 dot: `base * 1.5` — matches.
- 2 dots: `base * 1.5 * 1.5 = base * 2.25` — wrong, should be `base * 1.75`.

`dur` also drives `divisionsLeft`, which decides when a `</measure>` tag is emitted, so a single double-dotted note can force premature measure breaks for the rest of that voice, not just misreport its own length.

Fixed by replacing the loop with the same closed-form multiplier already used (and proven correct) by `durationToNoteValue()`:

```js
const dur = (32 / obj[1]) * (2 - 1 / Math.pow(2, obj[2]));
```

`js/__tests__/mxml.test.js`: added regression tests for single- and double-dotted duration values, and for the resulting measure-break accounting. The existing suite only exercised dot count 0, so this branch had no coverage.

---

## Steps to Reproduce

1. Build a stack with a note carrying two `Dot` blocks (dot count 2).
2. Save the project as MusicXML.
3. The affected note's `<duration>` is 2.25x the base note value instead of 1.75x, and a subsequent measure break in that voice can land in the wrong place.

## Testing

- `npx jest js/__tests__/mxml.test.js` — 10/10 passing
- `npx jest js/__tests__/mxml.test.js js/__tests__/lilypond.test.js js/__tests__/abc.test.js js/utils/__tests__/musicutils.test.js js/__tests__/notation.test.js` — 579/579 passing
- Full suite (`npx jest`) — only pre-existing, unrelated failures remain (`setupBlockDragController is not defined` in `RhythmBlocks.test.js`, confirmed present on `master` before this change)
- `npx eslint js/mxml.js js/__tests__/mxml.test.js` — clean
- `npx prettier --check js/mxml.js js/__tests__/mxml.test.js` — clean
- `npm audit --omit=dev --audit-level=high` — clean

## Notes

Scope is limited to the dot-duration computation. Tuplet durations (the other branch of `durationToNoteValue()`'s return value) aren't consumed anywhere in `mxml.js` today — that's a separate, pre-existing gap and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected dotted-note duration calculations.
  - Single-dotted notes now use the expected 1.5× duration.
  - Double-dotted notes now use the expected 1.75× duration instead of being overextended.
  - Improved measure-break handling so consecutive double-dotted quarter notes remain correctly within a measure.

- **Tests**
  - Added coverage for dotted durations, octave parsing in pitch strings, and measure-boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->