### PR TITLE
fix(mathutils): doMinus and doMultiply throw NanError for non-numeric inputs

### DIFF
--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -246,6 +246,35 @@ describe("MathUtility", () => {
             expect(() => MathUtility.doMinus("a", 3)).toThrow("NanError");
         });
 
+        test("throws error for null inputs", () => {
+            expect(() => MathUtility.doMinus(null, 3)).toThrow("NanError");
+        });
+
+        test("throws error for undefined inputs", () => {
+            expect(() => MathUtility.doMinus(undefined, 3)).toThrow("NanError");
+        });
+
+        test("throws error for array inputs", () => {
+            expect(() => MathUtility.doMinus([1], 3)).toThrow("NanError");
+        });
+
+        test("throws error for null as second input", () => {
+            expect(() => MathUtility.doMinus(3, null)).toThrow("NanError");
+        });
+
+        test("throws error for undefined as second input", () => {
+            expect(() => MathUtility.doMinus(3, undefined)).toThrow("NanError");
+        });
+
+        test("throws error for array as second input", () => {
+            expect(() => MathUtility.doMinus(3, [1])).toThrow("NanError");
+        });
+
+        test("throws error for NaN inputs", () => {
+            expect(() => MathUtility.doMinus(NaN, 3)).toThrow("NanError");
+            expect(() => MathUtility.doMinus(3, NaN)).toThrow("NanError");
+        });
+
         // Edge case tests
         test("handles negative result", () => {
             expect(MathUtility.doMinus(3, 5)).toBe(-2);
@@ -279,6 +308,35 @@ describe("MathUtility", () => {
 
         test("throws error for string inputs", () => {
             expect(() => MathUtility.doMultiply("a", 3)).toThrow("NanError");
+        });
+
+        test("throws error for null inputs", () => {
+            expect(() => MathUtility.doMultiply(null, 3)).toThrow("NanError");
+        });
+
+        test("throws error for undefined inputs", () => {
+            expect(() => MathUtility.doMultiply(undefined, 3)).toThrow("NanError");
+        });
+
+        test("throws error for array inputs", () => {
+            expect(() => MathUtility.doMultiply([1], 3)).toThrow("NanError");
+        });
+
+        test("throws error for null as second input", () => {
+            expect(() => MathUtility.doMultiply(3, null)).toThrow("NanError");
+        });
+
+        test("throws error for undefined as second input", () => {
+            expect(() => MathUtility.doMultiply(3, undefined)).toThrow("NanError");
+        });
+
+        test("throws error for array as second input", () => {
+            expect(() => MathUtility.doMultiply(3, [1])).toThrow("NanError");
+        });
+
+        test("throws error for NaN inputs", () => {
+            expect(() => MathUtility.doMultiply(NaN, 3)).toThrow("NanError");
+            expect(() => MathUtility.doMultiply(3, NaN)).toThrow("NanError");
         });
 
         // Edge case tests

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -187,7 +187,7 @@ class MathUtility {
      * @throws {string} NAN error if the arguments are not valid.
      */
     static doMinus(a, b) {
-        if (typeof a === "string" || typeof b === "string") {
+        if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
             throw new Error("NanError");
         }
 
@@ -204,7 +204,7 @@ class MathUtility {
      * @throws {string} NAN error if the arguments are not valid.
      */
     static doMultiply(a, b) {
-        if (typeof a === "string" || typeof b === "string") {
+        if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
             throw new Error("NanError");
         }
 


### PR DESCRIPTION
# Pull Request: fix(mathutils): doMinus and doMultiply throw NanError for non-numeric inputs

## Description

This PR fixes a silent coercion bug in `MathUtility.doMinus` and `MathUtility.doMultiply` where non-numeric inputs (such as `null`, `undefined`, arrays, or `NaN`) were incorrectly coerced into numbers or returned `NaN` instead of throwing a `NanError`. 

### The Problem
Previously, `doMinus` and `doMultiply` only guarded against `string` inputs:
```js
if (typeof a === "string" || typeof b === "string") {
    throw new Error("NanError");
}
```
This weak type guard resulted in inconsistent and silent failures for other types of invalid inputs:
- `MathUtility.doMinus(null, 5)` silently coerced `null` to `0`, incorrectly returning `-5`.
- `MathUtility.doMinus(undefined, 5)` silently returned `NaN` without surfacing the error to the block interpreter's catch block.
- `MathUtility.doMultiply(null, 5)` silently returned `0`.
- Passing `NaN` explicitly would just return `NaN` without raising a `NanError`.

This behavior was inconsistent with `doMod`, `doDivide`, and `doPower`, which strictly enforce positive numeric type checking.

### The Solution
Updated the type guards in both `doMinus` and `doMultiply` to strictly verify that both inputs are of type `"number"` and to explicitly reject `NaN` using `Number.isNaN()`. Any invalid type correctly triggers a `NanError`:
```js
if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
    throw new Error("NanError");
}
```
This ensures invalid inputs correctly surface a user-facing error message via the block interpreter instead of propagating silent incorrect results.

## Testing
- **New Tests Added**: Added comprehensive unit tests in `js/utils/__tests__/mathutils.test.js` to assert that `null`, `undefined`, `array`, and `NaN` inputs properly throw a `NanError` for both `doMinus` and `doMultiply`. Tests have been added for invalid inputs occurring as either the first operand or the second operand.
- **Existing Tests**: Verified that all 146 tests in `mathutils.test.js` pass successfully.

## Checklist
- [x] Code follows the style guidelines of the repository.
- [x] New unit tests have been added to cover the edge cases.
- [x] All existing and new tests pass locally.

## PR Category Required
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore
- [ ] UI/UX
- [ ] i18n
