### PR TITLE
refactor(styles): tokenize desktop windows and fix body cascade

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -742,7 +742,7 @@ img.icon:hover {
 }
 
 body {
-    background-color: #92b5c8 !important;
+    background-color: var(--color-bg-primary);
     /*  2.5B 7/4 */
     padding: 0;
     margin: 0;
@@ -756,7 +756,7 @@ body.noScroll {
 
 body.samples-shown {
     overflow-y: scroll;
-    background: white !important;
+    background: var(--color-bg-primary);
 }
 
 select {

--- a/dist/css/activities.css
+++ b/dist/css/activities.css
@@ -305,13 +305,13 @@ img.icon:hover {
   z-index: 89999;
 }
 body {
-  background-color: #92b5c8 !important;
+  background-color: var(--color-bg-primary);
   padding: 0;
   margin: 0;
 }
 body.samples-shown {
   overflow-y: scroll;
-  background: #fff !important;
+  background: var(--color-bg-primary);
 }
 select {
   background-color: #88e20a;

--- a/dist/css/windows.css
+++ b/dist/css/windows.css
@@ -44,12 +44,12 @@
 }
 
 #floatingWindows > .windowFrame > .wfTopBar .wftButton.close:hover {
-  background-color: #f44336;
+  background-color: var(--color-error);
   opacity: 0.7;
 }
 
 #floatingWindows > .windowFrame > .wfTopBar .wftButton.rollup:hover {
-  background-color: #18b500;
+  background-color: var(--color-success);
   opacity: 0.7;
 }
 
@@ -70,7 +70,7 @@
   left: 50%;
   top: 50%;
   position: absolute;
-  background-color: #fff;
+  background-color: var(--color-text-inverse);
   transform: translate(-50%, -50%);
 }
 
@@ -91,7 +91,7 @@
   left: 50%;
   top: 50%;
   position: absolute;
-  background-color: #fff;
+  background-color: var(--color-text-inverse);
   transform: translate(-50%, -50%) rotate(45deg);
 }
 
@@ -123,7 +123,7 @@
   width: 40px;
   height: 2px;
   margin: -2px 7px;
-  background-color: #000;
+  background-color: var(--color-widget-frame-border);
 }
 
 .wfbtItem {
@@ -131,7 +131,7 @@
   height: 50px;
   margin: 2px;
   transition: background-color 300ms;
-  background-color: #8cc6ff;
+  background-color: var(--color-selector-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -139,11 +139,11 @@
 }
 
 .wfbtItem:hover {
-  background-color: #7bb5ee;
+  background-color: var(--color-selector-selected);
 }
 
 .wfbtItem:focus-visible {
-  outline: 2px solid #005a9c;
+  outline: 2px solid var(--color-brand-primary);
   outline-offset: 2px;
 }
 
@@ -155,6 +155,7 @@
   font-weight: bold;
   background: transparent;
   text-align: center;
+  color: var(--color-selector-text);
 }
 
 #floatingWindows > .windowFrame > .wfWinBody > .wfbWidget {

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         </script>
     </head>
 
-    <body id="body" data-title="index" style="background: #f9f9f9">
+    <body id="body" data-title="index">
         <!-- Fallback for browsers that don't support preload -->
         <noscript> JavaScript is required to view this page. </noscript>
         <header>

--- a/js/__tests__/tokens-enforcement.test.js
+++ b/js/__tests__/tokens-enforcement.test.js
@@ -372,23 +372,92 @@ describe("Theme Switching & Inline Styles Purity", () => {
         expect(pmSource).not.toMatch(/importConfirm\.style\.backgroundColor/);
     });
 
