### PR TITLE
test: add focused coverage for rubrics and focus-cycle-manager

### DIFF
--- a/js/__tests__/focus-cycle-manager.test.js
+++ b/js/__tests__/focus-cycle-manager.test.js
@@ -475,4 +475,158 @@ describe("FocusCycleManager module", () => {
             manager.dispose();
         });
     });
+
+    describe("zone entry and exit against a populated chrome", () => {
+        // jsdom (even v30) ships no PointerEvent constructor; the workspace-enter
+        // path constructs one directly, so stub a minimal, standards-shaped
+        // version the way toolbar.test.js already does.
+        let realPointerEvent;
+        beforeAll(() => {
+            realPointerEvent = global.PointerEvent;
+            global.PointerEvent = class PointerEvent extends Event {
+                constructor(type, init = {}) {
+                    super(type, init);
+                }
+            };
+        });
+        afterAll(() => {
+            global.PointerEvent = realPointerEvent;
+        });
+
+        let paletteModel;
+        const mountChrome = ({ rows = 0 } = {}) => {
+            document.body.insertAdjacentHTML(
+                "beforeend",
+                `<div id="toolbars"><button id="tb1" tabindex="0">A</button></div>
+                 <div id="palette" tabindex="-1">
+                   <div><div></div><div><div></div><div id="paletteListBody"></div></div></div>
+                 </div>
+                 <div id="canvasHolder"></div>
+                 <canvas id="canvas"></canvas>`
+            );
+            const listBody = document.getElementById("paletteListBody");
+            for (let i = 0; i < rows; i++) {
+                listBody.appendChild(document.createElement("div"));
+            }
+            paletteModel = { resetKeyboardNavigation: jest.fn() };
+            globalThis.ActivityContext = {
+                getActivity: () => ({ palettes: paletteModel, blocks: {} })
+            };
+        };
+
+        afterEach(() => {
+            delete globalThis.ActivityContext;
+            paletteModel = undefined;
+        });
+
+        test("entering the workspace zone focuses #canvasHolder and announces it", () => {
+            mountChrome();
+            const holder = document.getElementById("canvasHolder");
+            const focusSpy = jest.spyOn(holder, "focus");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            // workspace -> Tab -> toolbar -> Tab -> palette -> Tab -> workspace
+            pressTab(false);
+            pressTab(false);
+            pressTab(false);
+
+            expect(manager._currentZone).toBe("workspace");
+            expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+            expect(holder.getAttribute("tabindex")).toBe("-1");
+            expect(document.getElementById("fcm-announcer").textContent).toBe("Workspace active");
+
+            manager.dispose();
+        });
+
+        test("entering the toolbar zone adds the focus ring and announces it", () => {
+            mountChrome();
+            const toolbars = document.getElementById("toolbars");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            pressTab(false);
+
+            expect(manager._currentZone).toBe("toolbar");
+            expect(toolbars.classList.contains("focus-zone-active")).toBe(true);
+            expect(document.getElementById("fcm-announcer").textContent).toBe("Toolbar active");
+
+            manager.dispose();
+        });
+
+        test("entering the palette zone syncs palette.js state and pre-focuses a block row", () => {
+            mountChrome({ rows: 3 });
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            pressTab(false); // toolbar
+            pressTab(false); // palette
+
+            expect(manager._currentZone).toBe("palette");
+            expect(paletteModel._keyboardNavActive).toBe(true);
+            expect(paletteModel._navSection).toBe("blocks");
+            expect(paletteModel._navBlockIndex).toBe(1);
+
+            const rows = document.getElementById("paletteListBody").children;
+            expect(rows[1].dataset.keyboardFocus).toBe("true");
+            expect(document.getElementById("fcm-announcer").textContent).toBe("Palette active");
+
+            manager.dispose();
+        });
+
+        test("leaving the palette zone resets palette keyboard navigation", () => {
+            mountChrome({ rows: 2 });
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            pressTab(false); // toolbar
+            pressTab(false); // palette
+            paletteModel.resetKeyboardNavigation.mockClear();
+            pressTab(false); // palette -> workspace, leaving palette
+
+            expect(paletteModel.resetKeyboardNavigation).toHaveBeenCalledWith({
+                closeMenus: true,
+                blur: true
+            });
+
+            manager.dispose();
+        });
+
+        test("leaving the toolbar zone strips the toolbar-btn-focused class", () => {
+            mountChrome();
+            const button = document.getElementById("tb1");
+            button.classList.add("toolbar-btn-focused");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            pressTab(false); // workspace -> toolbar
+            pressTab(false); // toolbar -> palette, leaving toolbar
+
+            expect(button.classList.contains("toolbar-btn-focused")).toBe(false);
+
+            manager.dispose();
+        });
+
+        test("a mousedown on the workspace focuses the holder and clears toolbar focus", () => {
+            mountChrome();
+            const holder = document.getElementById("canvasHolder");
+            const button = document.getElementById("tb1");
+            button.classList.add("toolbar-btn-focused");
+            const focusSpy = jest.spyOn(holder, "focus");
+
+            const manager = new FocusCycleManager();
+            manager.init();
+            holder.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+            expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+            expect(button.classList.contains("toolbar-btn-focused")).toBe(false);
+            expect(manager._currentZone).toBe("workspace");
+            expect(paletteModel.resetKeyboardNavigation).toHaveBeenCalledWith({
+                closeMenus: true,
+                blur: true
+            });
+
+            manager.dispose();
+        });
+    });
 });

