### PR TITLE
fix(turtledefs): handle restricted localStorage when retrieving language preference

### DIFF
--- a/js/__tests__/turtledefs.test.js
+++ b/js/__tests__/turtledefs.test.js
@@ -111,7 +111,10 @@ describe("Music Blocks mode (_THIS_IS_TURTLE_BLOCKS_ = false)", () => {
             "BLOCKMENUBUTTON",
             "CANVASMENUBUTTON",
             "RHYTHMPALETTEHELPICON",
-            "PITCHPREVIEWHELPBUTTON"
+            "PITCHPREVIEWHELPBUTTON",
+            "EMPTYTRASHCONFIRMBUTTON",
+            "COPYBUTTON",
+            "EXTRACTBUTTON"
         ];
         buttons.forEach(b => {
             global[b] = b;
@@ -153,5 +156,94 @@ describe("Music Blocks mode (_THIS_IS_TURTLE_BLOCKS_ = false)", () => {
 
     it("createDefaultStack should not throw when called", () => {
         expect(() => mb.createDefaultStack()).not.toThrow();
+    });
+
+    describe("getLanguagePreference & restricted storage (#7005)", () => {
+        afterEach(() => {
+            delete localStorage.languagePreference;
+        });
+
+        const withThrowingLocalStorage = fn => {
+            const originalLocalStorage = global.localStorage;
+            Object.defineProperty(global, "localStorage", {
+                get: () => {
+                    throw new Error("SecurityError: The operation is insecure.");
+                },
+                configurable: true
+            });
+            try {
+                fn();
+            } finally {
+                Object.defineProperty(global, "localStorage", {
+                    value: originalLocalStorage,
+                    configurable: true,
+                    writable: true
+                });
+            }
+        };
+
+        it("should return localStorage.languagePreference when defined", () => {
+            localStorage.languagePreference = "ja";
+            expect(mb.getLanguagePreference()).toBe("ja");
+        });
+
+        it("should fallback to navigator.language when localStorage.languagePreference is undefined", () => {
+            delete localStorage.languagePreference;
+            expect(mb.getLanguagePreference()).toBe(navigator.language);
+        });
+
+        it("should safely fallback to navigator.language when localStorage access throws SecurityError", () => {
+            withThrowingLocalStorage(() => {
+                expect(() => mb.getLanguagePreference()).not.toThrow();
+                expect(mb.getLanguagePreference()).toBe(navigator.language);
+            });
+        });
+
+        it("createDefaultStack should initialize default stack when localStorage access throws SecurityError", () => {
+            withThrowingLocalStorage(() => {
+                expect(() => mb.createDefaultStack()).not.toThrow();
+                expect(window.DATAOBJS).toBeDefined();
+                expect(window.DATAOBJS.length).toBeGreaterThan(0);
+                expect(window.DATAOBJS[10]).toEqual([10, ["solfege", { value: "sol" }], 0, 0, [9]]);
+            });
+        });
+
+        it("createHelpContent should initialize help content when localStorage access throws SecurityError", () => {
+            withThrowingLocalStorage(() => {
+                expect(() => mb.createHelpContent({})).not.toThrow();
+                expect(window.HELPCONTENT).toBeDefined();
+                expect(window.HELPCONTENT.length).toBeGreaterThan(0);
+                expect(window.HELPCONTENT[0][2]).toBe(
+                    `data:image/svg+xml;base64,${window.btoa(base64Encode(mb.LOGODEFAULT))}`
+                );
+            });
+        });
+
+        it("createDefaultStack should execute and produce Japanese stack when language is ja", () => {
+            localStorage.languagePreference = "ja";
+            expect(() => mb.createDefaultStack()).not.toThrow();
+            expect(window.DATAOBJS).toBeDefined();
+            expect(window.DATAOBJS[10]).toEqual([10, ["solfege", { value: "do" }], 0, 0, [9]]);
+        });
+
+        it("createHelpContent should select Japanese logo when language is ja", () => {
+            localStorage.languagePreference = "ja";
+            expect(() => mb.createHelpContent({})).not.toThrow();
+            expect(window.HELPCONTENT).toBeDefined();
+            expect(window.HELPCONTENT[0][2]).toBe(
+                `data:image/svg+xml;base64,${window.btoa(base64Encode(mb.LOGOJA))}`
+            );
+        });
+
+        it("should preserve language suffixes without truncation (e.g. ja-kana, zh-CN, en-US)", () => {
+            localStorage.languagePreference = "ja-kana";
+            expect(mb.getLanguagePreference()).toBe("ja-kana");
+
+            localStorage.languagePreference = "zh-CN";
+            expect(mb.getLanguagePreference()).toBe("zh-CN");
+
+            localStorage.languagePreference = "en-US";
+            expect(mb.getLanguagePreference()).toBe("en-US");
+        });
     });
 });

--- a/js/turtledefs.js
+++ b/js/turtledefs.js
@@ -28,9 +28,9 @@
 
 /* exported
 
-   createDefaultStack, createHelpContent, LOGOJA1, NUMBERBLOCKDEFAULT,
-   DEFAULTPALETTE, BUILTINPALETTES, MULTIPALETTES, SKIPPALETTES,
-   MULTIPALETTEICONS, MULTIPALETTENAMES, HELPCONTENT, DATAOBJS,
+   createDefaultStack, createHelpContent, getLanguagePreference, LOGODEFAULT, LOGOJA,
+   LOGOJA1, NUMBERBLOCKDEFAULT, DEFAULTPALETTE, BUILTINPALETTES, MULTIPALETTES,
+   SKIPPALETTES, MULTIPALETTEICONS, MULTIPALETTENAMES, HELPCONTENT, DATAOBJS,
    BUILTINPALETTESFORL23N, getMainToolbarButtonNames,
    getAuxToolbarButtonNames, TITLESTRING
  */
@@ -308,6 +308,20 @@ const getAuxToolbarButtonNames = name => {
     );
 };
 
+const getLanguagePreference = () => {
+    let language;
+    try {
+        language = localStorage.languagePreference;
+    } catch (e) {
+        // In restricted environments (e.g., Safari private browsing), localStorage may be unavailable
+        language = undefined;
+    }
+    if (language === undefined && typeof navigator !== "undefined") {
+        language = navigator.language;
+    }
+    return language;
+};
+
 const createDefaultStack = () => {
     if (_THIS_IS_TURTLE_BLOCKS_) {
         DATAOBJS = [
@@ -321,10 +335,7 @@ const createDefaultStack = () => {
             [7, ["number", { value: 90 }], 0, 0, [6]]
         ];
     } else {
-        let language = localStorage.languagePreference;
-        if (language === undefined) {
-            language = navigator.language;
-        }
+        const language = getLanguagePreference();
 
         if (language === "ja") {
             DATAOBJS = [
@@ -405,13 +416,13 @@ const createDefaultStack = () => {
             ];
         }
     }
+    if (typeof window !== "undefined") {
+        window.DATAOBJS = DATAOBJS;
+    }
 };
 
 const createHelpContent = activity => {
-    let language = localStorage.languagePreference;
-    if (language === undefined) {
-        language = navigator.language;
-    }
+    const language = getLanguagePreference();
 
     let LOGO = LOGODEFAULT;
     if (language === "ja") {
@@ -789,10 +800,17 @@ const createHelpContent = activity => {
             `data:image/svg+xml;base64,${window.btoa(base64Encode(LOGO))}`
         ]);
     }
+    if (typeof window !== "undefined") {
+        window.HELPCONTENT = HELPCONTENT;
+    }
 };
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         createDefaultStack,
+        createHelpContent,
+        getLanguagePreference,
+        LOGOJA,
+        LOGODEFAULT,
         LOGOJA1,
         NUMBERBLOCKDEFAULT,
         DEFAULTPALETTE,
@@ -801,6 +819,10 @@ if (typeof module !== "undefined" && module.exports) {
 }
 if (typeof window !== "undefined") {
     window.createDefaultStack = createDefaultStack;
+    window.createHelpContent = createHelpContent;
+    window.getLanguagePreference = getLanguagePreference;
+    window.LOGOJA = LOGOJA;
+    window.LOGODEFAULT = LOGODEFAULT;
     window.LOGOJA1 = LOGOJA1;
     window.NUMBERBLOCKDEFAULT = NUMBERBLOCKDEFAULT;
     window.DEFAULTPALETTE = DEFAULTPALETTE;


### PR DESCRIPTION
## Description

In restricted web environments (such as Safari in Private Browsing mode or contexts where storage permissions are disabled), attempting to access `window.localStorage` throws a `SecurityError`. Previously, `js/turtledefs.js` accessed `localStorage.languagePreference` directly in `createDefaultStack` and `createHelpContent`, resulting in an unhandled exception that halted Music Blocks initialization.

This pull request introduces a safe helper `getLanguagePreference()` in `js/turtledefs.js` that wraps the `localStorage` access in a `try...catch` block. If `localStorage` is inaccessible, throws an error, or if `localStorage.languagePreference` is `undefined`, it gracefully falls back to `navigator.language`.

## Related Issue

This PR fixes #7005

## PR Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance (load time, memory, rendering, etc.)
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to CI/CD workflows and automation

## Changes Made

- Extracted `getLanguagePreference()` in `js/turtledefs.js` to safely read `localStorage.languagePreference` with a fallback to `navigator.language` on error or when undefined.
- Refactored `createDefaultStack()` and `createHelpContent()` to use `getLanguagePreference()`.
- Added `getLanguagePreference` and `createHelpContent` to `/* exported */`, `module.exports`, and `window` exports.
- Added comprehensive unit tests in `js/__tests__/turtledefs.test.js` validating:
  - Normal preference reading from `localStorage`.
  - Fallback to `navigator.language` when undefined.
  - Safe fallback to `navigator.language` when `localStorage` throws `SecurityError`.
  - Resilience of `createDefaultStack` and `createHelpContent` under `SecurityError`.
  - Proper Japanese locale handling when language is `"ja"`.

## Testing Performed

- Ran `npx jest js/__tests__/turtledefs.test.js --coverage=false` (18/18 passed).
- Ran full test suite `npm test` (190 test suites, 6750 unit tests passed).
- Validated code formatting with `npx prettier --check .` and linting with `npm run lint`.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** _(required for auto-rebase; this only affects the PR branch, not your fork)_.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language selection using saved preferences, with browser-language fallback when needed.
  - Preserved language suffixes for more consistent locale handling.
  - Prevented help content and default music stacks from failing when browser storage access is restricted.
  - Added Japanese-specific default stacks and help branding when Japanese is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->