-    it("windows.css uses canonical tokens instead of hardcoded raw colors for window frame, topbar, and toolbars", () => {
+    it("windows.css uses canonical tokens in desktop window selectors instead of hardcoded colors", () => {
         const windowsCss = fs.readFileSync(
             path.join(ROOT_DIR, "dist", "css", "windows.css"),
             "utf8"
         );
 
-        expect(windowsCss).toContain("var(--color-widget-frame-border)");
-        expect(windowsCss).toContain("var(--color-widget-frame-bg)");
-        expect(windowsCss).toContain("var(--color-error)");
-        expect(windowsCss).toContain("var(--color-success)");
-        expect(windowsCss).toContain("var(--color-text-inverse)");
-        expect(windowsCss).toContain("var(--color-selector-bg)");
-        expect(windowsCss).toContain("var(--color-selector-selected)");
-        expect(windowsCss).toContain("var(--color-brand-primary)");
+        // Verify selector-specific declarations
+        expect(windowsCss).toMatch(
+            /#floatingWindows\s*>\s*\.windowFrame\s*\{[^}]*border:\s*2px\s+solid\s+var\(--color-widget-frame-border\);/
+        );
+        expect(windowsCss).toMatch(
+            /#floatingWindows\s*>\s*\.windowFrame\s*\{[^}]*background-color:\s*var\(--color-widget-frame-bg\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wftButton\.close:hover\s*\{[^}]*background-color:\s*var\(--color-error\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wftButton\.rollup:hover\s*\{[^}]*background-color:\s*var\(--color-success\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wftButton\.rollup::before[^}]*background-color:\s*var\(--color-text-inverse\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wftButton\.close::before[^}]*background-color:\s*var\(--color-text-inverse\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wfbtHR\s*\{[^}]*background-color:\s*var\(--color-widget-frame-border\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wfbtItem\s*\{[^}]*background-color:\s*var\(--color-selector-bg\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wfbtItem:hover\s*\{[^}]*background-color:\s*var\(--color-selector-selected\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wfbtItem:focus-visible\s*\{[^}]*outline:\s*2px\s+solid\s+var\(--color-brand-primary\);/
+        );
+        expect(windowsCss).toMatch(
+            /\.wfbtItem\s*>\s*input\s*\{[^}]*color:\s*var\(--color-selector-text\);/
+        );
 
         // Strip comments before checking for raw hex values
         const strippedCss = windowsCss.replace(/\/\*[\s\S]*?\*\//g, "");
         expect(strippedCss).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+    });
+
+    it("ensures body element in index.html and activities stylesheets uses tokens without inline styles or !important", () => {
+        const indexHtml = fs.readFileSync(path.join(ROOT_DIR, "index.html"), "utf8");
+
+        // Verify body tag in index.html does not contain inline style
+        const bodyTagMatch = indexHtml.match(/<body\b([^>]*)>/i);
+        expect(bodyTagMatch).not.toBeNull();
+        expect(bodyTagMatch[1]).not.toMatch(/\bstyle\s*=/i);
+
+        const stylesheetPaths = [
+            path.join(CSS_DIR, "activities.css"),
+            path.join(ROOT_DIR, "dist", "css", "activities.css")
+        ];
+
+        for (const cssPath of stylesheetPaths) {
+            const activitiesCss = fs.readFileSync(cssPath, "utf8");
+
+            // Verify all background declarations in base body rule consume --color-bg-primary without !important
+            const bodyBlockMatch = activitiesCss.match(/(?:^|\})\s*body\s*\{([^}]*)\}/);
+            expect(bodyBlockMatch).not.toBeNull();
+            const bodyBlock = bodyBlockMatch[1];
+            const bodyBgDecls = bodyBlock.match(/background(?:-color)?\s*:[^;]+/gi) || [];
+            expect(bodyBgDecls.length).toBeGreaterThan(0);
+            for (const decl of bodyBgDecls) {
+                expect(decl).toMatch(/:\s*var\(--color-bg-primary\)$/i);
+                expect(decl).not.toMatch(/!important/i);
+            }
+
+            // Verify all background declarations in body.samples-shown consume --color-bg-primary without !important
+            const samplesShownMatch = activitiesCss.match(
+                /(?:^|\})\s*body\.samples-shown\s*\{([^}]*)\}/
+            );
+            expect(samplesShownMatch).not.toBeNull();
+            const samplesShownBlock = samplesShownMatch[1];
+            const samplesShownBgDecls =
+                samplesShownBlock.match(/background(?:-color)?\s*:[^;]+/gi) || [];
+            expect(samplesShownBgDecls.length).toBeGreaterThan(0);
+            for (const decl of samplesShownBgDecls) {
+                expect(decl).toMatch(/:\s*var\(--color-bg-primary\)$/i);
+                expect(decl).not.toMatch(/!important/i);
+            }
+        }
     });
 });

--- a/js/__tests__/tokens-enforcement.test.js
+++ b/js/__tests__/tokens-enforcement.test.js
@@ -372,7 +372,7 @@ describe("Theme Switching & Inline Styles Purity", () => {
         expect(pmSource).not.toMatch(/importConfirm\.style\.backgroundColor/);
     });
 
