### PR TITLE
fix(utils): take the mixed-number whole part from the magnitude

### DIFF
--- a/js/blocks/ExtrasBlocks.js
+++ b/js/blocks/ExtrasBlocks.js
@@ -60,12 +60,8 @@ function setupExtrasBlocks(activity) {
                 activity.errorMsg(NOINPUTERRORMSG, blk);
                 return "0/1";
             } else {
-                let a = logo.parseArg(logo, turtle, cblk, blk, receivedArg);
+                const a = logo.parseArg(logo, turtle, cblk, blk, receivedArg);
                 if (typeof a === "number") {
-                    if (a < 0) {
-                        a = a * -1;
-                        return "-" + mixedNumber(a);
-                    }
                     return mixedNumber(a);
                 }
                 activity.errorMsg(NANERRORMSG, blk);

--- a/js/logo.js
+++ b/js/logo.js
@@ -886,8 +886,7 @@ class Logo {
                         } else {
                             const a = logo.parseArg(logo, turtle, cblk, blk, receivedArg);
                             if (typeof a === "number") {
-                                currentBlock.value =
-                                    a < 0 ? "-" + utils.mixedNumber(-a) : utils.mixedNumber(a);
+                                currentBlock.value = utils.mixedNumber(a);
                             } else {
                                 logo.deps.errorHandler(NANERRORMSG, blk);
                                 currentBlock.value = 0;

--- a/js/utils/__tests__/utils-logic.test.js
+++ b/js/utils/__tests__/utils-logic.test.js
@@ -152,6 +152,29 @@ describe("Utility Logic Functions", () => {
         it("returns input if not a number", () => {
             expect(mixedNumber("abc")).toBe("abc");
         });
+
+        it("takes the whole and fractional parts from the magnitude", () => {
+            // Flooring the signed value would give "-2 1/2", which reads as -2.5.
+            expect(mixedNumber(-1.5)).toBe("-1 1/2");
+            expect(mixedNumber(-2.75)).toBe("-2 3/4");
+        });
+
+        it("does not promote a negative proper fraction to a whole number", () => {
+            expect(mixedNumber(-0.25)).toBe("-1/4");
+            expect(mixedNumber(-0.875)).toBe("-7/8");
+        });
+
+        it("signs negative integers without changing their magnitude", () => {
+            expect(mixedNumber(-2)).toBe("-2/1");
+        });
+
+        it("rounds a negative just short of a whole number to that whole number", () => {
+            expect(mixedNumber(-1.9999999999)).toBe("-2");
+        });
+
+        it("falls back to two decimals for an awkward negative denominator", () => {
+            expect(mixedNumber(-2.123456)).toBe("-2.12");
+        });
     });
 
     describe("nearestBeat()", () => {

--- a/js/utils/__tests__/utils.test.js
+++ b/js/utils/__tests__/utils.test.js
@@ -276,7 +276,31 @@ describe("Utility Functions (logic-only)", () => {
             expect(mixedNumber(2)).toBe("2/1");
         });
         it("handles negative fraction", () => {
-            expect(mixedNumber(-1.5)).toBe("-2 1/2");
+            // The sign is carried on the front and the whole/fractional parts
+            // come from the magnitude, so this reads as -1.5 and not -2.5.
+            expect(mixedNumber(-1.5)).toBe("-1 1/2");
+            expect(mixedNumber(-2.75)).toBe("-2 3/4");
+        });
+
+        it("keeps a negative proper fraction below one", () => {
+            expect(mixedNumber(-0.25)).toBe("-1/4");
+            expect(mixedNumber(-0.5)).toBe("-1/2");
+            expect(mixedNumber(-0.875)).toBe("-7/8");
+        });
+
+        it("handles negative integers", () => {
+            expect(mixedNumber(-2)).toBe("-2/1");
+            expect(mixedNumber(-1)).toBe("-1/1");
+        });
+
+        it("formats negatives as the mirror of their positive counterpart", () => {
+            for (const n of [0.25, 0.5, 0.875, 1.5, 2.25, 2.75, 3, 1.9999999999, 2.123456]) {
+                expect(mixedNumber(-n)).toBe("-" + mixedNumber(n));
+            }
+        });
+
+        it("treats negative zero as zero", () => {
+            expect(mixedNumber(-0)).toBe("0/1");
         });
 
         it("handles zero", () => {

--- a/js/utils/utils-logic.js
+++ b/js/utils/utils-logic.js
@@ -294,30 +294,38 @@ function rationalToFraction(d) {
 
 /**
  * Converts a number to a mixed fraction string.
+ *
+ * The whole and fractional parts are taken from the magnitude and the sign is
+ * carried on the front, so -1.5 reads as "-1 1/2". Working straight off the
+ * signed value instead would floor -1.5 to -2 and render "-2 1/2", which reads
+ * as -2.5.
  */
 var mixedNumber = d => {
-    if (typeof d === "number") {
-        const floor = Math.floor(d);
-        if (d > floor) {
-            const obj = rationalToFraction(d - floor);
-            if (floor === 0) {
-                return obj[0] + "/" + obj[1];
+    if (typeof d !== "number") {
+        return d;
+    }
+
+    const sign = d < 0 ? "-" : "";
+    const magnitude = Math.abs(d);
+    const floor = Math.floor(magnitude);
+
+    if (magnitude > floor) {
+        const obj = rationalToFraction(magnitude - floor);
+        if (floor === 0) {
+            return sign + obj[0] + "/" + obj[1];
+        } else {
+            if (obj[0] === 1 && obj[1] === 1) {
+                return sign + (floor + 1).toString();
             } else {
-                if (obj[0] === 1 && obj[1] === 1) {
-                    return (floor + 1).toString();
+                if (obj[1] > 99) {
+                    return sign + magnitude.toFixed(2);
                 } else {
-                    if (obj[1] > 99) {
-                        return d.toFixed(2);
-                    } else {
-                        return floor + " " + obj[0] + "/" + obj[1];
-                    }
+                    return sign + floor + " " + obj[0] + "/" + obj[1];
                 }
             }
-        } else if (floor === d) {
-            return d.toString() + "/1";
         }
-    } else {
-        return d;
+    } else if (floor === magnitude) {
+        return sign + magnitude.toString() + "/1";
     }
 };
 

--- a/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
+++ b/scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json
@@ -495,7 +495,7 @@
       "isGenerator": false,
       "returns": 6,
       "throws": 0,
-      "branches": 7
+      "branches": 8
     },
     {
       "name": "nearestBeat",
@@ -819,7 +819,7 @@
     },
     {
       "target": "mixedNumber",
-      "description": "Converts a number to a mixed fraction string.",
+      "description": "Converts a number to a mixed fraction string. The whole and fractional parts are taken from the magnitude and the sign is carried on the front, so -1.5 reads as \"-1 1/2\". Working straight off the signed value instead would floor -1.5 to -2 and render \"-2 1/2\", which reads as -2.5.",
       "tags": []
     },
     {
@@ -921,7 +921,7 @@
     }
   ],
   "totals": {
-    "branches": 195,
+    "branches": 196,
     "returns": 105,
     "throws": 0
   }


### PR DESCRIPTION
## Description

`mixedNumber` took the whole part with `Math.floor` applied to the **signed** value. `Math.floor` rounds toward negative infinity, so for negatives it pushed the whole part away from zero and the fractional remainder was then measured from the wrong whole number. Every negative non-integer came out wrong in both sign and magnitude.

The divide block is a parameter block (`LeftBlock` sets `flows.left`, which sets `parameter = true`), so `js/blocks.js:7064` renders its live on-canvas label through `mixedNumber`:

| Divide block | Value | Before | After |
| --- | --- | --- | --- |
| `-1 / 4` | -0.25 | **-1 3/4** | -1/4 |
| `-1 / 2` | -0.5 | **-1 1/2** | -1/2 |
| `-7 / 8` | -0.875 | **-1 1/8** | -7/8 |
| `-3 / 2` | -1.5 | **-2 1/2** | -1 1/2 |
| `-11 / 4` | -2.75 | **-3 1/4** | -2 3/4 |

`-1/4` displaying as `-1 3/4` is not a rounding nit — it is a different number.

## Related Issue

**Fixes:** #8540

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`js/utils/utils-logic.js`** — `mixedNumber` now derives the whole and fractional parts from `Math.abs(d)` and carries the sign on the front. The branch structure is otherwise unchanged.

**`js/logo.js` and `js/blocks/ExtrasBlocks.js`** — both call sites already worked around this by negating the value and prepending `"-"` themselves. Those branches are redundant once the function is correct, so they are removed and the convention lives in one place. Both are provably equivalent: the old code passed the magnitude in and prefixed the sign, which is exactly what the function now does.

**`js/utils/__tests__/utils.test.js`** — the case named `"handles negative fraction"` asserted the old `"-2 1/2"`; corrected and extended.

**`js/utils/__tests__/utils-logic.test.js`** — added cases for the mixed, proper-fraction, integer, near-whole-rounding and two-decimal-fallback paths on the negative side.

**`scripts/generate-tests/__tests__/fixtures/utils-logic.plan.json`** — regenerated. This fixture is a committed structural snapshot compared byte-for-byte, and `mixedNumber`'s branch count (7 → 8) and JSDoc changed. The diff is three lines, all confined to `mixedNumber` plus the module branch total.

---

## Steps to Reproduce

1. From the **Number** palette, drag a **divide** block and set it to `-1` divided by `4`.
2. Plug it into a **print** block inside a **start** block so it evaluates, and run.
3. Read the divide block's label on the canvas.

Before: `-1 3/4`. After: `-1/4`.

---

## Testing Performed

- `npx jest` — full suite green: **231 suites, 8948 passed**, 1 skipped.
- Mutation-tested: reverting `mixedNumber` alone while keeping the new tests fails exactly **6** of them.
- Verified positive input is untouched, and that non-number and non-finite input (`NaN`, `±Infinity`, strings, `null`, `undefined`) returns byte-identical results to `master` — the change is confined to negative non-integers.
- Confirmed the reachability claim rather than assuming it: built a faithful replica of `DivideBlock`'s constructor against the exported `ProtoBlock.LeftBlock` and asserted `parameter === true`, which is what opens the `blocks.js:7064` label path.
- `npm run lint` — clean. `npx prettier --check` on the five changed JS files — clean.

---

## Additional Notes

**Two things deliberately left alone:**

`mixedNumber(NaN)` returns `undefined` via an implicit fall-through. That is pre-existing, unchanged by this PR, and out of scope for the sign bug — I verified it behaves identically before and after. Worth a separate follow-up to make the function total, but folding it in here would mix two unrelated behaviour changes.

The regenerated plan fixture is not Prettier-clean — but neither is the version currently on `master`. It is emitted by `stringifyPlan` and compared byte-for-byte, so running `--write` on it would break `scripts/generate-tests/__tests__/real-modules.test.js`. It is left exactly as the generator produces it.

Related but distinct: #8397 fixed sign handling in `rationalToFraction`, the helper `mixedNumber` calls, and did not touch `mixedNumber` itself.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected negative number formatting in mixed-number displays.
  * Negative values now render with the sign applied correctly, such as `-1 1/2` instead of `-2 1/2`.
  * Improved handling of negative fractions, integers, rounding, and negative zero.

* **Tests**
  * Added coverage for negative mixed numbers and related edge cases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->