### PR TITLE
test(musicutils): cover getNote and _calculate_pitch_number

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -4238,3 +4238,78 @@ describe("generateNoteNames EDO length contract", () => {
         }
     });
 });
+
+describe("getNote", () => {
+    // getNote is imported by piemenus, turtle-singer, synthutils, PitchBlocks
+    // and EnsembleBlocks, but had no tests of its own. It returns
+    // [name, octave, cents].
+    // getNote(noteArg, octave, transposition, keySignature, movable,
+    //         direction, errorMsg, ...) -- name the positions rather than
+    //         spreading, so a signature change fails loudly instead of
+    //         silently shifting arguments into the wrong slots.
+    const note = (noteArg, octave, transposition, keySignature) =>
+        getNote(noteArg, octave, transposition, keySignature, false, null, null);
+
+    describe("transposition within an octave", () => {
+        it("returns the note unchanged for no transposition", () => {
+            expect(note("C", 4, 0, "C major")).toEqual(["C", 4, 0]);
+        });
+
+        it("transposes up by semitones", () => {
+            expect(note("C", 4, 2, "C major")).toEqual(["D", 4, 0]);
+        });
+
+        it("transposes down by semitones", () => {
+            // A downward transposition returns -0 cents rather than 0, which
+            // toEqual distinguishes. Compare the parts so the assertion is
+            // about the note rather than the sign of a zero.
+            const [name, octave, cents] = note("D", 4, -2, "C major");
+            expect([name, octave]).toEqual(["C", 4]);
+            expect(cents).toBe(-0);
+        });
+    });
+
+    describe("octave boundaries", () => {
+        it("carries into the next octave transposing up past B", () => {
+            expect(note("B", 4, 1, "C major")).toEqual(["C", 5, 0]);
+        });
+
+        it("borrows from the previous octave transposing down past C", () => {
+            const [name, octave] = note("C", 4, -1, "C major");
+            expect([name, octave]).toEqual(["B", 3]);
+        });
+
+        it("moves a whole octave for twelve semitones", () => {
+            expect(note("C", 4, 12, "C major")).toEqual(["C", 5, 0]);
+            const [name, octave] = note("C", 4, -12, "C major");
+            expect([name, octave]).toEqual(["C", 3]);
+        });
+    });
+
+    describe("accepted note spellings", () => {
+        it("accepts a sharp", () => {
+            expect(note("F♯", 4, 0, "C major")).toEqual(["F♯", 4, 0]);
+        });
+
+        it("normalises an ASCII flat to the unicode sign", () => {
+            expect(note("Gb", 4, 0, "C major")).toEqual(["G♭", 4, 0]);
+        });
+
+        it("accepts a solfege name", () => {
+            expect(note("sol", 4, 0, "C major")).toEqual(["G", 4, 0]);
+        });
+
+        it("accepts a pitch number", () => {
+            expect(note(7, 4, 0, "C major")).toEqual(["G", 4, 0]);
+        });
+    });
+
+    describe("key signatures", () => {
+        it.each(["C major", "G major", "A minor"])(
+            "returns a natural unchanged in %s",
+            keySignature => {
+                expect(note("C", 4, 0, keySignature)).toEqual(["C", 4, 0]);
+            }
+        );
+    });
+});

--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -4313,3 +4313,60 @@ describe("getNote", () => {
         );
     });
 });
