### PR TITLE
chore: remove debug console statements from phrasemaker.js

### DIFF
--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -600,8 +600,6 @@ class PhraseMaker {
         widgetWindow.clear();
         widgetWindow.show();
 
-        console.debug("notes " + this.rowLabels + " octave " + this.rowArgs);
-
         this._notesToPlay = [];
         this._matrixHasTuplets = false;
         this._loadDrumSynthsForRows(turtleIndex);
@@ -1393,7 +1391,6 @@ class PhraseMaker {
                     rArg = 0;
                     break;
                 default:
-                    console.debug(label + " not found");
                     break;
             }
 
@@ -2789,7 +2786,6 @@ class PhraseMaker {
             if (i === 0) {
                 this._sortedRowMap.push(0);
             } else if (i > 0 && obj[1] !== "hertz" && obj[1] === this._deps.last(this.rowLabels)) {
-                console.debug("skipping " + obj[1] + " " + this._deps.last(this.rowLabels));
                 this._sortedRowMap.push(this._deps.last(this._sortedRowMap));
                 if (oldColumnBlockMap[sortedList[lastObj][3]] !== undefined) {
                     setTimeout(
@@ -2809,7 +2805,6 @@ class PhraseMaker {
                 this._rowMap[i] = this._rowMap[i - 1];
                 continue;
             } else {
-                console.debug("pushing " + obj[1] + " " + this._deps.last(this.rowLabels));
                 this._sortedRowMap.push(this._deps.last(this._sortedRowMap) + 1);
                 lastObj = i;
                 this.stylePhraseMaker();


### PR DESCRIPTION
Part of #5464

## Description

Removed unnecessary debug `console.debug` statements from `js/widgets/phrasemaker.js` as part of the cleanup of debug console statements from production code. No functional behavior is changed.

## Related Issue

**Part of:** #5464

---
## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] Performance — Improves performance
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] CI/CD — Changes to CI/CD workflows and automation
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] i18n — Internationalization and localization changes
---

## Changes Made

* Removed debug output related to notes and octaves.
* Removed the unused `"label not found"` debug statement.
* Removed debug output used while sorting phrase-maker rows.
* Preserved diagnostic messages related to export-window creation and note-object parsing.
* Limited the changes to `js/widgets/phrasemaker.js`.
* No functional behavior was intentionally changed.

---

## Steps to Reproduce

Not applicable. This is a code cleanup with no intended behavior change.

## Visual Changes

Not applicable.

## Testing Performed

* Ran `npm run lint` successfully.
* Ran `npx prettier --check js/widgets/phrasemaker.js` successfully.
* Ran `git diff --check` successfully.
* Verified that only the intended debug statements were removed.
* Confirmed that the remaining diagnostic `console.debug` statements were intentionally preserved.

---

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This PR is limited to removing debug-only console statements from `phrasemaker.js`. Diagnostic messages that provide useful information when an operation fails have been intentionally retained.

No functional behavior was intentionally changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed internal diagnostic logging from the PhraseMaker widget.
  - No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->