--- a/js/__tests__/rubrics.test.js
+++ b/js/__tests__/rubrics.test.js
@@ -31,10 +31,11 @@ const {
     runAnalytics,
     getStatsFromNotation
 } = require("../rubrics");
-const { isCustomTemperament } = require("../utils/musicutils");
+const { isCustomTemperament, getTemperament } = require("../utils/musicutils");
 
 global.last = jest.fn();
 global.isCustomTemperament = isCustomTemperament;
+global.getTemperament = getTemperament;
 global.TextEncoder = require("util").TextEncoder;
 global.TextDecoder = require("util").TextDecoder;
 
@@ -132,6 +133,63 @@ describe("rubrics.js test suite", () => {
             warnSpy.mockRestore();
             PALS_INDEX_MAP.set("turtlep", origIndex);
         });
+
+        it("skips a slot-1 flow block (tie/start/...) whose child connection is empty", () => {
+            const notespIdx = PALS_INDEX_MAP.get("notesp");
+
+            const withChild = analyzeProject({
+                blocks: { blockList: [{ name: "tie", connections: [null, {}] }] }
+            });
+            const withoutChild = analyzeProject({
+                blocks: { blockList: [{ name: "tie", connections: [null, null] }] }
+            });
+
+            // A "tie" with a real child flow scores rhythm points; an empty one
+            // is dropped before scoring.
+            expect(withChild[notespIdx]).toBeGreaterThan(0);
+            expect(withoutChild.every(score => score === 0)).toBe(true);
+        });
+
+        it("skips a tuplet2 block whose slot-3 connection is empty", () => {
+            const scored = analyzeProject({
+                blocks: { blockList: [{ name: "tuplet2", connections: [null, {}, {}, {}] }] }
+            });
+            const dropped = analyzeProject({
+                blocks: { blockList: [{ name: "tuplet2", connections: [null, {}, {}, null] }] }
+            });
+
+            expect(scored.some(score => score > 0)).toBe(true);
+            expect(dropped.every(score => score === 0)).toBe(true);
+        });
+
+        it("skips an invert block whose slot-4 connection is empty", () => {
+            const kept = analyzeProject({
+                blocks: {
+                    blockList: [{ name: "invert", connections: [null, {}, {}, {}, {}] }]
+                }
+            });
+            const dropped = analyzeProject({
+                blocks: {
+                    blockList: [{ name: "invert", connections: [null, {}, {}, {}, null] }]
+                }
+            });
+
+            expect(Array.isArray(kept)).toBe(true);
+            expect(dropped.every(score => score === 0)).toBe(true);
+        });
+
+        it("logs a debug line for a retained block that is absent from the catalog", () => {
+            const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+            analyzeProject({
+                blocks: {
+                    blockList: [{ name: "notacatalogblock", connections: [{}, {}] }]
+                }
+            });
+
+            expect(debugSpy).toHaveBeenCalledWith("notacatalogblock not in catalog");
+            debugSpy.mockRestore();
+        });
     });
 
     describe("scoreToChartData", () => {
@@ -145,6 +203,12 @@ describe("rubrics.js test suite", () => {
             expect(chartData.datasets).toHaveLength(1);
             expect(chartData.datasets[0]).toHaveProperty("data");
             expect(chartData.datasets[0].data.length).toBe(scores.length);
+        });
+
+        it("handles an all-zero score vector without dividing by zero", () => {
+            const chartData = scoreToChartData([0, 0, 0]);
+
+            expect(chartData.datasets[0].data).toEqual([0, 0, 0]);
         });
     });
 
