### PR TITLE
docs(guide-es): add alt text to button images (Fixes #8568)

### DIFF
--- a/Docs/guide-es/README.md
+++ b/Docs/guide-es/README.md
@@ -466,13 +466,13 @@ individual notes (or chords if you click on more than one cell in a
 column). In the figure, three quarter notes are selected (black
 cells). First `Re 4`, followed by `Mi 4`, followed by `Sol 4`.
 
-<img src="../../header-icons/play-button.svg" height="36">
+<img alt="Play button" src="../../header-icons/play-button.svg" height="36">
 
 If you click on the _Play_ button (found in the top row of the grid),
 you will hear a sequence of notes played (from left to right): `Re 4`,
 `Mi 4`, `Sol 4`.
 
-<img src="../../header-icons/export-chunk.svg" height="36">
+<img alt="Save button" src="../../header-icons/export-chunk.svg" height="36">
 
 Once you have a group of notes (a "chunk") that you like, click on the
 _Save_ button (just to the right of the _Play_ button). This will
@@ -482,17 +482,17 @@ programmatically. (More on that below.)
 You can rearrange the selected notes in the grid and safe other chunks
 as well.
 
-<img src="../../header-icons/sort.svg" height="36">
+<img alt="Sort button" src="../../header-icons/sort.svg" height="36">
 
 The _Sort_ button will reorder the pitches in the matrix from highest
 to lowest and eliminate any duplicate _Pitch_ blocks.
 
-<img src="../../header-icons/close-button.svg" height="36">
+<img alt="Close button" src="../../header-icons/close-button.svg" height="36">
 
 Or hide the matrix by clicking on the _Close_ button (the right-most
 button in the top row of the grid.)
 
-<img src="../../header-icons/erase-button.svg" height="36">
+<img alt="Erase button" src="../../header-icons/erase-button.svg" height="36">
 
 There is also an Erase button that will clear the grid.
 


### PR DESCRIPTION


## Description

Adds descriptive alternative text (`alt` attributes) to the 5 button images in the matrix section of `Docs/guide-es/README.md` as requested in #8568. 
Per W3C Web Accessibility Guidelines for functional controls, the alternative text explicitly identifies them as buttons (`Play button`, `Save button`, `Sort button`, `Close button`, `Erase button`), providing seamless clarity for screen-reader users and matching the surrounding guide text.

## Related Issue

**Fixes:** #8568

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [x] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

In `Docs/guide-es/README.md`:
- Updated `play-button.svg` to include `alt="Play button"`
- Updated `export-chunk.svg` to include `alt="Save button"`
- Updated `sort.svg` to include `alt="Sort button"`
- Updated `close-button.svg` to include `alt="Close button"`
- Updated `erase-button.svg` to include `alt="Erase button"`

---



---

## Testing Performed

- Validated with Prettier: `npx prettier --check Docs/guide-es/README.md` (100% compliant).
- Validated with ESLint: `npm run lint` (0 errors, 0 warnings).
- Clean conventional commit adhering to project `commitlint` and signed off with DCO.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


---

## Additional Notes

Submitted with confirmation and approval from @walterbender on #8568.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive alternative text to six matrix-control images, improving accessibility while keeping the existing image content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->