### PR TITLE
fix: refresh stale cache in searchIndexForMusicBlock on block ID change

### DIFF
--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -124,6 +124,23 @@ describe("AIWidget Utilities", () => {
             expect(searchIndexForMusicBlock(array, 30)).toBe(0);
             expect(searchIndexForMusicBlock(array, 10)).toBe(1);
         });
+
+        it("should handle null elements during stale cache rebuild", () => {
+            const array = [
+                [10, "start"],
+                [20, "pitch"]
+            ];
+
+            // Prime the cache
+            expect(searchIndexForMusicBlock(array, 20)).toBe(1);
+
+            // Stale: replace with null element
+            array[1] = null;
+
+            // Should handle null gracefully during rebuild
+            expect(searchIndexForMusicBlock(array, 20)).toBe(-1);
+            expect(searchIndexForMusicBlock(array, 10)).toBe(0);
+        });
     });
 
     describe("createPitchBlocks", () => {

--- a/js/widgets/__tests__/aiwidget.test.js
+++ b/js/widgets/__tests__/aiwidget.test.js
@@ -105,6 +105,25 @@ describe("AIWidget Utilities", () => {
             expect(searchIndexForMusicBlock([], 10)).toBe(-1);
             expect(searchIndexForMusicBlock([null, [10]], 10)).toBe(1);
         });
+
+        it("should refresh cached indexes when block IDs change without changing array length", () => {
+            const array = [
+                [10, "start"],
+                [20, "pitch"]
+            ];
+
+            expect(searchIndexForMusicBlock(array, 20)).toBe(1);
+
+            array[1] = [30, "duration"];
+
+            expect(searchIndexForMusicBlock(array, 20)).toBe(-1);
+            expect(searchIndexForMusicBlock(array, 30)).toBe(1);
+
+            array.reverse();
+
+            expect(searchIndexForMusicBlock(array, 30)).toBe(0);
+            expect(searchIndexForMusicBlock(array, 10)).toBe(1);
+        });
     });
 
     describe("createPitchBlocks", () => {

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -1324,29 +1324,29 @@ function searchIndexForMusicBlock(array, x) {
     }
     const index = map.get(x);
 
-    if (index !== undefined && array[index]?.[0] === x) {
+    if (index === undefined) {
+        for (let i = 0; i < array.length; i++) {
+            if (array[i]?.[0] === x) {
+                map.set(x, i);
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    if (array[index]?.[0] === x) {
         return index;
     }
 
-    if (index !== undefined) {
-        map = new Map();
-        for (let i = 0; i < array.length; i++) {
-            if (array[i] && array[i][0] !== undefined) {
-                map.set(array[i][0], i);
-            }
-        }
-        _indexMaps.set(array, map);
-        return map.get(x) ?? -1;
-    }
-
+    // Cache is stale — rebuild and retry
+    map = new Map();
     for (let i = 0; i < array.length; i++) {
-        if (array[i]?.[0] === x) {
-            map.set(x, i);
-            return i;
+        if (array[i] && array[i][0] !== undefined) {
+            map.set(array[i][0], i);
         }
     }
-
-    return -1;
+    _indexMaps.set(array, map);
+    return map.get(x) ?? -1;
 }
 
 if (typeof module !== "undefined" && module.exports) {

--- a/js/widgets/aiwidget.js
+++ b/js/widgets/aiwidget.js
@@ -1323,7 +1323,30 @@ function searchIndexForMusicBlock(array, x) {
         _indexMaps.set(array, map);
     }
     const index = map.get(x);
-    return index !== undefined ? index : -1;
+
+    if (index !== undefined && array[index]?.[0] === x) {
+        return index;
+    }
+
+    if (index !== undefined) {
+        map = new Map();
+        for (let i = 0; i < array.length; i++) {
+            if (array[i] && array[i][0] !== undefined) {
+                map.set(array[i][0], i);
+            }
+        }
+        _indexMaps.set(array, map);
+        return map.get(x) ?? -1;
+    }
+
+    for (let i = 0; i < array.length; i++) {
+        if (array[i]?.[0] === x) {
+            map.set(x, i);
+            return i;
+        }
+    }
+
+    return -1;
 }
 
 if (typeof module !== "undefined" && module.exports) {


### PR DESCRIPTION
## Description

`searchIndexForMusicBlock` uses a WeakMap cache invalidated only when array
length changes. When block IDs are mutated in-place (same length), the cache
returns stale indexes causing wrong block lookups.

Added an in-place validation check: if the cached index exists but
`array[index][0] !== x`, the map is rebuilt immediately before returning.

## Related Issue

**Fixes:** #8555

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

---

## Changes Made

- `js/widgets/aiwidget.js`: Added stale-cache detection in
  `searchIndexForMusicBlock`. If a cached index exists but the element at that
  index no longer matches the requested ID, the index map is fully rebuilt.
- `js/widgets/__tests__/aiwidget.test.js`: Added regression test that mutates
  block IDs in-place and reverses the array, verifying correct indexes are
  returned after each mutation.

---

## Steps to Reproduce

1. Create an array of blocks: `[[10, "start"], [20, "pitch"]]`
2. Call `searchIndexForMusicBlock(array, 20)` → returns `1` (cache built)
3. Mutate in-place: `array[1] = [30, "duration"]` (length unchanged)
4. Call `searchIndexForMusicBlock(array, 20)` → **incorrectly returns `1`**
   instead of `-1` (stale cache bug)

---

## Testing Performed

- Added focused Jest regression test covering:
  - In-place block ID mutation (same array length)
  - Array reversal
  - All 39 tests pass (`npm test`)
- `npm run lint` — no errors
- `npx prettier --check` — no errors

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved music block lookup reliability when block IDs change or blocks are reordered.
  - Ensured stale cached indexes are refreshed and missing or unavailable blocks are handled correctly.
  - Improved consistency when music block data changes dynamically, helping prevent incorrect lookup results and maintaining reliable playback-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->