### PR TITLE
fix(heap): restore the turtle heap as an array, not an object

### DIFF
--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -830,6 +830,12 @@ describe("numberOfNotes — state restoration and tally logic", () => {
 
     test("should restore an untouched heap as an array, not an object", () => {
         delete logoMock.turtleHeaps[0];
+        // The counted run fills a heap the turtle did not have; restoring it
+        // must leave an empty array behind, not an object.
+        logoMock.runFromBlockNow = jest.fn(() => {
+            turtleMock.singer.tallyNotes += 5;
+            logoMock.turtleHeaps[0] = [8, 9];
+        });
 
         Singer.numberOfNotes(logoMock, 0, 123);
 
@@ -841,8 +847,15 @@ describe("numberOfNotes — state restoration and tally logic", () => {
         expect(logoMock.turtleHeaps[0]).toEqual([7]);
     });
 
-    test("should restore the previous heap contents unchanged", () => {
+    test("should undo heap mutations made during the counted run", () => {
         logoMock.turtleHeaps[0] = [1, 2, 3];
+        // Mutate the heap in place and by reassignment so the assertion fails
+        // if restoration is skipped.
+        logoMock.runFromBlockNow = jest.fn(() => {
+            turtleMock.singer.tallyNotes += 5;
+            logoMock.turtleHeaps[0].push(99);
+            logoMock.turtleHeaps[0][0] = -1;
+        });
 
         Singer.numberOfNotes(logoMock, 0, 123);
 
@@ -952,6 +965,11 @@ describe("noteCounter regression behavior", () => {
 
     test("should restore an untouched heap as an array, not an object", () => {
         delete logoMock.turtleHeaps[0];
+        // The counted run fills a heap the turtle did not have; restoring it
+        // must leave an empty array behind, not an object.
+        activityMock.logo.runFromBlockNow = jest.fn(() => {
+            logoMock.turtleHeaps[0] = [8, 9];
+        });
 
         Singer.noteCounter(logoMock, 0, 1);
 
@@ -963,8 +981,14 @@ describe("noteCounter regression behavior", () => {
         expect(logoMock.turtleHeaps[0]).toEqual([7]);
     });
 
-    test("should restore the previous heap contents unchanged", () => {
+    test("should undo heap mutations made during the counted run", () => {
         logoMock.turtleHeaps[0] = [4, 5];
+        // Mutate the heap in place and by reassignment so the assertion fails
+        // if restoration is skipped.
+        activityMock.logo.runFromBlockNow = jest.fn(() => {
+            logoMock.turtleHeaps[0].push(99);
+            logoMock.turtleHeaps[0][0] = -1;
+        });
 
         Singer.noteCounter(logoMock, 0, 1);
 

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -800,24 +800,22 @@ describe("numberOfNotes — state restoration and tally logic", () => {
                 ithTurtle: jest.fn().mockReturnValue(turtleMock),
                 getTurtle: jest.fn().mockReturnValue({ queue: [] }),
                 turtleList: [turtleMock]
-            },
-            logo: {
-                runFromBlockNow: jest.fn((logo, turtle) => {
-                    const tur = turtleMock;
-                    tur.singer.tallyNotes += 5;
-                }),
-                boxes: {},
-                turtleHeaps: { 0: {} },
-                turtleDicts: { 0: {} }
             }
         };
 
+        // numberOfNotes reads the saved state off the logo it is handed and
+        // restores it onto activity.logo. Those are the same object at runtime,
+        // so the mock has to share one object too.
         logoMock = {
             activity: activityMock,
+            runFromBlockNow: jest.fn(() => {
+                turtleMock.singer.tallyNotes += 5;
+            }),
             boxes: {},
-            turtleHeaps: { 0: {} },
+            turtleHeaps: { 0: [] },
             turtleDicts: { 0: {} }
         };
+        activityMock.logo = logoMock;
     });
 
     test("should return tally difference and restore state", () => {
@@ -828,6 +826,27 @@ describe("numberOfNotes — state restoration and tally logic", () => {
         expect(result).toBe(5);
         expect(turtleMock.singer.tallyNotes).toBe(2);
         expect(turtleMock.painter.doPenUp).toHaveBeenCalled();
+    });
+
+    test("should restore an untouched heap as an array, not an object", () => {
+        delete logoMock.turtleHeaps[0];
+
+        Singer.numberOfNotes(logoMock, 0, 123);
+
+        expect(logoMock.turtleHeaps[0]).toEqual([]);
+        expect(Array.isArray(logoMock.turtleHeaps[0])).toBe(true);
+
+        // An object fallback makes the next push block throw.
+        logoMock.turtleHeaps[0].push(7);
+        expect(logoMock.turtleHeaps[0]).toEqual([7]);
+    });
+
+    test("should restore the previous heap contents unchanged", () => {
+        logoMock.turtleHeaps[0] = [1, 2, 3];
+
+        Singer.numberOfNotes(logoMock, 0, 123);
+
+        expect(logoMock.turtleHeaps[0]).toEqual([1, 2, 3]);
     });
 });
 
@@ -909,7 +928,7 @@ describe("noteCounter regression behavior", () => {
             queue: []
         });
         logoMock.boxes = {};
-        logoMock.turtleHeaps = { 0: {} };
+        logoMock.turtleHeaps = { 0: [] };
         logoMock.turtleDicts = { 0: {} };
         activityMock.logo.runFromBlockNow = jest.fn();
         singer = turtleMock.singer;
@@ -929,6 +948,27 @@ describe("noteCounter regression behavior", () => {
         const originalLength = singer.justCounting.length;
         Singer.noteCounter(logoMock, 0, 1);
         expect(singer.justCounting.length).toBe(originalLength);
+    });
+
+    test("should restore an untouched heap as an array, not an object", () => {
+        delete logoMock.turtleHeaps[0];
+
+        Singer.noteCounter(logoMock, 0, 1);
+
+        expect(logoMock.turtleHeaps[0]).toEqual([]);
+        expect(Array.isArray(logoMock.turtleHeaps[0])).toBe(true);
+
+        // An object fallback makes the next push block throw.
+        logoMock.turtleHeaps[0].push(7);
+        expect(logoMock.turtleHeaps[0]).toEqual([7]);
+    });
+
+    test("should restore the previous heap contents unchanged", () => {
+        logoMock.turtleHeaps[0] = [4, 5];
+
+        Singer.noteCounter(logoMock, 0, 1);
+
+        expect(logoMock.turtleHeaps[0]).toEqual([4, 5]);
     });
 });
 

--- a/js/blocks/HeapBlocks.js
+++ b/js/blocks/HeapBlocks.js
@@ -69,6 +69,10 @@ function setupHeapBlocks(activity) {
          * @returns {string} - The JSON string representation of the heap.
          */
         arg(logo, turtle, blk) {
+            if (!(turtle in logo.turtleHeaps)) {
+                logo.turtleHeaps[turtle] = [];
+            }
+
             if (
                 logo.inStatusMatrix &&
                 activity.blocks.blockList[activity.blocks.blockList[blk].connections[0]].name ===
@@ -392,6 +396,10 @@ function setupHeapBlocks(activity) {
          * @param {number} turtle - The turtle number.
          */
         flow(args, logo, turtle) {
+            if (!(turtle in logo.turtleHeaps)) {
+                logo.turtleHeaps[turtle] = [];
+            }
+
             // Reverse the order of the turtle's heap
             logo.turtleHeaps[turtle] = logo.turtleHeaps[turtle].reverse();
         }

--- a/js/blocks/IntervalsBlocks.js
+++ b/js/blocks/IntervalsBlocks.js
@@ -478,7 +478,7 @@ function setupIntervalsBlocks(activity) {
 
             // Restore previous state
             logo.boxes = saveBoxes;
-            logo.turtleHeaps[turtle] = saveTurtleHeaps ?? {};
+            logo.turtleHeaps[turtle] = saveTurtleHeaps ?? [];
             logo.turtleDicts[turtle] = saveTurtleDicts ?? {};
 
             tur.painter.doPenUp();
@@ -599,7 +599,7 @@ function setupIntervalsBlocks(activity) {
 
             // Restore previous state
             logo.boxes = saveBoxes;
-            logo.turtleHeaps[turtle] = saveTurtleHeaps ?? {};
+            logo.turtleHeaps[turtle] = saveTurtleHeaps ?? [];
             logo.turtleDicts[turtle] = saveTurtleDicts ?? {};
 
             tur.painter.doPenUp();

--- a/js/blocks/__tests__/HeapBlocks.test.js
+++ b/js/blocks/__tests__/HeapBlocks.test.js
@@ -154,6 +154,16 @@ describe("setupHeapBlocks", () => {
             expect(result).toBeUndefined();
             expect(logo.statusFields).toContainEqual([blk, "heap"]);
         });
+
+        it("should create an empty heap and return '[]' if the turtle heap is undefined", () => {
+            const turtle = 1;
+            delete logo.turtleHeaps[turtle];
+            const heapBlock = createdBlocks["heap"];
+            logo.inStatusMatrix = false;
+            const result = heapBlock.arg(logo, turtle, 99);
+            expect(result).toBe("[]");
+            expect(logo.turtleHeaps[turtle]).toEqual([]);
+        });
     });
 
     describe("ShowHeapBlock", () => {
@@ -240,6 +250,23 @@ describe("setupHeapBlocks", () => {
             const reverseHeapBlock = createdBlocks["reverseHeap"];
             reverseHeapBlock.flow([], logo, turtle);
             expect(logo.turtleHeaps[turtle]).toEqual([4, 3, 2, 1]);
+        });
+
+        it("should create an empty heap if the turtle heap is undefined", () => {
+            const turtle = 1;
+            delete logo.turtleHeaps[turtle];
+            const reverseHeapBlock = createdBlocks["reverseHeap"];
+            reverseHeapBlock.flow([], logo, turtle);
+            expect(logo.turtleHeaps[turtle]).toEqual([]);
+            expect(Array.isArray(logo.turtleHeaps[turtle])).toBe(true);
+        });
+
+        it("should leave a single-entry heap unchanged", () => {
+            const turtle = 0;
+            setTurtleHeap(turtle, [9]);
+            const reverseHeapBlock = createdBlocks["reverseHeap"];
+            reverseHeapBlock.flow([], logo, turtle);
+            expect(logo.turtleHeaps[turtle]).toEqual([9]);
         });
     });
 

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -923,13 +923,39 @@ describe("setupIntervalsBlocks", () => {
             logo.runFromBlockNow = jest.fn();
         });
 
-        it("Heap absent before measurement: logo.turtleHeaps[turtle] is not set (key absent) and should be {} after cycle", () => {
+        it("Heap absent before measurement: the heap is restored as an empty array, not an object", () => {
             logo.turtleHeaps = {};
             logo.turtleDicts = { [turtleIndex]: {} };
 
             createdBlocks.measureintervalsemitones.arg(logo, turtleIndex, "blkMeasure");
 
-            expect(logo.turtleHeaps[turtleIndex]).toEqual({});
+            expect(logo.turtleHeaps[turtleIndex]).toEqual([]);
+            expect(Array.isArray(logo.turtleHeaps[turtleIndex])).toBe(true);
+
+            // The restored heap must still behave like a heap: an object fallback
+            // makes the next push block throw "push is not a function".
+            logo.turtleHeaps[turtleIndex].push(42);
+            expect(logo.turtleHeaps[turtleIndex]).toEqual([42]);
+        });
+
+        it("Heap absent before a scalar measurement: the heap is restored as an empty array", () => {
+            logo.turtleHeaps = {};
+            logo.turtleDicts = { [turtleIndex]: {} };
+
+            createdBlocks.measureintervalscalar.arg(logo, turtleIndex, "blkMeasure");
+
+            expect(logo.turtleHeaps[turtleIndex]).toEqual([]);
+            expect(Array.isArray(logo.turtleHeaps[turtleIndex])).toBe(true);
+        });
+
+        it("Empty heap before measurement: the heap stays an empty array", () => {
+            logo.turtleHeaps = { [turtleIndex]: [] };
+            logo.turtleDicts = { [turtleIndex]: {} };
+
+            createdBlocks.measureintervalsemitones.arg(logo, turtleIndex, "blkMeasure");
+
+            expect(logo.turtleHeaps[turtleIndex]).toEqual([]);
+            expect(Array.isArray(logo.turtleHeaps[turtleIndex])).toBe(true);
         });
 
         it("Heap present before measurement: logo.turtleHeaps[turtle] is [1, 2, 3] and should be deep cloned", () => {

--- a/js/blocks/__tests__/IntervalsBlocks.test.js
+++ b/js/blocks/__tests__/IntervalsBlocks.test.js
@@ -926,6 +926,11 @@ describe("setupIntervalsBlocks", () => {
         it("Heap absent before measurement: the heap is restored as an empty array, not an object", () => {
             logo.turtleHeaps = {};
             logo.turtleDicts = { [turtleIndex]: {} };
+            // The measured run fills a heap the turtle did not have; restoring
+            // it must leave an empty array behind, not an object.
+            logo.runFromBlockNow = jest.fn(() => {
+                logo.turtleHeaps[turtleIndex] = [8, 9];
+            });
 
             createdBlocks.measureintervalsemitones.arg(logo, turtleIndex, "blkMeasure");
 
@@ -941,6 +946,9 @@ describe("setupIntervalsBlocks", () => {
         it("Heap absent before a scalar measurement: the heap is restored as an empty array", () => {
             logo.turtleHeaps = {};
             logo.turtleDicts = { [turtleIndex]: {} };
+            logo.runFromBlockNow = jest.fn(() => {
+                logo.turtleHeaps[turtleIndex] = [8, 9];
+            });
 
             createdBlocks.measureintervalscalar.arg(logo, turtleIndex, "blkMeasure");
 
@@ -948,9 +956,12 @@ describe("setupIntervalsBlocks", () => {
             expect(Array.isArray(logo.turtleHeaps[turtleIndex])).toBe(true);
         });
 
-        it("Empty heap before measurement: the heap stays an empty array", () => {
+        it("Empty heap before measurement: heap entries added while measuring are discarded", () => {
             logo.turtleHeaps = { [turtleIndex]: [] };
             logo.turtleDicts = { [turtleIndex]: {} };
+            logo.runFromBlockNow = jest.fn(() => {
+                logo.turtleHeaps[turtleIndex].push(1, 2);
+            });
 
             createdBlocks.measureintervalsemitones.arg(logo, turtleIndex, "blkMeasure");
 
@@ -962,10 +973,18 @@ describe("setupIntervalsBlocks", () => {
             const originalHeap = [1, 2, 3];
             logo.turtleHeaps = { [turtleIndex]: originalHeap };
             logo.turtleDicts = { [turtleIndex]: {} };
+            // Mutate in place and by reassignment so the assertions below fail
+            // if restoration is skipped.
+            logo.runFromBlockNow = jest.fn(() => {
+                logo.turtleHeaps[turtleIndex].push(99);
+                logo.turtleHeaps[turtleIndex][0] = -1;
+            });
 
             createdBlocks.measureintervalsemitones.arg(logo, turtleIndex, "blkMeasure");
 
-            expect(logo.turtleHeaps[turtleIndex]).toEqual(originalHeap);
+            // Compared against a literal: the run above mutates originalHeap,
+            // and the restored heap must be the pre-run snapshot, not that.
+            expect(logo.turtleHeaps[turtleIndex]).toEqual([1, 2, 3]);
             expect(logo.turtleHeaps[turtleIndex]).not.toBe(originalHeap);
         });
 

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -608,7 +608,7 @@ class Singer {
 
         // Restore previous state
         logo.boxes = saveBoxes ?? {};
-        logo.turtleHeaps[turtle] = saveTurtleHeaps ?? {};
+        logo.turtleHeaps[turtle] = saveTurtleHeaps ?? [];
         logo.turtleDicts[turtle] = saveTurtleDicts ?? {};
 
         tur.painter.doPenUp();
@@ -713,7 +713,7 @@ class Singer {
         });
 
         activity.logo.boxes = saveState.boxes ?? {};
-        activity.logo.turtleHeaps[turtle] = saveState.turtleHeaps ?? {};
+        activity.logo.turtleHeaps[turtle] = saveState.turtleHeaps ?? [];
         activity.logo.turtleDicts[turtle] = saveState.turtleDicts ?? {};
 
         tur.painter.doPenUp();


### PR DESCRIPTION
## Description

The blocks that silently re-run part of the program to measure it save the turtle heap and restore it afterwards. The restore fell back to `{}` when the mouse had no heap yet, but the heap is an **array** everywhere else in the codebase. Because the restore line runs unconditionally, it also *created* the key — so simply using **note counter**, **sum note values**, **glide**, or either interval-measure block left the heap as a plain object.

Every heap block afterwards then misbehaved: **push** threw `push is not a function`, **set heap** skipped its grow loop (`undefined < idx`) and wrote a numeric key onto the object, and **heap** printed `{"2":100}` instead of `[0,0,100]`.

## Related Issue

**Fixes:** #8537

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**Restore the heap as an array (4 sites)** — `?? {}` becomes `?? []`:

- `js/turtle-singer.js:611` — `Singer.noteCounter`, used by **sum note values** and **glide**
- `js/turtle-singer.js:716` — `Singer.numberOfNotes`, used by **note counter**
- `js/blocks/IntervalsBlocks.js:481` — **semi-tone interval measure**
- `js/blocks/IntervalsBlocks.js:602` — **scalar interval measure**

The adjacent `turtleDicts[turtle] = saveTurtleDicts ?? {}` lines are left alone — dicts really are objects.

**Add the missing initialisation guard (2 blocks)** in `js/blocks/HeapBlocks.js`:

- `reverseHeap` — threw `Cannot read properties of undefined (reading 'reverse')` on an untouched heap
- `heap` — returned `undefined` rather than `"[]"`

These were the only two of the ten heap blocks without the guard. The exported-JavaScript API already routes `HEAP` and `reverseHeap()` through `_ensureHeap()`, so this brings the block palette in line with the generated JavaScript.

**Tests** — the existing test `"Heap absent before measurement ... should be {} after cycle"` asserted the object fallback, so it is updated to expect an array and to check the restored heap still accepts a `push`. Five further cases cover the other sites and the boundary cases (empty heap, populated heap, single-entry reverse).

---

## Steps to Reproduce

**A. Hard crash**

1. From the **Meter** palette, put a **note counter** block inside a **print** block, with any **note** block in the note counter's clamp.
2. Below it, add **push** `1` from the **Heap** palette.
3. Run.

Before this PR the program stops with `TypeError: ...push is not a function`; after it, the push succeeds.

**B. Silent corruption**

Same setup, but use **set heap** `3` to `100` and then **print** **heap**. Before: `{"2":100}`. After: `[0,0,100]`.

---

## Testing Performed

- `npx jest` — full suite green: **231 suites, 8948 passed**, 1 skipped.
- Confirmed the tests actually catch the defect: with the six source lines reverted to their previous state but the new tests in place, exactly **6 tests fail**, one per defect site. Restoring the fix turns all six green.
- `npm run lint` — clean.
- `npx prettier --check` on the six changed files — clean.

---

## Additional Notes

`Singer.numberOfNotes` reads the saved state off the `logo` it is handed but restores onto `activity.logo`. Those are the same object at runtime, so this is not a bug, but the test mock had them as two separate objects — which meant the restore was never actually observed by assertions. The mock now shares one object, matching runtime. No production behaviour depends on this.

Happy to split the two `HeapBlocks.js` guards into their own PR if reviewers prefer to keep this to the `?? []` change alone.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed heap handling so missing heaps are restored as usable arrays instead of objects.
  - Prevented errors when reading, reversing, or restoring empty heaps.
  - Preserved existing heap contents during note counting and interval measurements.
  - Ensured temporary heap changes are discarded when restoring saved state.
  - Kept restored heap data independent from the original contents.

- **Tests**
  - Added regression coverage for missing, empty, and single-entry heaps.
  - Verified restored heaps support adding new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->