-    it("windows.css uses canonical tokens instead of hardcoded grays for window frame and topbar", () => {
+    it("windows.css uses canonical tokens instead of hardcoded raw colors for window frame, topbar, and toolbars", () => {
         const windowsCss = fs.readFileSync(
             path.join(ROOT_DIR, "dist", "css", "windows.css"),
             "utf8"
@@ -380,5 +380,15 @@ describe("Theme Switching & Inline Styles Purity", () => {
 
         expect(windowsCss).toContain("var(--color-widget-frame-border)");
         expect(windowsCss).toContain("var(--color-widget-frame-bg)");
+        expect(windowsCss).toContain("var(--color-error)");
+        expect(windowsCss).toContain("var(--color-success)");
+        expect(windowsCss).toContain("var(--color-text-inverse)");
+        expect(windowsCss).toContain("var(--color-selector-bg)");
+        expect(windowsCss).toContain("var(--color-selector-selected)");
+        expect(windowsCss).toContain("var(--color-brand-primary)");
+
+        // Strip comments before checking for raw hex values
+        const strippedCss = windowsCss.replace(/\/\*[\s\S]*?\*\//g, "");
+        expect(strippedCss).not.toMatch(/#[0-9a-fA-F]{3,6}/);
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

<!-- Describe the changes introduced by this pull request. Explain what problem it solves or what feature/fix it adds. -->

This pull request completes two essential styling refactors to standardize design token usage and ensure natural CSS cascading across the application:
1. **Tokenize Desktop Windows (`windows.css`)**: Replaces all hardcoded hex values in `dist/css/windows.css` (close button, rollup button, icons, toolbar dividers, and selector inputs) with canonical design tokens from `tokens.css`.
2. **Fix Page Cascade on Body Element (#8512)**: Removes the inline `style="background: #f9f9f9"` on `<body>` in `index.html` and removes the forced `!important` declarations from `body` and `body.samples-shown` in `activities.css`, replacing them with `var(--color-bg-primary)`.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:**  #8512 , #8578
**Related:** #6799
---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [x] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

<!-- Provide a summary of the technical details, architecture changes, or key modifications. -->

### 1. `dist/css/windows.css` (Desktop Window Controls)
- `.wftButton.close:hover`: Replaced `#f44336` with `var(--color-error)`
- `.wftButton.rollup:hover`: Replaced `#18b500` with `var(--color-success)`
- `.wftButton.rollup::before, .wftButton.rollup::after`: Replaced `#fff` with `var(--color-text-inverse)`
- `.wftButton.close::before, .wftButton.close::after`: Replaced `#fff` with `var(--color-text-inverse)`
- `.wfbtHR`: Replaced `#000` with `var(--color-widget-frame-border)`
- `.wfbtItem`: Replaced `#8cc6ff` with `var(--color-selector-bg)`
- `.wfbtItem:hover`: Replaced `#7bb5ee` with `var(--color-selector-selected)`
- `.wfbtItem:focus-visible`: Replaced `#005a9c` with `var(--color-brand-primary)`
- `.wfbtItem > input`: Explicitly styled with `color: var(--color-selector-text)`
- Retained dynamic geometry and layout calculations in `widgetWindows.js` as-is.
### 2. `index.html`, `css/activities.css`, and `dist/css/activities.css` (Page Cascade)
- **`index.html`**: Removed inline `style="background: #f9f9f9"` from the `<body>` tag.
- **`css/activities.css` & `dist/css/activities.css`**:
  - Replaced `background-color: #92b5c8 !important;` on `body` with `background-color: var(--color-bg-primary);`.
  - Replaced `background: white !important;` on `body.samples-shown` with `background: var(--color-bg-primary);`.
### 3. Automated Enforcement Tests (`js/__tests__/tokens-enforcement.test.js`)
- Updated `windows.css` test to assert that canonical tokens (`--color-error`, `--color-success`, `--color-text-inverse`, `--color-selector-bg`, `--color-selector-selected`, `--color-brand-primary`) are used and verified that zero raw hex colors remain in rule definitions.
- Added a regression test ensuring `index.html` has no inline `style` attribute on `<body>` and `activities.css` applies `var(--color-bg-primary)` without `!important`.


---



## Testing Performed

<!-- Describe the testing that you have performed to validate these changes (e.g., test cases, environments). -->

- **Prettier**: `npx prettier --check` passed across all modified files.
- **ESLint**: `npx eslint` passed with 0 errors and 0 warnings.
- **Commitlint**: Verified all commit messages comply with Conventional Commits specifications.
- **DCO Check**: All commits carry valid `Signed-off-by` trailers.
- **Jest Unit Tests**: All 31 tests in `tokens-enforcement.test.js` and `themes-contrast.test.js` passed.
- **Manual UI Verification**: Verified theme switching between light, dark, and high-contrast modes to confirm background and floating desktop window toolbars render cleanly.


---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---



- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated activity and page backgrounds to use the active theme’s primary background color.
  - Removed the page’s fixed inline background color and forced styling for more consistent themed display.
  - Improved background consistency across standard and sample views when themes change.

- **Tests**
  - Expanded styling checks to verify required design tokens, reject hard-coded color values, and enforce approved theme conventions.
  - Added validation to prevent inline page background styling from being reintroduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->