### PR TITLE
fix: export if blocks nested in repeat loops

### DIFF
--- a/js/js-export/ASTutils.js
+++ b/js/js-export/ASTutils.js
@@ -760,7 +760,7 @@ class ASTUtils {
                 continue;
             }
             if (flow[0] === "if") {
-                ASTs.push(ASTUtils._getIfAST(flow[1], flow[2], iterMax));
+                ASTs.push(ASTUtils._getIfAST(flow[1], flow[2], undefined, iterMax));
             } else if (flow[0] === "ifthenelse") {
                 ASTs.push(ASTUtils._getIfAST(flow[1], flow[2], flow[3], iterMax));
             } else if (flow[0] === "repeat") {

--- a/js/js-export/__tests__/ASTutils.test.js
+++ b/js/js-export/__tests__/ASTutils.test.js
@@ -18,6 +18,7 @@
  */
 
 const ASTUtils = require("../ASTutils");
+const astring = require("../../../lib/astring.min.js");
 
 global.last = jest.fn(array => array[array.length - 1]);
 global.JSInterface = {
@@ -918,6 +919,39 @@ describe("ASTUtils", () => {
                     ]
                 }
             });
+        });
+
+        it("should export a repeat containing an if with a nested repeat", async () => {
+            const tree = [
+                [
+                    "repeat",
+                    [2],
+                    [
+                        ["if", [["less", [1, 2]]], [["repeat", [3], [["print", ["hello"]]]]]],
+                        ["if", [["less", [2, 1]]], [["print", ["never"]]]]
+                    ]
+                ]
+            ];
+
+            JSInterface.isSetter.mockReturnValue(false);
+            JSInterface.isMethod.mockReturnValue(true);
+            JSInterface.isClampBlock.mockReturnValue(false);
+            JSInterface.isGetter.mockReturnValue(false);
+            JSInterface.methodReturns.mockReturnValue(false);
+            JSInterface.getMethodName.mockImplementation(methodName => methodName);
+            JSInterface.rearrangeMethodArgs.mockImplementation((methodName, args) => args);
+
+            const code = astring.generate(ASTUtils.getMouseAST(tree));
+            expect(code).toContain("let i0 = 0");
+            expect(code).toContain("let i1 = 0");
+
+            const printed = [];
+            let flow;
+            new Function("Mouse", code)(function Mouse(mouseFlow) {
+                flow = mouseFlow;
+            });
+            await flow({ print: value => printed.push(value) });
+            expect(printed).toEqual(["hello", "hello", "hello", "hello", "hello", "hello"]);
         });
     });
 });


### PR DESCRIPTION
## Description

Exporting a repeat containing an if block can throw `TypeError: flows is not iterable`. The exporter catches the error and replaces the program with an empty mouse.

## Related Issue

Fixes #8558

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

Pass the loop depth as the fourth argument to `_getIfAST`, leaving its optional else body unset. The regression exports nested repeat/if blocks, executes the generated JavaScript, and checks the output and separate loop counters.

## Steps to Reproduce

Export a Start → Repeat 2 → If 1 < 2 → Print "hello" stack as JavaScript. The exported program should print twice instead of becoming an empty mouse.

## Testing Performed

On Node 20, all 220 suites and 8,049 tests pass on this branch. The new regression fails without the fix. A real block graph also passes through `JSGenerate.run` and its generated code prints twice. Full ESLint and Prettier checks for the changed files pass. The patch was also tested against current upstream, where all 9,003 tests pass.

## Checklist

- [x] Automated tests pass locally.
- [x] A regression test reproduces the failure without the fix.
- [x] Lint and changed-file formatting checks pass.

## Additional Notes

Browser testing is pending; the export pipeline and generated JavaScript were exercised automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated JavaScript for conditional flows without an alternate branch.
  - Improved reliability for nested repeat-and-condition logic, including correct loop iteration and repeated output.

- **Tests**
  - Added coverage that generates and executes nested repeat/condition scenarios to verify expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->