### PR TITLE
fix(CacheManager): use >= in  _isExpired to match clearExpired boundary

### DIFF
--- a/planet/js/CacheManager.js
+++ b/planet/js/CacheManager.js
@@ -421,7 +421,7 @@ class CacheManager {
      * @private
      */
     _isExpired(expiry) {
-        return Date.now() > expiry;
+        return Date.now() >= expiry;
     }
 
     /**

--- a/planet/js/__tests__/CacheManager.test.js
+++ b/planet/js/__tests__/CacheManager.test.js
@@ -104,14 +104,20 @@ describe("CacheManager", () => {
             expect(cacheManager._isExpired(pastTime)).toBe(true);
         });
 
-        it("should return true when expiry equals current time (exact boundary)", () => {
-            const now = Date.now();
-            expect(cacheManager._isExpired(now)).toBe(true);
-        });
-
         it("should return false for future timestamps", () => {
             const futureTime = Date.now() + 1000;
             expect(cacheManager._isExpired(futureTime)).toBe(false);
+        });
+
+        it("should return true when expiry equals current time (exact boundary)", () => {
+            const now = 1700000000000;
+            jest.spyOn(Date, "now").mockReturnValue(now);
+
+            try {
+                expect(cacheManager._isExpired(now)).toBe(true);
+            } finally {
+                Date.now.mockRestore();
+            }
         });
     });
 

--- a/planet/js/__tests__/CacheManager.test.js
+++ b/planet/js/__tests__/CacheManager.test.js
@@ -104,6 +104,11 @@ describe("CacheManager", () => {
             expect(cacheManager._isExpired(pastTime)).toBe(true);
         });
 
+        it("should return true when expiry equals current time (exact boundary)", () => {
+            const now = Date.now();
+            expect(cacheManager._isExpired(now)).toBe(true);
+        });
+
         it("should return false for future timestamps", () => {
             const futureTime = Date.now() + 1000;
             expect(cacheManager._isExpired(futureTime)).toBe(false);


### PR DESCRIPTION
## Description

`_isExpired()` uses `Date.now() > expiry` (strict greater than), but
`clearExpired()` uses `IDBKeyRange.upperBound(now)` which deletes entries
where `expiry <= now`.

At the exact expiry timestamp, both methods behave differently:
- `getMetadata()` / `getProject()` treat the entry as **valid**
- `clearExpired()` **deletes** the same entry

Fix: Change `>` to `>=` in `_isExpired()` so both methods treat the
exact expiry boundary consistently.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

---

## Changes Made

- Changed `>` to `>=` in `_isExpired()` in `planet/js/CacheManager.js` (line 424)
- Added exact boundary test case in `planet/js/__tests__/CacheManager.test.js`

---

## Steps to Reproduce

1. Cache a project entry with a specific expiry timestamp
2. Call `getMetadata()` at exact expiry time → returns data (treated as valid)
3. Call `clearExpired()` at exact expiry time → deletes same data
4. Both methods behave inconsistently at the exact boundary

---

## Testing Performed

- Added boundary test: `_isExpired()` returns `true` when `Date.now() === expiry`
- All **235 test suites pass** (9112 tests)
- Ran `npx prettier --check` — no issues

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"**

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache entries now expire precisely when their expiry time is reached, improving the accuracy of metadata, project, and thumbnail cache reads.
  * Cache behavior is now consistent at the exact expiration boundary, preventing stale entries from being returned.

* **Tests**
  * Added deterministic coverage to verify cache expiration at the exact expiry timestamp and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->