### PR TITLE
fix(activity): dynamic viewport scaling in fullscreen mode

### DIFF
--- a/js/__tests__/activity_fullscreen_resize.test.js
+++ b/js/__tests__/activity_fullscreen_resize.test.js
@@ -131,6 +131,8 @@ describe("Activity Fullscreen and Viewport Resize Handling (Issue #8536)", () =>
         expect(overCanvas.height).toBe(1080);
         expect(canvasHolder.width).toBe(1920);
         expect(canvasHolder.height).toBe(1080);
+        expect(canvasHolder.style.width).toBe("1920px");
+        expect(canvasHolder.style.height).toBe("1080px");
         expect(mockRefreshCanvas).toHaveBeenCalled();
     });
 
@@ -148,6 +150,8 @@ describe("Activity Fullscreen and Viewport Resize Handling (Issue #8536)", () =>
         expect(canvas.height).toBe(1440);
         expect(overCanvas.width).toBe(2560);
         expect(overCanvas.height).toBe(1440);
+        expect(canvasHolder.style.width).toBe("2560px");
+        expect(canvasHolder.style.height).toBe("1440px");
     });
 
     test("dynamically resizes in standard windowed mode (1366x768)", () => {
@@ -164,6 +168,52 @@ describe("Activity Fullscreen and Viewport Resize Handling (Issue #8536)", () =>
         expect(canvas.height).toBe(768);
         expect(overCanvas.width).toBe(1366);
         expect(overCanvas.height).toBe(768);
+        expect(canvasHolder.style.width).toBe("1366px");
+        expect(canvasHolder.style.height).toBe("768px");
+    });
+
+    test("dynamically resizes using outerWidth/outerHeight on Android WebKit", () => {
+        const activityPath = path.resolve(__dirname, "../activity.js");
+        const code = fs.readFileSync(activityPath, "utf8");
+        const handleResizeMarker = "function handleResize() {";
+        const startIdx = code.indexOf(handleResizeMarker);
+        let endIdx = startIdx + handleResizeMarker.length;
+        let braceDepth = 1;
+        while (braceDepth > 0 && endIdx < code.length) {
+            if (code[endIdx] === "{") braceDepth++;
+            else if (code[endIdx] === "}") braceDepth--;
+            endIdx++;
+        }
+        const fnSource = code.substring(startIdx, endIdx);
+
+        window.innerWidth = 800;
+        window.innerHeight = 1200;
+        window.outerWidth = 1080;
+        window.outerHeight = 1920;
+
+        const androidSandbox = {
+            document,
+            window,
+            container,
+            canvas,
+            overCanvas,
+            canvasHolder,
+            platform: { androidWebkit: true },
+            that: {
+                refreshCanvas: mockRefreshCanvas
+            }
+        };
+        vm.createContext(androidSandbox);
+        vm.runInContext(`${fnSource}\nthis.handleResize = handleResize;`, androidSandbox);
+
+        androidSandbox.handleResize();
+
+        expect(container.style.width).toBe("1080px");
+        expect(container.style.height).toBe("1920px");
+        expect(canvas.width).toBe(1080);
+        expect(canvas.height).toBe(1920);
+        expect(canvasHolder.style.width).toBe("1080px");
+        expect(canvasHolder.style.height).toBe("1920px");
     });
 
     test("skips resize calculations when document is hidden to avoid zero-dimension corruption", () => {

--- a/js/__tests__/activity_fullscreen_resize.test.js
+++ b/js/__tests__/activity_fullscreen_resize.test.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2026 Sugar Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+describe("Activity Fullscreen and Viewport Resize Handling (Issue #8536)", () => {
+    let handleResize;
+    let container;
+    let canvas;
+    let overCanvas;
+    let canvasHolder;
+    let hideContents;
+    let mockRefreshCanvas;
+    let mockSetupPaletteMenu;
+    let activityInstance;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="canvasHolder">
+                <div id="canvasContainer">
+                    <canvas id="myCanvas" width="1200" height="900"></canvas>
+                </div>
+            </div>
+            <canvas id="canvas" width="1200" height="900"></canvas>
+            <div id="hideContents"></div>
+        `;
+
+        container = document.getElementById("canvasContainer");
+        canvas = document.getElementById("myCanvas");
+        overCanvas = document.getElementById("canvas");
+        canvasHolder = document.getElementById("canvasHolder");
+        hideContents = document.getElementById("hideContents");
+
+        mockRefreshCanvas = jest.fn();
+        mockSetupPaletteMenu = jest.fn();
+
+        // Extract and instantiate the handleResize function from activity.js
+        const activityPath = path.resolve(__dirname, "../activity.js");
+        const code = fs.readFileSync(activityPath, "utf8");
+
+        // Extract the handleResize function block
+        const handleResizeMarker = "function handleResize() {";
+        const startIdx = code.indexOf(handleResizeMarker);
+        expect(startIdx).not.toBe(-1);
+
+        let endIdx = startIdx + handleResizeMarker.length;
+        let braceDepth = 1;
+        while (braceDepth > 0 && endIdx < code.length) {
+            if (code[endIdx] === "{") braceDepth++;
+            else if (code[endIdx] === "}") braceDepth--;
+            endIdx++;
+        }
+        const fnSource = code.substring(startIdx, endIdx);
+
+        // Run in VM with properly scoped references
+        const sandbox = {
+            document,
+            window,
+            container,
+            canvas,
+            overCanvas,
+            canvasHolder,
+            that: {
+                refreshCanvas: mockRefreshCanvas
+            }
+        };
+
+        vm.createContext(sandbox);
+        vm.runInContext(`${fnSource}\nthis.handleResize = handleResize;`, sandbox);
+        handleResize = sandbox.handleResize;
+
+        // Reset dimensions
+        Object.defineProperty(window, "innerWidth", {
+            writable: true,
+            configurable: true,
+            value: 1024
+        });
+        Object.defineProperty(window, "innerHeight", {
+            writable: true,
+            configurable: true,
+            value: 768
+        });
+        Object.defineProperty(window.screen, "width", {
+            writable: true,
+            configurable: true,
+            value: 1920
+        });
+        Object.defineProperty(window.screen, "height", {
+            writable: true,
+            configurable: true,
+            value: 1080
+        });
+        Object.defineProperty(document, "hidden", {
+            writable: true,
+            configurable: true,
+            value: false
+        });
+    });
+
+    test("dynamically resizes container and canvases to 100% viewport in fullscreen mode (1920x1080)", () => {
+        // Entering fullscreen on a standard 1080p display
+        window.innerWidth = 1920;
+        window.innerHeight = 1080;
+        window.screen.width = 1920;
+        window.screen.height = 1080;
+
+        handleResize();
+
+        // Must not be clamped to legacy 1600x900
+        expect(container.style.width).toBe("1920px");
+        expect(container.style.height).toBe("1080px");
+        expect(canvas.width).toBe(1920);
+        expect(canvas.height).toBe(1080);
+        expect(overCanvas.width).toBe(1920);
+        expect(overCanvas.height).toBe(1080);
+        expect(canvasHolder.width).toBe(1920);
+        expect(canvasHolder.height).toBe(1080);
+        expect(mockRefreshCanvas).toHaveBeenCalled();
+    });
+
+    test("dynamically resizes container and canvases to high-resolution viewports (2560x1440 2K)", () => {
+        window.innerWidth = 2560;
+        window.innerHeight = 1440;
+        window.screen.width = 2560;
+        window.screen.height = 1440;
+
+        handleResize();
+
+        expect(container.style.width).toBe("2560px");
+        expect(container.style.height).toBe("1440px");
+        expect(canvas.width).toBe(2560);
+        expect(canvas.height).toBe(1440);
+        expect(overCanvas.width).toBe(2560);
+        expect(overCanvas.height).toBe(1440);
+    });
+
+    test("dynamically resizes in standard windowed mode (1366x768)", () => {
+        window.innerWidth = 1366;
+        window.innerHeight = 768;
+        window.screen.width = 1920;
+        window.screen.height = 1080;
+
+        handleResize();
+
+        expect(container.style.width).toBe("1366px");
+        expect(container.style.height).toBe("768px");
+        expect(canvas.width).toBe(1366);
+        expect(canvas.height).toBe(768);
+        expect(overCanvas.width).toBe(1366);
+        expect(overCanvas.height).toBe(768);
+    });
+
+    test("skips resize calculations when document is hidden to avoid zero-dimension corruption", () => {
+        container.style.width = "1024px";
+        container.style.height = "768px";
+
+        document.hidden = true;
+        window.innerWidth = 1920;
+        window.innerHeight = 1080;
+
+        handleResize();
+
+        // Dimensions should remain unchanged
+        expect(container.style.width).toBe("1024px");
+        expect(container.style.height).toBe("768px");
+        expect(mockRefreshCanvas).not.toHaveBeenCalled();
+    });
+
+    test("guards against zero or negative dimensions", () => {
+        container.style.width = "1024px";
+        container.style.height = "768px";
+
+        window.innerWidth = 0;
+        window.innerHeight = 0;
+
+        handleResize();
+
+        expect(container.style.width).toBe("1024px");
+        expect(container.style.height).toBe("768px");
+        expect(mockRefreshCanvas).not.toHaveBeenCalled();
+    });
+});

--- a/js/activity.js
+++ b/js/activity.js
@@ -1799,8 +1799,6 @@ class Activity {
         const canvas = document.getElementById("myCanvas");
         const overCanvas = document.getElementById("canvas");
         const canvasHolder = document.getElementById("canvasHolder");
-        const defaultWidth = 1600;
-        const defaultHeight = 900;
 
         function handleResize() {
             // Skip resize when the tab is hidden to prevent 0×0 canvas
@@ -1808,33 +1806,29 @@ class Activity {
                 return;
             }
 
-            const isMaximized =
-                window.innerWidth === window.screen.width &&
-                window.innerHeight === window.screen.height;
-            if (isMaximized) {
-                container.style.width = defaultWidth + "px";
-                container.style.height = defaultHeight + "px";
-                canvas.width = defaultWidth;
-                canvas.height = defaultHeight;
-                overCanvas.width = canvas.width;
-                overCanvas.height = canvas.height;
-                canvasHolder.width = defaultWidth;
-                canvasHolder.height = defaultHeight;
-            } else {
-                const windowWidth = window.innerWidth;
-                const windowHeight = window.innerHeight;
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
 
-                // Guard against zero or invalid dimensions
-                if (windowWidth <= 0 || windowHeight <= 0) {
-                    return;
-                }
+            // Guard against zero or invalid dimensions
+            if (windowWidth <= 0 || windowHeight <= 0) {
+                return;
+            }
 
+            if (container) {
                 container.style.width = windowWidth + "px";
                 container.style.height = windowHeight + "px";
-                overCanvas.width = canvas.width;
-                overCanvas.height = canvas.height;
-                canvasHolder.width = canvas.width;
-                canvasHolder.height = canvas.height;
+            }
+            if (canvas && (canvas.width !== windowWidth || canvas.height !== windowHeight)) {
+                canvas.width = windowWidth;
+                canvas.height = windowHeight;
+            }
+            if (overCanvas) {
+                overCanvas.width = canvas ? canvas.width : windowWidth;
+                overCanvas.height = canvas ? canvas.height : windowHeight;
+            }
+            if (canvasHolder) {
+                canvasHolder.width = canvas ? canvas.width : windowWidth;
+                canvasHolder.height = canvas ? canvas.height : windowHeight;
             }
             const hideContents = document.getElementById("hideContents");
             if (hideContents) {

--- a/js/activity.js
+++ b/js/activity.js
@@ -1806,8 +1806,14 @@ class Activity {
                 return;
             }
 
-            const windowWidth = window.innerWidth;
-            const windowHeight = window.innerHeight;
+            const windowWidth =
+                typeof platform !== "undefined" && platform.androidWebkit
+                    ? window.outerWidth
+                    : window.innerWidth;
+            const windowHeight =
+                typeof platform !== "undefined" && platform.androidWebkit
+                    ? window.outerHeight
+                    : window.innerHeight;
 
             // Guard against zero or invalid dimensions
             if (windowWidth <= 0 || windowHeight <= 0) {
@@ -1827,8 +1833,12 @@ class Activity {
                 overCanvas.height = canvas ? canvas.height : windowHeight;
             }
             if (canvasHolder) {
-                canvasHolder.width = canvas ? canvas.width : windowWidth;
-                canvasHolder.height = canvas ? canvas.height : windowHeight;
+                const holderWidth = canvas ? canvas.width : windowWidth;
+                const holderHeight = canvas ? canvas.height : windowHeight;
+                canvasHolder.width = holderWidth;
+                canvasHolder.height = holderHeight;
+                canvasHolder.style.width = holderWidth + "px";
+                canvasHolder.style.height = holderHeight + "px";
             }
             const hideContents = document.getElementById("hideContents");
             if (hideContents) {


### PR DESCRIPTION


## Description

This PR fixes a bug in fullscreen mode where the main workspace, canvas, and toolbar do not scale to fill the available screen real estate on modern displays (such as 1080p, 1440p, or 4K), leaving a large empty black region at the bottom of the viewport.

## Related Issue

Fixes: #8536

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage


---

## Changes Made

js/activity.js:

Removed legacy constants defaultWidth = 1600; and defaultHeight = 900;.
Removed the if (isMaximized) clamp block in handleResize().
Unified handleResize() so both windowed and fullscreen/maximized states dynamically resize #canvasContainer, #myCanvas, #canvas, and #canvasHolder to 100% of the actual viewport (window.innerWidth and window.innerHeight).
Added defensive null checks and zero-dimension guards (windowWidth <= 0 || windowHeight <= 0) to prevent canvas coordinate corruption.

js/__tests__/activity_fullscreen_resize.test.js:

Added 5 unit tests validating:

Fullscreen mode dynamic scaling (1920×1080) without 1600×900 clamping.
High-resolution scaling on 2K/4K displays (2560×1440).
Proper scaling in standard windowed mode (1366×768).
Document hidden guard (document.hidden === true) to safely skip calculations.
Zero/negative dimension defensive guards.


---

## Steps to Reproduce

-Open Music Blocks in a browser on a screen with resolution 1920×1080 or higher.
-Click the Fullscreen toggle button in the top toolbar (or press F11).
-Observed (before fix): The workspace remains constrained to 1600×900, leaving a large 180px black dead space bar across the bottom of the screen.
-Expected (after fix): The workspace, toolbar, and canvas dynamically expand to fill 100% of the viewport height and width without black bars.

## Visual Changes

Before
<img width="1917" height="1020" alt="before" src="https://github.com/user-attachments/assets/3cb9720d-d7a1-4349-8d36-265f22c63314" />



After
<img width="1917" height="1021" alt="after" src="https://github.com/user-attachments/assets/0e47d283-8d30-4bf4-b295-b9a9369d9908" />


---

## Testing Performed

Automated Tests
✅ npm test -- js/__tests__/activity_fullscreen_resize.test.js (5/5 unit tests passed)
✅ npm test -- js/__tests__/activity_listeners.test.js js/__tests__/activity_fullscreen_resize.test.js (13/13 tests passed)
✅ npm run lint (0 errors, 0 warnings)
✅ npx prettier --check js/activity.js js/__tests__/activity_fullscreen_resize.test.js (100% formatted)

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---


---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved canvas and activity resizing on Android WebKit by using the correct outer window dimensions.
  - Canvas container styles now stay synchronized with calculated dimensions during fullscreen, high-resolution, and windowed resizing.

- **Tests**
  - Added coverage validating visible canvas container dimensions across resize modes.
  - Added a regression test for Android WebKit window sizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->