### PR TITLE
fix(phrasemaker): guard export against a blocked popup window

### DIFF
--- a/js/widgets/__tests__/phrasemaker.test.js
+++ b/js/widgets/__tests__/phrasemaker.test.js
@@ -2951,6 +2951,66 @@ describe("PhraseMaker Widget", () => {
         });
     });
 
+    describe("_export", () => {
+        afterEach(() => {
+            delete global.window.open;
+        });
+
+        test("shows an error and returns safely when the popup is blocked", () => {
+            global.window.open = jest.fn().mockReturnValue(null);
+            phraseMaker.activity = { errorMsg: jest.fn() };
+
+            expect(() => phraseMaker._export()).not.toThrow();
+
+            expect(phraseMaker.activity.errorMsg).toHaveBeenCalledTimes(1);
+        });
+
+        test("builds the export document without an error when the popup opens", () => {
+            const makeCell = () => ({
+                style: {},
+                width: "",
+                colSpan: 1,
+                childNodes: [],
+                appendChild: jest.fn(),
+                setAttribute: jest.fn()
+            });
+            const makeRow = () => ({ insertCell: jest.fn(makeCell) });
+            const exportTableMock = {
+                createTHead: jest.fn(() => ({ insertRow: jest.fn(makeRow) }))
+            };
+            const elements = [];
+            const exportDocumentMock = {
+                createElement: jest.fn(() => {
+                    const el = {
+                        style: {},
+                        appendChild: jest.fn(),
+                        setAttribute: jest.fn()
+                    };
+                    elements.push(el);
+                    return el;
+                }),
+                getElementById: jest.fn(id =>
+                    id === "exportTable" ? exportTableMock : { download: "", href: "" }
+                ),
+                head: { appendChild: jest.fn() },
+                body: { appendChild: jest.fn() },
+                documentElement: { outerHTML: "<html></html>" },
+                close: jest.fn()
+            };
+            global.window.open = jest.fn().mockReturnValue({ document: exportDocumentMock });
+            phraseMaker.activity = { errorMsg: jest.fn() };
+            phraseMaker.rowLabels = [];
+            phraseMaker._matrixHasTuplets = false;
+            phraseMaker._noteValueRow = { cells: [] };
+            global.PhraseMakerUtils.generateDataURI = jest.fn(() => "data:text/html;base64,mock");
+
+            expect(() => phraseMaker._export()).not.toThrow();
+
+            expect(phraseMaker.activity.errorMsg).not.toHaveBeenCalled();
+            expect(exportDocumentMock.close).toHaveBeenCalled();
+        });
+    });
+
     describe("handleClose", () => {
         test("cleans up state and calls PhraseMakerAudio.clearPlaybackTimers on close", () => {
             phraseMaker.activity = {

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -2857,11 +2857,13 @@ class PhraseMaker {
      */
     _export() {
         const exportWindow = window.open("");
-        const exportDocument = exportWindow.document;
-        if (exportDocument === undefined) {
-            console.debug("Could not create export window");
+        if (!exportWindow) {
+            this.activity.errorMsg(
+                this._("Could not open the export window. A pop-up blocker may have blocked it.")
+            );
             return;
         }
+        const exportDocument = exportWindow.document;
 
         const title = exportDocument.createElement("title");
         title.textContent = "Music Matrix";


### PR DESCRIPTION
## Description

When a browser or extension blocks pop-ups, the PhraseMaker export action crashed with a TypeError instead of informing the user. `window.open("")` returns `null` when the pop-up is blocked, and the code read `.document` from it before any check, so the widget threw `Cannot read properties of null (reading 'document')` and no export window appeared and no message was shown.

This change guards the export path: if the export window cannot be opened, it now shows an error message telling the user a pop-up blocker may have blocked it and returns safely instead of crashing.

## Related Issue

**Fixes:** #7082

## Category

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/refactor
- [ ] Documentation
- [ ] Other

## Changes Made

- In `js/widgets/phrasemaker.js` `_export()`, replaced the unreachable `exportDocument === undefined` check with a `!exportWindow` guard that reports the blocked pop-up through `activity.errorMsg()` and returns before touching the window.
- Added two Jest tests in `js/widgets/__tests__/phrasemaker.test.js` covering the blocked pop-up path (error shown, no throw) and the successful export path (document built, no error).

## Steps to Reproduce

1. Open Music Blocks and open the PhraseMaker widget.
2. Add a few notes in the matrix so there is something to export.
3. Enable a pop-up blocker for the site (or run a browser with pop-ups disabled).
4. Click the export button on the PhraseMaker.
5. Before: nothing appears and the console shows `TypeError: Cannot read properties of null (reading 'document')`. After: an error message is shown in the UI.

## Visual Changes

_None. The only new UI is the standard error toast via `activity.errorMsg()`._

## Testing Performed

- `npx jest js/widgets/__tests__/phrasemaker.test.js`: 138 passed (136 pre-existing plus 2 new).
- `npm test` full suite: 8941 passed, 1 skipped, 231 suites passed, 0 failures.
- `npm run lint` and `npx prettier --check` on the modified files: clean.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/sugarlabs/musicblocks/blob/master/CONTRIBUTING.md).
- [x] My code follows the project's code style.
- [x] I have signed my commits with DCO (`git commit -s`).
- [x] I have added/updated tests where appropriate.
- [x] All new and existing tests pass locally.
- [x] I have allowed edits from maintainers.

## Additional Notes

PR #7721 previously attempted this fix but has been conflicting and inactive for over six weeks. I commented there asking if the author is still active and will close this in their favor if they resume work.

Opening as a draft for now and will mark it ready for review after a few days if there is no response, or per maintainer guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML export handling when pop-up windows are blocked by displaying an error message instead of causing an unexpected failure.
  * Exported content now completes cleanly when the pop-up opens successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->