### PR TITLE
fix(tempo): rename _firstClickTimes to _firstClickTime in init()

### DIFF
--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -580,6 +580,27 @@ describe("Tempo Widget", () => {
             expect(tempoWidget._firstClickTime).not.toBeNull();
         });
 
+        test("init() resets _firstClickTime to null so first tap is always captured", () => {
+            // Simulate a first click that sets _firstClickTime
+            const canvas = tempoWidget.tempoCanvases[0];
+            jest.setSystemTime(1000);
+            canvas.onclick();
+            expect(tempoWidget._firstClickTime).not.toBeNull();
+
+            // Re-initialising the widget must reset _firstClickTime back to null,
+            // so the very next tap is treated as the FIRST tap (not the second).
+            tempoWidget.BPMs = [100];
+            tempoWidget.init(mockActivity);
+            expect(tempoWidget._firstClickTime).toBeNull();
+
+            // After re-init the first tap should set _firstClickTime, not compute a BPM.
+            const canvas2 = tempoWidget.tempoCanvases[0];
+            jest.setSystemTime(2000);
+            canvas2.onclick();
+            expect(tempoWidget._firstClickTime).not.toBeNull();
+            expect(tempoWidget.BPMs[0]).toBe(100); // BPM unchanged on first tap
+        });
+
         test("should calculate correct BPM on the second tap", () => {
             const canvas = tempoWidget.tempoCanvases[0];
             jest.setSystemTime(1000);

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -56,7 +56,7 @@ class Tempo {
         this._directions = [];
         this._widgetFirstTimes = [];
         this._widgetNextTimes = [];
-        this._firstClickTimes = null;
+        this._firstClickTime = null;
         this._intervals = [];
         this.isMoving = true;
         if (this._intervalID !== undefined && this._intervalID !== null) {


### PR DESCRIPTION
# fix(tempo): rename `_firstClickTimes` to `_firstClickTime` in `init()`

## Description

`Tempo.init()` resets a property named `this._firstClickTimes` (plural) to `null` before each widget session, but the canvas click handler reads and writes `this._firstClickTime` (singular) throughout. Because these are **two different JavaScript properties**, `this._firstClickTime` is always `undefined` after `init()` is called — and `undefined !== null` — so the very first tap on the Tempo canvas always falls into the wrong code branch.

### Root Cause

In `js/widgets/tempo.js`, line 59 of `init()`:

```js
// Before — wrong property name (plural)
this._firstClickTimes = null;
```

The canvas `onclick` handler on lines 192–203 reads and writes the **singular** form:

```js
if (this._firstClickTime === null) {        // first tap: record anchor time
    this._firstClickTime = d.getTime();
} else {                                    // second tap: compute BPM
    newBPM = parseInt((60 * 1000) / (d.getTime() - this._firstClickTime), 10);
    ...
    this._firstClickTime = null;            // reset after successful tap
}
```

Because `init()` wrote to `_firstClickTimes` (plural), `_firstClickTime` (singular) is `undefined` after every `init()`. Since `undefined !== null`, the handler's `if` branch never matches, causing the **first tap to be treated as a second tap** — which produces a nonsensical BPM and immediately resets the timer. The user must tap a third time to get a reading instead of two taps.

### Fix

A one-character change in `init()`:

```diff
- this._firstClickTimes = null;
+ this._firstClickTime = null;
```

This ensures the property reset in `init()` targets the same property that the click handler reads, restoring the intended two-tap BPM detection behavior.

## Testing

- **New test added** in `js/widgets/__tests__/tempo.test.js`:
  - `init() resets _firstClickTime to null so first tap is always captured` — verifies that:
    1. After a first tap, `_firstClickTime` is set (non-null).
    2. After `init()` is called again, `_firstClickTime` is reset to `null`.
    3. The very next tap after re-init correctly sets `_firstClickTime` (treated as first tap) without changing BPM.

- **All 73 existing tests continue to pass** locally.

## PR Category

- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore
- [ ] UI/UX
- [ ] i18n

## Checklist

- [x] The fix addresses a real reproducible bug.
- [x] A new regression test is included.
- [x] All existing tests pass locally (`npx jest --testPathPattern="tempo.test.js"`).
- [x] The change is a minimal, focused fix with no unrelated edits.
- [x] Code follows the project's style guidelines (ESLint + Prettier passed).
- [x] Commit is signed off (`-s`) per the DCO requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reinitializing the Canvas Tap Tempo widget now correctly resets tap tracking.
  * The next tap after re-initialization is treated as the first tap, preventing stale timing data from affecting BPM calculations.

* **Tests**
  * Added coverage to verify tap tracking and BPM behavior after the widget is re-initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->