### PR TITLE
docs: repair broken links and image paths in the guides

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,5 +1,5 @@
 <img
-src='https://rawgithub.com/sugarlabs/musicblocks/master/Minsky.jpg'/>
+src='https://raw.githubusercontent.com/sugarlabs/musicblocks/master/Minsky.jpg'/>
 Photo by Cynthia Solomon (CC-BY 2016)
 
 Marvin Minsky, the inventor of the digital synthesizer, inspired a

--- a/Docs/documentation-es/README.md
+++ b/Docs/documentation-es/README.md
@@ -2,7 +2,7 @@
 ==================
 
 Music Blocks is a fork of [Turtle
-Blocks](href="https://turtle.sugarlabs.org). It has extensions for
+Blocks](https://turtle.sugarlabs.org). It has extensions for
 exploring music: pitch and rhythm.
 
 Music Blocks is designed to run in a browser. Most of the development
@@ -20,7 +20,7 @@ Edge	      | Coming soon
 You can run it from
 [https://musicblocks.sugarlabs.org](https://musicblocks.sugarlabs.org).
 
-![alt tag](https://rawgithub.com/sugarlabs/musicblocks/master/documentation/getting-started.png "Music Blocks in a browser")
+![alt tag](https://raw.githubusercontent.com/sugarlabs/musicblocks/master/Docs/documentation/getting-started.png "Music Blocks in a browser")
 
 Getting Started
 ---------------
@@ -34,7 +34,7 @@ of blocks representing four notes: `Do 4`, `Mi 4`, `Sol 4` and `Do
 
 https://github.com/sugarlabs
 
-![alt tag](../header-icons/play-button.svg "play button")
+![alt tag](../../header-icons/play-button.svg "play button")
 
 Try clicking on the *Start* block or click on the *Play* button. You should hear the notes play in succession: `Do` `Mi` `Sol` `Do`.
 
@@ -123,7 +123,7 @@ See the
 for general details on how to use the blocks.
 
 See the
-[Music Blocks Programming Guide](https://github.com/sugarlabs/turtleblocksjs/blob/master/guide/README.md)
+[Music Blocks Programming Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md)
 for details specific to music: *Rhythm*, *Meter*, *Pitch*, *Intervals*,
 *Tone*, *Ornament*, *Volume*, *Drum*, and *Widget*.
 
@@ -174,7 +174,7 @@ in that it lets you scroll through `C`, `D`, `E`, `F`, `G`, `A`,
 `B`. It also uses a second selector for sharps and flats.
 
 As noted, and described in more detail in the
-[Music Blocks Programming Guide](http://rawgithub.com/sugarlabs/musicblocks/tree/master/guide/README.md),
+[Music Blocks Programming Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md),
 you can put as many *Pitch* blocks inside a note as you'd like. They
 will play together as a chord. You can also insert graphics blocks
 inside a note in order to create sound-sync animations.

--- a/Docs/documentation-pt/README.md
+++ b/Docs/documentation-pt/README.md
@@ -147,7 +147,7 @@ bemois: <code>##</code>, <code>#</code>, <code>e</code>. O bloco <em>tom-nome</e
 na medida que permite percorrer <code>C</code>, <code>D</code>, <code>E</code>, <code>F</code>, <code>G</code>, <code>A</code>,
 <code>B</code>. Ele também usa um segundo seletor para sustenidos e bemois.</p>
 <p>Como observado, e descrito com mais detalhes no
-<a href="http://github.com/sugarlabs/musicblocks/tree/master/guide-pt/README.md">Guia de Programação do Music Blocks</a>,
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide-pt/MusicBlocks_Guide_PT.pdf">Guia de Programação do Music Blocks</a>,
 você pode colocar quantos blocos de <em>Tom</em> você quiser em uma nota. Eles
 vão tocar juntos como um acorde. Você também pode inserir blocos gráficos
 dentro de uma nota para criar animações sincronizadas com o som.</p>
@@ -195,7 +195,7 @@ modificadas.)</p>
 <p>As ações são um elemento organizacional poderoso para o seu programa e podem
 ser usadas de muitas formas poderosas. Por exemplo, uma ação pode ser associada a
 um evento, como uma batida ou uma ausência de batida ou um clique do mouse. Veja
-<a href="http://github.com/sugarlabs/musicblocks/tree/master/guide-pt/README.md">Guia de Programação de Music blocks</a>,
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide-pt/MusicBlocks_Guide_PT.pdf">Guia de Programação de Music blocks</a>,
 para mais detalhes e exemplos.</p>
 <p><a target="_blank" rel="noopener noreferrer" href="https://github.com/sugarlabs/musicblocks/blob/master/documentation-pt/storebox1_block.svg"><img src="https://github.com/sugarlabs/musicblocks/raw/master/documentation-pt/storebox1_block.svg?sanitize=true" alt="alt tag" title="storein-Box-Add One" style="max-width:100%;"></a></p>
 <p>O bloco <em>Armazenar em</em>, encontrado na paleta <em>Caixas</em>, é usado para armazenar um
@@ -308,7 +308,7 @@ tentará fazer uma alteração correspondente na matriz.</p>
 <p>Observe: você pode construir uma matriz a partir de pedaços de blocos, incluindo
 o pedaço no gancho do bloco <em>Matriz tempo-tom</em>.</p>
 <p>Mais detalhes sobre todos os widgets estão disponíveis no
-<a href="http://github.com/sugarlabs/musicblocks/tree/master/guide-pt/README.md">Guia de Programação de Music Blocks</a>.</p>
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide-pt/MusicBlocks_Guide_PT.pdf">Guia de Programação de Music Blocks</a>.</p>
 </article>
   </div>
     </div>

--- a/Docs/documentation/README.md
+++ b/Docs/documentation/README.md
@@ -1,7 +1,7 @@
 # Using Music Blocks
 
 Music Blocks is a fork of [Turtle
-Blocks](href="https://turtle.sugarlabs.org). It has extensions for
+Blocks](https://turtle.sugarlabs.org). It has extensions for
 exploring music: pitch and rhythm.
 
 Music Blocks is designed to run in a browser. Most of the development
@@ -372,14 +372,14 @@ The block palettes are displayed on the left side of the screen. These
 palettes contain the blocks used to create programs.
 
 Looking for a block? Find it in the [Palette
-Tables](https://github.com/sugarlabs/musicblocks/blob/master/guide/README.md#APPENDIX_1).
+Tables](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md#6-appendix).
 
 See the
 [Turtle Blocks Programming Guide](http://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md)
 for general details on how to use the blocks.
 
 See the
-[Music Blocks Programming Guide](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md)
+[Music Blocks Programming Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md)
 for details specific to music: _Rhythm_, _Meter_, _Pitch_, _Intervals_,
 _Tone_, _Ornament_, _Volume_, _Drum_, and _Widget_.
 
@@ -429,7 +429,7 @@ in that it lets you scroll through `C`, `D`, `E`, `F`, `G`, `A`,
 `B`. It also uses a second selector for sharps and flats.
 
 As noted, and described in more detail in the
-[Music Blocks Programming Guide](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md),
+[Music Blocks Programming Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md),
 you can put as many _Pitch_ blocks inside a note as you'd like. They
 will play together as a chord. You can also insert graphics blocks
 inside a note in order to create sound-sync animations.
@@ -507,7 +507,7 @@ Actions are a powerful organizational element for your program and can
 be used in many powerful ways, e.g., an action can be associated with
 an event, such as an on beat or off beat or mouse click. See [Music
 Blocks Programming
-Guide](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md),
+Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md),
 for further details and examples.
 
 ![The Storein Box block](./storebox1_block.svg "Store in box & Add 1 to Block")
@@ -771,11 +771,11 @@ build their melodies with LEGO bricks.
 If you want to read more about the LEGO Bricks widget, including
 detailed usage instructions and educational applications, see the
 [Music Blocks Programming
-Guide](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md#427-lego-bricks-widget).
+Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md#427-lego-bricks-widget).
 
 More details about all of the widgets are available in the [Music
 Blocks Programming
-Guide](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md).
+Guide](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md).
 
 ## 8. Program Palette
 

--- a/Docs/documentation/index.html
+++ b/Docs/documentation/index.html
@@ -54,7 +54,7 @@ has been done in Chrome. </p>
 <p>When you first launch Music Blocks in your browser, you&#39;ll see a stack
 of blocks representing three notes: <code>Sol 4</code>, <code>Mi 4</code>, and <code>Sol 2</code>. The
 first two notes are <code>1/4</code> notes; the third note is a <code>1/2</code> note.</p>
-<p><img src="../header-icons/play-button.svg" alt="play-button.svg" title="play button"></p>
+<p><img src="../../header-icons/play-button.svg" alt="play-button.svg" title="play button"></p>
 <p>Try clicking on the <em>Start</em> block or click on the <em>Play</em> button. You should hear the notes play in succession: <code>Sol</code> <code>Mi</code> <code>Sol</code>.</p>
 <p>To write your own programs, drag blocks from their respective palettes
 on the left side of the screen. Use multiple blocks in stack(s) to
@@ -110,7 +110,7 @@ palettes contain the blocks used to create programs.</p>
 <a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/guide/README.md">Turtle Blocks Programming Guide</a>
 for general details on how to use the blocks. </p>
 <p>See the
-<a href="https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md">Music Blocks Programming Guide</a>
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md">Music Blocks Programming Guide</a>
 for details specific to music: <em>Rhythm</em>, <em>Pitch</em>, <em>Meter</em>, <em>Tone</em>,
 <em>Intervals</em>, <em>Volume</em>, <em>Drum</em>, and <em>Widget</em>.</p>
 <p>All of the other palettes are described in the 
@@ -154,7 +154,7 @@ flats: <code>##</code>, <code>#</code>, <code>and</code>. The <em>Pitch-Name</em
 in that it lets you scroll through <code>C</code>, <code>D</code>, <code>E</code>, <code>F</code>, <code>G</code>, <code>A</code>,
 <code>B</code>. It also uses a second selector for sharps and flats.</p>
 <p>As noted, and described in more detail in the
-<a href="https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md">Music Blocks Programming Guide</a>,
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md">Music Blocks Programming Guide</a>,
 you can put as many <em>Pitch</em> blocks inside a note as you&#39;d like. They
 will play together as a chord. You can also insert graphics blocks
 inside a note in order to create sound-sync animations.</p>
@@ -206,7 +206,7 @@ modified.)</p>
 <p>Actions are a powerful organizational element for your program and can
 be used in many powerful ways, e.g., an action can be associated with
 an event, such as an on beat or off beat or mouse click. See
-<a href="https://github.com/sugarlabs/musicblocks/tree/master/guide/README.md">Music Blocks Programming Guide</a>,
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md">Music Blocks Programming Guide</a>,
 for further details and examples.</p>
 <p><img src="storein_block.svg" alt="storein_block.svg" title="storein"></p>
 <p><img src="box_block.svg" alt="box_block.svg" title="box"></p>
@@ -332,7 +332,7 @@ try to make a corresponding change in the matrix.</p>
 <p>Note: You can construct a matrix from a chuck of blocks by including
 the chunk in the clamp of the <em>Pitch-time Marix</em> block.</p>
 <p>More details about all of the widgets are available in the
-<a href="https://github.com/sugarlabs/musicblocks/tree/master/guide/index.html">Music Blocks Programming Guide</a>.</p>
+<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/index.html">Music Blocks Programming Guide</a>.</p>
       </div>
     </div>
   </body>

--- a/Docs/guide-es/README.md
+++ b/Docs/guide-es/README.md
@@ -21,9 +21,9 @@ su computadora.
 
 Para más detalles sobre el uso de Bloques de Música, ver [Uso de
 Bloques de Música]
-(http://github.com/sugarlabs/musicblocks/tree/master/documentation)
+(http://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation)
 y para más detalles sobre cómo utilizar los bloques de la tortuga, ver
-[Uso de la tortuga bloques
+[Uso de la tortuga bloques](http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation)
 
 ## ACERCA DE ESTA GUÍA
 
@@ -466,15 +466,13 @@ individual notes (or chords if you click on more than one cell in a
 column). In the figure, three quarter notes are selected (black
 cells). First `Re 4`, followed by `Mi 4`, followed by `Sol 4`.
 
-<img
-src='../header-icons/play-button.svg' height="36"</img>
+<img src="../../header-icons/play-button.svg" height="36">
 
 If you click on the _Play_ button (found in the top row of the grid),
 you will hear a sequence of notes played (from left to right): `Re 4`,
 `Mi 4`, `Sol 4`.
 
-<img
-src='../header-icons/export-chunk.svg' height="36"</img>
+<img src="../../header-icons/export-chunk.svg" height="36">
 
 Once you have a group of notes (a "chunk") that you like, click on the
 _Save_ button (just to the right of the _Play_ button). This will
@@ -484,20 +482,17 @@ programmatically. (More on that below.)
 You can rearrange the selected notes in the grid and safe other chunks
 as well.
 
-<img
-src='../header-icons/sort.svg' height="36"</img>
+<img src="../../header-icons/sort.svg" height="36">
 
 The _Sort_ button will reorder the pitches in the matrix from highest
 to lowest and eliminate any duplicate _Pitch_ blocks.
 
-<img
-src='../header-icons/close-button.svg' height="36"</img>
+<img src="../../header-icons/close-button.svg" height="36">
 
 Or hide the matrix by clicking on the _Close_ button (the right-most
 button in the top row of the grid.)
 
-<img
-src='../header-icons/erase-button.svg' height="36"</img>
+<img src="../../header-icons/erase-button.svg" height="36">
 
 There is also an Erase button that will clear the grid.
 

--- a/Docs/guide-es/index.html
+++ b/Docs/guide-es/index.html
@@ -117,7 +117,7 @@ su computadora.</p>
 Bloques de Música]
 (<a href="https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md">https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md</a>)
 y para más detalles sobre cómo utilizar los bloques de la tortuga, ver
-[Uso de la tortuga bloques</p>
+<a href="http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">Uso de la tortuga bloques</a></p>
 <h2 id="acerca-de-esta-gu-a">ACERCA DE ESTA GUÍA</h2>
 <p>Esta guía se divide en cuatro secciones: (i) una descripción general
 de la <em>Nota</em> estructura; (ii) una guía de programación; (iii) los

--- a/Docs/guide-ja/README.md
+++ b/Docs/guide-ja/README.md
@@ -58,7 +58,7 @@
 
 ミュージック・ブロックスはブラウザーで実行するために作られています。クローム・ブラウザーで一番テストされていますがファイヤーフォックスも実行できます。[github io（ギットハーブ）](https://musicblocks.sugarlabs.org)のウェブサイトから実行でき、ミュージック・ブロックスのソース・コードもダウンロードして自分のパソコンで実行できます。
 
-この案内よりミュージック・ブロックスの細かいを楽しみたかったら、[ミュージック・ブロックスの基本](http://github.com/sugarlabs/musicblocks/tree/master/documentation)をどうぞ、読んでください。
+この案内よりミュージック・ブロックスの細かいを楽しみたかったら、[ミュージック・ブロックスの基本](http://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation)をどうぞ、読んでください。
 ミュージック・ブロックスの元のタートル・ブロックスの細かいを楽しみたかったら、[タートル・ブロックスの基本](http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation)をどうぞ読んでください。
 
 ## <a name="音符"></a>
@@ -541,13 +541,13 @@ individual notes (or 和音s if you クリック on more than one cell in a
 column). In the figure, three quarter notes are selected (black
 cells). First `レ 4`, followed by `ミ 4`, followed by `ソ 4`.
 
-![alt tag](../header-icons/play-button.svg "play button")
+![alt tag](../../header-icons/play-button.svg "play button")
 
 If you クリック on the *Play* button (found in the top row of the grid),
 you will hear a sequence of notes played (from left to right): `レ 4`,
 `ミ 4`, `ソ 4`.
 
-![alt tag](../header-icons/export-chunk.svg "save button")
+![alt tag](../../header-icons/export-chunk.svg "save button")
 
 
 Once you have a group of notes (a "チャンク") that you like, クリック on the
@@ -558,19 +558,19 @@ programmatically. (More on that below.)
 You can rearrange the selected notes in the grid and save other チャンク
 as well.
 
-![alt tag](../header-icons/sort.svg "sort button")
+![alt tag](../../header-icons/sort.svg "sort button")
 
 
 The *Sort* button will reorder the ピッチ in the matrix from highest
 to lowest and eliminate any 重に *ピッチ* blocks.
 
-![alt tag](../header-icons/close-button.svg "close button")
+![alt tag](../../header-icons/close-button.svg "close button")
 
 
 You can hide the matrix by クリックing on the *Close* button (the right-most
 button in the top row of the grid.)
 
-![alt tag](../header-icons/erase-button.svg "erase button")
+![alt tag](../../header-icons/erase-button.svg "erase button")
 
 
 There is also an Erase button that will clear the grid.

--- a/Docs/guide-ja/index.html
+++ b/Docs/guide-ja/index.html
@@ -165,7 +165,7 @@
 <h2 id="-a-name-a-1-"><a name="初めに"></a>1. 初めに</h2>
 <p><a href="#table-of-contents">目次に戻す</a> | <a href="#音符">次のトピック (2. 音符の音を鳴らすのに)</a></p>
 <p>ミュージック・ブロックスはブラウザーで実行するために作られています。クローム・ブラウザーで一番テストされていますがファイヤーフォックスも実行できます。<a href="https://musicblocks.sugarlabs.org">github io（ギットハーブ）</a>のウェブサイトから実行でき、ミュージック・ブロックスのソース・コードもダウンロードして自分のパソコンで実行できます。</p>
-<p>この案内よりミュージック・ブロックスの細かいを楽しみたかったら、<a href="https://github.com/sugarlabs/musicblocks/tree/master/documentation">ミュージック・ブロックスの基本</a>をどうぞ、読んでください。
+<p>この案内よりミュージック・ブロックスの細かいを楽しみたかったら、<a href="https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation">ミュージック・ブロックスの基本</a>をどうぞ、読んでください。
 ミュージック・ブロックスの元のタートル・ブロックスの細かいを楽しみたかったら、<a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">タートル・ブロックスの基本</a>をどうぞ読んでください。</p>
 <h2 id="table-of-contents"><a name="音符"></a></h2>
 <ol>

--- a/Docs/guide-pt/index.html
+++ b/Docs/guide-pt/index.html
@@ -275,7 +275,7 @@
         </p>
         <p>
           Para mais detalhes sobre como usar o Music Blocks, veja
-          <a href="https://github.com/sugarlabs/musicblocks/tree/master/documentation"
+          <a href="https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation"
             >Usando Music Blocks</a
           >. Para mais detalhes sobre como usar o Turtle Blocks, veja
           <a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/documentation"
@@ -958,7 +958,7 @@
         </p>
         <p>
           <a
-            href="https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&run=True&run=True"
+            href="https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&run=True"
             >EXECUTAR AO VIVO</a
           >
         </p>
@@ -1041,7 +1041,7 @@
           Music Blocks para melhorar sua experiência.
         </p>
         <p>Todo widget tem um menu com pelo menos dois botões.</p>
-        <p><img src="../header-icons/close-button.svg" title="botão fechar" alt="widget" /></p>
+        <p><img src="../../header-icons/close-button.svg" title="botão fechar" alt="widget" /></p>
         <p>Você pode ocultar o widget clicando no botão <em>Fechar</em>.</p>
         <p>Você pode mover o widget arrastando sua janela.</p>
         <h3 id="41-status"><a name="status">4.1 Status</a></h3>
@@ -1108,13 +1108,13 @@
           selecionadas (células pretas). Primeiro <code>Ré 4</code>, seguido por <code>Mi 4</code>, seguido
           por <code>Sol 4</code>.
         </p>
-        <p><img src="../header-icons/play-button.svg" title="botão tocar" alt="widget" /></p>
+        <p><img src="../../header-icons/play-button.svg" title="botão tocar" alt="widget" /></p>
         <p>
           Se você clicar no botão <em>Tocar</em> (encontrado na linha superior da grade), você ouvirá
           uma sequência de notas tocadas (da esquerda para a direita): <code>Ré 4</code>, <code>Mi 4</code>,
           <code>Sol 4</code>.
         </p>
-        <p><img src="../header-icons/export-chunk.svg" title="botão salvar" alt="widget" /></p>
+        <p><img src="../../header-icons/export-chunk.svg" title="botão salvar" alt="widget" /></p>
         <p>
           Depois de ter um grupo de notas (um "trecho") que você gosta, clique no
           botão <em>Salvar</em> (logo à direita do botão <em>Tocar</em>). Isso criará uma
@@ -1122,12 +1122,12 @@
           abaixo.)
         </p>
         <p>Você pode reorganizar as notas selecionadas na grade e salvar outros trechos também.</p>
-        <p><img src="../header-icons/sort.svg" title="botão ordenar" alt="widget" /></p>
+        <p><img src="../../header-icons/sort.svg" title="botão ordenar" alt="widget" /></p>
         <p>
           O botão <em>Ordenar</em> reordenará as alturas na matriz da mais alta para a mais baixa e
           eliminará quaisquer blocos de <em>Altura</em> duplicados.
         </p>
-        <p><img src="../header-icons/erase-button.svg" title="botão apagar" alt="widget" /></p>
+        <p><img src="../../header-icons/erase-button.svg" title="botão apagar" alt="widget" /></p>
         <p>Há também um botão Apagar que limpará a grade.</p>
         <p>
           Não se preocupe. Você pode reabrir a matriz a qualquer momento (ela lembrará seu estado anterior)

--- a/Docs/guide-zhCN/README.md
+++ b/Docs/guide-zhCN/README.md
@@ -60,7 +60,7 @@
 《音乐拼块》是设计在游览器上使用。大多数的程序发展是在 Google Chrome 上做的，可是程序也应该在 Mozilla Firefox 上使用。
 你可以从 [github.io](http://sugarlabs.github.io/musicblocks) 执行程序， 或下载一个程序的复制，直接在自己的电脑上，使用文件系统执行下载的复制程序。
 
-想知道更多关于《音乐拼块》的详情，你可以看 [Using MusicBlocks](http://github.com/sugarlabs/musicblocks/tree/master/documentation).
+想知道更多关于《音乐拼块》的详情，你可以看 [Using MusicBlocks](http://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation).
 想知道更多关于《乌龟拼块》的详情，你可以看 [Using TurtleBlocksJS](http://github.com/sugarlabs/turtleblocksjs/tree/master/documentation).
 
 ## <a name="NOTES"></a>2. 发出声音
@@ -527,26 +527,26 @@ LIVE](https://musicblocks.sugarlabs.org/index.html?id=1522885752309944&run=True)
 通过点击网格中的单元格，您应该可以听到几个单个音符（或和弦，如果你点击一个以上的单元格。
 在这个图中，三个四分之一的音符被选中（黑色格子），`Re 4`, 接着`Mi 4`,最后 `Sol 4`.
 
-![alt tag](../header-icons/play-button.svg "play button")
+![alt tag](../../header-icons/play-button.svg "play button")
 
 如果你点击 *Play* 按钮 (在格子中的第一行),你会听到一系类的音符被播放 (从左到右): `Re 4`, `Mi 4`, `Sol 4`.
 
-![alt tag](../header-icons/export-chunk.svg "save button")
+![alt tag](../../header-icons/export-chunk.svg "save button")
 
 如果你有一系列你喜欢的的音符 (一个 "chunk"), 点击 *Save* 按钮(在 *Play* 按钮的右边)。
 《音乐拼块》会用程序产生同样一系列的拼块来播放这些音符。 (以下有更多详情.)
 
 你也可以使用格子从新安排锁定的音符，保存其他的拼块。
 
-![alt tag](../header-icons/sort.svg "sort button")
+![alt tag](../../header-icons/sort.svg "sort button")
 
 *Sort* 按钮将把所有格子里的音调根据高低从新安排，出掉多余的 *Pitch* 拼块.
 
-![alt tag](../header-icons/close-button.svg "close button")
+![alt tag](../../header-icons/close-button.svg "close button")
 
 你可以把格子藏起来，只需要按 *Close* 按钮 (在最上面的一排，最右手边的按钮)
 
-![alt tag](../header-icons/erase-button.svg "erase button")
+![alt tag](../../header-icons/erase-button.svg "erase button")
 
 还有一个删除按钮，将清除网格。
 你可以随时重新打开矩阵（它会记住的它以前的状态）。

--- a/Docs/guide-zhCN/index.html
+++ b/Docs/guide-zhCN/index.html
@@ -168,7 +168,7 @@
 <p><a href="#table-of-contents">回去目录</a> | <a href="#NOTES">下一章 (2. 发出声音)</a></p>
 <p>《音乐拼块》是设计在游览器上使用。大多数的程序发展是在 Google Chrome 上做的，可是程序也应该在 Mozilla Firefox 上使用。
 你可以从 <a href="https://sugarlabs.github.io/musicblocks">github.io</a> 执行程序， 或下载一个程序的复制，直接在自己的电脑上，使用文件系统执行下载的复制程序。</p>
-<p>想知道更多关于《音乐拼块》的详情，你可以看 <a href="https://github.com/sugarlabs/musicblocks/tree/master/documentation">Using MusicBlocks</a>.
+<p>想知道更多关于《音乐拼块》的详情，你可以看 <a href="https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation">Using MusicBlocks</a>.
 想知道更多关于《乌龟拼块》的详情，你可以看 <a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">Using TurtleBlocksJS</a>.</p>
 <h2 id="-a-name-notes-a-2-"><a name="NOTES"></a>2. 发出声音</h2>
 <p><a href="#GETTING-STARTED">上一章 (1. 开始)</a> | <a href="#table-of-contents">回去目录</a> |<a href="#PROGRAMMING-WITH-MUSIC">下一章 (3. 使用音乐设计程序)</a></p>

--- a/Docs/guide/01-getting-started.html
+++ b/Docs/guide/01-getting-started.html
@@ -54,7 +54,7 @@
 	    may also be interested in the <a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/guide">Turtle Blocks
 	      Guide</a>,
 	    which reviews many programming features common to both projects.</p>
-	  <p>For more details on how to use Music Blocks, see <a href="https://github.com/sugarlabs/musicblocks/tree/master/documentation">Using Music
+	  <p>For more details on how to use Music Blocks, see <a href="https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation">Using Music
 	      Blocks</a>.
 	    For more details on how to use Turtle Blocks, see <a href="https://github.com/sugarlabs/turtleblocksjs/tree/master/documentation">Using Turtle Blocks
 	      JS</a>.</p>

--- a/Docs/guide/03-programming-with-music.html
+++ b/Docs/guide/03-programming-with-music.html
@@ -1523,7 +1523,7 @@
 	    <code>Re</code> each time the <em>Note value</em> block is played. In the bottom example
 	    above, the <em>One-of</em> block is used to randomly select between <code>chunk1</code>
 	    and <code>chunk2</code>.</p>
-	  <p>Musical Paint has been a popular activity dating back to programs such
+	  <p><a name="musical-paint"></a>Musical Paint has been a popular activity dating back to programs such
 	    as Dan Franzblau's <em>Vidsizer</em> (1979) or Morwaread Farbood's
 	    <em>Hyperscore</em> (2002). Music Blocks can be used to create musical paint
 	    as well. In the somewhat ambitious example below, we go a step further
@@ -1553,7 +1553,7 @@
 	    stack can be copied and pasted into another composition.</p>
 	  <p>While a bit fanciful, this example, which can be run by clicking on
 	    the link below, takes musical paint in a novel direction.</p>
-	  <p><a href="https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&amp;run=True&amp;run=True">RUN LIVE</a></p>
+	  <p><a href="https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&amp;run=True">RUN LIVE</a></p>
 	  <h3><a name="ENSEMBLE">3.8 Ensemble</a></h3>
 	  <p>Much of music involves multiple instruments (voices or "mice" in Music
 	    Blocks) playing together. There are a number of special blocks that

--- a/Docs/guide/04-widgets.html
+++ b/Docs/guide/04-widgets.html
@@ -45,7 +45,7 @@
 	  <p>This section of the guide will talk about the various Widgets that can
 	    be used within Music Blocks to enhance your experience.</p>
 	  <p>Every widget has a menu with at least two buttons.</p>
-	  <p><img alt="widget" src="../header-icons/close-button.svg" title="close button" /></p>
+	  <p><img alt="widget" src="../../header-icons/close-button.svg" title="close button" /></p>
 	  <p>You can hide the widget by clicking on the <em>Close</em> button.</p>
 	  <p>You can move the widget by dragging its containing the window.</p>
 	  <h3><a name="status">4.1 Monitoring Status</a></h3>
@@ -92,21 +92,21 @@
 	    individual notes (or chords if you click on more than one cell in a
 	    column). In the figure, three quarter notes are selected (black
 	    cells). First <code>Re 4</code>, followed by <code>Mi 4</code>, followed by <code>Sol 4</code>.</p>
-	  <p><img alt="widget" src="../header-icons/play-button.svg" title="play button" /></p>
+	  <p><img alt="widget" src="../../header-icons/play-button.svg" title="play button" /></p>
 	  <p>If you click on the <em>Play</em> button (found in the top row of the grid),
 	    you will hear a sequence of notes played (from left to right): <code>Re 4</code>,
 	    <code>Mi 4</code>, <code>Sol 4</code>.</p>
-	  <p><img alt="widget" src="../header-icons/export-chunk.svg" title="save button" /></p>
+	  <p><img alt="widget" src="../../header-icons/export-chunk.svg" title="save button" /></p>
 	  <p>Once you have a group of notes (a "chunk") that you like, click on the
 	    <em>Save</em> button (just to the right of the <em>Play</em> button). This will
 	    create a stack of blocks that can used to play these same notes
 	    programmatically. (More on that below.)</p>
 	  <p>You can rearrange the selected notes in the grid and save other chunks
 	    as well.</p>
-	  <p><img alt="widget" src="../header-icons/sort.svg" title="sort button" /></p>
+	  <p><img alt="widget" src="../../header-icons/sort.svg" title="sort button" /></p>
 	  <p>The <em>Sort</em> button will reorder the pitches in the matrix from highest
 	    to lowest and eliminate any duplicate <em>Pitch</em> blocks.</p>
-	  <p><img alt="widget" src="../header-icons/erase-button.svg" title="erase button" /></p>
+	  <p><img alt="widget" src="../../header-icons/erase-button.svg" title="erase button" /></p>
 	  <p>There is also an Erase button that will clear the grid.</p>
 	  <p>Don't worry. You can reopen the matrix at anytime (it will remember
 	    its previous state) and since you can define as many chunks as you

--- a/Docs/guide/README.md
+++ b/Docs/guide/README.md
@@ -117,7 +117,7 @@ Guide](https://github.com/sugarlabs/turtleblocksjs/tree/master/guide),
 which reviews many programming features common to both projects.
 
 For more details on how to use Music Blocks, see [Using Music
-Blocks](https://github.com/sugarlabs/musicblocks/tree/master/documentation).
+Blocks](https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation).
 For more details on how to use Turtle Blocks, see [Using Turtle Blocks
 JS](https://github.com/sugarlabs/turtleblocksjs/tree/master/documentation).
 
@@ -1523,6 +1523,8 @@ above, the *One-of* block is used to randomly assign either `Do` or
 above, the *One-of* block is used to randomly select between `chunk1`
 and `chunk2`.
 
+<a name="musical-paint"></a>
+
 Musical Paint has been a popular activity dating back to programs such
 as Dan Franzblau's *Vidsizer* (1979) or Morwaread Farbood's
 *Hyperscore* (2002). Music Blocks can be used to create musical paint
@@ -1561,7 +1563,7 @@ stack can be copied and pasted into another composition.
 While a bit fanciful, this example, which can be run by clicking on
 the link below, takes musical paint in a novel direction.
 
-[RUN LIVE](https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&run=True&run=True)
+[RUN LIVE](https://sugarlabs.github.io/musicblocks/index.html?id=1523896294964170&run=True)
 
 ### <a name="ENSEMBLE">3.8 Ensemble</a>
 
@@ -1643,7 +1645,7 @@ be used within Music Blocks to enhance your experience.
 
 Every widget has a menu with at least two buttons.
 
-![widget](../header-icons/close-button.svg "close button")
+![widget](../../header-icons/close-button.svg "close button")
 
 You can hide the widget by clicking on the *Close* button.
 
@@ -1712,13 +1714,13 @@ individual notes (or chords if you click on more than one cell in a
 column). In the figure, three quarter notes are selected (black
 cells). First `Re 4`, followed by `Mi 4`, followed by `Sol 4`.
 
-![widget](../header-icons/play-button.svg "play button")
+![widget](../../header-icons/play-button.svg "play button")
 
 If you click on the *Play* button (found in the top row of the grid),
 you will hear a sequence of notes played (from left to right): `Re 4`,
 `Mi 4`, `Sol 4`.
 
-![widget](../header-icons/export-chunk.svg "save button")
+![widget](../../header-icons/export-chunk.svg "save button")
 
 Once you have a group of notes (a "chunk") that you like, click on the
 *Save* button (just to the right of the *Play* button). This will
@@ -1728,12 +1730,12 @@ programmatically. (More on that below.)
 You can rearrange the selected notes in the grid and save other chunks
 as well.
 
-![widget](../header-icons/sort.svg "sort button")
+![widget](../../header-icons/sort.svg "sort button")
 
 The *Sort* button will reorder the pitches in the matrix from highest
 to lowest and eliminate any duplicate *Pitch* blocks.
 
-![widget](../header-icons/erase-button.svg "erase button")
+![widget](../../header-icons/erase-button.svg "erase button")
 
 There is also an Erase button that will clear the grid.
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -23,9 +23,9 @@
 シューガー(Sugar OS)を使っている際は「ブラウズ」(Browse activity)に組み込みのミュージック・ブロックスのアップリを開きます。([組み込みミュージック・ブロックス]を読んでください(http://activities.sugarlabs.org/en-US/sugar/addon/4804)) または「ブラウズ」でミュージック・ブロックスのURLを開いて、再生します。
 
 この次のお勧めの読み物：
-[ミュージック・ブロックスの使い方(細）](http://github.com/sugarlabs/musicblocks/tree/master/documentation/README.md)
+[ミュージック・ブロックスの使い方(細）](https://github.com/sugarlabs/musicblocks/blob/master/Docs/documentation/README.md)
 または、
-[ミュージック・ブロックス案内](http://github.com/sugarlabs/musicblocks/tree/master/guide/README.md)
+[ミュージック・ブロックス案内](https://github.com/sugarlabs/musicblocks/blob/master/Docs/guide/README.md)
 
 クレジット
 ---------

--- a/js/guide_addingblocks.md
+++ b/js/guide_addingblocks.md
@@ -230,4 +230,4 @@ You have to go to [turtledefs.js](https://github.com/sugarlabs/musicblocks/blob/
 
 Remember to add it under the right `palette`.
 
-You also need to add the `.svg` file (your example of usage of the Block) to the [musiclabs/documentation folder](https://github.com/sugarlabs/musicblocks/tree/master/documentation).
+You also need to add the `.svg` file (your example of usage of the Block) to the [Docs/documentation folder](https://github.com/sugarlabs/musicblocks/tree/master/Docs/documentation).

--- a/js/widgets/aidebugger-guide.md
+++ b/js/widgets/aidebugger-guide.md
@@ -156,7 +156,7 @@ curl -X POST http://localhost:8000/analyze \
 ### Resources
 
 - **GitHub Issues**: [Music Blocks Issues](https://github.com/sugarlabs/musicblocks/issues)
-- **Documentation**: [Music Blocks Guide](https://github.com/sugarlabs/musicblocks/tree/master/guide)
+- **Documentation**: [Music Blocks Guide](https://github.com/sugarlabs/musicblocks/tree/master/Docs/guide)
 - **Backend Repo**: [AI Debugger Backend](https://github.com/omsuneri/AI-powered-Debugger-for-Music-Blocks)
 
 ---


### PR DESCRIPTION
## Description

Following on from #8467, this fixes links in the documentation that no longer resolve. Most of them predate the move of the docs into `Docs/` and were never updated.

- Links pointing at top-level `guide/` and `documentation/` paths now point at `Docs/guide/` and `Docs/documentation/`. One of them, a Music Blocks guide link in the EN manual, pointed into the `turtleblocksjs` repo altogether. I also switched the `tree/master/....md` forms to `blob/`, which is the URL GitHub serves a file on.
- Header-icon images written as `../header-icons/play-button.svg` from files inside `Docs/guide-*/`, which resolves to `Docs/header-icons/`. The icons are at the repo root, so these are now `../../header-icons/`.
- Two `rawgithub.com` URLs. That host stopped serving years ago; both are now `raw.githubusercontent.com`, and the one that also had a stale path (`master/documentation/getting-started.png`) now points at `master/Docs/documentation/getting-started.png`.
- A malformed markdown link in the EN and ES manuals, `[Turtle Blocks](href="https://turtle.sugarlabs.org)`, which renders as literal text rather than a link.
- An ES manual line that had lost its link target entirely and read `[Uso de la tortuga bloques` mid-sentence.
- `#APPENDIX_1` in the ES guide - no heading carries that anchor; the section renders as `#6-appendix`.
- `#musical-paint` in the programming guide, which had no anchor to land on. I added the anchor rather than dropping the link, since the paragraph it points at is still there.
- A duplicated `&run=True` in one RUN LIVE URL.
- Five `<img>` tags in the ES guide written as `<img src='...' height="36"</img>` - no closing `>` on the opening tag, and `img` is a void element that takes no end tag. These are the same five widget icons whose paths I corrected, so fixing the path alone would not have made them appear. They are the only ones of their kind under `Docs/`; `lilypond/README.md` has fourteen more `</img>` tags, which I have left alone as they are outside what this PR touches.
- The link label `musiclabs/documentation` in `js/guide_addingblocks.md`, on a line I was already retargeting - the repo is `musicblocks` and the folder is now `Docs/documentation`.

The Portuguese "Guia de Programação" links pointed at `guide-pt/README.md`, which does not exist - `Docs/guide-pt/` ships the guide as `MusicBlocks_Guide_PT.pdf`, so they point there now.

## Related Issue

**Fixes:** #

---

## Category

- [x] Documentation — Updates to docs, comments, or README

---

## Changes Made

Text-only changes across 19 files: the `Docs/` guides and manuals plus `CREDITS.md`, `README-ja.md`, `js/guide_addingblocks.md` and `js/widgets/aidebugger-guide.md`. No JavaScript, no build files.

---

## Testing Performed

I checked each changed target by hand: that the file or directory exists in the tree at the path used, that the heading anchors resolve, and that the image paths are right relative to the file doing the linking. None of this is covered by the test suite.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

Prettier reports the same pre-existing formatting differences on these files before and after the change, and CI runs it only over changed JS, so nothing here gets reformatted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links across English, Spanish, Portuguese, Japanese, and Chinese materials to reflect the current documentation locations.
  - Corrected image and toolbar icon paths so screenshots and interface references display properly.
  - Fixed malformed links, outdated repository URLs, and duplicated live-example parameters.
  - Added a direct anchor for the Musical Paint section to improve navigation.
  - Updated the Minsky image source to a valid URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->