### PR TITLE
fix(canvas): stop stray tooltips when the bottom buttons are rebuilt

### DIFF
--- a/js/__tests__/activity_helpful_wheel.test.js
+++ b/js/__tests__/activity_helpful_wheel.test.js
@@ -184,6 +184,9 @@ describe("Helpful wheel bulk actions (issue #7794)", () => {
             innerHTML: ""
         };
         document.getElementById = jest.fn(() => mockElement);
+        // setupPaletteMenu tears down and re-initialises the bottom buttons'
+        // Materialize tooltips around the rebuild.
+        window.jQuery = jest.fn(() => ({ tooltip: jest.fn() }));
 
         activity = new Activity();
 

--- a/js/activity/__tests__/context-menu-controller.test.js
+++ b/js/activity/__tests__/context-menu-controller.test.js
@@ -725,5 +725,61 @@ describe("ContextMenuController", () => {
 
             expect(after).toEqual(before);
         });
+
+        test("tears down the old buttons' tooltips before removing their container", () => {
+            // Materialize parks each tooltip node in <body>, so removing
+            // #buttoncontainerBOTTOM without a "remove" first strands them
+            // there -- a tooltip that was visible at that moment never gets a
+            // mouseleave and stays on screen until the page is reloaded.
+            const calls = [];
+            window.jQuery = jest.fn(selector => ({
+                tooltip: jest.fn(options => calls.push({ selector, options }))
+            }));
+            mockElement.parentNode.removeChild = jest.fn(() =>
+                calls.push({ selector: "REMOVED_CONTAINER" })
+            );
+
+            controller.setupPaletteMenu();
+
+            const teardown = calls.findIndex(
+                c => c.selector === "#buttoncontainerBOTTOM .tooltipped" && c.options === "remove"
+            );
+            const removal = calls.findIndex(c => c.selector === "REMOVED_CONTAINER");
+            expect(teardown).toBeGreaterThanOrEqual(0);
+            expect(removal).toBeGreaterThan(teardown);
+        });
+
+        test("re-initialises the rebuilt buttons' tooltips once the row is complete", () => {
+            // makeButton() initialises tooltips before appending its button,
+            // so the last button built is otherwise left without one.
+            const calls = [];
+            window.jQuery = jest.fn(selector => ({
+                tooltip: jest.fn(options => calls.push({ selector, options }))
+            }));
+
+            controller.setupPaletteMenu();
+
+            const last = calls[calls.length - 1];
+            expect(last.selector).toBe("#buttoncontainerBOTTOM .tooltipped");
+            expect(last.options).toEqual({ html: true, delay: 100 });
+        });
+
+        test("does not re-initialise tooltips when they are disabled", () => {
+            const calls = [];
+            window.jQuery = jest.fn(selector => ({
+                tooltip: jest.fn(options => calls.push({ selector, options }))
+            }));
+            activity.toolbar.tooltipsDisabled = true;
+
+            controller.setupPaletteMenu();
+
+            expect(
+                calls.some(
+                    c =>
+                        c.selector === "#buttoncontainerBOTTOM .tooltipped" &&
+                        c.options !== "remove"
+                )
+            ).toBe(false);
+        });
     });
 });