@@ -220,6 +284,98 @@ describe("rubrics.js test suite", () => {
             expect(stats.numberOfNotes).toBeGreaterThan(0);
             expect(stats).toHaveProperty("rests", 1);
             expect(stats).toHaveProperty("ornaments", 1);
+        });
+
+        it("counts tuplet groupings, tracks the pitch range and reads articulation markers", () => {
+            const freq = { C4: 300, D4: 100, F4: 400, G4: 500 };
+            const activity = {
+                logo: {
+                    notation: {
+                        notationStaging: {
+                            0: [
+                                [["C4"], 2],
+                                [["D4", "F4"], 3],
+                                [["G4"], 5],
+                                [["R"], 4],
+                                "begin articulation",
+                                "end articulation"
+                            ]
+                        }
+                    },
+                    synth: {
+                        inTemperament: "equal",
+                        _getFrequency: jest.fn(note => freq[note] ?? NaN)
+                    }
+                },
+                blocks: {
+                    blockList: [
+                        {
+                            name: "rest2",
+                            trash: false,
+                            protoblock: { palette: { name: "rhythm" } }
+                        },
+                        { name: "flat", trash: true },
+                        {
+                            name: "flat",
+                            trash: false,
+                            protoblock: { palette: { name: "ornaments" } }
+                        }
+                    ]
+                }
+            };
+
+            const stats = getStatsFromNotation(activity);
+
+            expect(stats.duples).toBe(1);
+            expect(stats.triplets).toBe(1);
+            expect(stats.quintuplets).toBe(1);
+            // C4, D4, F4, G4 and the rest "R" each count as a note.
+            expect(stats.numberOfNotes).toBe(5);
+            // D4 is the cheapest frequency, G4 the dearest. Each tuple is
+            // [noteName, runningNoteId, frequency]; the ids follow encounter
+            // order C4=0, D4=1, F4=2, G4=3.
+            expect(stats.lowestNote).toEqual(["D4", 1, 100]);
+            expect(stats.highestNote).toEqual(["G4", 3, 500]);
+            expect(stats.pitchNames.has("R")).toBe(true);
+            expect(stats.pitchNames.has("C")).toBe(true);
+            // Both markers are recorded by their staging index. Assert the
+            // combined count rather than that they both land in .begin, so the
+            // test still holds if the "end articulation" branch is later
+            // corrected to push into .end.
+            expect(stats.articulation.begin).toContain("4");
+            expect(stats.articulation.begin.length + stats.articulation.end.length).toBe(2);
+            expect(stats.rests).toBe(1);
+            expect(stats.ornaments).toBe(1);
+        });
+
+        it("resolves note names through the custom temperament table when one is active", () => {
+            isCustomTemperament.mockReturnValueOnce(true);
+            getTemperament.mockReturnValueOnce([["idx", "Cff", "ratio", "C"]]);
+
+            const activity = {
+                logo: {
+                    notation: {
+                        notationStaging: {
+                            0: [[["C4"], 4]]
+                        }
+                    },
+                    synth: {
+                        inTemperament: "custom",
+                        getCustomFrequency: jest.fn(() => 261.6),
+                        _getFrequency: jest.fn(() => {
+                            throw new Error("_getFrequency must not be used in custom temperament");
+                        })
+                    }
+                },
+                blocks: { blockList: [] }
+            };
+
+            const stats = getStatsFromNotation(activity);
+
+            expect(activity.logo.synth.getCustomFrequency).toHaveBeenCalled();
+            // "C" matched row[3], so the stored name becomes row[1] + octave.
+            expect(stats.pitchNames.has("Cff")).toBe(true);
+            expect(stats.pitches).toContain(261.6);
         });
     });
 });


