### PR TITLE
fix(rhythmruler): reset circular view state when the widget relaunches

### DIFF
--- a/js/widgets/rhythmruler.js
+++ b/js/widgets/rhythmruler.js
@@ -541,6 +541,13 @@ class RhythmRuler {
          */
         this._expanded = false;
 
+        // init() builds a fresh widget window, so a canvas kept from an
+        // earlier run is detached by the time anything draws into it again.
+        // Drop it and fall back to the table view, the same pair of resets the
+        // close handler performs.
+        this._circularCanvas = null;
+        this._circularView = false;
+
         // If there are no drums, add one.
         if (this.Drums.length === 0) {
             this.Drums.push(null);


### PR DESCRIPTION
- [x] Bug fix

## Description

Turning on **Circular view** in the Rhythm Maker and then running the block again left the widget pointing at a canvas that no longer existed. Re-running rebuilds the widget window, but `_circularView` stayed `true` and `_circularCanvas` still referenced the canvas from the destroyed window, so the next redraw hit `getComputedStyle(canvas.parentNode)` on a detached node and threw:

```
Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window':
parameter 1 is not of type 'Element'
    at RhythmRuler._drawCircularView (rhythmruler.js:3211)
```

After that, **Clear** and **Play all** did nothing for the rest of the session.

Fixed by resetting `_circularCanvas` and `_circularView` in `_resetPlaybackState()`, which `init()` runs on every launch, the same pair the close handler already resets. The widget comes back in table view, and Circular view can be switched on again as normal.

## Steps to Reproduce

1. Open the **Widgets** palette and drag the **rhythm maker** block onto the canvas.
2. Click the block to run it. The Rhythm Maker widget opens.
3. Click **Circular view**. The ruler redraws as rings, working normally.
4. Click the **rhythm maker** block again to re-run it.
5. The widget reopens in table view even though Circular view was never switched off.
6. Click **Clear** (or **Play all**). Nothing happens, and the console shows the `getComputedStyle` TypeError above.

---

## Visual Changes

### Before

https://github.com/user-attachments/assets/5e6bbbcb-f9df-4b49-b569-48e6ed96ad84



### After

https://github.com/user-attachments/assets/5f03b4f4-45de-4321-a538-1cb026b676ee




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rebuilt Rhythm Ruler widgets now reliably return to table view during initialization.
  - Prevented stale circular-view graphics from persisting after a widget is rebuilt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