+
+describe("_calculate_pitch_number", () => {
+    // Exported and used by getNote and pitchToFrequency, with 19 uncovered
+    // branches. Returns a MIDI-style pitch number.
+    const pitch = (name, octave) => _calculate_pitch_number(name, octave, 0, undefined);
+
+    describe("MIDI numbering", () => {
+        it("places middle C at 60", () => {
+            expect(pitch("C", 4)).toBe(60);
+        });
+
+        it("places concert A at 69", () => {
+            expect(pitch("A", 4)).toBe(69);
+        });
+
+        it("adds twelve per octave", () => {
+            expect(pitch("C", 5) - pitch("C", 4)).toBe(12);
+            expect(pitch("C", 4) - pitch("C", 0)).toBe(48);
+        });
+
+        it("numbers B just below the next C", () => {
+            expect(pitch("B", 4)).toBe(pitch("C", 5) - 1);
+        });
+    });
+
+    describe("accidentals", () => {
+        it("raises a semitone for a sharp", () => {
+            expect(pitch("C#", 4)).toBe(pitch("C", 4) + 1);
+        });
+
+        it("lowers a semitone for a flat", () => {
+            expect(pitch("Db", 4)).toBe(pitch("D", 4) - 1);
+        });
+
+        it("gives enharmonic spellings the same number", () => {
+            expect(pitch("C#", 4)).toBe(pitch("Db", 4));
+        });
+
+        it("accepts both x and * for a double sharp", () => {
+            expect(pitch("Cx", 4)).toBe(pitch("C", 4) + 2);
+            expect(pitch("C*", 4)).toBe(pitch("Cx", 4));
+        });
+    });
+
+    describe("rejects what is not a pitch name", () => {
+        // "Invalid" and null are already covered above; these are the other
+        // shapes a caller can pass. INVALIDPITCH is a global from
+        // logoconstants.js, not a musicutils export.
+        it.each([
+            ["a number", 42],
+            ["an empty string", ""],
+            ["an unknown letter", "Q"]
+        ])("returns the invalid marker for %s", (_label, value) => {
+            expect(pitch(value, 4)).toBe(global.INVALIDPITCH);
+        });
+    });
+});


### PR DESCRIPTION
### Why

`getNote` is imported by `piemenus.js`, `turtle-singer.js`, `synthutils.js`, `PitchBlocks.js` and `EnsembleBlocks.js`. It is also already imported at the top of `musicutils.test.js` — but never called there. At **109 uncovered branches** it was the largest untested function in the file.

This is the "ensure we have test coverage" half of the Music Blocks Maintenance project, so I started with the biggest gap rather than an arbitrary one.

### What is covered

Thirteen tests over the documented contract:

- transposition up and down within an octave
- both octave boundaries — `B4 +1 → C5`, `C4 -1 → B3`, and `±12` semitones
- accepted spellings: sharp (`F♯`), ASCII flat normalised to the unicode sign (`Gb → G♭`), solfege (`sol → G`), and a pitch number (`7 → G`)
- a natural returned unchanged across `C major`, `G major` and `A minor`

### One quirk asserted rather than hidden

A **downward** transposition returns `-0` cents, not `0`, and `toEqual` distinguishes the two. That is what made my first draft fail on exactly the three negative-transposition cases.

Rather than switch to a looser matcher and move on, the tests compare name and octave separately there and check the sign deliberately, so the behaviour is recorded. It is cosmetic — `-0 === 0` is true in JS — but it is real, and a future reader hitting it will find it documented instead of rediscovering it.

### On the coverage number

Honest framing: this moves `musicutils.js` from **76.0% to 76.09%** statements. Small, because most of `getNote`'s 109 branches are non-12-EDO temperament paths that need a much larger fixture to reach. What these tests do buy is a guard on the behaviour every caller actually depends on — the 12-EDO path — which previously had none at all.

Happy to extend into the temperament branches if that is wanted; I would rather land the contract first and check the direction.

### Testing

`npx jest` — **232 suites, 8975 tests passing**. `eslint --max-warnings 0` clean.

### Category
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [x] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore / Refactor
- [ ] UI/UX
- [ ] i18n

### AI

I used Claude Code for these tests and this description. The coverage figures, the `-0` finding and the suite counts are all from running the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for note transposition, octave boundaries, pitch numbers, alternate spellings, and key signatures.
  * Added validation for accidentals, enharmonic equivalents, double sharps, invalid inputs, and optional argument handling in note calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->