### PR DESCRIPTION
## Description

Extends the existing Jest test suites for two under-tested deterministic modules: `js/rubrics.js` and `js/focus-cycle-manager.js`.

The tests were selected from a full-suite coverage baseline based on meaningful uncovered branches, clear public APIs, existing test scaffolding, and maintenance value. The AST `ModuleTestPlan` was used only to enumerate the public surface and identify branch gaps; the tests themselves were written as evidence-based behavioral tests rather than generated blindly.

**No production code is changed.**

## Category

* [ ] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] UI/UX — Changes to the user interface or user experience
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

### `js/rubrics.js`

Added behavioral coverage for project analytics, including:

* `analyzeProject()` connection guards
* Slot 1/3/4 connection cases
* Not-in-catalog debug path
* Tuplet counting
* Pitch-range tracking
* Articulation markers
* Rests
* Custom temperament handling
* Zero-vector handling in `scoreToChartData()`

Branch coverage increased from **56.7% to 90.8%**, function coverage from **85.7% to 100%**, and mutation score for the touched functions increased from **25.2% to 88.4%**.

The tests intentionally avoid locking in the pre-existing `"end articulation"` routing quirk, so a future correction to that behavior will not require rewriting the test.

### `js/focus-cycle-manager.js`

Added coverage for the keyboard accessibility state machine using a populated DOM, including:

* Workspace focus
* Toolbar focus
* Palette focus
* Zone entry and exit
* Palette state synchronization
* Focus-ring cleanup
* Mousedown handoff

Branch coverage increased from **66.8% to 81.6%** and function coverage from **88.2% to 97.1%**.

### Remaining gaps

The remaining uncovered branches were deliberately not chased because they are primarily:

* AMD/`window` environment shims
* Defensive branches unreachable through the normal public API
* Alternative DOM/environment shapes
* Equivalent mutants with limited additional regression value

The goal is meaningful behavioral coverage rather than maximizing coverage percentages alone.

---

## Steps to Reproduce

Not applicable. This PR only adds tests and does not change production behavior.

---

## Testing Performed

* Full Jest suite: **233 suites / 9,015 tests passed**
* `eslint .` passed
* Prettier formatting/checks passed for the modified test files
* Mutation testing performed for the relevant `js/rubrics.js` functions
* Changes verified after rebasing onto the latest `upstream/master`
* DCO sign-off included
* No production files modified

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run lint and formatting checks with no errors.
* [x] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"**.

---

## Additional Notes

This is intentionally a **test-only** PR. The selected modules were chosen after reviewing the full Jest coverage baseline rather than extending the AST test-generation approach repo-wide.

The tests focus on observable behavior and meaningful branches rather than implementation details. No production behavior is modified by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for focus behavior when entering and leaving workspace areas, including toolbar, palette, and canvas interactions.
  - Added verification for keyboard-navigation resets, focus announcements, and toolbar state cleanup.
  - Expanded rubric tests for flow-block filtering, unknown catalogs, chart normalization, notation statistics, tuplets, articulations, rests, ornaments, and custom temperaments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->