### PR TITLE
docs(guide-es): add alt text to Spanish guide buttons (Fixes #8568)

### DIFF
--- a/Docs/guide-es/README.md
+++ b/Docs/guide-es/README.md
@@ -466,13 +466,13 @@ individual notes (or chords if you click on more than one cell in a
 column). In the figure, three quarter notes are selected (black
 cells). First `Re 4`, followed by `Mi 4`, followed by `Sol 4`.
 
-<img src="../../header-icons/play-button.svg" height="36">
+<img src="../../header-icons/play-button.svg" height="36" alt="Play">
 
 If you click on the _Play_ button (found in the top row of the grid),
 you will hear a sequence of notes played (from left to right): `Re 4`,
 `Mi 4`, `Sol 4`.
 
-<img src="../../header-icons/export-chunk.svg" height="36">
+<img src="../../header-icons/export-chunk.svg" height="36" alt="Save">
 
 Once you have a group of notes (a "chunk") that you like, click on the
 _Save_ button (just to the right of the _Play_ button). This will
@@ -482,17 +482,17 @@ programmatically. (More on that below.)
 You can rearrange the selected notes in the grid and safe other chunks
 as well.
 
-<img src="../../header-icons/sort.svg" height="36">
+<img src="../../header-icons/sort.svg" height="36" alt="Sort">
 
 The _Sort_ button will reorder the pitches in the matrix from highest
 to lowest and eliminate any duplicate _Pitch_ blocks.
 
-<img src="../../header-icons/close-button.svg" height="36">
+<img src="../../header-icons/close-button.svg" height="36" alt="Close">
 
 Or hide the matrix by clicking on the _Close_ button (the right-most
 button in the top row of the grid.)
 
-<img src="../../header-icons/erase-button.svg" height="36">
+<img src="../../header-icons/erase-button.svg" height="36" alt="Erase">
 
 There is also an Erase button that will clear the grid.
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

Adds alt text to the five button images in the Spanish guide for better accessibility.
## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #8568 

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [x] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Added concise alt text for the Play, Save, Sort, Close, and Erase button images in Docs/guide-es/README.md.

---

## Steps to Reproduce

Not applicable.
## Visual Changes

Not applicable.
### Before

<img width="610" height="685" alt="image" src="https://github.com/user-attachments/assets/aeb2d574-b847-41b6-9895-676a05fe2672" />


### After

<img width="316" height="346" alt="image" src="https://github.com/user-attachments/assets/904812b5-2ba2-4d9c-9f84-2257c23d94fc" />

---

## Testing Performed

Verified the five targeted images now have alt text.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Documentation-only accessibility improvement. No application code was changed.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive alternative text to matrix toolbar icons, including Play, Save, Sort, Close, and Erase actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->