### PR TITLE
fix: guard against null cblk1 in OutputToolsBlocks.arg() (#6608)

### DIFF
--- a/js/blocks/PitchBlocks.js
+++ b/js/blocks/PitchBlocks.js
@@ -495,7 +495,9 @@ function setupPitchBlocks(activity) {
                 if (cblk1 !== null) {
                     arg1 = logo.parseArg(logo, turtle, cblk1, blk, receivedArg);
                 }
-                if (activity.blocks.blockList[cblk1].name === "notename") {
+                if (cblk1 === null) {
+                    notePlayed = "G4";
+                } else if (activity.blocks.blockList[cblk1].name === "notename") {
                     notePlayed = arg1 + (tur.singer.currentOctave ? tur.singer.currentOctave : 4);
                 } else if (
                     activity.blocks.blockList[cblk1].name === "solfege" ||

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -675,6 +675,14 @@ describe("setupPitchBlocks", () => {
         });
     });
 
+    describe("OutputToolsBlocks null-connection repro", () => {
+        it("arg does not crash when the note input is unconnected", () => {
+            const block = createdBlocks["outputtools"];
+            activity.blocks.blockList[10].connections[1] = null;
+            expect(() => block.arg(logo, 0, 10)).not.toThrow();
+        });
+    });
+
     describe("StaffYToPitch", () => {
         it("arg with all connection combinations", () => {
             const block = createdBlocks["ytopitch"];

--- a/js/blocks/__tests__/PitchBlocks.test.js
+++ b/js/blocks/__tests__/PitchBlocks.test.js
@@ -679,7 +679,7 @@ describe("setupPitchBlocks", () => {
         it("arg does not crash when the note input is unconnected", () => {
             const block = createdBlocks["outputtools"];
             activity.blocks.blockList[10].connections[1] = null;
-            expect(() => block.arg(logo, 0, 10)).not.toThrow();
+            expect(block.arg(logo, 0, 10)).toBe("G4");
         });
     });
 


### PR DESCRIPTION
## Description

Fixes a `TypeError: Cannot read properties of undefined (reading 'name')` crash in `OutputToolsBlocks.arg()` when the block's note input is unconnected.

Line 498 read `activity.blocks.blockList[cblk1].name` without checking `cblk1` for `null` first — even though the line immediately above it (`if (cblk1 !== null) { arg1 = logo.parseArg(...) }`) already guards the same variable before its first use. If nothing is plugged into the block's second input, `cblk1` is `null`, `blockList[null]` is `undefined`, and reading `.name` on it throws.

Reproduced live via a Status/current-pitch widget fed by an `outputtools` block with no note connected:

Fixed by adding an explicit `cblk1 === null` branch ahead of the existing `else if` chain, falling back to `"G4"`. This isn't an arbitrary default — it matches the exact fallback the sibling `StaffYToPitch` function elsewhere in this same file already uses for an unconnected pitch input, so the "unconnected → G4" convention stays consistent across the file rather than introducing a new one.

## Related Issue

Part of #6608

## Category

- [x] Bug Fix

## Type of Change

- [x] Bug Fix

## Testing Performed

1. Added a regression test (`OutputToolsBlocks null-connection repro`) that calls `arg()` with `connections[1] = null` — confirmed it fails with the exact same `TypeError` at line 498 *before* the fix, and passes after.
2. Ran the full `PitchBlocks.test.js` suite — 83/83 pass, no regressions.
3. `npx eslint js/blocks/PitchBlocks.js js/blocks/__tests__/PitchBlocks.test.js` — clean.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pitch conversion now uses G4 when no note input is connected, preventing failures.
  * Existing conversion behavior remains unchanged when a note input is provided.

* **Tests**
  * Added regression coverage to verify the G4 fallback for disconnected note inputs.
  * Confirmed that pitch conversion continues to work with connected note inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->