### PR TITLE
fix(musicutils): give equal19 all nineteen of its ratios

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -4175,6 +4175,55 @@ describe("non-EDO temperament helpers", () => {
         it("returns null for a temperament without usable ratios", () => {
             expect(getNonEDOModeSteps("major", "_no_ratios")).toBeNull();
         });
+
+        it("derives the textbook 19-EDO major scale", () => {
+            // In 19-EDO a whole tone is 3 steps and a diatonic semitone is 2,
+            // so major is T T S T T T S = 3,3,2,3,3,3,2 and sums to the octave.
+            const steps = getNonEDOModeSteps("major", "equal19");
+            expect(steps).toEqual([3, 3, 2, 3, 3, 3, 2]);
+            expect(steps.reduce((a, b) => a + b, 0)).toBe(19);
+        });
+
+        it("agrees with the other 19-note temperament", () => {
+            // 1/3 comma meantone also divides the octave into 19 and computes
+            // its steps from an independent ratio table, so the two must match.
+            expect(getNonEDOModeSteps("major", "equal19")).toEqual(
+                getNonEDOModeSteps("major", "1/3 comma meantone")
+            );
+        });
+    });
+
+    describe("temperament ratio tables", () => {
+        const withRatios = () =>
+            getTemperamentKeys()
+                .map(key => [key, getTemperament(key)])
+                .filter(([, t]) => t && Array.isArray(t.ratios) && t.pitchNumber);
+
+        it("gives every temperament one ratio per pitch", () => {
+            // equal19 shipped 15 ratios against a pitchNumber of 19, so anything
+            // reading ratios[pitchNumber - 1] fell off the end. Check them all
+            // rather than that one, so the next short table is caught here.
+            const mismatched = withRatios()
+                .filter(([, t]) => t.ratios.length !== t.pitchNumber)
+                .map(
+                    ([key, t]) => `${key}: ${t.ratios.length} ratios, pitchNumber ${t.pitchNumber}`
+                );
+            expect(mismatched).toEqual([]);
+        });
+
+        it("spaces every equal temperament evenly across the octave", () => {
+            for (const [key, t] of withRatios()) {
+                if (!t.isEDO) {
+                    continue;
+                }
+                const expected = [...Array(t.pitchNumber).keys()].map(i =>
+                    Math.pow(2, i / t.pitchNumber)
+                );
+                t.ratios.forEach((ratio, i) => {
+                    expect(Number(ratio)).toBeCloseTo(expected[i], 10);
+                });
+            }
+        });
     });
 });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2601,10 +2601,13 @@ const TEMPERAMENT = {
         "description": "19 Equal Divisions of the Octave",
         "ratios": [
             1,
+            Math.pow(2, 1 / 19),
             Math.pow(2, 2 / 19),
             Math.pow(2, 3 / 19),
+            Math.pow(2, 4 / 19),
             Math.pow(2, 5 / 19),
             Math.pow(2, 6 / 19),
+            Math.pow(2, 7 / 19),
             Math.pow(2, 8 / 19),
             Math.pow(2, 9 / 19),
             Math.pow(2, 10 / 19),
@@ -2614,6 +2617,7 @@ const TEMPERAMENT = {
             Math.pow(2, 14 / 19),
             Math.pow(2, 15 / 19),
             Math.pow(2, 16 / 19),
+            Math.pow(2, 17 / 19),
             Math.pow(2, 18 / 19)
         ],
         "octaveRatio": 2,


### PR DESCRIPTION
## Description

`equal19` declares `"pitchNumber": 19` but its `ratios` table lists only **15**
entries. The exponents **1, 4, 7 and 17** are missing, so every ratio after the
first names the wrong interval, and indices 15–18 do not exist at all.

It is the only temperament where the two disagree:

| temperament | pitchNumber | ratios |
|---|---|---|
| equal5 / equal7 / equal17 / equal31 | 5 / 7 / 17 / 31 | 5 / 7 / 17 / 31 ✅ |
| just intonation / Pythagorean | 12 | 12 ✅ |
| 1/3 comma meantone | 19 | 19 ✅ |
| 1/4 comma meantone | 21 | 21 ✅ |
| **equal19** | **19** | **15** ❌ |

The four gaps line up with `augmented 1`, `augmented 2`, `augmented 3` and
`augmented 7` — which the same entry *does* define individually
(`Math.pow(2, 1 / 19)` and friends) and which its own `interval` array lists in
order. The 15 values that are present are exact 19-EDO steps, so this is four
omitted lines rather than a rounding problem.

## Related Issue

**Fixes:** _n/a — found while reading the temperament tables, no issue filed._

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

The `ratios` array is now `Math.pow(2, k / 19)` for `k = 0 … 18`, matching how
every other EDO entry is written.

`getNonEDOModeSteps` is the reader that walks the table by `pitchNumber`:

```js
const n = t.pitchNumber || t.ratios.length;   // 19
for (let r = 1; r < n; r++) {
    const ratio = Number(t.ratios[r]);        // undefined for r = 15..18
```

so it read `undefined` on the last four turns and matched the wrong ratio on
the rest. Before and after, for the major scale:

```
before   [2, 2, 1, 3, 3, 3, 5]   <- indices into a table missing four steps
after    [3, 3, 2, 3, 3, 3, 2]   <- T T S T T T S, 3 per tone, 2 per semitone
```

The corrected value is the textbook 19-EDO major scale, it sums to 19, and it
is exactly what `1/3 comma meantone` — the other 19-note temperament — derives
from its own independent ratio table.

**On user-visible impact, to be straight about it:** there is none today. Every
path that reads `.ratios` is gated on the temperament being non-EDO
(`isNonEDO`, `!t.isEDO`, `!isTrueEDO`), and `equal19` is flagged `isEDO`, so
nothing currently reaches the short table. This corrects the data and keeps the
next reader from inheriting it.

## Steps to Reproduce

```js
const t = getTemperament("equal19");
t.pitchNumber;                              // 19
t.ratios.length;                            // 15
t.ratios[17];                               // undefined
getNonEDOModeSteps("major", "equal19");     // [2, 2, 1, 3, 3, 3, 5]
```

## Testing Performed

Four tests in `js/utils/__tests__/musicutils.test.js`, all four failing when
`musicutils.js` is restored from `master`:

```
✕ derives the textbook 19-EDO major scale
✕ agrees with the other 19-note temperament
✕ gives every temperament one ratio per pitch
✕ spaces every equal temperament evenly across the octave
```

The last two check the invariant across **every** temperament rather than just
this one, so the next short table fails here instead of silently. The even
spacing test asserts each EDO ratio equals `2^(i/pitchNumber)` to 10 decimal
places.

Full suite **235 suites, 9116 tests, all passing**. ESLint and Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored missing pitch ratios for the 19-tone equal temperament, ensuring all steps across the octave are available.

- **Tests**
  - Added coverage for 19-tone scale step calculations.
  - Added validation for temperament ratio tables and equal-temperament spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->