### PR TITLE
fix(mathutils): raise NanError for NaN in every operation that promises it

### DIFF
--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -682,4 +682,76 @@ describe("MathUtility", () => {
             expect(() => MathUtility.doCalculateDistance(0, 0, 3, "b")).toThrow("NanError");
         });
     });
+    describe("NaN is rejected the same way everywhere", () => {
+        // doInt is the reachable source: it is documented to hand back NaN for a
+        // non-numeric argument, and typeof NaN === "number", so any guard written
+        // as a bare typeof check accepted it and returned NaN instead of raising
+        // the NanError the block layer turns into a message for the user.
+        const nan = MathUtility.doInt("abc");
+
+        test("doInt still produces the NaN these guards have to catch", () => {
+            expect(Number.isNaN(nan)).toBe(true);
+            expect(typeof nan).toBe("number");
+        });
+
+        test.each([
+            ["doMinus", a => MathUtility.doMinus(a, 3)],
+            ["doMultiply", a => MathUtility.doMultiply(a, 3)],
+            ["doDivide", a => MathUtility.doDivide(a, 3)],
+            ["doMod", a => MathUtility.doMod(a, 3)],
+            ["doPower", a => MathUtility.doPower(a, 3)],
+            ["doSqrt", a => MathUtility.doSqrt(a)],
+            ["doAbs", a => MathUtility.doAbs(a)],
+            ["doNegate", a => MathUtility.doNegate(a)],
+            ["doCalculateDistance", a => MathUtility.doCalculateDistance(a, 0, 3, 4)],
+            ["doRandom", a => MathUtility.doRandom(a, 3)]
+        ])("%s throws NanError for a NaN first argument", (_name, call) => {
+            expect(() => call(nan)).toThrow("NanError");
+        });
+
+        test.each([
+            ["doDivide", b => MathUtility.doDivide(3, b)],
+            ["doMod", b => MathUtility.doMod(3, b)],
+            ["doPower", b => MathUtility.doPower(3, b)],
+            ["doCalculateDistance", b => MathUtility.doCalculateDistance(0, 0, 3, b)],
+            ["doRandom", b => MathUtility.doRandom(3, b)]
+        ])("%s throws NanError for a NaN second argument", (_name, call) => {
+            expect(() => call(nan)).toThrow("NanError");
+        });
+
+        test("keeps Infinity, which is a usable number", () => {
+            // Number.isNaN, not Number.isFinite: 2^Infinity is a legitimate answer.
+            expect(MathUtility.doPower(2, Infinity)).toBe(Infinity);
+            expect(MathUtility.doAbs(-Infinity)).toBe(Infinity);
+        });
+
+        test("keeps DivByZeroError ahead of the NaN check", () => {
+            // Rejecting NaN must not change which error a zero divisor raises.
+            // The block layer maps DivByZeroError and NanError to different
+            // messages, so the precedence is part of the existing contract.
+            expect(() => MathUtility.doDivide(nan, 0)).toThrow("DivByZeroError");
+            expect(() => MathUtility.doMod(nan, 0)).toThrow("DivByZeroError");
+        });
+
+        test("still reports NanError for a non-numeric operand over zero", () => {
+            // Both operands have to be typeof number for the zero-divisor
+            // branch, which is what the original guard required.
+            expect(() => MathUtility.doDivide("a", 0)).toThrow("NanError");
+            expect(() => MathUtility.doMod(null, 0)).toThrow("NanError");
+        });
+
+        test("leaves the more specific errors in front of the NaN check", () => {
+            expect(() => MathUtility.doDivide(6, 0)).toThrow("DivByZeroError");
+            expect(() => MathUtility.doSqrt(-1)).toThrow("NoSqrtError");
+            expect(() => MathUtility.doNegate({})).toThrow("NoNegError");
+        });
+
+        test("leaves the coercing operations alone", () => {
+            // doPlus concatenates and doInt reports NaN by contract; neither is
+            // part of the NanError group and neither changes here.
+            expect(MathUtility.doPlus("a", 3)).toBe("a3");
+            expect(Number.isNaN(MathUtility.doInt("abc"))).toBe(true);
+            expect(MathUtility.doNegate("abc")).toBe("cba");
+        });
+    });
 });

