### PR TITLE
fix: scope the value-bar hotkey guard instead of blocking all shortcuts (#6608)

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -1841,6 +1841,77 @@ describe("Logo runFromBlockNow", () => {
             expect(mockActivity.textMsg).toHaveBeenCalledWith("width: 77");
             expect(logo.stopTurtle).toBe(true);
         });
+        test("a second value display within 3s extends the valueBarVisible window instead of being cut short", () => {
+            jest.useFakeTimers();
+            logo.parseArg = jest.fn(() => 77);
+            const widthBlock = {
+                name: "width",
+                value: 77,
+                protoblock: { args: 0, dockTypes: ["numberout"] },
+                connections: [],
+                isValueBlock: () => false,
+                isArgBlock: () => true
+            };
+            logo.blockList = [widthBlock];
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+            expect(mockActivity.valueBarVisible).toBe(true);
+
+            jest.advanceTimersByTime(2000);
+            logo.stopTurtle = false;
+            logo.runFromBlockNow(logo, 0, 0, 0, null); // second display, 2s into the first window
+
+            jest.advanceTimersByTime(2000); // 4s since first display, but only 2s since second
+            expect(mockActivity.valueBarVisible).toBe(true);
+
+            jest.advanceTimersByTime(1000); // 3s since the second display
+            expect(mockActivity.valueBarVisible).toBe(false);
+
+            jest.useRealTimers();
+        });
+
+        test("doStopTurtles resets valueBarVisible even if it interrupts the window", () => {
+            jest.useFakeTimers();
+            logo.parseArg = jest.fn(() => 77);
+            const widthBlock = {
+                name: "width",
+                value: 77,
+                protoblock: { args: 0, dockTypes: ["numberout"] },
+                connections: [],
+                isValueBlock: () => false,
+                isArgBlock: () => true
+            };
+            logo.blockList = [widthBlock];
+
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+            expect(mockActivity.valueBarVisible).toBe(true);
+
+            logo.doStopTurtles();
+            expect(mockActivity.valueBarVisible).toBe(false);
+
+            // A new value display 2s after stop starts its own 3s window,
+            // due to end at t=5000 (relative to the run above).
+            jest.advanceTimersByTime(2000);
+            logo.stopTurtle = false;
+            logo.runFromBlockNow(logo, 0, 0, 0, null);
+            expect(mockActivity.valueBarVisible).toBe(true);
+
+            // t=3000: this is when the FIRST (stopped) display's original
+            // timer would have fired, if doStopTurtles() had failed to
+            // cancel it via _timerManager. If that stale callback fires here,
+            // it wrongly clears valueBarVisible mid-way through the second
+            // display's own window - this is what actually proves
+            // cancellation happened, not just that doStopTurtles() sets the
+            // flag directly.
+            jest.advanceTimersByTime(1000);
+            expect(mockActivity.valueBarVisible).toBe(true);
+
+            // t=5000: the second display's own timer fires on schedule.
+            jest.advanceTimersByTime(2000);
+            expect(mockActivity.valueBarVisible).toBe(false);
+
+            jest.useRealTimers();
+        });
     });
 
     describe("profiling", () => {

--- a/js/activity/__tests__/keyboard-controller-valuebar.test.js
+++ b/js/activity/__tests__/keyboard-controller-valuebar.test.js
@@ -1,0 +1,89 @@
+/**
+ * Verifies the printText.show guard in __keyPressed() is scoped to the
+ * value-bar case (#4931) and no longer blocks unrelated status messages.
+ */
+const path = require("path");
+
+beforeAll(() => {
+    global._ = key => key;
+    global.platformColor = { stopIconcolor: "red" };
+    global.STANDARDBLOCKHEIGHT = 20;
+    global.disableHorizScrollIcon = { style: { display: "none" } };
+});
+
+let setupKeyboardController;
+beforeAll(() => {
+    jest.resetModules();
+    ({ setupKeyboardController } = require(path.resolve(__dirname, "../keyboard-controller.js")));
+});
+
+beforeEach(() => {
+    document.getElementById = jest.fn(id => {
+        if (id === "labelDiv") return { classList: { contains: () => false } };
+        if (["lilypondModal", "planet-iframe", "wheelDiv"].includes(id)) return { style: {} };
+        return null;
+    });
+    document.getElementsByClassName = jest.fn(() => []);
+    global.window.widgetWindows = { isOpen: jest.fn(() => false), openWindows: {} };
+});
+
+test("an unrelated status message (e.g. Alt-R Play) does not block ENTER-to-stop", () => {
+    const doHardStop = jest.fn();
+    const activity = {
+        keyboardEnableFlag: true,
+        currentKeyCode: 0,
+        currentKey: "",
+        printText: { classList: { contains: c => c === "show" } },
+        isInputON: false,
+        searchWidget: { style: { visibility: "hidden" } },
+        helpfulSearchWidget: { style: { visibility: "hidden" } },
+        pasteBox: { createBox: jest.fn(), show: jest.fn(), getPos: jest.fn(() => [10, 20]) },
+        paste: { style: { visibility: "hidden" }, value: "", focus: jest.fn() },
+        turtles: { running: jest.fn(() => true), setStageScale: jest.fn() },
+        blocks: { activeBlock: null },
+        _doHardStopButton: doHardStop,
+        textMsg: jest.fn()
+    };
+
+    const controller = setupKeyboardController(activity);
+    const event = new Event("keydown", { cancelable: true });
+    Object.defineProperty(event, "keyCode", { value: 13, configurable: true });
+    Object.defineProperty(event, "altKey", { value: false, configurable: true });
+
+    controller.__keyPressed(event);
+    controller.dispose();
+
+    // Before the fix this failed: doHardStop was never called because the
+    // old printText.show guard returned early before ENTER's own handling ran.
+    expect(doHardStop).toHaveBeenCalledTimes(1);
+});
+
+test("value-bar display still blocks hotkeys (the original #4931 protection is preserved)", () => {
+    const doHardStop = jest.fn();
+    const activity = {
+        keyboardEnableFlag: true,
+        currentKeyCode: 0,
+        currentKey: "",
+        printText: { classList: { contains: () => false } },
+        valueBarVisible: true,
+        isInputON: false,
+        searchWidget: { style: { visibility: "hidden" } },
+        helpfulSearchWidget: { style: { visibility: "hidden" } },
+        pasteBox: { createBox: jest.fn(), show: jest.fn(), getPos: jest.fn(() => [10, 20]) },
+        paste: { style: { visibility: "hidden" }, value: "", focus: jest.fn() },
+        turtles: { running: jest.fn(() => true), setStageScale: jest.fn() },
+        blocks: { activeBlock: null },
+        _doHardStopButton: doHardStop,
+        textMsg: jest.fn()
+    };
+
+    const controller = setupKeyboardController(activity);
+    const event = new Event("keydown", { cancelable: true });
+    Object.defineProperty(event, "keyCode", { value: 13, configurable: true });
+    Object.defineProperty(event, "altKey", { value: false, configurable: true });
+
+    controller.__keyPressed(event);
+    controller.dispose();
+
+    expect(doHardStop).not.toHaveBeenCalled();
+});

--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -92,8 +92,15 @@ class KeyboardController {
         if (document.getElementById("labelDiv").classList.contains("hasKeyboard")) {
             return;
         }
-        // Skip hotkeys when value bar is visible (prevents accidental block creation)
-        if (activity.printText && activity.printText.classList.contains("show")) {
+        // Skip hotkeys when the screen-dimension block value bar is visible
+        // (prevents accidental block creation, #4931). This used to check
+        // activity.printText's shared "show" class, but that class is set by
+        // every textMsg() call in the app (Alt-R "Play", scroll toggles,
+        // etc.), not just the value bar - which meant any status message
+        // silently blocked every hotkey for up to 60s (AlertController.
+        // MSG_TIMEOUT). valueBarVisible is a dedicated flag set only by the
+        // value-bar display itself (js/logo.js), scoped to a short window.
+        if (activity.valueBarVisible) {
             return;
         }
 

--- a/js/logo.js
+++ b/js/logo.js
@@ -2082,6 +2082,15 @@ class Logo {
                     const displayText = label ? label + ": " + value : value;
                     logo.deps.textMsg(displayText);
                 }
+                // Briefly block hotkeys so a hotkey press right after clicking
+                // this value display can't accidentally spawn a new block
+                // (#4931). Scoped to just this case, not every status message.
+                if (logo.activity) {
+                    logo.activity.valueBarVisible = true;
+                    setTimeout(() => {
+                        if (logo.activity) logo.activity.valueBarVisible = false;
+                    }, 3000);
+                }
             } else {
                 logo.deps.errorHandler("I do not know how to " + blockName + ".", blk);
             }

--- a/js/logo.js
+++ b/js/logo.js
@@ -200,6 +200,7 @@ class Logo {
 
         // Related to running programs
         this._lastNoteTimeout = null;
+        this._valueBarTimeout = null;
         this._alreadyRunning = false;
         this._prematureRestart = false;
         this._runningBlock = null;
@@ -1303,6 +1304,12 @@ class Logo {
         // Prevent stale timeout from firing cleanup on next run.
         this._lastNoteTimeout = null;
 
+        // clearAll() above cancels the value-bar timeout without running its
+        // callback, so reset both directly to avoid valueBarVisible getting
+        // stuck true (and hotkeys stuck blocked) if a stop happens mid-window.
+        this._valueBarTimeout = null;
+        if (this.activity) this.activity.valueBarVisible = false;
+
         this._cleanupAfterCompletion();
 
         for (const arg in this.evalOnStopList) {
@@ -2087,7 +2094,11 @@ class Logo {
                 // (#4931). Scoped to just this case, not every status message.
                 if (logo.activity) {
                     logo.activity.valueBarVisible = true;
-                    setTimeout(() => {
+                    if (logo._valueBarTimeout !== null) {
+                        logo._timerManager.clearTimeout(logo._valueBarTimeout);
+                    }
+                    logo._valueBarTimeout = logo._timerManager.setTimeout(() => {
+                        logo._valueBarTimeout = null;
                         if (logo.activity) logo.activity.valueBarVisible = false;
                     }, 3000);
                 }


### PR DESCRIPTION
## Description

The `printText.show` guard in `__keyPressed()` (`js/activity/keyboard-controller.js`) was blocking every keyboard shortcut in the app, not just the case it was meant to cover.

The guard checks `activity.printText.classList.contains("show")`, originally introduced in #4931 to prevent a hotkey from accidentally spawning a new block while a screen-dimension block's value display (the "value bar") is showing. Traced via `git log -S` back to #4931 to confirm this original intent before changing anything.

The problem: that `"show"` class is set by `activity.textMsg()`, a generic status-message function called by nearly every shortcut in the file - Alt-R "Play", Alt-B, scroll-toggle messages, etc. - and stays for up to 60 seconds (`AlertController.MSG_TIMEOUT`). So any status message, unrelated to the value bar, silently swallowed every subsequent keydown for up to a minute, including ENTER-to-stop and Alt+S while a program is running.

Fixed by introducing a dedicated `activity.valueBarVisible` flag, set only by the value-bar display call site in `js/logo.js` for a short 3-second window, and pointing the guard at that instead of the shared `textMsg`/`printText` mechanism. The original #4931 protection is preserved - it's just no longer coupled to every other status message in the app.

## Related Issue

Part of #6608

## Category

- [x] Bug Fix

## Type of Change

- [x] Bug Fix
- [x] Accessibility Enhancement

## Testing Performed

1. Added a regression test reproducing the exact prior failure first - confirmed on unmodified `master` that an unrelated status message (simulating "Alt-R Play") blocks ENTER-to-stop, then confirmed it passes after the fix.
2. Added a second test confirming the original #4931 value-bar protection still blocks hotkeys when `valueBarVisible` is true.
3. Confirmed `logo.activity` and the `activity` instance read in `keyboard-controller.js` are the same object - both `setupKeyboardController(this)` and `new Logo(this)` are constructed with the same `this` in `js/activity.js` - so no additional wiring was needed.
4. Ran the full `keyboard-controller.test.js` suite (30 tests) and `logo.test.js` suite (146 tests) - no regressions.
5. `npx eslint` on all three changed/new files - clean.

## Additional Notes

#8268 is still open and also touches the top of `__keyPressed()` in this same file (the Alt+S-at-top fix). This PR is based on current `master`, which doesn't yet include that change. The two touch nearby but non-overlapping lines, so should merge cleanly either order, but flagging in case a rebase is needed depending on merge order.

## PR Checklist

- [x] I have tested these changes locally
- [x] My changes generate no new warnings or console errors
- [x] I have checked for and resolved any merge conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Keyboard shortcuts remain available when unrelated status text is displayed.
  - Hotkeys are blocked while a value display is visible.
  - Improved Enter-key behavior when stopping running activities.
  - Value displays now refresh their visibility period when shown again and hide immediately when activities are stopped.

- **Tests**
  - Added coverage for keyboard behavior, value-display timing, repeated displays, and stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->