### PR TITLE
fix(blocks): reject reserved dictionary names

### DIFF
--- a/js/blocks/ProgramBlocks.js
+++ b/js/blocks/ProgramBlocks.js
@@ -12,7 +12,7 @@
 /*
    global
 
-   LeftBlock, FlowBlock, NOINPUTERRORMSG, getTargetTurtle, Turtle, isSafeUrl
+   LeftBlock, FlowBlock, NOINPUTERRORMSG, getTargetTurtle, Turtle, isSafeUrl, isUnsafeObjectKey
  */
 
 /* exported setupProgramBlocks */
@@ -438,6 +438,10 @@ function setupProgramBlocks(activity) {
             }
 
             const a = args[0];
+            if (isUnsafeObjectKey(a)) {
+                activity.errorMsg(_("The dictionary name is reserved."), blk);
+                return;
+            }
             // Not sure this can happen.
             if (!(turtle in logo.turtleDicts)) {
                 logo.turtleDicts[turtle] = {};
@@ -558,6 +562,10 @@ function setupProgramBlocks(activity) {
             }
 
             const a = args[0];
+            if (isUnsafeObjectKey(a)) {
+                activity.errorMsg(_("The dictionary name is reserved."), blk);
+                return;
+            }
             // Not sure this can happen.
             if (!(turtle in logo.turtleDicts)) {
                 logo.turtleDicts[turtle] = {};

--- a/js/blocks/__tests__/ProgramBlocks.test.js
+++ b/js/blocks/__tests__/ProgramBlocks.test.js
@@ -21,9 +21,11 @@
  */
 
 const { setupProgramBlocks } = jest.requireActual("../ProgramBlocks");
+const { isUnsafeObjectKey } = jest.requireActual("../../utils/utils-logic");
 
 global._ = s => s;
 global.NOINPUTERRORMSG = "NO_INPUT";
+global.isUnsafeObjectKey = isUnsafeObjectKey;
 global.XMLHttpRequest = jest.fn();
 global.getTargetTurtle = jest.fn();
 global.isSafeUrl = function (urlString) {
@@ -472,6 +474,34 @@ describe("ProgramBlocks", () => {
             expect(logo.turtleDicts[turtle]["MyDict"]).toEqual({ key1: "value1" });
         });
 
+        test.each(["__proto__", "constructor", "prototype"])(
+            "rejects unsafe dictionary name %s when loading from file",
+            dictionaryName => {
+                const blk = 10;
+                const turtle = 0;
+                logo.turtleDicts[turtle] = {};
+                const registryPrototype = Object.getPrototypeOf(logo.turtleDicts[turtle]);
+                global.getTargetTurtle.mockReturnValue(null);
+
+                activity.blocks.blockList[blk] = {
+                    connections: [null, null, 20]
+                };
+                activity.blocks.blockList[20] = {
+                    name: "loadFile",
+                    value: ["filename", '{"key1": "value1"}']
+                };
+
+                getBlock("loadDict").flow([dictionaryName, [null, null]], logo, turtle, blk);
+
+                expect(activity.errorMsg).toHaveBeenCalledWith(
+                    "The dictionary name is reserved.",
+                    blk
+                );
+                expect(Object.hasOwn(logo.turtleDicts[turtle], dictionaryName)).toBe(false);
+                expect(Object.getPrototypeOf(logo.turtleDicts[turtle])).toBe(registryPrototype);
+            }
+        );
+
         test("loads dictionary onto target turtle", () => {
             const blk = 10;
             const turtle = 0;
@@ -595,6 +625,33 @@ describe("ProgramBlocks", () => {
             expect(logo.turtleDicts[turtle]).toHaveProperty("MyDict");
             expect(logo.turtleDicts[turtle]["MyDict"]).toEqual({ key1: "value1" });
         });
+
+        test.each(["__proto__", "constructor", "prototype"])(
+            "rejects unsafe dictionary name %s when setting from JSON",
+            dictionaryName => {
+                const blk = 10;
+                const turtle = 0;
+                logo.turtleDicts[turtle] = {};
+                const registryPrototype = Object.getPrototypeOf(logo.turtleDicts[turtle]);
+                global.getTargetTurtle.mockReturnValue(null);
+
+                activity.blocks.blockList[blk] = {
+                    connections: [null, null, 20]
+                };
+                activity.blocks.blockList[20] = {
+                    value: '{"key1": "value1"}'
+                };
+
+                getBlock("setDictionary").flow([dictionaryName, {}], logo, turtle, blk);
+
+                expect(activity.errorMsg).toHaveBeenCalledWith(
+                    "The dictionary name is reserved.",
+                    blk
+                );
+                expect(Object.hasOwn(logo.turtleDicts[turtle], dictionaryName)).toBe(false);
+                expect(Object.getPrototypeOf(logo.turtleDicts[turtle])).toBe(registryPrototype);
+            }
+        );
 
         test("sets dictionary onto target turtle", () => {
             const blk = 10;


### PR DESCRIPTION
## Description

`set dictionary` and `load dictionary` accepted reserved JavaScript property names such as `__proto__`. Importing data under that name modified the internal dictionary registry instead of creating a dictionary entry, so a later save exported `{}`.

  This change rejects reserved dictionary names before they can alter the registry.

  ## Related Issue

  **Fixes:** #8573

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [ ] Feature — Adds new functionality
  - [ ] UI/UX — Changes to the user interface or user experience
  - [ ] Performance — Improves load time, memory, rendering, etc.
  - [x] Tests — Adds or updates test coverage
  - [ ] Documentation — Updates to docs, comments, or README
  - [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
  - [ ] CI/CD — Changes to workflows and automation

  ---

  ## Changes Made

  - Reused `isUnsafeObjectKey()` to validate names in both dictionary import blocks.
  - Show an error when the name is `__proto__`, `constructor`, or `prototype`.
  - Added regression tests for all three names in both `set dictionary` and `load dictionary`.

  ---

  ## Steps to Reproduce

  1. Create a project with a `set dictionary` block.
  2. Set the dictionary name to `__proto__`.
  3. Provide `{"answer":42}` as the dictionary content.
  4. Save the dictionary.

On `master`, the saved file contains `{}`. With this change, Music Blocks shows `The dictionary name is reserved.` and does not create the invalid dictionary.

  ---

  ## Testing Performed

  - `npm test -- --runInBand js/blocks/__tests__/ProgramBlocks.test.js --silent`
  - `npm test -- --runInBand` — 235 suites and 9117 tests passed.
  - `npm run lint`
  - `npx prettier --check js/blocks/ProgramBlocks.js js/blocks/__tests__/ProgramBlocks.test.js`

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [ ] I have updated the documentation to reflect these changes, if applicable.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [ ] I have addressed the code review feedback from the previous submission, if applicable.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

`npx prettier --check .` reports formatting differences in unrelated existing repository files. The two changed files pass Prettier checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented dictionaries from being created or loaded using reserved names such as `__proto__`, `constructor`, and `prototype`.
  - Added a clear error message when a reserved dictionary name is entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->