### PR TITLE
test(search-controller): cover the search drag handle

### DIFF
--- a/js/activity/__tests__/search-controller.test.js
+++ b/js/activity/__tests__/search-controller.test.js
@@ -97,6 +97,126 @@ function makeActivity(protoBlocks = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// drag handle
+// ---------------------------------------------------------------------------
+
+/** jsdom has no Pointer Capture API, so stand one in on the handle element. */
+function stubPointerCapture(handle) {
+    const captured = new Set();
+    handle.setPointerCapture = jest.fn(id => captured.add(id));
+    handle.releasePointerCapture = jest.fn(id => captured.delete(id));
+    handle.hasPointerCapture = jest.fn(id => captured.has(id));
+    return captured;
+}
+
+function pointerEvent(type, props) {
+    const event = new Event(type, { bubbles: true });
+    Object.assign(event, props);
+    return event;
+}
+
+describe("SearchController drag handle", () => {
+    let activity, sc;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        activity = makeActivity();
+        activity.searchWidget.getBoundingClientRect = jest.fn(() => ({
+            left: 200,
+            top: 120,
+            height: 50
+        }));
+        setupSearchController(activity);
+        sc = activity.searchController;
+    });
+
+    test("creates the handle once and reuses it on a second call", () => {
+        sc._addSearchDragHandle();
+        const first = document.getElementById("searchDragHandle");
+        expect(first).not.toBeNull();
+        expect(first.style.display).toBe("flex");
+
+        sc._addSearchDragHandle();
+        expect(document.querySelectorAll("#searchDragHandle")).toHaveLength(1);
+        expect(document.getElementById("searchDragHandle")).toBe(first);
+    });
+
+    test("positions the handle from the widget's bounding box", () => {
+        sc._addSearchDragHandle();
+        const handle = document.getElementById("searchDragHandle");
+        // left + 4, and centred on a 38px handle: top + (height - 38) / 2
+        expect(handle.style.left).toBe("204px");
+        expect(handle.style.top).toBe("126px");
+    });
+
+    test("dragging moves the widget by the pointer delta", () => {
+        sc._addSearchDragHandle();
+        const handle = document.getElementById("searchDragHandle");
+        stubPointerCapture(handle);
+        activity.searchWidget.style.left = "200px";
+        activity.searchWidget.style.top = "120px";
+
+        handle.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 300, clientY: 400, pointerId: 1 })
+        );
+        expect(handle.style.cursor).toBe("grabbing");
+        expect(activity.searchWidget.style.transition).toBe("none");
+
+        handle.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 330, clientY: 375, pointerId: 1 })
+        );
+        expect(activity.searchWidget.style.left).toBe("230px");
+        expect(activity.searchWidget.style.top).toBe("95px");
+    });
+
+    test("ignores pointermove when the pointer was never captured", () => {
+        sc._addSearchDragHandle();
+        const handle = document.getElementById("searchDragHandle");
+        stubPointerCapture(handle);
+        activity.searchWidget.style.left = "200px";
+
+        handle.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 999, clientY: 999, pointerId: 7 })
+        );
+        expect(activity.searchWidget.style.left).toBe("200px");
+    });
+
+    test("pointerup releases the capture and restores the cursor", () => {
+        sc._addSearchDragHandle();
+        const handle = document.getElementById("searchDragHandle");
+        stubPointerCapture(handle);
+
+        handle.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10, pointerId: 3 })
+        );
+        handle.dispatchEvent(pointerEvent("pointerup", { pointerId: 3 }));
+
+        expect(handle.releasePointerCapture).toHaveBeenCalledWith(3);
+        expect(handle.style.cursor).toBe("grab");
+        expect(activity.searchWidget.style.transition).toBe("");
+    });
+
+    test("_positionSearchDragHandle does nothing without a bounding box", () => {
+        sc._addSearchDragHandle();
+        const handle = document.getElementById("searchDragHandle");
+        handle.style.left = "50px";
+        delete activity.searchWidget.getBoundingClientRect;
+
+        expect(() => sc._positionSearchDragHandle()).not.toThrow();
+        expect(handle.style.left).toBe("50px");
+    });
+
+    test("_hideSearchDragHandle hides it, and is safe when absent", () => {
+        sc._addSearchDragHandle();
+        sc._hideSearchDragHandle();
+        expect(document.getElementById("searchDragHandle").style.display).toBe("none");
+
+        document.body.innerHTML = "";
+        expect(() => sc._hideSearchDragHandle()).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
 // setupSearchController
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

`js/activity/search-controller.js` sat at **51.35% of statements**, with 19 of
its 43 functions never executed by any test. The whole search drag handle was
part of that gap: `_addSearchDragHandle`, `_positionSearchDragHandle` and
`_hideSearchDragHandle`, plus the three pointer handlers the drag is built out
of, had no coverage at all.

This adds seven tests for that group. No production code changes.

## Related Issue

**Fixes:** _n/a — coverage work, no issue filed._

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

One file touched, `js/activity/__tests__/search-controller.test.js`, adding a
`SearchController drag handle` block that covers:

- the handle is created once and **reused** on a second call, rather than
  appended twice
- it is positioned from the widget's bounding box — `left + 4`, and vertically
  centred on a 38px handle at `top + (height - 38) / 2`
- a drag moves the widget by the pointer delta
- a `pointermove` for a pointer that was never captured is ignored
- `pointerup` releases the capture and restores the `grab` cursor and the
  widget's transition
- `_positionSearchDragHandle` is a no-op when the widget has no
  `getBoundingClientRect`
- `_hideSearchDragHandle` hides the handle, and does not throw when it is absent

jsdom implements no Pointer Capture API, so the tests stub
`setPointerCapture` / `releasePointerCapture` / `hasPointerCapture` on the
handle element. Everything else reuses the existing `makeActivity()` helper in
the file, so the new block matches the style of the 48 tests already there.

## Testing Performed

Coverage for `js/activity/search-controller.js`:

| | before | after |
|---|---|---|
| Statements | 51.35% (209/407) | **56.51%** (230/407) |
| Functions | 55.81% (24/43) | **62.79%** (27/43) |
| Lines | — | 56.81% (225/396) |
| Branches | — | 56.47% (109/193) |

The tests were checked against a mutation, not just run: adding `+ 1` to the
`newLeft` calculation in `search-controller.js` makes
`dragging moves the widget by the pointer delta` fail, so it is asserting the
arithmetic rather than merely executing it. Reverted afterwards.

Full suite is unaffected — **235 suites, 9119 tests, all passing**. ESLint and
Prettier are clean on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for search drag-handle behavior, including positioning, pointer-based movement, pointer capture, and cursor restoration.
  * Added safeguards tests for missing widget bounds or drag-handle elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->