### PR TITLE
fix(pitchstaircase): validate supported frequency bounds in _dissectStair

### DIFF
--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -478,9 +478,42 @@ describe("PitchStaircase Widget", () => {
             expect(psc._makeStairs).toHaveBeenCalled();
         });
 
+        test("accepts boundary frequency at exactly MAX_FREQUENCY (20000 Hz)", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc.Stairs = [["A", "", 10000.0, 1, 1, 10000.0, 4]];
+            // inputNum = 1 / 2 = 0.5 => newFrequency = 10000 / 0.5 = 20000.0 === MAX_FREQUENCY
+            psc._musicRatio1 = { value: "2" };
+            psc._musicRatio2 = { value: "1" };
+
+            psc._dissectStair(makeEvent(10000));
+
+            expect(psc.Stairs).toHaveLength(2);
+            expect(psc.Stairs[0][2]).toBe(PitchStaircase.MAX_FREQUENCY);
+            expect(psc._makeStairs).toHaveBeenCalled();
+            expect(mockTextMsg).not.toHaveBeenCalled();
+        });
+
+        test("accepts boundary frequency at exactly MIN_FREQUENCY (20 Hz)", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc.Stairs = [["A", "", 40.0, 1, 1, 40.0, 4]];
+            // inputNum = 2 / 1 = 2 => newFrequency = 40 / 2 = 20.0 === MIN_FREQUENCY
+            psc._musicRatio1 = { value: "1" };
+            psc._musicRatio2 = { value: "2" };
+
+            psc._dissectStair(makeEvent(40));
+
+            expect(psc.Stairs).toHaveLength(2);
+            expect(psc.Stairs[1][2]).toBe(PitchStaircase.MIN_FREQUENCY);
+            expect(psc._makeStairs).toHaveBeenCalled();
+            expect(mockTextMsg).not.toHaveBeenCalled();
+        });
+
         test("rejects frequency above MAX_FREQUENCY (20000 Hz) and notifies user", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
+            const initialStairs = [["A", "", 15000.0, 1, 1, 15000.0, 4]];
             psc.Stairs = [["A", "", 15000.0, 1, 1, 15000.0, 4]];
             // inputNum = inputNum2 / inputNum1 = 1 / 2 => newFrequency = 15000 / 0.5 = 30000 > 20000
             psc._musicRatio1 = { value: "2" };
@@ -488,7 +521,7 @@ describe("PitchStaircase Widget", () => {
 
             psc._dissectStair(makeEvent(15000));
 
-            expect(psc.Stairs).toHaveLength(1);
+            expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
             expect(mockTextMsg).toHaveBeenCalledWith(
                 "Frequency is outside audible range (20 Hz - 20000 Hz).",
@@ -499,6 +532,7 @@ describe("PitchStaircase Widget", () => {
         test("rejects frequency below MIN_FREQUENCY (20 Hz) and notifies user", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
+            const initialStairs = [["A", "", 30.0, 1, 1, 30.0, 4]];
             psc.Stairs = [["A", "", 30.0, 1, 1, 30.0, 4]];
             // inputNum = inputNum2 / inputNum1 = 2 / 1 = 2 => newFrequency = 30 / 2 = 15 < 20
             psc._musicRatio1 = { value: "1" };
@@ -506,7 +540,7 @@ describe("PitchStaircase Widget", () => {
 
             psc._dissectStair(makeEvent(30));
 
-            expect(psc.Stairs).toHaveLength(1);
+            expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
             expect(mockTextMsg).toHaveBeenCalledWith(
                 "Frequency is outside audible range (20 Hz - 20000 Hz).",
@@ -517,11 +551,17 @@ describe("PitchStaircase Widget", () => {
         test("rejects non-finite or NaN frequency and notifies user", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
-            psc.Stairs = [["A", "", NaN, 1, 1, 220.0, 4]];
+            const initialStairs = [["A", "", Infinity, 1, 1, Infinity, 4]];
+            psc.Stairs = [["A", "", Infinity, 1, 1, Infinity, 4]];
 
-            psc._dissectStair(makeEvent(NaN));
+            psc._dissectStair(makeEvent(Infinity));
 
+            expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
+            expect(mockTextMsg).toHaveBeenCalledWith(
+                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                3000
+            );
         });
     });
 

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -130,6 +130,11 @@ describe("PitchStaircase Widget", () => {
         test("should have correct DEFAULTFREQUENCY", () => {
             expect(PitchStaircase.DEFAULTFREQUENCY).toBe(220.0);
         });
+
+        test("should have correct MIN_FREQUENCY and MAX_FREQUENCY", () => {
+            expect(PitchStaircase.MIN_FREQUENCY).toBe(20.0);
+            expect(PitchStaircase.MAX_FREQUENCY).toBe(20000.0);
+        });
     });
 
     // --- Stairs Data Tests ---
@@ -471,6 +476,52 @@ describe("PitchStaircase Widget", () => {
 
             expect(psc.Stairs).toHaveLength(2);
             expect(psc._makeStairs).toHaveBeenCalled();
+        });
+
+        test("rejects frequency above MAX_FREQUENCY (20000 Hz) and notifies user", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc.Stairs = [["A", "", 15000.0, 1, 1, 15000.0, 4]];
+            // inputNum = inputNum2 / inputNum1 = 1 / 2 => newFrequency = 15000 / 0.5 = 30000 > 20000
+            psc._musicRatio1 = { value: "2" };
+            psc._musicRatio2 = { value: "1" };
+
+            psc._dissectStair(makeEvent(15000));
+
+            expect(psc.Stairs).toHaveLength(1);
+            expect(psc._makeStairs).not.toHaveBeenCalled();
+            expect(mockTextMsg).toHaveBeenCalledWith(
+                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                3000
+            );
+        });
+
+        test("rejects frequency below MIN_FREQUENCY (20 Hz) and notifies user", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc.Stairs = [["A", "", 30.0, 1, 1, 30.0, 4]];
+            // inputNum = inputNum2 / inputNum1 = 2 / 1 = 2 => newFrequency = 30 / 2 = 15 < 20
+            psc._musicRatio1 = { value: "1" };
+            psc._musicRatio2 = { value: "2" };
+
+            psc._dissectStair(makeEvent(30));
+
+            expect(psc.Stairs).toHaveLength(1);
+            expect(psc._makeStairs).not.toHaveBeenCalled();
+            expect(mockTextMsg).toHaveBeenCalledWith(
+                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                3000
+            );
+        });
+
+        test("rejects non-finite or NaN frequency and notifies user", () => {
+            const mockTextMsg = jest.fn();
+            psc.activity = { textMsg: mockTextMsg };
+            psc.Stairs = [["A", "", NaN, 1, 1, 220.0, 4]];
+
+            psc._dissectStair(makeEvent(NaN));
+
+            expect(psc._makeStairs).not.toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/__tests__/pitchstaircase.test.js
+++ b/js/widgets/__tests__/pitchstaircase.test.js
@@ -132,8 +132,8 @@ describe("PitchStaircase Widget", () => {
         });
 
         test("should have correct MIN_FREQUENCY and MAX_FREQUENCY", () => {
-            expect(PitchStaircase.MIN_FREQUENCY).toBe(20.0);
-            expect(PitchStaircase.MAX_FREQUENCY).toBe(20000.0);
+            expect(PitchStaircase.MIN_FREQUENCY).toBe(27.5);
+            expect(PitchStaircase.MAX_FREQUENCY).toBe(16744.04);
         });
     });
 
@@ -478,15 +478,15 @@ describe("PitchStaircase Widget", () => {
             expect(psc._makeStairs).toHaveBeenCalled();
         });
 
-        test("accepts boundary frequency at exactly MAX_FREQUENCY (20000 Hz)", () => {
+        test("accepts boundary frequency at exactly MAX_FREQUENCY (16744.04 Hz)", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
-            psc.Stairs = [["A", "", 10000.0, 1, 1, 10000.0, 4]];
-            // inputNum = 1 / 2 = 0.5 => newFrequency = 10000 / 0.5 = 20000.0 === MAX_FREQUENCY
+            psc.Stairs = [["A", "", 8372.02, 1, 1, 8372.02, 4]];
+            // inputNum = 1 / 2 = 0.5 => newFrequency = 8372.02 / 0.5 = 16744.04 === MAX_FREQUENCY
             psc._musicRatio1 = { value: "2" };
             psc._musicRatio2 = { value: "1" };
 
-            psc._dissectStair(makeEvent(10000));
+            psc._dissectStair(makeEvent(8372.02));
 
             expect(psc.Stairs).toHaveLength(2);
             expect(psc.Stairs[0][2]).toBe(PitchStaircase.MAX_FREQUENCY);
@@ -494,15 +494,15 @@ describe("PitchStaircase Widget", () => {
             expect(mockTextMsg).not.toHaveBeenCalled();
         });
 
-        test("accepts boundary frequency at exactly MIN_FREQUENCY (20 Hz)", () => {
+        test("accepts boundary frequency at exactly MIN_FREQUENCY (27.5 Hz)", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
-            psc.Stairs = [["A", "", 40.0, 1, 1, 40.0, 4]];
-            // inputNum = 2 / 1 = 2 => newFrequency = 40 / 2 = 20.0 === MIN_FREQUENCY
+            psc.Stairs = [["A", "", 55.0, 1, 1, 55.0, 4]];
+            // inputNum = 2 / 1 = 2 => newFrequency = 55.0 / 2 = 27.5 === MIN_FREQUENCY
             psc._musicRatio1 = { value: "1" };
             psc._musicRatio2 = { value: "2" };
 
-            psc._dissectStair(makeEvent(40));
+            psc._dissectStair(makeEvent(55));
 
             expect(psc.Stairs).toHaveLength(2);
             expect(psc.Stairs[1][2]).toBe(PitchStaircase.MIN_FREQUENCY);
@@ -510,40 +510,40 @@ describe("PitchStaircase Widget", () => {
             expect(mockTextMsg).not.toHaveBeenCalled();
         });
 
-        test("rejects frequency above MAX_FREQUENCY (20000 Hz) and notifies user", () => {
+        test("rejects frequency above MAX_FREQUENCY (16744.04 Hz) and notifies user", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
-            const initialStairs = [["A", "", 15000.0, 1, 1, 15000.0, 4]];
-            psc.Stairs = [["A", "", 15000.0, 1, 1, 15000.0, 4]];
-            // inputNum = inputNum2 / inputNum1 = 1 / 2 => newFrequency = 15000 / 0.5 = 30000 > 20000
+            const initialStairs = [["A", "", 10000.0, 1, 1, 10000.0, 4]];
+            psc.Stairs = [["A", "", 10000.0, 1, 1, 10000.0, 4]];
+            // inputNum = inputNum2 / inputNum1 = 1 / 2 => newFrequency = 10000 / 0.5 = 20000 > 16744.04
             psc._musicRatio1 = { value: "2" };
             psc._musicRatio2 = { value: "1" };
 
-            psc._dissectStair(makeEvent(15000));
+            psc._dissectStair(makeEvent(10000));
 
             expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
             expect(mockTextMsg).toHaveBeenCalledWith(
-                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                "Frequency is outside supported range (27.5 Hz - 16744.04 Hz).",
                 3000
             );
         });
 
-        test("rejects frequency below MIN_FREQUENCY (20 Hz) and notifies user", () => {
+        test("rejects frequency below MIN_FREQUENCY (27.5 Hz) and notifies user", () => {
             const mockTextMsg = jest.fn();
             psc.activity = { textMsg: mockTextMsg };
-            const initialStairs = [["A", "", 30.0, 1, 1, 30.0, 4]];
-            psc.Stairs = [["A", "", 30.0, 1, 1, 30.0, 4]];
-            // inputNum = inputNum2 / inputNum1 = 2 / 1 = 2 => newFrequency = 30 / 2 = 15 < 20
+            const initialStairs = [["A", "", 40.0, 1, 1, 40.0, 4]];
+            psc.Stairs = [["A", "", 40.0, 1, 1, 40.0, 4]];
+            // inputNum = inputNum2 / inputNum1 = 2 / 1 = 2 => newFrequency = 40 / 2 = 20 < 27.5
             psc._musicRatio1 = { value: "1" };
             psc._musicRatio2 = { value: "2" };
 
-            psc._dissectStair(makeEvent(30));
+            psc._dissectStair(makeEvent(40));
 
             expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
             expect(mockTextMsg).toHaveBeenCalledWith(
-                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                "Frequency is outside supported range (27.5 Hz - 16744.04 Hz).",
                 3000
             );
         });
@@ -559,7 +559,7 @@ describe("PitchStaircase Widget", () => {
             expect(psc.Stairs).toEqual(initialStairs);
             expect(psc._makeStairs).not.toHaveBeenCalled();
             expect(mockTextMsg).toHaveBeenCalledWith(
-                "Frequency is outside audible range (20 Hz - 20000 Hz).",
+                "Frequency is outside supported range (27.5 Hz - 16744.04 Hz).",
                 3000
             );
         });

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -44,6 +44,8 @@ class PitchStaircase {
     static BUTTONSIZE = 53;
     static ICONSIZE = 32;
     static DEFAULTFREQUENCY = 220.0;
+    static MIN_FREQUENCY = 20.0;
+    static MAX_FREQUENCY = 20000.0;
 
     /**
      * @constructor
@@ -288,6 +290,18 @@ class PitchStaircase {
         }
 
         const newFrequency = parseFloat(frequency) / inputNum;
+        if (
+            !Number.isFinite(newFrequency) ||
+            newFrequency < PitchStaircase.MIN_FREQUENCY ||
+            newFrequency > PitchStaircase.MAX_FREQUENCY
+        ) {
+            const act = this.activity || (typeof activity !== "undefined" ? activity : null);
+            if (act && typeof act.textMsg === "function") {
+                act.textMsg(_("Frequency is outside audible range (20 Hz - 20000 Hz)."), 3000);
+            }
+            return;
+        }
+
         const obj = frequencyToPitch(newFrequency);
         let foundStep = false;
         let repeatStep = false;

--- a/js/widgets/pitchstaircase.js
+++ b/js/widgets/pitchstaircase.js
@@ -44,8 +44,8 @@ class PitchStaircase {
     static BUTTONSIZE = 53;
     static ICONSIZE = 32;
     static DEFAULTFREQUENCY = 220.0;
-    static MIN_FREQUENCY = 20.0;
-    static MAX_FREQUENCY = 20000.0;
+    static MIN_FREQUENCY = 27.5; // A0
+    static MAX_FREQUENCY = 16744.04; // C10
 
     /**
      * @constructor
@@ -297,7 +297,10 @@ class PitchStaircase {
         ) {
             const act = this.activity || (typeof activity !== "undefined" ? activity : null);
             if (act && typeof act.textMsg === "function") {
-                act.textMsg(_("Frequency is outside audible range (20 Hz - 20000 Hz)."), 3000);
+                act.textMsg(
+                    _("Frequency is outside supported range (27.5 Hz - 16744.04 Hz)."),
+                    3000
+                );
             }
             return;
         }


### PR DESCRIPTION
## Description

Prevents runaway frequency compounding beyond Music Blocks' supported pitch range (.5\text{ Hz} \le f \le 16744.04\text{ Hz}$, $ to {10}$) when dissecting stairs in the Pitch Staircase widget. When a frequency exceeds or falls below supported bounds, the widget notifies the user via `activity.textMsg` and halts step insertion, preventing table layout distortion (collapsing to 20px slivers), scientific notation overflow, Tone.js synthesis failures, and pitch classification label errors.

## Related Issue

**Fixes:** #8332

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`js/widgets/pitchstaircase.js`**:
  - Added `static MIN_FREQUENCY = 27.5;` ($) and `static MAX_FREQUENCY = 16744.04;` ({10}$) class constants matching the pitch limits in `js/utils/musicutils.js`.
  - In `_dissectStair(event)`: validated that computed `newFrequency` is finite and within `[MIN_FREQUENCY, MAX_FREQUENCY]`.
  - Dispatches `activity.textMsg(_("Frequency is outside supported range (27.5 Hz - 16744.04 Hz)."), 3000);` and aborts stair insertion when bounds are breached.
- **`js/widgets/__tests__/pitchstaircase.test.js`**:
  - Added unit tests for `MIN_FREQUENCY` and `MAX_FREQUENCY` constants.
  - Added boundary tests verifying exact acceptance at .5\text{ Hz}$ and .04\text{ Hz}$.
  - Added tests for `_dissectStair` verifying early return, unchanged `Stairs` data, omitted `_makeStairs` calls, and user notification messages for frequencies $> 16744.04\text{ Hz}$, $< 27.5\text{ Hz}$, and non-finite/NaN values.

---

## Steps to Reproduce

1. Open Music Blocks.
2. Launch the Pitch Staircase widget.
3. With custom ratios (e.g. /4$ or /100$), repeatedly click on a stair step.
4. **Before**: Frequency compounded exponentially up to ^{38}\text{ Hz}$, collapsing stair table cells into 20px slivers, overflowing text with exponential notation (`1.044345e+38 C10`), and failing Tone.js oscillator playback.
5. **After**: Step creation stops cleanly at .04\text{ Hz}$ ({10}$) or .5\text{ Hz}$ ($), a friendly notification banner alerts the user, and layout, note labeling, and audio remain stable.

---

## Testing Performed

- `npx jest js/widgets/__tests__/pitchstaircase.test.js` (all 66 tests pass green)
- `npm test` (all 235 suites / 9,132 tests pass green)
- `npx eslint js/widgets/pitchstaircase.js js/widgets/__tests__/pitchstaircase.test.js` (0 errors, 0 warnings)
- `npx prettier --check js/widgets/pitchstaircase.js js/widgets/__tests__/pitchstaircase.test.js` (pass)

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Pitch staircase generation now accepts frequencies within the supported range of 27.5 Hz to 16,744.04 Hz.
  * Frequencies outside this range, including invalid or non-finite values, are rejected with a message showing the supported limits.
  * Rejected inputs leave the existing staircase unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->