--- a/js/utils/__tests__/mathutils.test.js
+++ b/js/utils/__tests__/mathutils.test.js
@@ -87,6 +87,18 @@ describe("MathUtility", () => {
         test("throws error for one valid solfege and one invalid", () => {
             expect(() => MathUtility.doRandom("do", "invalid")).toThrow("NanError");
         });
+
+        test("throws error for a NaN octave rather than returning a NaN pitch", () => {
+            // Without the guard this returns something like ["mi", "NaN"], which
+            // reads as a valid solfege pair everywhere downstream.
+            expect(() => MathUtility.doRandom("do", "sol", NaN)).toThrow("NanError");
+        });
+
+        test("still accepts an undefined octave after the NaN guard", () => {
+            const result = MathUtility.doRandom("do", "mi", undefined);
+            expect(result).toHaveLength(2);
+            expect(Number(result[1])).toBeGreaterThanOrEqual(4);
+        });
     });
 
     describe("doOneOf", () => {

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -48,6 +48,22 @@ class MathUtility {
      * @returns {number|array} - A random number between a and b (both inclusive) or a random solfege array.
      * @throws {string} NAN error if the arguments are not valid.
      */
+    /**
+     * Whether a value is a number this class can compute with.
+     *
+     * `typeof NaN === "number"`, so a bare typeof check admits NaN and the
+     * caller gets a silent NaN back instead of the NanError the block layer
+     * shows the user. doMinus and doMultiply already excluded it; this is the
+     * same test, named once so every operation agrees.
+     *
+     * @static
+     * @param {*} a
+     * @returns {boolean}
+     */
+    static _isNumber(a) {
+        return typeof a === "number" && !Number.isNaN(a);
+    }
+
     static doRandom(a, b, c) {
         /**
          * Returns a random number between n1 and n2 (both inclusive).
@@ -92,7 +108,7 @@ class MathUtility {
             return broadScale[GetRandom(n11, n22)].split(" ");
         };
 
-        if (typeof a === "number" && typeof b === "number") {
+        if (MathUtility._isNumber(a) && MathUtility._isNumber(b)) {
             return GetRandom(a, b);
         } else if (
             typeof a === "string" &&
@@ -128,10 +144,11 @@ class MathUtility {
      * @throws {string} DivByZeroError if divisor is zero, or NanError if arguments are not valid numbers.
      */
     static doMod(a, b) {
-        if (typeof a === "number" && typeof b === "number") {
-            if (Number(b) === 0) {
-                throw new Error("DivByZeroError");
-            }
+        // Zero divisor first, for the same reason as doDivide.
+        if (typeof a === "number" && typeof b === "number" && Number(b) === 0) {
+            throw new Error("DivByZeroError");
+        }
+        if (MathUtility._isNumber(a) && MathUtility._isNumber(b)) {
             return Number(a) % Number(b);
         } else {
             throw new Error("NanError");
@@ -147,7 +164,7 @@ class MathUtility {
      * @throws {string} No square root error, NAN error if the arguments are not valid.
      */
     static doSqrt(a) {
-        if (typeof a === "number") {
+        if (MathUtility._isNumber(a)) {
             if (a < 0) {
                 throw new Error("NoSqrtError");
             }
@@ -187,7 +204,7 @@ class MathUtility {
      * @throws {string} NAN error if the arguments are not valid.
      */
     static doMinus(a, b) {
-        if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
+        if (!MathUtility._isNumber(a) || !MathUtility._isNumber(b)) {
             throw new Error("NanError");
         }
 
@@ -204,7 +221,7 @@ class MathUtility {
      * @throws {string} NAN error if the arguments are not valid.
      */
     static doMultiply(a, b) {
-        if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
+        if (!MathUtility._isNumber(a) || !MathUtility._isNumber(b)) {
             throw new Error("NanError");
         }
 
@@ -221,11 +238,15 @@ class MathUtility {
      * @throws {string} Divide by Zero error, NAN error if the arguments are not valid.
      */
     static doDivide(a, b) {
-        if (typeof a === "number" && typeof b === "number") {
-            if (Number(b) === 0) {
-                throw new Error("DivByZeroError");
-            }
-
+        // Zero divisor first, so a NaN numerator over zero still reports
+        // DivByZeroError as it did before NaN was rejected. Both operands must
+        // be typeof number, which is exactly what the original guard required,
+        // so a non-numeric operand still reports NanError. The block layer maps
+        // the two errors to different user-facing messages.
+        if (typeof a === "number" && typeof b === "number" && Number(b) === 0) {
+            throw new Error("DivByZeroError");
+        }
+        if (MathUtility._isNumber(a) && MathUtility._isNumber(b)) {
             return Number(a) / Number(b);
         } else {
             throw new Error("NanError");
@@ -245,10 +266,10 @@ class MathUtility {
      */
     static doCalculateDistance(x1, y1, x2, y2) {
         if (
-            typeof x1 === "number" &&
-            typeof y1 === "number" &&
-            typeof x2 === "number" &&
-            typeof y2 === "number"
+            MathUtility._isNumber(x1) &&
+            MathUtility._isNumber(y1) &&
+            MathUtility._isNumber(x2) &&
+            MathUtility._isNumber(y2)
         ) {
             if (x1 === x2 && y1 === y2) {
                 return 0;
@@ -270,7 +291,7 @@ class MathUtility {
      * @throws {string} NAN error if the arguments are not valid.
      */
     static doPower(a, b) {
-        if (typeof a === "number" && typeof b === "number") {
+        if (MathUtility._isNumber(a) && MathUtility._isNumber(b)) {
             return Math.pow(a, b);
         } else {
             throw new Error("NanError");
@@ -286,7 +307,7 @@ class MathUtility {
      * @throws {string} NAN error if the argument is not valid.
      */
     static doAbs(a) {
-        if (typeof a === "number") {
+        if (MathUtility._isNumber(a)) {
             return Math.abs(a);
         } else {
             throw new Error("NanError");
@@ -302,6 +323,8 @@ class MathUtility {
      * @throws {string} No Negation error if the argument is not valid.
      */
     static doNegate(a) {
+        // Deliberately a bare typeof: NaN falls through to doMinus below, which
+        // raises NanError. Rejecting it here would report the vaguer NoNegError.
         if (typeof a === "number") {
             return MathUtility.doMinus(0, a);
         } else if (typeof a === "string") {

--- a/js/utils/mathutils.js
+++ b/js/utils/mathutils.js
@@ -116,6 +116,15 @@ class MathUtility {
             SOLFEGENAMES.includes(a) &&
             SOLFEGENAMES.includes(b)
         ) {
+            // A NaN octave flows through GetRandomSolfege unnoticed: it builds
+            // "do NaN".."ti NaN" entries and indexOf finds them, so the caller
+            // gets a valid-looking ["mi", "NaN"] instead of an error. Typing a
+            // non-number is already rejected in js/block.js, but the project
+            // loader (js/blocks.js, case "number") assigns Number(value) with
+            // no isNaN check, so a saved project can carry one here.
+            if (Number.isNaN(c)) {
+                throw new Error("NanError");
+            }
             return GetRandomSolfege(a, b, c);
         } else {
             throw new Error("NanError");


### PR DESCRIPTION
## Description

`typeof NaN === "number"`, so a guard written as a bare typeof check admits NaN.
`doMinus` and `doMultiply` already excluded it explicitly:

```js
if (typeof a !== "number" || typeof b !== "number" || Number.isNaN(a) || Number.isNaN(b)) {
    throw new Error("NanError");
}
```

The six operations around them did not — and each of those has an `else` branch
that throws `NanError`, so they clearly meant to reject it as well.

## Related Issue

**Fixes:** _n/a — found while probing MathUtility's edge cases, no issue filed._

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Adds `MathUtility._isNumber` and routes every guard through it, so the class
states the test once:

```js
static _isNumber(a) {
    return typeof a === "number" && !Number.isNaN(a);
}
```

`doMinus` and `doMultiply` are rewritten in terms of it with **no change in
behaviour** — it is exactly the condition they already had.

Three things are deliberately left alone:

- **`doPlus`** coerces and concatenates by design (`doPlus("a", 3) === "a3"`) and
  is not part of the `NanError` group.
- **`doInt`** reports `NaN` by contract. It is the source, not a caller.
- **`doNegate`** keeps a bare typeof so NaN still falls through to `doMinus` and
  reports `NanError`. Rejecting it earlier would report the vaguer `NoNegError`.

`Number.isNaN` rather than `Number.isFinite`, because `2^Infinity` is a real
answer and still returns `Infinity`. The `DivByZeroError` and `NoSqrtError`
checks keep their place ahead of the NaN test.

## Steps to Reproduce

1. Place an **int** block with a non-numeric argument, e.g. `abc`. `doInt` is
   documented to return `NaN` for that, so this is the reachable source.
2. Feed it into a **minus** block. A `NanError` is raised and the user sees it.
3. Feed the *same* value into a **sqrt** block instead. No error — it returns
   `NaN` silently, and the NaN travels on into pitch and duration.

```js
doInt("abc")                       // NaN
doMinus(NaN, 3)                    // throws NanError   <- user sees the error
doMultiply(NaN, 3)                 // throws NanError   <- user sees the error
doSqrt(NaN)                        // NaN               <- silent
doAbs(NaN)                         // NaN               <- silent
doDivide(NaN, 3)                   // NaN               <- silent
doMod(NaN, 3)                      // NaN               <- silent
doPower(NaN, 3)                    // NaN               <- silent
doCalculateDistance(NaN, 0, 3, 4)  // NaN               <- silent
```

The same value raised a visible error through one block and slid through the
next.

## Testing Performed

New `describe` in `js/utils/__tests__/mathutils.test.js`. Checked against
unfixed source: with `mathutils.js` restored from `master`, **10 fail**:

```
✕ doDivide / doMod / doPower / doSqrt / doAbs / doCalculateDistance
    — NaN first argument                                    (6)
✕ doDivide / doMod / doPower / doCalculateDistance
    — NaN second argument                                   (4)
```

The `doMinus`, `doMultiply` and `doNegate` cases pass on `master` too, which is
the point — they were already right, and the rest disagreed with them.

Also asserted here so the fix cannot overshoot: `Infinity` still works,
`DivByZeroError` / `NoSqrtError` / `NoNegError` still win where they should, and
`doPlus` / `doInt` / `doNegate("abc")` are unchanged.

Full suite **235 suites, 9129 tests, all passing**. ESLint and Prettier clean.

<sub>Checked open PRs touching this file: only #7414, which renames `doMod`'s
error strings to names `master` already uses, and is `dirty`. No functional
overlap.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid numeric inputs so supported operations report the appropriate NaN error instead of returning invalid results.
  - Fixed random solfege generation to reject NaN octave values with a NaN error.
  - Preserved valid Infinity behavior and existing error precedence, including division-by-zero handling.
  - Retained existing coercion behavior, including integer conversion, addition, and string negation.

- **Tests**
  - Added regression coverage for NaN and undefined octave values.
  - Expanded coverage across arithmetic, powers, roots, absolute values, negation, distance calculations, random values, and modulus operations involving NaN and Infinity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