--- a/js/activity/__tests__/context-menu-controller.test.js
+++ b/js/activity/__tests__/context-menu-controller.test.js
@@ -750,8 +750,6 @@ describe("ContextMenuController", () => {
         });
 
         test("re-initialises the rebuilt buttons' tooltips once the row is complete", () => {
-            // makeButton() initialises tooltips before appending its button,
-            // so the last button built is otherwise left without one.
             const calls = [];
             window.jQuery = jest.fn(selector => ({
                 tooltip: jest.fn(options => calls.push({ selector, options }))
@@ -759,9 +757,10 @@ describe("ContextMenuController", () => {
 
             controller.setupPaletteMenu();
 
-            const last = calls[calls.length - 1];
-            expect(last.selector).toBe("#buttoncontainerBOTTOM .tooltipped");
-            expect(last.options).toEqual({ html: true, delay: 100 });
+            const initializations = calls.filter(c => c.options !== "remove");
+            expect(initializations).toHaveLength(1);
+            expect(initializations[0].selector).toBe("#buttoncontainerBOTTOM .tooltipped");
+            expect(initializations[0].options).toEqual({ html: true, delay: 100 });
         });
 
         test("does not re-initialise tooltips when they are disabled", () => {
@@ -773,6 +772,10 @@ describe("ContextMenuController", () => {
 
             controller.setupPaletteMenu();
 
+            expect(calls).toContainEqual({
+                selector: "#buttoncontainerBOTTOM .tooltipped",
+                options: "remove"
+            });
             expect(
                 calls.some(
                     c =>

--- a/js/activity/context-menu-controller.js
+++ b/js/activity/context-menu-controller.js
@@ -202,6 +202,17 @@ class ContextMenuController {
 
         const removeButtonContainer = document.getElementById("buttoncontainerBOTTOM");
         if (removeButtonContainer) {
+            // Materialize keeps a tooltip's node in <body>, not inside the
+            // button it belongs to, so removing the container below orphans
+            // the nodes of the buttons it holds. An orphan that happened to be
+            // visible at that moment has no element left to fire mouseleave
+            // on, so it stays on screen at its old coordinates until the page
+            // is reloaded -- e.g. hovering Home and then zooming (which fires
+            // resize, which rebuilds these buttons) leaves a stray
+            // "Home [HOME]" tooltip floating over the canvas. "remove" is the
+            // only teardown Materialize recognises; the rebuilt buttons are
+            // re-initialised at the end of this function.
+            window.jQuery("#buttoncontainerBOTTOM .tooltipped").tooltip("remove");
             removeButtonContainer.parentNode.removeChild(removeButtonContainer);
         }
 
@@ -420,6 +431,17 @@ class ContextMenuController {
                 display: true,
                 fn: this._hideHelpfulSearchWidget.bind(this)
             });
+
+        // makeButton() initialises tooltips before it appends its button to
+        // the DOM, so the last button built above is still uninitialised here
+        // (and, after the teardown at the top of this function, so are any
+        // whose tooltip we just removed). Initialise the finished row once.
+        if (!(activity.toolbar && activity.toolbar.tooltipsDisabled)) {
+            window.jQuery("#buttoncontainerBOTTOM .tooltipped").tooltip({
+                html: true,
+                delay: 100
+            });
+        }
     }
 
     /*
@@ -498,10 +520,10 @@ class ContextMenuController {
                 container.blur?.();
             });
         }
-        window.jQuery(".tooltipped").tooltip({
-            html: true,
-            delay: 100
-        });
+        // No tooltip init here: the container is not in the DOM yet, so this
+        // only ever re-initialised *other* elements' tooltips (once per button
+        // built) and left the last button of a row without one. setupPaletteMenu
+        // initialises the whole row after it has been appended.
 
         container.onmouseover = () => {
             if (!activity.loading) {

--- a/js/activity/context-menu-controller.js
+++ b/js/activity/context-menu-controller.js
@@ -432,10 +432,7 @@ class ContextMenuController {
                 fn: this._hideHelpfulSearchWidget.bind(this)
             });
 
-        // makeButton() initialises tooltips before it appends its button to
-        // the DOM, so the last button built above is still uninitialised here
-        // (and, after the teardown at the top of this function, so are any
-        // whose tooltip we just removed). Initialise the finished row once.
+        // Initialize tooltips after all bottom-toolbar buttons have been appended.
         if (!(activity.toolbar && activity.toolbar.tooltipsDisabled)) {
             window.jQuery("#buttoncontainerBOTTOM .tooltipped").tooltip({
                 html: true,
@@ -520,10 +517,6 @@ class ContextMenuController {
                 container.blur?.();
             });
         }
-        // No tooltip init here: the container is not in the DOM yet, so this
-        // only ever re-initialised *other* elements' tooltips (once per button
-        // built) and left the last button of a row without one. setupPaletteMenu
-        // initialises the whole row after it has been appended.
 
         container.onmouseover = () => {
             if (!activity.loading) {


### PR DESCRIPTION
--- [x] Bug fix --

## Description

Fixes a bug where stale Materialize tooltips could remain visible after the bottom toolbar was rebuilt.

`setupPaletteMenu()` rebuilds `#buttoncontainerBOTTOM` during events such as browser resize/zoom. Materialize moves tooltip elements outside their buttons, so removing the toolbar container could leave previously created tooltip elements attached to the document. If a tooltip was visible during the rebuild, it could remain floating over the canvas until the page was reloaded.

This was especially noticeable in Play-Only Mode, where the workspace is otherwise mostly empty.

The PR also fixes tooltip initialization in `makeButton()`. Tooltip initialization was happening before the newly created button was appended, causing unnecessary repeated initialization and leaving the last button in a row without a tooltip until another initialization occurred.



## Changes Made

* Remove existing bottom-toolbar tooltips using Materialize's `remove` method before destroying `#buttoncontainerBOTTOM`.
* Follow the same tooltip cleanup pattern already used by `Turtles.__makeAllButtons` for the top toolbar.
* Remove tooltip initialization from `makeButton()`.
* Initialize tooltips once after the complete bottom toolbar has been created.
* Respect `toolbar.tooltipsDisabled` when initializing the finished toolbar.
* Prevent stale tooltip elements from accumulating across toolbar rebuilds.

---

## Steps to Reproduce

1. Open Music Blocks.
2. Hover over the **Home** button so that its tooltip is displayed.
3. Trigger a browser resize or change the browser zoom level.
4. Observe the bottom toolbar being rebuilt.
5. In the affected setup, the tooltip can remain visible over the canvas even though the original button has been removed.
6. Reloading the page clears the stale tooltip.

The issue is setup-dependent and may not reproduce on every browser/system configuration.

---

## Visual Changes

### Before

A tooltip could remain visible at its previous position after the bottom toolbar was rebuilt, resulting in a stray tooltip floating over the canvas.

### After

The existing tooltips are removed before the toolbar is rebuilt, so no stale tooltip remains after resizing or browser zooming.

---

## Testing Performed

* Verified the bottom toolbar can be rebuilt without leaving stale tooltip elements.
* Verified hovering toolbar buttons still displays their tooltips correctly after rebuilding.
* Verified browser resize/zoom no longer leaves a tooltip floating over the canvas.
* Verified the tooltip initialization respects `toolbar.tooltipsDisabled`.
* Verified the last button in the rebuilt toolbar receives its tooltip correctly.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of this change.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The issue is not consistently reproducible across all browser/system configurations. The stale tooltip occurs when a tooltip is active while the bottom toolbar is rebuilt, which is why it may appear only on certain setups.

The tooltip cleanup mirrors the existing implementation used for the top toolbar, while initializing the completed bottom toolbar avoids repeated tooltip setup and unnecessary tooltip DOM nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed palette menu tooltips during resizing and rebuilding.
  - Tooltips now close cleanly before the old button row is removed and reappear correctly on rebuilt buttons.
  - Prevented tooltips from being initialized when tooltip display is disabled.
  - Improved tooltip behavior to provide a more consistent experience when the palette layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->