### PR TITLE
fix(volume): pass volume, turtle and block to setMasterVolume

### DIFF
--- a/js/blocks/VolumeBlocks.js
+++ b/js/blocks/VolumeBlocks.js
@@ -117,12 +117,14 @@ function setupVolumeBlocks(activity) {
          * @param {object} logo - Logo object.
          * @param {number} value - Volume value.
          * @param {number} turtle - Turtle index.
+         * @param {string} blk - Block ID.
          */
-        setter(logo, value, turtle) {
+        setter(logo, value, turtle, blk) {
             const len = Singer.masterVolume.length;
             Singer.masterVolume[len - 1] = value;
             if (!activity.turtles.ithTurtle(turtle).singer.suppressOutput) {
-                Singer.VolumeActions.setMasterVolume(logo, value);
+                // setMasterVolume takes (volume, turtle, blk), not (logo, value).
+                Singer.VolumeActions.setMasterVolume(value, turtle, blk);
             }
         }
 

--- a/js/blocks/VolumeBlocks.js
+++ b/js/blocks/VolumeBlocks.js
@@ -123,7 +123,6 @@ function setupVolumeBlocks(activity) {
             const len = Singer.masterVolume.length;
             Singer.masterVolume[len - 1] = value;
             if (!activity.turtles.ithTurtle(turtle).singer.suppressOutput) {
-                // setMasterVolume takes (volume, turtle, blk), not (logo, value).
                 Singer.VolumeActions.setMasterVolume(value, turtle, blk);
             }
         }

--- a/js/blocks/__tests__/VolumeBlocks.test.js
+++ b/js/blocks/__tests__/VolumeBlocks.test.js
@@ -234,6 +234,68 @@ describe("setupVolumeBlocks", () => {
             const ret = masterVolBlock.updateParameter(logo, turtleIndex, blk);
             expect(ret).toEqual(95);
         });
+
+        describe("setter", () => {
+            const blk = "blkMasterVolSetter";
+
+            beforeEach(() => {
+                // Production initialises this to [DEFAULTVOLUME].
+                Singer.masterVolume = [50];
+            });
+
+            it("hands setMasterVolume the volume, the turtle and the block", () => {
+                createdBlocks["notevolumefactor"].setter(logo, 60, turtleIndex, blk);
+
+                expect(Singer.VolumeActions.setMasterVolume).toHaveBeenCalledWith(
+                    60,
+                    turtleIndex,
+                    blk
+                );
+            });
+
+            it("does not pass the logo object where a volume is expected", () => {
+                createdBlocks["notevolumefactor"].setter(logo, 60, turtleIndex, blk);
+
+                const [volumeArg, turtleArg] = Singer.VolumeActions.setMasterVolume.mock.calls[0];
+                expect(typeof volumeArg).toBe("number");
+                expect(volumeArg).toBe(60);
+                expect(turtleArg).toBe(turtleIndex);
+            });
+
+            // Guard, not a regression case: this line is unchanged by the argument
+            // fix, so it passes either way. It pins the state update in place.
+            it("records the new volume in Singer.masterVolume", () => {
+                createdBlocks["notevolumefactor"].setter(logo, 60, turtleIndex, blk);
+
+                expect(Singer.masterVolume[Singer.masterVolume.length - 1]).toBe(60);
+            });
+
+            // Guard, not a regression case: the suppressed branch never reaches the
+            // action, so it passes either way. It pins the branch that must not call.
+            it("skips the action but still records the value when output is suppressed", () => {
+                activity.turtles.ithTurtle(turtleIndex).singer.suppressOutput = true;
+
+                createdBlocks["notevolumefactor"].setter(logo, 60, turtleIndex, blk);
+
+                expect(Singer.VolumeActions.setMasterVolume).not.toHaveBeenCalled();
+                expect(Singer.masterVolume[Singer.masterVolume.length - 1]).toBe(60);
+            });
+
+            it("forwards boundary values unchanged, leaving clamping to the action", () => {
+                for (const value of [0, 100, 150, -50]) {
+                    Singer.VolumeActions.setMasterVolume.mockClear();
+                    Singer.masterVolume = [50];
+
+                    createdBlocks["notevolumefactor"].setter(logo, value, turtleIndex, blk);
+
+                    expect(Singer.VolumeActions.setMasterVolume).toHaveBeenCalledWith(
+                        value,
+                        turtleIndex,
+                        blk
+                    );
+                }
+            });
+        });
     });
 
     describe("SetSynthVolume2Block", () => {


### PR DESCRIPTION
## Description

`MasterVolumeBlock.setter` called the action as `setMasterVolume(logo, value)`, but `VolumeActions.setMasterVolume` is declared `(volume, turtle, blk)`. The `logo` object arrived as the volume, and the volume arrived as the turtle index.

What followed, in order:

1. `clampNumber(logo, 0, 100)` falls back to its minimum for a non-numeric input, so `volume` became `0`
2. `Singer.masterVolume.push(0)` — **the project was silenced**, before anything threw
3. an unasked-for `Setting volume to 0.` message appeared
4. `ithTurtle(60)` — the volume number used as an index — returned `undefined`, and reading `.singer` threw a `TypeError`
5. `IncrementBlock.flow` catches that and reports `Block does not support incrementing.`, which is wrong — the block does support it

The only production route to a block setter is `activity.blocks.blockSetter`, which has exactly one caller: the **add ... to** block in the Boxes palette. So `add 10 to master volume` ended at 0 instead of 60, with two misleading messages. That block's own help text documents this use: *"It can also be used with other blocks such as Color and Pen size."*

## Related Issue

Fixes #8580

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`js/blocks/VolumeBlocks.js`** — pass the arguments the action declares, and take `blk` through the setter so the error message points at the offending block. The two `BoxesBlocks` setters already take `blk`, so this matches existing convention.

The `Singer.masterVolume[len - 1] = value` line above the call is deliberately left alone: it runs on the suppressed-output path too, where the action is skipped, so removing it would change behaviour during silent counting runs. That is outside the scope of this fix.

**`js/blocks/__tests__/VolumeBlocks.test.js`** — `setter` had no coverage at all, which is how this survived. Five cases added. Three fail against the old call: the argument contract, a check that no object is passed where a volume belongs, and a boundary sweep over `0 / 100 / 150 / -50`. Two are labelled in comments as guards that pass either way — the state update, and the suppressed-output branch that must not call the action.

## Steps to Reproduce

1. From the **Boxes** palette, drag an **add ... to** block into a **start** block.
2. Into its first socket, plug the **master volume** block from the **Volume** palette.
3. Into its second socket, a **number** block with `10`.
4. Add a **note** after it so there is something to hear.
5. Run.

Before: the volume ends at 0, the note is silent, and both `Setting volume to 0.` and `Block does not support incrementing.` appear. After: the volume goes to 60 and the note plays, with no messages.

---

## Testing Performed

- `npx jest` — full suite green: **235 suites, 9116 passed**, 1 skipped.
- Mutation-tested: reverting the one call while keeping the new tests fails **3 of the 5** new cases.
- Verified the whole chain before writing the fix, using the real `IncrementBlock.flow`, the real `MasterVolumeBlock.setter` and the real `VolumeActions.setMasterVolume`, with only `blockSetter`'s one-line dispatch replicated from `js/blocks.js`. That reproduced the volume landing on 0 and both messages, and a control confirmed the documented argument order yields 60 with no errors.
- Confirmed reachability at every link: `blockSetter` has one production caller; `MasterVolumeBlock` extends `ValueBlock` so its dock 0 is `numberout` and `numberout:anyin` is an allowed connection; the block is registered, not hidden, not deprecated; and its `arg()` returns the live master volume so the first argument evaluates.
- `npm run lint` clean; `npx prettier --check` on both changed files clean; `commitlint` exits 0.

---

## Additional Notes

**The correct call already existed twice.** `js/blocks/VolumeBlocks.js:674` — the `set master volume` block's `flow`, 550 lines below in this same file — calls `setMasterVolume(args[0], turtle, blk)`. So does the exported JavaScript API at `js/js-export/export.js:575`. Line 125 was the only one of the three that was wrong, which is why the `set master volume` block always worked while `add to` did not.

**Every other block setter treats `turtle` as a turtle index.** There are twelve `setter(logo, value, turtle)` implementations across `BoxesBlocks`, `GraphicsBlocks`, `MeterBlocks`, `PenBlocks`, `PitchBlocks` and `VolumeBlocks`; all the others use `ithTurtle(turtle)` or `getTurtle(companionTurtle(turtle))`. This was the sole outlier.

**Provenance.** `git log -S` shows the only commit ever to touch this line is `befbc0232` ("Transport setMasterVolume and setSynthVolume to Singer"), the port that introduced the mis-ordering. The correct sibling call dates to `71cffffa7` and has always been right.

One small irony worth noting: the existing mock in this test file already declared the right signature — `setMasterVolume: jest.fn((value, turtle, blk) => {})` — while production called it the other way.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Master volume changes now use the correct volume value and preserve associated block context.
  * Volume updates continue to be recorded correctly, including when output is suppressed.
  * Boundary volume values are handled without alteration.

* **Tests**
  * Expanded coverage for master volume updates, suppressed output, value validation, and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->