### PR TITLE
fix(blocks): preserve loaded JSON data in named dictionaries

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -432,16 +432,19 @@ function setupProgramBlocks(activity) {
                 } else {
                     try {
                         const d = JSON.parse(activity.blocks.blockList[c].value[1]);
+                        if (typeof d !== "object" || d === null || Array.isArray(d)) {
+                            throw new Error("not an object");
+                        }
                         // Is the dictionary the same as a turtle name?
                         const target = getTargetTurtle(activity.turtles, a);
                         if (target !== null) {
                             // Copy any internal entries now.
                             const k = Object.keys(d);
                             for (let i = 0; i < k.length; i++) {
-                                Turtle.DictActions.setDictValue(target, turtle, k[i], d[k[i]]);
+                                Turtle.DictActions.SetDictValue(target, turtle, k[i], d[k[i]]);
                             }
-                        } else if (!(a in logo.turtleDicts[turtle])) {
-                            logo.turtleDicts[turtle][a] = {};
+                        } else {
+                            logo.turtleDicts[turtle][a] = d;
                         }
                     } catch (e) {
                         activity.errorMsg(
@@ -535,16 +538,19 @@ function setupProgramBlocks(activity) {
             if (c !== null) {
                 try {
                     const d = JSON.parse(activity.blocks.blockList[c].value);
+                    if (typeof d !== "object" || d === null || Array.isArray(d)) {
+                        throw new Error("not an object");
+                    }
                     // Is the dictionary the same as a turtle name?
                     const target = getTargetTurtle(activity.turtles, a);
                     if (target !== null) {
                         // Copy any internal entries now.
                         const k = Object.keys(d);
                         for (let i = 0; i < k.length; i++) {
-                            Turtle.DictActions.setDictValue(target, turtle, k[i], d[k[i]]);
+                            Turtle.DictActions.SetDictValue(target, turtle, k[i], d[k[i]]);
                         }
-                    } else if (!(a in logo.turtleDicts[turtle])) {
-                        logo.turtleDicts[turtle][a] = {};
+                    } else {
+                        logo.turtleDicts[turtle][a] = d;
                     }
                 } catch (e) {
                     activity.errorMsg(
@@ -704,9 +710,13 @@ function setupProgramBlocks(activity) {
             // Is the dictionary the same as a turtle name?
             const target = getTargetTurtle(activity.turtles, a);
             if (target === null) {
+                const dictData =
+                    a in logo.turtleDicts[turtle] && logo.turtleDicts[turtle][a] !== undefined
+                        ? logo.turtleDicts[turtle][a]
+                        : {};
                 activity.save.download(
                     "json",
-                    "data:text/json;charset-utf-8," + JSON.stringify(logo.turtleDicts[turtle][a]),
+                    "data:text/json;charset-utf-8," + JSON.stringify(dictData),
                     args[1]
                 );
             } else {

--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -18,6 +18,12 @@
 /* exported setupProgramBlocks */
 
 function setupProgramBlocks(activity) {
+    /**
+     * Determines whether a dictionary key is a built-in turtle status property.
+     *
+     * @param {string} key - The dictionary key to check.
+     * @returns {boolean} True if the key represents a turtle status property, false otherwise.
+     */
     function isTurtleStatusKey(key) {
         return (
             key === _("color") ||

--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -18,6 +18,18 @@
 /* exported setupProgramBlocks */
 
 function setupProgramBlocks(activity) {
+    function isTurtleStatusKey(key) {
+        return (
+            key === _("color") ||
+            key === _("shade") ||
+            key === _("grey") ||
+            key === _("pen size") ||
+            key === _("font") ||
+            key === _("heading") ||
+            key === "x" ||
+            key === "y"
+        );
+    }
     /**
      * Represents a block that loads the heap from a web page in the logo programming language.
      * @extends {FlowBlock}
@@ -442,6 +454,17 @@ function setupProgramBlocks(activity) {
                             const k = Object.keys(d);
                             for (let i = 0; i < k.length; i++) {
                                 Turtle.DictActions.SetDictValue(target, turtle, k[i], d[k[i]]);
+                                if (!isTurtleStatusKey(k[i])) {
+                                    if (
+                                        !Object.prototype.hasOwnProperty.call(
+                                            logo.turtleDicts[turtle],
+                                            target
+                                        )
+                                    ) {
+                                        logo.turtleDicts[turtle][target] = {};
+                                    }
+                                    logo.turtleDicts[turtle][target][k[i]] = d[k[i]];
+                                }
                             }
                         } else {
                             logo.turtleDicts[turtle][a] = d;
@@ -548,6 +571,17 @@ function setupProgramBlocks(activity) {
                         const k = Object.keys(d);
                         for (let i = 0; i < k.length; i++) {
                             Turtle.DictActions.SetDictValue(target, turtle, k[i], d[k[i]]);
+                            if (!isTurtleStatusKey(k[i])) {
+                                if (
+                                    !Object.prototype.hasOwnProperty.call(
+                                        logo.turtleDicts[turtle],
+                                        target
+                                    )
+                                ) {
+                                    logo.turtleDicts[turtle][target] = {};
+                                }
+                                logo.turtleDicts[turtle][target][k[i]] = d[k[i]];
+                            }
                         }
                     } else {
                         logo.turtleDicts[turtle][a] = d;
@@ -711,7 +745,8 @@ function setupProgramBlocks(activity) {
             const target = getTargetTurtle(activity.turtles, a);
             if (target === null) {
                 const dictData =
-                    a in logo.turtleDicts[turtle] && logo.turtleDicts[turtle][a] !== undefined
+                    Object.prototype.hasOwnProperty.call(logo.turtleDicts[turtle], a) &&
+                    logo.turtleDicts[turtle][a] !== undefined
                         ? logo.turtleDicts[turtle][a]
                         : {};
                 activity.save.download(

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -484,7 +484,7 @@ describe("ProgramBlocks", () => {
             };
             activity.blocks.blockList[20] = {
                 name: "loadFile",
-                value: ["filename", '{"color": "red"}']
+                value: ["filename", '{"color": "red", "custom": "value"}']
             };
 
             const block = getBlock("loadDict");
@@ -496,6 +496,13 @@ describe("ProgramBlocks", () => {
                 "color",
                 "red"
             );
+            expect(global.Turtle.DictActions.SetDictValue).toHaveBeenCalledWith(
+                targetTurtleIndex,
+                turtle,
+                "custom",
+                "value"
+            );
+            expect(logo.turtleDicts[turtle][targetTurtleIndex]).toEqual({ custom: "value" });
         });
 
         test("rejects non-object JSON array when loading from file", () => {
@@ -600,7 +607,7 @@ describe("ProgramBlocks", () => {
                 connections: [null, null, 20]
             };
             activity.blocks.blockList[20] = {
-                value: '{"shade": 50}'
+                value: '{"shade": 50, "custom": "value"}'
             };
 
             const block = getBlock("setDictionary");
@@ -612,6 +619,13 @@ describe("ProgramBlocks", () => {
                 "shade",
                 50
             );
+            expect(global.Turtle.DictActions.SetDictValue).toHaveBeenCalledWith(
+                targetTurtleIndex,
+                turtle,
+                "custom",
+                "value"
+            );
+            expect(logo.turtleDicts[turtle][targetTurtleIndex]).toEqual({ custom: "value" });
         });
 
         test("rejects non-object JSON array", () => {
@@ -689,6 +703,21 @@ describe("ProgramBlocks", () => {
 
             const block = getBlock("saveDict");
             block.flow(["NonExistentDict", "dict.json"], logo, turtle, 10);
+
+            expect(activity.save.download).toHaveBeenCalledWith(
+                "json",
+                "data:text/json;charset-utf-8,{}",
+                "dict.json"
+            );
+        });
+
+        test("falls back to empty dictionary if dictionary name is an inherited property", () => {
+            const turtle = 0;
+            logo.turtleDicts[turtle] = {};
+            global.getTargetTurtle.mockReturnValue(null);
+
+            const block = getBlock("saveDict");
+            block.flow(["constructor", "dict.json"], logo, turtle, 10);
 
             expect(activity.save.download).toHaveBeenCalledWith(
                 "json",

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -36,6 +36,7 @@ global.isSafeUrl = function (urlString) {
 };
 global.Turtle = {
     DictActions: {
+        SetDictValue: jest.fn(),
         setDictValue: jest.fn(),
         SerializeDict: jest.fn(() => "{}")
     }
@@ -468,6 +469,55 @@ describe("ProgramBlocks", () => {
             block.flow(["MyDict", [null, null]], logo, turtle, blk);
 
             expect(logo.turtleDicts[turtle]).toHaveProperty("MyDict");
+            expect(logo.turtleDicts[turtle]["MyDict"]).toEqual({ key1: "value1" });
+        });
+
+        test("loads dictionary onto target turtle", () => {
+            const blk = 10;
+            const turtle = 0;
+            const targetTurtleIndex = 5;
+            logo.turtleDicts[turtle] = {};
+            global.getTargetTurtle.mockReturnValue(targetTurtleIndex);
+
+            activity.blocks.blockList[blk] = {
+                connections: [null, null, 20]
+            };
+            activity.blocks.blockList[20] = {
+                name: "loadFile",
+                value: ["filename", '{"color": "red"}']
+            };
+
+            const block = getBlock("loadDict");
+            block.flow(["turtle5", [null, null]], logo, turtle, blk);
+
+            expect(global.Turtle.DictActions.SetDictValue).toHaveBeenCalledWith(
+                targetTurtleIndex,
+                turtle,
+                "color",
+                "red"
+            );
+        });
+
+        test("rejects non-object JSON array when loading from file", () => {
+            const blk = 10;
+            const turtle = 0;
+            logo.turtleDicts[turtle] = {};
+
+            activity.blocks.blockList[blk] = {
+                connections: [null, null, 20]
+            };
+            activity.blocks.blockList[20] = {
+                name: "loadFile",
+                value: ["filename", '["not", "a", "dictionary"]']
+            };
+
+            const block = getBlock("loadDict");
+            block.flow(["MyDict", [null, null]], logo, turtle, blk);
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "The file you selected does not contain a valid dictionary.",
+                blk
+            );
         });
 
         test("handles null arguments", () => {
@@ -536,6 +586,53 @@ describe("ProgramBlocks", () => {
             block.flow(["MyDict", {}], logo, turtle, blk);
 
             expect(logo.turtleDicts[turtle]).toHaveProperty("MyDict");
+            expect(logo.turtleDicts[turtle]["MyDict"]).toEqual({ key1: "value1" });
+        });
+
+        test("sets dictionary onto target turtle", () => {
+            const blk = 10;
+            const turtle = 0;
+            const targetTurtleIndex = 3;
+            logo.turtleDicts[turtle] = {};
+            global.getTargetTurtle.mockReturnValue(targetTurtleIndex);
+
+            activity.blocks.blockList[blk] = {
+                connections: [null, null, 20]
+            };
+            activity.blocks.blockList[20] = {
+                value: '{"shade": 50}'
+            };
+
+            const block = getBlock("setDictionary");
+            block.flow(["turtle3", {}], logo, turtle, blk);
+
+            expect(global.Turtle.DictActions.SetDictValue).toHaveBeenCalledWith(
+                targetTurtleIndex,
+                turtle,
+                "shade",
+                50
+            );
+        });
+
+        test("rejects non-object JSON array", () => {
+            const blk = 10;
+            const turtle = 0;
+            logo.turtleDicts[turtle] = {};
+
+            activity.blocks.blockList[blk] = {
+                connections: [null, null, 20]
+            };
+            activity.blocks.blockList[20] = {
+                value: '["not", "a", "dictionary"]'
+            };
+
+            const block = getBlock("setDictionary");
+            block.flow(["MyDict", {}], logo, turtle, blk);
+
+            expect(activity.errorMsg).toHaveBeenCalledWith(
+                "The block you selected does not contain a valid dictionary.",
+                blk
+            );
         });
 
         test("handles null arguments", () => {
@@ -581,6 +678,21 @@ describe("ProgramBlocks", () => {
             expect(activity.save.download).toHaveBeenCalledWith(
                 "json",
                 'data:text/json;charset-utf-8,{"key":"value"}',
+                "dict.json"
+            );
+        });
+
+        test("falls back to empty dictionary if named dictionary is not set", () => {
+            const turtle = 0;
+            logo.turtleDicts[turtle] = {};
+            global.getTargetTurtle.mockReturnValue(null);
+
+            const block = getBlock("saveDict");
+            block.flow(["NonExistentDict", "dict.json"], logo, turtle, 10);
+
+            expect(activity.save.download).toHaveBeenCalledWith(
+                "json",
+                "data:text/json;charset-utf-8,{}",
                 "dict.json"
             );
         });

--- a/js/turtleactions/DictActions.js
+++ b/js/turtleactions/DictActions.js
@@ -153,6 +153,20 @@ function setupDictActions(activity) {
         }
 
         /**
+         * Alias for SetDictValue for backward compatibility.
+         *
+         * @static
+         * @param {Number} target - target Turtle index in turtle.turtleList
+         * @param {Number} turtle - Turtle index in turtle.turtleList
+         * @param {String} key - key
+         * @param {*} value - value
+         * @returns {void}
+         */
+        static setDictValue(target, turtle, key, value) {
+            Turtle.DictActions.SetDictValue(target, turtle, key, value);
+        }
+
+        /**
          * Utility function to display dictionary as JSON.
          *
          * @static

--- a/js/turtleactions/__tests__/DictActions.test.js
+++ b/js/turtleactions/__tests__/DictActions.test.js
@@ -196,6 +196,11 @@ describe("setupDictActions", () => {
                 expect(targetTurtle.painter[method]).not.toHaveBeenCalled();
             });
         });
+
+        it("should support lowercase setDictValue alias", () => {
+            Turtle.DictActions.setDictValue(0, turtle, "color", "blue");
+            expect(targetTurtle.painter.doSetColor).toHaveBeenCalledWith("blue");
+        });
     });
 
     describe("SerializeDict", () => {


### PR DESCRIPTION
## Description

When loading or setting a dictionary using `loadDict` or `setDictionary`, parsed dictionary data was discarded for named dictionaries, reinitializing `logo.turtleDicts[turtle][a]` to an empty object `{}` instead of storing the loaded dictionary `d`. In addition, a casing mismatch (`setDictValue` vs `SetDictValue`) caused runtime exceptions when applying loaded dictionary entries to target turtles. 

This PR fixes both issues by properly assigning the parsed dictionary object to `logo.turtleDicts[turtle][a]`, correcting the method call casing to `Turtle.DictActions.SetDictValue`, providing an alias on `DictActions` for backward compatibility, and safeguarding `saveDict` with a safe fallback when saving an unset named dictionary.

## Related Issue

Fixes: #8470

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

---

## Changes Made

- **`js/blocks/ProgramBlocks.js`**:
  - In `loadDict` and `setDictionary`, assigned the parsed dictionary `d` directly to `logo.turtleDicts[turtle][a]` instead of reinitializing with `{}`.
  - Added strict validation to ensure the loaded content is a valid dictionary object (`typeof d === "object" && d !== null && !Array.isArray(d)`).
  - Fixed casing when calling `Turtle.DictActions.SetDictValue(target, turtle, k[i], d[k[i]])`.
  - In `saveDict`, added fallback to `{}` if the specified named dictionary is unset or undefined.
- **`js/turtleactions/DictActions.js`**:
  - Added a backward-compatible static alias `setDictValue(...)` that delegates to `SetDictValue(...)`.
- **`js/blocks/__tests__/ProgramBlocks.test.js`**:
  - Added test cases verifying named dictionary JSON data preservation when loading from files and block connections.
  - Added tests for target turtle loading delegation.
  - Added error handling tests for invalid non-object JSON arrays.
  - Added fallback test for saving an unset dictionary.
- **`js/turtleactions/__tests__/DictActions.test.js`**:
  - Added unit test verifying the `setDictValue` static alias.

---

## Steps to Reproduce

1. Open MusicBlocks.
2. Create a named dictionary block (e.g. `MyDict`).
3. Load a valid JSON file containing keys/values into `MyDict` using the `load dictionary` block.
4. Attempt to read keys from `MyDict` or export it using `save dictionary`.
5. Observe that `MyDict` was reset to `{}` and all imported data was lost.

---

## Testing Performed

- Executed unit test suites with Jest:
  - `js/blocks/__tests__/ProgramBlocks.test.js` & `js/turtleactions/__tests__/DictActions.test.js` (120/120 tests passed).
  - `js/blocks/__tests__/DictBlocks.test.js` (48/48 tests passed).
- Ran ESLint (`eslint --max-warnings=0`) with zero errors and zero warnings.
- Ran Prettier formatting check across all modified files.
- Verified manual local server execution with dictionary blocks.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custom keys in target-turtle dictionaries are now preserved when dictionaries are loaded or updated.
  - Recognized turtle status values continue to be applied correctly during dictionary updates.
  - Saving a missing or unavailable named dictionary now returns an empty dictionary (`{}`), including for inherited names.

- **Compatibility**
  - Added support for the lowercase dictionary value-setting action name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->