### PR TITLE
fix(volume): clamp relative volume to 0 so a decrease cannot raise it

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -117,7 +117,11 @@ function setupVolumeActions(activity) {
 
             for (const synth of synthList) {
                 let newVolume = (last(tur.singer.synthVolume[synth]) * (100 + volume)) / 100;
-                newVolume = clampNumber(newVolume, -100, 100);
+                // Clamp to 0 rather than -100, matching doCrescendo, setMasterVolume and
+                // setSynthVolume. A stored negative volume is not just unplayable: the
+                // next relative change multiplies by it, so a further decrease turns
+                // into an increase.
+                newVolume = clampNumber(newVolume, 0, 100);
 
                 if (tur.singer.synthVolume[synth] === undefined) {
                     tur.singer.synthVolume[synth] = [newVolume];

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -311,14 +311,56 @@ describe("setupVolumeActions", () => {
             expect(targetTurtle.singer.synthVolume.default).toContain(100);
         });
 
-        it("should clamp relative volume to min -100", () => {
+        it("should clamp relative volume to min 0", () => {
             targetTurtle.singer.synthVolume = {
                 default: [50]
             };
 
             Singer.VolumeActions.setRelativeVolume(-300, 0, 1);
 
-            expect(targetTurtle.singer.synthVolume.default).toContain(-100);
+            expect(targetTurtle.singer.synthVolume.default).toEqual([50, 0]);
+            expect(synthVolumeSpy).toHaveBeenCalledWith(activity.logo, 0, "default", 0);
+        });
+
+        it("should keep a further decrease from raising the volume", () => {
+            targetTurtle.singer.synthVolume = {
+                default: [50]
+            };
+
+            // A decrease large enough to bottom out, then another decrease.
+            Singer.VolumeActions.setRelativeVolume(-300, 0, 1);
+            const afterFirst = last(targetTurtle.singer.synthVolume.default);
+            Singer.VolumeActions.setRelativeVolume(-150, 0, 1);
+            const afterSecond = last(targetTurtle.singer.synthVolume.default);
+
+            expect(afterFirst).toBe(0);
+            expect(afterSecond).toBe(0);
+            expect(afterSecond).toBeLessThanOrEqual(afterFirst);
+        });
+
+        it("should stay at 0 once the volume has bottomed out", () => {
+            // Guard, not a regression case: the relative change is multiplicative,
+            // so 0 is absorbing. This held before the clamp change too, and is
+            // scoped to the clamp because the listener pops the value on exit.
+            targetTurtle.singer.synthVolume = {
+                default: [0]
+            };
+
+            Singer.VolumeActions.setRelativeVolume(20, 0, 1);
+
+            expect(last(targetTurtle.singer.synthVolume.default)).toBe(0);
+        });
+
+        it("should never store a negative volume for any argument", () => {
+            for (const arg of [-1000, -300, -201, -200, -199, -100, -50, 0, 50, 1000]) {
+                targetTurtle.singer.synthVolume = { default: [50] };
+
+                Singer.VolumeActions.setRelativeVolume(arg, 0, 1);
+
+                const stored = last(targetTurtle.singer.synthVolume.default);
+                expect(stored).toBeGreaterThanOrEqual(0);
+                expect(stored).toBeLessThanOrEqual(100);
+            }
         });
 
         it("should call notationBeginArticulation when justCounting is empty", () => {


### PR DESCRIPTION
## Description

`setRelativeVolume` was the only volume setter in `js/turtleactions/VolumeActions.js` clamping to a negative floor. `doCrescendo`, `setMasterVolume` and `setSynthVolume` all clamp to 0–100; `setPanning`'s `-100` is correct because panning is bipolar.

The relative change is multiplicative — `newVolume = base * (100 + arg) / 100` — so once `base` is negative the multiplier flips the direction of every later change:

| current | arg | before | after |
| --- | --- | --- | --- |
| 50 | -300 | **-100** | 0 |
| -100 | -150 | **+50** — a further decrease made it *louder* | 0 |
| -25 | +20 | **-30** — an increase made it *quieter* | 0 |

Audio was already protected, because `Singer.setSynthVolume` re-clamps to 0–100. Only the stored state was wrong, which is why this went unnoticed. But the **synth volume** block reads that state through `getSynthVolume`, so it reported a negative volume, and nested **set relative volume** blocks moved the volume the wrong way.

## Related Issue

Fixes #8548

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`js/turtleactions/VolumeActions.js`** — one line: `clampNumber(newVolume, -100, 100)` becomes `clampNumber(newVolume, 0, 100)`, with a comment recording why the floor is 0 and what the negative floor did.

**`js/turtleactions/__tests__/VolumeActions.test.js`** — the case named `"should clamp relative volume to min -100"` asserted the old behaviour, so it is corrected to expect `0`, and now also asserts the value handed to the synth rather than only the stored array. Three cases added:

- the two-step decrease that used to invert (`-300` then `-150`)
- a sweep over ten arguments from `-1000` to `1000` asserting nothing can store a value outside 0–100
- a guard that 0 stays absorbing

## Steps to Reproduce

1. From the **Volume** palette, place **set relative volume** with `-300`.
2. Inside its clamp, another **set relative volume** with `-150`, and a **note** inside that.
3. After the outer block, **print** a **synth volume** block.
4. Run.

Before: the inner block raises the volume to `50` even though it asked for a further decrease, and printing inside the outer clamp shows `-100`. After: both read `0`.

---

## Testing Performed

- `npx jest` — full suite green: **232 suites, 8964 passed**, 1 skipped.
- Mutation-tested: reverting the one source line while keeping the new tests fails **3 of the 4** new cases. The fourth is a boundary guard that passes either way, and is labelled as such in a comment rather than presented as a regression case.
- Verified against the real `setRelativeVolume` through `setupVolumeActions`, not a re-implementation of the formula, including a control confirming `setMasterVolume(-300)` → 0 and that `doCrescendo` never stores a negative.
- `npm run lint` clean; `npx prettier --check` on both changed files clean; `commitlint` exits 0 with no warnings.

---

## Additional Notes

**Why 0 and not input validation.** The JavaScript-export API already constrains this operation's input to `min: -50, max: 50` (`js/js-export/constraints.js:789`, `js/js-export/interface.js:1425`), which keeps `100 + arg` positive — the JS-editor path cannot reach this. The block path does not validate. Clamping the result to 0 fixes it for every argument regardless of which path calls in, and matches what the three sibling setters already do. Tightening the block's input to match the declared JS range is a reasonable follow-up but is a behaviour change for existing projects, so it is not done here.

**0 is absorbing, and that is pre-existing.** Because the change is multiplicative, once the volume reaches 0 a relative change cannot raise it again. That was equally true of the old `-100` floor (escapable only via the sign-flip bug this PR removes), and it is scoped to the clamp: the articulation listener pops the value when the clamp exits, restoring the previous volume.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Relative synthesizer volume adjustments are now constrained to the valid range of 0–100.
  - Prevents negative volume values and ensures repeated decreases cannot produce invalid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->