### PR TITLE
fix: reset tempo widget state when closed (Related to #8581)

### DIFF
--- a/js/activity/__tests__/keyboard-controller.test.js
+++ b/js/activity/__tests__/keyboard-controller.test.js
@@ -449,6 +449,31 @@ describe("KeyboardController", () => {
                 -10
             );
         });
+
+        it("resets inTempoWidget and scrolls active palette on up/down arrows when tempo widget is closed and activeBlock is null", () => {
+            const activity = makeActivity();
+            activity.blocks.activeBlock = null;
+            const rhythm = { scrollEvent: jest.fn(), scrollDiff: 40 };
+            activity.palettes.dict = { rhythm };
+            activity.palettes.activePalette = "rhythm";
+            const controller = createController(activity);
+
+            // First simulate tempo widget open
+            window.widgetWindows.isOpen.mockImplementation(name => name === "tempo");
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            expect(activity.inTempoWidget).toBe(true);
+            expect(activity.logo.tempo.speedUp).toHaveBeenCalledWith(0);
+            expect(rhythm.scrollEvent).not.toHaveBeenCalled();
+
+            // Now simulate tempo widget closed
+            window.widgetWindows.isOpen.mockImplementation(() => false);
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            expect(activity.inTempoWidget).toBe(false);
+            expect(rhythm.scrollEvent).toHaveBeenCalledWith(20, 1);
+
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }));
+            expect(rhythm.scrollEvent).toHaveBeenCalledWith(-20, 1);
+        });
     });
 
     describe("modifier keys", () => {

--- a/js/activity/__tests__/keyboard-controller.test.js
+++ b/js/activity/__tests__/keyboard-controller.test.js
@@ -399,23 +399,55 @@ describe("KeyboardController", () => {
     describe("tempo widget integration", () => {
         it("speeds up tempo on the up arrow while the tempo widget is active", () => {
             const activity = makeActivity();
-            activity.inTempoWidget = true;
+            window.widgetWindows.isOpen.mockImplementation(name => name === "tempo");
             const controller = createController(activity);
 
             controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
 
+            expect(activity.inTempoWidget).toBe(true);
             expect(activity.logo.tempo.speedUp).toHaveBeenCalledWith(0);
             expect(activity.blocks.moveStackRelative).not.toHaveBeenCalled();
         });
 
         it("slows down tempo on the down arrow while the tempo widget is active", () => {
             const activity = makeActivity();
-            activity.inTempoWidget = true;
+            window.widgetWindows.isOpen.mockImplementation(name => name === "tempo");
             const controller = createController(activity);
 
             controller.__keyPressed(makeEvent({ keyCode: KEYCODE.DOWN }));
 
+            expect(activity.inTempoWidget).toBe(true);
             expect(activity.logo.tempo.slowDown).toHaveBeenCalledWith(0);
+        });
+
+        it("resets inTempoWidget and moves blocks when tempo widget is closed", () => {
+            const activity = makeActivity();
+            activity.blocks.activeBlock = { id: "block-1" };
+            const controller = createController(activity);
+
+            // First simulate tempo widget open
+            window.widgetWindows.isOpen.mockImplementation(name => name === "tempo");
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            expect(activity.inTempoWidget).toBe(true);
+            expect(activity.logo.tempo.speedUp).toHaveBeenCalledWith(0);
+            expect(activity.blocks.moveStackRelative).not.toHaveBeenCalled();
+
+            // Now simulate tempo widget closed
+            window.widgetWindows.isOpen.mockImplementation(() => false);
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.LEFT }));
+            expect(activity.inTempoWidget).toBe(false);
+            expect(activity.blocks.moveStackRelative).toHaveBeenCalledWith(
+                activity.blocks.activeBlock,
+                -10,
+                0
+            );
+
+            controller.__keyPressed(makeEvent({ keyCode: KEYCODE.UP }));
+            expect(activity.blocks.moveStackRelative).toHaveBeenCalledWith(
+                activity.blocks.activeBlock,
+                0,
+                -10
+            );
         });
     });
 

--- a/js/activity/keyboard-controller.js
+++ b/js/activity/keyboard-controller.js
@@ -192,13 +192,7 @@ class KeyboardController {
             pasteEl.style.visibility === "visible" ||
             wheelDiv.style.display === "" ||
             activity.turtles.running();
-        const widgetTitle = document.getElementsByClassName("wftTitle");
-        for (let i = 0; i < widgetTitle.length; i++) {
-            if (widgetTitle[i].innerHTML === "tempo") {
-                activity.inTempoWidget = true;
-                break;
-            }
-        }
+        activity.inTempoWidget = this._isWidgetOpen("tempo");
         if (
             (event.altKey && !disableKeys) ||
             event.keyCode === 13 ||


### PR DESCRIPTION



## Description

Fixes #8581.
Previously, opening the Tempo widget set `activity.inTempoWidget = true`, but closing the widget never reset the flag back to `false`. As a result, subsequent workspace arrow-key presses remained stuck:
- `Left` and `Right` arrow keys did nothing (`!activity.inTempoWidget` check failed).
- `Up` and `Down` arrow keys continued adjusting tempo in the background instead of moving blocks or scrolling palettes.
- Checking `widgetTitle[i].innerHTML === "tempo"` also broke under non-English locales where "tempo" is translated.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #8581
---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- In `js/activity/keyboard-controller.js`: Replaced the `wftTitle` DOM iteration loop with `activity.inTempoWidget = this._isWidgetOpen("tempo");`, which dynamically queries `window.widgetWindows.isOpen("tempo")`.
- In `js/activity/__tests__/keyboard-controller.test.js`:
  - Updated tempo integration unit tests to mock `window.widgetWindows.isOpen("tempo")`.
  - Added a test confirming that closing the tempo widget resets `activity.inTempoWidget` to `false` and restores normal arrow-key navigation for blocks.

---

## Steps to Reproduce

1. Open Music Blocks and place any block on the canvas.
2. Open the Tempo widget.
3. Close the Tempo widget using its close button.
4. Select the block on the canvas and try to move it using the `Left Arrow` or `Right Arrow` keys.
5. Notice that the block does not move horizontally, and pressing `Up Arrow` or `Down Arrow` continues adjusting tempo in the background.


---

## Testing Performed

- **Automated Unit Tests**: Ran `npx jest js/activity/__tests__/keyboard-controller.test.js` (all 33 tests passed).
- **Linter**: Ran `npx eslint js/activity/keyboard-controller.js js/activity/__tests__/keyboard-controller.test.js` (0 errors, 0 warnings).
- **Formatter**: Ran `npx prettier --check js/activity/keyboard-controller.js js/activity/__tests__/keyboard-controller.test.js` (all files match Prettier style).

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Using `this._isWidgetOpen("tempo")` matches the existing patterns used for `slider` and `JavaScript Editor` in `KeyboardController`, ensuring resilience against language localization and proper lifecycle cleanup.
---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard handling for the tempo widget by accurately recognizing whether it is open.
  - Arrow keys now correctly return to moving the active block when the tempo widget is closed.
  - Palette scrolling is restored when the tempo widget closes and no block is active.
  - Updated keyboard behavior tests to cover both open and closed tempo widget states, including transitions between widget interaction and normal editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->