### PR TITLE
test(activity): make activity.js visible to the coverage report

### DIFF
--- a/js/__tests__/helpers/activity-vm-sandbox.js
+++ b/js/__tests__/helpers/activity-vm-sandbox.js
@@ -27,6 +27,25 @@
 const fs = require("fs");
 const path = require("path");
 const vm = require("vm");
+const { createInstrumenter } = require("istanbul-lib-instrument");
+
+// activity.js is never require()d - it is read as text and run through
+// vm.runInContext below - so jest's babel transform never sees it and every
+// one of its ~1400 statements reports as uncovered however well it is tested.
+// Instrumenting the source here, against the same coverage variable jest
+// reads, makes the file visible to the report. jest.config.js sets
+// collectCoverage: true for every run, so this is not gated on a flag.
+let instrumenter = null;
+const instrumentForCoverage = (source, filename) => {
+    if (!instrumenter) {
+        instrumenter = createInstrumenter({
+            coverageVariable: "__coverage__",
+            esModules: false,
+            compact: true
+        });
+    }
+    return instrumenter.instrumentSync(source, filename);
+};
 
 const ACTIVITY_PATH = path.resolve(__dirname, "../../activity.js");
 
@@ -118,9 +137,18 @@ const createBaseSandbox = () => ({
  */
 const loadActivitySandbox = ({ overrides = {}, prependCode = "" } = {}) => {
     const sandbox = { ...createBaseSandbox(), ...overrides };
-    const code =
+    const code = instrumentForCoverage(
         fs.readFileSync(ACTIVITY_PATH, "utf8") +
-        "\nthis.activity = activity;\nthis.Activity = Activity;";
+            "\nthis.activity = activity;\nthis.Activity = Activity;",
+        ACTIVITY_PATH
+    );
+
+    // The instrumented code increments counters on __coverage__. Point the
+    // context at jest's own global so the reporter reads the same object.
+    if (!global.__coverage__) {
+        global.__coverage__ = {};
+    }
+    sandbox.__coverage__ = global.__coverage__;
 
     vm.createContext(sandbox);
     if (prependCode) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "gulp-prettier": "^3.0.0",
                 "gulp-uglify": "^3.0.2",
                 "husky": "^9.1.7",
+                "istanbul-lib-instrument": "^6.0.3",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^30.4.1",
                 "lint-staged": "^15.5.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "gulp-prettier": "^3.0.0",
         "gulp-uglify": "^3.0.2",
         "husky": "^9.1.7",
+        "istanbul-lib-instrument": "^6.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.4.1",
         "lint-staged": "^15.5.2",


### PR DESCRIPTION
## Description

`js/activity.js` reports 0% coverage however well it is tested, because the sandbox helper runs it through `vm.runInContext` rather than `require()`-ing it, and jest's babel transform never sees code that reaches V8 that way. This instruments the source before it enters the vm so the file appears in the coverage report.

## Related Issue

**Fixes:** #8562

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

`js/__tests__/helpers/activity-vm-sandbox.js`:

- run the file text through `istanbul-lib-instrument` before `vm.runInContext`, with `coverageVariable: "__coverage__"` so it matches what jest reads;
- point the vm context's `__coverage__` at jest's own global, so the counters the instrumented code increments are the ones the reporter collects.

`istanbul-lib-instrument` was already in the tree as a transitive dependency of jest. It is declared in `devDependencies` so the helper does not rely on hoisting — one line in `package.json` and one in `package-lock.json`, no other lockfile churn.

Nothing else changes: activity.js still runs unmodified, the appended `this.activity = activity;` bootstrap is untouched, and both existing sandbox suites keep passing.

## Steps to Reproduce

```
npx jest js/__tests__/activity_toolbar_integration.test.js --coverage \
  --collectCoverageFrom='js/activity.js' --coverageReporters=text-summary
```

On `master`: `Statements : 0% ( 0/1393 )` with 7 tests passing.
On this branch: `Statements : 20.5% ( 285/1390 )` with the same tests passing.

---

## Testing Performed

Full suite, both ways:

| | master | this branch |
|---|---|---|
| statements | 70.39% (43734/62125) | **70.85%** (44019/62127) |
| branches | 61.05% (17046/27917) | **61.22%** (17093/27917) |
| functions | 70.66% (4514/6388) | **70.83%** (4525/6388) |
| lines | 70.79% (42344/59809) | **71.26%** (42625/59811) |

- `npx jest` — **235 suites, 9097 tests, all passing**, unchanged from master.
- Rebased onto `master` at 9e49c151 and re-measured, so these are today's numbers.
- Coverage rises on every metric, so the *Coverage delta vs base* job sees an improvement rather than a drop.
- The denominator moves by two statements, because the instrumented text is what gets counted.
- Cost: the two sandbox suites go from 0.469s to 0.854s. Nothing else is instrumented, so the rest of the suite is unaffected.
- `npm run lint` — clean.
- `npx prettier --check` on the three changed files — clean. (`prettier --check .` across the whole repo reports 332 pre-existing warnings on `master` too, all markdown/YAML.)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

Two things worth a reviewer's opinion:

1. **No flag guard.** `jest.config.js` sets `collectCoverage: true` for every run, so the rewrite always happens rather than being gated on `--coverage`. If you would rather pay nothing on a `--coverage=false` run, I can gate it on an env var the config sets.
2. **This is why `codecov/patch` is red on activity.js PRs.** Any change to that file currently reports "0.00% of diff hit" no matter what tests come with it — #8494 is a live example. Once this lands that check becomes meaningful for activity.js instead of always failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage reporting for activity execution in sandboxed test environments.
  - Coverage results now exclude sandbox bootstrap code, providing more accurate measurements.

- **Chores**
  - Updated development tooling to support consistent instrumentation and coverage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->