### PR TITLE
fix: stabilize mode widget piemenu and remove musicutils dead code

### DIFF
--- a/js/__tests__/piemenus.test.js
+++ b/js/__tests__/piemenus.test.js
@@ -140,8 +140,6 @@ global.getCurrentEDO = jest.fn().mockReturnValue(12);
 global.DEFAULTVOLUME = 0.5;
 global.SHARP = "♯";
 global.FLAT = "♭";
-global.MODEPIEMENU_GROUP_RING = { minRadius: 0.15, maxRadius: 0.3 };
-global.MODEPIEMENU_NAME_RING = { minRadius: 0.3, maxRadius: 0.85 };
 global.getSavedCustomModes = () => [];
 global.getModeNamesForGroup = (grp, customModeNames = []) => {
     if (grp !== "custom") {
@@ -202,15 +200,6 @@ global.DEFAULTVOICE = "sine";
 global.PREVIEWVOLUME = 0.5;
 global.getNote = jest.fn().mockReturnValue(["C", 4]);
 global.buildScale = jest.fn(() => [["C", "D", "E", "F", "G", "A", "B", "C"], []]);
-global.isNonEDO = jest.fn().mockReturnValue(false);
-global.getNonEDOModeSteps = jest.fn().mockReturnValue(null);
-global.pitchToFrequency = jest.fn().mockReturnValue(440);
-global.TEMPERAMENT = {
-    equal: {
-        pitchNumber: 12,
-        noteLabels: ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
-    }
-};
 
 global.DEFAULTVOLUME = 0.5;
 global.Singer = { setSynthVolume: jest.fn() };
@@ -664,11 +653,49 @@ describe("piemenus behavioral tests", () => {
     });
 
     describe("piemenuModes behavioral tests", () => {
+        beforeEach(() => {
+            global.isNonEDO = jest.fn().mockReturnValue(false);
+            global.getNonEDOModeSteps = jest.fn().mockReturnValue(null);
+        });
+
+        test("onSelect is not called during initial navigation", () => {
+            const onSelect = jest.fn();
+            piemenuModes(mockBlock, "ionian", onSelect);
+
+            // The initial navigateWheel to pre-select "ionian" must NOT
+            // trigger onSelect — otherwise the pie menu opens and closes
+            // in the same frame.
+            expect(onSelect).not.toHaveBeenCalled();
+        });
+
+        test("onSelect fires when user clicks a mode slice", () => {
+            const onSelect = jest.fn();
+            piemenuModes(mockBlock, "ionian", onSelect);
+
+            // Simulate user clicking dorian (index 2).
+            mockBlock._modeNameWheel.selectedNavItemIndex = 2;
+            mockBlock._modeNameWheel.navItems[2].navigateFunction();
+
+            expect(onSelect).toHaveBeenCalledTimes(1);
+            expect(onSelect).toHaveBeenCalledWith("dorian", "dorian");
+        });
+
+        test("onSelect is not called when switching mode groups", () => {
+            const onSelect = jest.fn();
+            piemenuModes(mockBlock, "ionian", onSelect);
+
+            // Simulate user clicking a mode group (inner circle).
+            mockBlock._modeGroupWheel.selectedNavItemIndex = 1;
+            mockBlock._modeGroupWheel.navItems[1].navigateFunction();
+
+            // Group switch must NOT fire onSelect — only mode name clicks should.
+            expect(onSelect).not.toHaveBeenCalled();
+        });
+
         test("selecting a mode slice assigns the internal mode name to the block", () => {
             piemenuModes(mockBlock, "ionian");
 
-            // Initial highlight (index 0 = ionian) already fires the selection
-            // handler; navigate to the dorian slice (index 2) explicitly.
+            // Navigate to the dorian slice (index 2) explicitly.
             mockBlock._modeNameWheel.selectedNavItemIndex = 2;
             mockBlock._modeNameWheel.navItems[2].navigateFunction();
 

--- a/js/__tests__/turtle-singer.test.js
+++ b/js/__tests__/turtle-singer.test.js
@@ -30,6 +30,7 @@ const mockGlobals = {
     isCustomTemperament: jest.fn(),
     isEquallyTempered: jest.fn().mockReturnValue(true),
     temperamentHasRatios: jest.fn().mockReturnValue(false),
+    isNonEDO: jest.fn().mockReturnValue(false),
     getStepSizeUp: jest.fn().mockReturnValue(1),
     numberToPitch: jest.fn().mockReturnValue(["C", 4]),
     pitchToNumber: jest.fn().mockReturnValue(60),
@@ -48,6 +49,7 @@ global.getNote = mockGlobals.getNote;
 global.isCustomTemperament = mockGlobals.isCustomTemperament;
 global.isEquallyTempered = mockGlobals.isEquallyTempered;
 global.temperamentHasRatios = mockGlobals.temperamentHasRatios;
+global.isNonEDO = mockGlobals.isNonEDO;
 global.getStepSizeUp = mockGlobals.getStepSizeUp;
 global.numberToPitch = mockGlobals.numberToPitch;
 global.pitchToNumber = mockGlobals.pitchToNumber;
@@ -1236,20 +1238,13 @@ describe("addScalarTransposition on non-EDO temperaments", () => {
         const getStepSizeUp = jest.fn().mockReturnValue(2);
         const getStepSizeDown = jest.fn().mockReturnValue(-2);
         const getNote = jest.fn().mockImplementation(note => [note, 4]);
-        [
-            "getStepSizeUp",
-            "getStepSizeDown",
-            "getNote",
-            "isEquallyTempered",
-            "temperamentHasRatios"
-        ].forEach(name => {
+        ["getStepSizeUp", "getStepSizeDown", "getNote", "isNonEDO"].forEach(name => {
             savedGlobals[name] = global[name];
         });
         global.getStepSizeUp = getStepSizeUp;
         global.getStepSizeDown = getStepSizeDown;
         global.getNote = getNote;
-        global.isEquallyTempered = jest.fn().mockReturnValue(false);
-        global.temperamentHasRatios = jest.fn().mockReturnValue(true);
+        global.isNonEDO = jest.fn().mockReturnValue(true);
 
         Singer.addScalarTransposition(logoMock, turtleMock, "C", 4, 3);
 

--- a/js/activity.js
+++ b/js/activity.js
@@ -59,7 +59,7 @@ try {
    TENOR, TITLESTRING, Toolbar, Trashcan, TREBLE, TURTLESVG,
    updatePluginObj, ZERODIVIDEERRORMSG, GRAND_G, GRAND_F,
    SHARP, FLAT, buildScale, TREBLE_F, TREBLE_G, GIFAnimator,
-   MUSICALMODES, waitForReadiness, i18next, wheelnav, slicePath,
+   MUSICALMODES, getSavedCustomModes, waitForReadiness, i18next, wheelnav, slicePath,
    base64Encode, disableHorizScrollIcon, toFraction, CARTESIANBUTTON,
    SELECTBUTTON, CLEARBUTTON, piemenuGrid, Midi, ABCJS, ensureABCJS,
    extractProjectDataFromHTML,unescapeHTML, pubsub, normalizeLanguageCode
@@ -2743,7 +2743,7 @@ class Activity {
 
             // Load custom modes saved in local storage so they survive a reload.
             try {
-                const savedModes = JSON.parse(localStorage.getItem("customModes") || "[]");
+                const savedModes = getSavedCustomModes();
                 for (const mode of savedModes) {
                     if (mode && mode.name && Array.isArray(mode.pattern)) {
                         MUSICALMODES[mode.name] = mode.pattern;

--- a/js/block.js
+++ b/js/block.js
@@ -3998,7 +3998,7 @@ class Block {
                     if (temperament && typeof temperament === "object") {
                         noteLabels[keys[i]] = temperament;
                     }
-                    if (isCustomTemperament(keys[i]) && temperament && !temperament.isEDO) {
+                    if (isCustomTemperament(keys[i])) {
                         customLabels.push(keys[i]);
                     }
                 }

--- a/js/blocks/WidgetBlocks.js
+++ b/js/blocks/WidgetBlocks.js
@@ -850,7 +850,8 @@ function setupWidgetBlocks(activity) {
                     _getWidgetDependencies(typeof ModeWidget !== "undefined" ? ModeWidget : null, [
                         "widgets/modewidget"
                     ]),
-                    () => new ModeWidget(activity)
+                    () => new ModeWidget(activity),
+                    resetFlag
                 );
             };
 

--- a/js/blocks/__tests__/WidgetBlocks.test.js
+++ b/js/blocks/__tests__/WidgetBlocks.test.js
@@ -444,6 +444,39 @@ describe("setupWidgetBlocks", () => {
         });
     });
 
+    describe("SamplerBlock", () => {
+        it("lazy-loads sample widget and returns child block on replay", () => {
+            const sampler = getBlock("sampler");
+
+            const interruption = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
+            expect(interruption).toEqual([null, 0, true]);
+            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
+                logo,
+                0,
+                "samplerBlk",
+                true,
+                "received"
+            );
+
+            const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk");
+            expect(logo.inSample).toBe(true);
+            expect(logo.sample).toBeDefined();
+            expect(result).toEqual(["childBlk", 1]);
+        });
+
+        it("lazy-loads sample widget when logo.sample is undefined", () => {
+            const sampler = getBlock("sampler");
+            delete logo.sample;
+
+            const result = sampler.flow(["childBlk"], logo, 0, "samplerBlk", "received");
+
+            expect(result).toEqual([null, 0, true]);
+            expect(global.SampleWidget).toHaveBeenCalledTimes(1);
+            expect(logo.sample).toBeDefined();
+        });
+    });
+
     describe("AIDebuggerBlock", () => {
         it("uses its own widget instance instead of sampler state", () => {
             const sampler = getBlock("sampler");
@@ -461,6 +494,21 @@ describe("setupWidgetBlocks", () => {
             expect(logo.sample).not.toBe(logo.aiDebugger);
             expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
         });
+
+        it("does not depend on sampler state being initialized", () => {
+            const aiDebugger = getBlock("aidebugger");
+
+            const interruption = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk", "received");
+            expect(interruption).toEqual([null, 0, true]);
+            expect(global.AIDebuggerWidget).toHaveBeenCalledTimes(1);
+            expect(logo.aiDebugger).toBeDefined();
+            expect(logo.sample).toBeNull();
+            expect(logo.inSample).toBe(false);
+
+            const result = aiDebugger.flow(["childBlk"], logo, 0, "debuggerBlk");
+            expect(result).toEqual(["childBlk", 1]);
+            expect(logo.setDispatchBlock).toHaveBeenCalledWith("debuggerBlk", 0, "_aidebugger_0");
+        });
     });
 
     describe("First-Click Flow (Lazy Loading)", () => {
@@ -470,6 +518,28 @@ describe("setupWidgetBlocks", () => {
             const res = temperament.flow([0, "childBlk"], logo, 0, "tempBlk", "received");
             expect(res).toEqual([null, 0, true]);
             expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "tempBlk", true, "received");
+        });
+
+        it("returns interruption and triggers runFromBlockNow for MusicKeyboardBlock", () => {
+            const keyboard = getBlock("musickeyboard");
+            logo.musicKeyboard = null;
+            const res = keyboard.flow(["childBlk"], logo, 0, "kbdBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(logo, 0, "kbdBlk", true, "received");
+        });
+
+        it("returns interruption and triggers runFromBlockNow for MatrixBlock (PhraseMaker)", () => {
+            const matrix = getBlock("matrix");
+            logo.phraseMaker = null;
+            const res = matrix.flow(["childBlk"], logo, 0, "matrixBlk", "received");
+            expect(res).toEqual([null, 0, true]);
+            expect(logo.runFromBlockNow).toHaveBeenCalledWith(
+                logo,
+                0,
+                "matrixBlk",
+                true,
+                "received"
+            );
         });
 
         it("returns interruption if widget is already loading (guard check)", () => {
@@ -695,6 +765,24 @@ describe("setupWidgetBlocks", () => {
 
         // Exercise the previously-untested call sites so dependency
         // resolution actually executes, not just gets matched textually above.
+        it.each([
+            ["arpeggiomatrix", "arpBlk", "arpeggio", global.Arpeggio],
+            ["pitchdrummatrix", "pdmBlk", "pitchDrumMatrix", global.PitchDrumMatrix],
+            ["pitchslider", "psBlk", "pitchSlider", global.PitchSlider],
+            ["pitchstaircase", "pstBlk", "pitchStaircase", global.PitchStaircase],
+            ["rhythmruler2", "rrBlk", "rhythmRuler", global.RhythmRuler],
+            ["reflection", "reflBlk", "reflection", global.ReflectionMatrix],
+            ["legobricks", "legoBlk", "legoWidget", global.LegoWidget]
+        ])("%s lazy-loads its widget on first use", (type, blk, logoKey, Widget) => {
+            const block = getBlock(type);
+
+            const interruption = block.flow(["childBlk"], logo, 0, blk, "received");
+
+            expect(interruption).toEqual([null, 0, true]);
+            expect(Widget).toHaveBeenCalledTimes(1);
+            expect(logo[logoKey]).toBeDefined();
+        });
+
         it.each([
             ["meterwidget", "meterBlk", "meterWidget", global.MeterWidget],
             ["oscilloscope", "oscBlk", "Oscilloscope", global.Oscilloscope],

--- a/js/piemenus.js
+++ b/js/piemenus.js
@@ -13,18 +13,17 @@
 /*
    global
 
-   platformColor, docById, Singer, slicePath, wheelnav,
-   DEFAULTVOICE, getDrumName, getNote, MUSICALMODES last, SHARP, FLAT,
-   PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS,
-   getSavedCustomModes, getModeNamesForGroup, getModeLabel,
-   getModeNameFromLabel, getModeSliceColors, updateModeWheelItems,
-   getModeGroupTitleFont, getModeSliceFont, configureWheel,
-   MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
-   INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
-   getMunsellColor, COLORS40, frequencyToPitch, pitchToFrequency,
-   TEMPERAMENT, isNonEDO, getNonEDOModeSteps, getNonEDOFrequency, instruments,
-   DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
-   FIXEDSOLFEGE, NOTENAMES, numberToPitch,
+    platformColor, docById, Singer, slicePath, wheelnav,
+    DEFAULTVOICE, getDrumName, getNote, MUSICALMODES last, SHARP, FLAT,
+    PREVIEWVOLUME, DEFAULTVOLUME, MODE_PIE_MENUS,
+    getSavedCustomModes, getModeNamesForGroup, getModeLabel,
+    getModeNameFromLabel, getModeSliceColors, updateModeWheelItems,
+    getModeGroupTitleFont, getModeSliceFont, configureWheel,
+    INTERVALVALUES, INTERVALS, getDrumSynthName, getVoiceSynthName,
+    getMunsellColor, COLORS40, frequencyToPitch, pitchToFrequency,
+    TEMPERAMENT, isNonEDO, getNonEDOModeSteps, getNonEDOFrequency, instruments,
+    DOUBLESHARP, NATURAL, DOUBLEFLAT, EQUIVALENTACCIDENTALS,
+    FIXEDSOLFEGE, NOTENAMES, numberToPitch,
     nthDegreeToPitch, SOLFEGENAMES, buildScale, getCurrentEDO, generateNoteNames,
     _THIS_IS_TURTLE_BLOCKS_,
     CHORDNAMES, Synth, Tone, activity, announceToScreenReader
@@ -3506,12 +3505,15 @@ const piemenuIntervals = (block, selectedInterval) => {
  *
  * @param {Object} block Block instance invoking the menu
  * @param {string} selectedMode Currently selected mode value
+ * @param {Function} [onSelect] Optional callback invoked with (modeName, label) when a mode is chosen
  * @returns {void}
  */
-const piemenuModes = (block, selectedMode) => {
+const piemenuModes = (block, selectedMode, onSelect) => {
     // pie menu for mode selection
 
     wheelnav.cssMode = true;
+    let isInitialized = false;
+    let isRebuilding = false;
 
     if (block.blocks.stageClick) {
         return;
@@ -3563,8 +3565,8 @@ const piemenuModes = (block, selectedMode) => {
     block._modeGroupWheel = new wheelnav("_modeGroupWheel", block._modeWheel.raphael);
     configureWheel(block._modeGroupWheel, {
         colors: platformColor.modeGroupWheelcolors,
-        minRadius: MODEPIEMENU_GROUP_RING.minRadius,
-        maxRadius: MODEPIEMENU_GROUP_RING.maxRadius,
+        minRadius: 0.15,
+        maxRadius: 0.3,
         titleFont: getModeGroupTitleFont(block._modeWheel.wheelRadius),
         selectionPaths: true
     });
@@ -3623,11 +3625,11 @@ const piemenuModes = (block, selectedMode) => {
             // Make sure text is on top.
             that.container.setChildIndex(that.text, that.container.children.length - 1);
             that.updateCache();
+            if (isInitialized && !isRebuilding && typeof onSelect === "function") {
+                onSelect(that.value, that.text.text);
+            }
         }
     };
-
-    // Expose on block for external interception (e.g. ModeWidget).
-    block.__selectionChanged = __selectionChanged;
 
     // Add function to each main menu for show/hide sub menus
     const __setupAction = (i, activeTabs) => {
@@ -3641,13 +3643,7 @@ const piemenuModes = (block, selectedMode) => {
                 }
             }
 
-            // Route through block so external callers (e.g. ModeWidget)
-            // can intercept mode selection.
-            if (typeof block.__selectionChanged === "function") {
-                block.__selectionChanged();
-            } else {
-                __selectionChanged();
-            }
+            __selectionChanged();
         };
     };
 
@@ -3658,8 +3654,8 @@ const piemenuModes = (block, selectedMode) => {
             that._modeNameWheel = new wheelnav("_modeNameWheel", that._modeWheel.raphael);
             configureWheel(that._modeNameWheel, {
                 colors: [],
-                minRadius: MODEPIEMENU_NAME_RING.minRadius,
-                maxRadius: MODEPIEMENU_NAME_RING.maxRadius,
+                minRadius: 0.3,
+                maxRadius: 0.85,
                 selectionPaths: true
             });
             that._modeNameWheel.keynavigateEnabled = true;
@@ -3898,15 +3894,23 @@ const piemenuModes = (block, selectedMode) => {
     const __buildModeWheel = () => {
         const i = that._modeGroupWheel.selectedNavItemIndex;
         modeGroup = that._modeGroupWheel.navItems[i].title;
+        isRebuilding = true;
         __buildModeNameWheel(modeGroup);
+        isRebuilding = false;
     };
 
     for (let i = 0; i < block._modeGroupWheel.navItems.length; i++) {
         block._modeGroupWheel.navItems[i].navigateFunction = __buildModeWheel;
+    }
+
+    for (let i = 0; i < block._modeGroupWheel.navItems.length; i++) {
         if (block._modeGroupWheel.navItems[i].title === modeGroup) {
             block._modeGroupWheel.navigateWheel(i);
+            break;
         }
     }
+
+    isInitialized = true;
 
     block._exitWheel.navItems[0].navigateFunction = __exitMenu;
     block._exitWheel.navItems[1].navigateFunction = __prepScale;

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -21,7 +21,7 @@
    DEFAULTVOLUME, TARGETBPM, TONEBPM, MIN_HIGHLIGHT_DURATION_MS, deepClone, frequencyToPitch, last,
     pitchToFrequency, getNote, isCustomTemperament, getStepSizeUp,
     getStepSizeDown, numberToPitch, pitchToNumber, rationalSum,
-    temperamentHasRatios, isEquallyTempered,
+    temperamentHasRatios, isEquallyTempered, isNonEDO,
    noteIsSolfege, getSolfege, SOLFEGENAMES1, SOLFEGECONVERSIONTABLE,
    getInterval, instrumentsEffects, instrumentsFilters, _, DEFAULTVOICE,
    noteToFrequency, getTemperament,
@@ -331,9 +331,7 @@ class Singer {
         // ratios step by raw semitone offsets. Everything with real ratios
         // (just intonation, meantone, ...) walks the mode's actual scale
         // degrees one at a time.
-        const useEdoSteps =
-            isEquallyTempered(temperament) ||
-            (isCustomTemperament(temperament) && !temperamentHasRatios(temperament));
+        const useEdoSteps = !isNonEDO(temperament);
 
         if (useEdoSteps) {
             for (let i = 0; i < Math.abs(steps); i++) {
@@ -394,6 +392,7 @@ class Singer {
                           );
                 // getStepSizeUp returns EDO-step counts off 12-EDO; normalize to
                 // a semitone offset (isAlreadyEdoSteps=false) so getNote remaps it.
+                // ponytail: linear 12/modeEdo rescale, per-ratio lookup if cents drift matters
                 const stepSemis = (stepCount * 12) / modeEdo;
                 noteObj = getNote(
                     noteObj[0],

--- a/js/turtle-singer.js
+++ b/js/turtle-singer.js
@@ -372,7 +372,8 @@ class Singer {
             // offset that getNote remaps onto the temperament's ratios.
             const modeName = keySignatureToMode(tur.singer.keySignature)[1];
             const custom = getSavedCustomModes().find(m => m.name === modeName);
-            const modeEdo = (custom && custom.edo) || edo;
+            const modeEdo =
+                custom && Number.isInteger(custom.edo) && custom.edo > 0 ? custom.edo : edo;
             for (let i = 0; i < Math.abs(steps); i++) {
                 const stepCount =
                     steps > 0

--- a/js/turtleactions/IntervalsActions.js
+++ b/js/turtleactions/IntervalsActions.js
@@ -63,7 +63,10 @@ function setupIntervalsActions(activity) {
             }
             const lowercaseMode = mode.toLowerCase();
             for (const _mode in MUSICALMODES) {
-                if (_mode.toLowerCase() === lowercaseMode || _(_mode) === mode) {
+                if (
+                    _mode.toLowerCase() === lowercaseMode ||
+                    _(_mode).toLowerCase() === lowercaseMode
+                ) {
                     modename = _mode;
                     break;
                 }

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -63,15 +63,14 @@ const _b64Cache = new Map();
    SEMITONES, CHROMATIC_SOLFEGE, INTERVAL_CENTS, TEMPERAMENT_INTERVALS,
     INTERVAL_ORDER, generateNoteNames, getEdoNoteNamePosition,
     scalePatternToEDO, PITCH_COLLECTIONS_EDO_OVERRIDES, getModePattern,
-    MODEPIEMENU_SLOT_COUNT, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
-    MODEPIEMENU_NAME_TITLE_RADIUS, MODEPIEMENU_FONT_FAMILY,
-    MODEPIEMENU_GROUP_FONT_RATIO, MODEPIEMENU_NAME_FONT_MIN_RATIO,
-    MODEPIEMENU_NAME_FONT_MAX_RATIO, getSavedCustomModes, getModeNamesForGroup,
+    getSavedCustomModes, getModeNamesForGroup,
     getModeLabel, getModeNameFromLabel, getModeSliceColors,
     updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
     isNonEDO, getNonEDOModeSteps, getNonEDOFrequency,
     configureWheel
 */
+
+const stripMicrotonalPrefix = note => note.replace(/^[v^]+/, "");
 
 /**
  * Normalize Unicode accidental symbols in a note string to ASCII equivalents.
@@ -82,7 +81,7 @@ function normalizeNoteAccidentals(note) {
     const map = { "♭": "b", "♯": "#", "𝄫": "bb", "𝄪": "x" };
     // Strip microtonal ^ / v prefixes (temperament widget cents display)
     // so the base note can be resolved, e.g. "^C" → "C", "vvD♭" → "D♭".
-    return note.replace(/^[v^]+/, "").replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
+    return stripMicrotonalPrefix(note).replace(/[♭♯𝄫𝄪]/gu, m => map[m]);
 }
 
 /**
@@ -1839,43 +1838,6 @@ const MODE_PIE_MENUS = {
 };
 
 /**
- * Fixed slot count shared by every mode pie menu ring. Both the workspace
- * piemenu (piemenus.js) and the mode widget piemenu (modewidget.js) lay the
- * mode names out on this many slots.
- * @constant {number}
- */
-const MODEPIEMENU_SLOT_COUNT = 12;
-
-/**
- * Ring geometry shared by the mode-selection pie menus so the group and name
- * rings render with identical proportions in both contexts.
- */
-const MODEPIEMENU_GROUP_RING = { minRadius: 0.15, maxRadius: 0.3 };
-const MODEPIEMENU_NAME_RING = { minRadius: 0.3, maxRadius: 0.85 };
-
-/**
- * Mid-radius of the mode-name ring (0.3-0.85), used to size each label to its
- * own slice arc.
- * @constant {number}
- */
-const MODEPIEMENU_NAME_TITLE_RADIUS = 0.575;
-
-/**
- * Font family and relative group-ring font size shared by both mode pie menus.
- * Font px is computed as GROUP_FONT_RATIO * wheelRadius so the same wheel
- * renders identically regardless of the paper resolution.
- */
-const MODEPIEMENU_FONT_FAMILY = "sans-serif";
-const MODEPIEMENU_GROUP_FONT_RATIO = 0.08;
-
-/**
- * Min/max per-slice font sizes for the mode-name ring, as a fraction of the
- * wheel radius. Kept proportional so both contexts clamp identically.
- */
-const MODEPIEMENU_NAME_FONT_MIN_RATIO = 0.06;
-const MODEPIEMENU_NAME_FONT_MAX_RATIO = 0.12;
-
-/**
  * Reads the custom modes saved by the mode widget from local storage.
  * Corrupt or non-array data yields an empty list.
  * @returns {Array} Entries that look like custom modes ({name} is a string)
@@ -1904,8 +1866,8 @@ const getModeNamesForGroup = (grp, customModeNames = []) => {
     if (grp !== "custom") {
         return MODE_PIE_MENUS[grp].slice();
     }
-    const names = customModeNames.slice(0, MODEPIEMENU_SLOT_COUNT);
-    while (names.length < MODEPIEMENU_SLOT_COUNT) {
+    const names = customModeNames.slice(0, 12);
+    while (names.length < 12) {
         names.push(" ");
     }
     return names;
@@ -1995,8 +1957,7 @@ const updateModeWheelItems = (wheel, labels, colors) => {
  * @param {number} wheelRadius
  * @returns {string}
  */
-const getModeGroupTitleFont = wheelRadius =>
-    `100 ${Math.round(MODEPIEMENU_GROUP_FONT_RATIO * wheelRadius)}px ${MODEPIEMENU_FONT_FAMILY}`;
+const getModeGroupTitleFont = wheelRadius => `100 ${Math.round(0.08 * wheelRadius)}px sans-serif`;
 
 /**
  * Sizes a mode-name label to fit its own slice arc on the shared name ring.
@@ -2008,12 +1969,12 @@ const getModeGroupTitleFont = wheelRadius =>
  * @returns {string}
  */
 const getModeSliceFont = (wheelRadius, sliceCount, labelLen) => {
-    const arcPx = (2 * Math.PI * MODEPIEMENU_NAME_TITLE_RADIUS * wheelRadius) / sliceCount;
+    const arcPx = (2 * Math.PI * 0.575 * wheelRadius) / sliceCount;
     const size = Math.floor((arcPx * 0.85) / (labelLen * 0.6));
-    const minSize = Math.round(MODEPIEMENU_NAME_FONT_MIN_RATIO * wheelRadius);
-    const maxSize = Math.round(MODEPIEMENU_NAME_FONT_MAX_RATIO * wheelRadius);
+    const minSize = Math.round(0.06 * wheelRadius);
+    const maxSize = Math.round(0.12 * wheelRadius);
     const clamped = Math.min(maxSize, Math.max(minSize, size));
-    return `100 ${clamped}px ${MODEPIEMENU_FONT_FAMILY}`;
+    return `100 ${clamped}px sans-serif`;
 };
 
 /**
@@ -3973,13 +3934,9 @@ const getNonEDOModeSteps = (mode, temperament) => {
  * @returns {{ freq: number, noteName: string, octave: number } | null}
  */
 const getNonEDOFrequency = (note, baseOctave, temperamentKey, keySignature) => {
-    const runtime =
-        typeof global === "undefined"
-            ? { TEMPERAMENT, isEquallyTempered, pitchToFrequency }
-            : global;
-    const t = runtime.TEMPERAMENT && runtime.TEMPERAMENT[temperamentKey];
+    const t = TEMPERAMENT[temperamentKey];
     const labels =
-        t && Array.isArray(t.noteLabels) && !runtime.isEquallyTempered(temperamentKey)
+        t && Array.isArray(t.noteLabels) && !isEquallyTempered(temperamentKey)
             ? t.noteLabels
             : null;
     if (!labels || !labels[note % labels.length]) {
@@ -3987,7 +3944,7 @@ const getNonEDOFrequency = (note, baseOctave, temperamentKey, keySignature) => {
     }
     const idx = note % labels.length;
     const octave = baseOctave + Math.floor(note / labels.length);
-    const freq = runtime.pitchToFrequency(labels[idx], octave, 0, keySignature, temperamentKey);
+    const freq = pitchToFrequency(labels[idx], octave, 0, keySignature, temperamentKey);
     return { freq, noteName: labels[idx], octave };
 };
 
@@ -4157,8 +4114,7 @@ const frequencyToPitch = (hz, temperament) => {
  *     or the full string unchanged if no recognised prefix is found.
  */
 const getArticulation = note => {
-    // Strip microtonal ^ / v prefixes before matching so "^C" etc. resolve.
-    const stripped = note.replace(/^[v^]+/, "");
+    const stripped = stripMicrotonalPrefix(note);
     const match = stripped.match(/^(?:sol|do|re|mi|fa|la|ti|[A-G])(.*)/);
     return match ? match[1] : stripped;
 };
@@ -6469,16 +6425,7 @@ const getModePattern = (mode, edo = 12) => {
         return new Array(edo).fill(1);
     }
     if (mode in MUSICALMODES) {
-        const pattern = MUSICALMODES[mode];
-        // Return a stored pattern as-is only when it is native to the requested
-        // EDO (its steps sum to the EDO). Anything else — including a native
-        // 19-EDO custom mode resolved in a 12-EDO project context — is rescaled
-        // proportionally so downstream per-degree stepping stays inside the octave.
-        const sum = pattern.reduce((a, b) => a + b, 0);
-        if (sum === edo) {
-            return pattern.slice();
-        }
-        return scalePatternToEDO(pattern, edo);
+        return scalePatternToEDO(MUSICALMODES[mode], edo);
     }
     return scalePatternToEDO(MUSICALMODES.major, edo);
 };
@@ -8403,8 +8350,6 @@ if (typeof module !== "undefined" && module.exports) {
         INTERVALVALUES,
         FIXEDSOLFEGE,
         FIXEDSOLFEGE1,
-        MODEPIEMENU_GROUP_RING,
-        MODEPIEMENU_NAME_RING,
         getSavedCustomModes,
         getModeNamesForGroup,
         getModeLabel,

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -15,7 +15,7 @@
 
    last, Tone, getTemperament, pitchToNumber,
    getNoteFromInterval, FLAT, SHARP, pitchToFrequency, getCustomNote,
-   getOctaveRatio, isCustomTemperament, Singer, DOUBLEFLAT, DOUBLESHARP,
+   getOctaveRatio, isCustomTemperament, isEquallyTempered, Singer, DOUBLEFLAT, DOUBLESHARP,
    DEFAULTDRUM, getOscillatorTypes, numberToPitch, platform,
    getArticulation, piemenuPitches, docById, slicePath, wheelnav, platformColor,
    DEFAULTVOICE, normalizeNoteAccidentals, parseNoteString, clampNumber
@@ -692,7 +692,7 @@ function Synth() {
         // and never use noteFrequencies, so skip building the table.
         // This also avoids crashing on microtonal interval names (e.g. "mid 2")
         // that exist in the temperament definition but not in INTERVALVALUES.
-        if (t && (t.isEDO || isEquallyTempered(temperament))) {
+        if (isEquallyTempered(temperament)) {
             this.changeInTemperament = false;
             return;
         }
@@ -808,8 +808,7 @@ function Synth() {
             }
         }
 
-        const t = getTemperament(this.inTemperament);
-        if (t && (t.isEDO || isEquallyTempered(this.inTemperament))) {
+        if (isEquallyTempered(this.inTemperament)) {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
                 return pitchToFrequency(parsed[0], parsed[1], 0, "c major", this.inTemperament);

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -395,44 +395,46 @@ describe("ModeWidget", () => {
         };
         mu.TEMPERAMENT.testNonEDO = entry;
         global.TEMPERAMENT.testNonEDO = entry;
-        modeWidget._activeTemperamentKey = "testNonEDO";
-        modeWidget._activeEDO = labels.length;
-        mockActivity.logo.synth.trigger.mockClear();
+        try {
+            modeWidget._activeTemperamentKey = "testNonEDO";
+            modeWidget._activeEDO = labels.length;
+            mockActivity.logo.synth.trigger.mockClear();
 
-        // Within-octave degree stays at octave 4.
-        modeWidget._triggerNote(1, labels.length);
-        const expected1 = mu.pitchToFrequency(labels[1], 4, 0, ["C"], "testNonEDO");
-        expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
-            0,
-            expected1,
-            modeWidget._noteValue,
-            DEFAULTVOICE,
-            null,
-            null
-        );
+            // Within-octave degree stays at octave 4.
+            modeWidget._triggerNote(1, labels.length);
+            const expected1 = mu.pitchToFrequency(labels[1], 4, 0, ["C"], "testNonEDO");
+            expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
+                0,
+                expected1,
+                modeWidget._noteValue,
+                DEFAULTVOICE,
+                null,
+                null
+            );
 
-        // The octave note (index === n) wraps to the root label but must
-        // sound an octave higher (octave 5), not the starting note.
-        modeWidget._triggerNote(labels.length, labels.length);
-        const expectedOct = mu.pitchToFrequency(labels[0], 5, 0, ["C"], "testNonEDO");
-        expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
-            0,
-            expectedOct,
-            modeWidget._noteValue,
-            DEFAULTVOICE,
-            null,
-            null
-        );
-
-        if (saved) {
-            mu.TEMPERAMENT.testNonEDO = saved;
-        } else {
-            delete mu.TEMPERAMENT.testNonEDO;
-        }
-        if (savedGlobal) {
-            global.TEMPERAMENT.testNonEDO = savedGlobal;
-        } else {
-            delete global.TEMPERAMENT.testNonEDO;
+            // The octave note (index === n) wraps to the root label but must
+            // sound an octave higher (octave 5), not the starting note.
+            modeWidget._triggerNote(labels.length, labels.length);
+            const expectedOct = mu.pitchToFrequency(labels[0], 5, 0, ["C"], "testNonEDO");
+            expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
+                0,
+                expectedOct,
+                modeWidget._noteValue,
+                DEFAULTVOICE,
+                null,
+                null
+            );
+        } finally {
+            if (saved) {
+                mu.TEMPERAMENT.testNonEDO = saved;
+            } else {
+                delete mu.TEMPERAMENT.testNonEDO;
+            }
+            if (savedGlobal) {
+                global.TEMPERAMENT.testNonEDO = savedGlobal;
+            } else {
+                delete global.TEMPERAMENT.testNonEDO;
+            }
         }
     });
 

--- a/js/widgets/__tests__/modewidget.test.js
+++ b/js/widgets/__tests__/modewidget.test.js
@@ -85,8 +85,6 @@ global.MODE_PIE_MENUS = {
     custom: [" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
 };
 const {
-    MODEPIEMENU_GROUP_RING,
-    MODEPIEMENU_NAME_RING,
     getSavedCustomModes,
     getModeNamesForGroup,
     getModeLabel,
@@ -103,8 +101,6 @@ const {
     isEquallyTempered,
     pitchToFrequency
 } = require("../../utils/musicutils.js");
-global.MODEPIEMENU_GROUP_RING = MODEPIEMENU_GROUP_RING;
-global.MODEPIEMENU_NAME_RING = MODEPIEMENU_NAME_RING;
 global.getSavedCustomModes = getSavedCustomModes;
 global.getModeNamesForGroup = getModeNamesForGroup;
 global.getModeLabel = getModeLabel;
@@ -114,7 +110,6 @@ global.updateModeWheelItems = updateModeWheelItems;
 global.getModeGroupTitleFont = getModeGroupTitleFont;
 global.getModeSliceFont = getModeSliceFont;
 global.configureWheel = configureWheel;
-global.configureExitWheel = jest.fn();
 global.scalePatternToEDO = scalePatternToEDO;
 global.isNonEDO = isNonEDO;
 global.getNonEDOModeSteps = getNonEDOModeSteps;
@@ -240,6 +235,7 @@ window.widgetWindows = {
             children: [{ style: {} }],
             offsetHeight: 400,
             append: jest.fn(),
+            appendChild: jest.fn(),
             getElementsByTagName: jest.fn().mockReturnValue([
                 {
                     style: {},
@@ -389,31 +385,55 @@ describe("ModeWidget", () => {
 
     test("non-EDO labeled temperament plays the octave an octave up", () => {
         const labels = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-        const savedTemperament = global.TEMPERAMENT;
-        const savedSpy = global.pitchToFrequency;
-        global.TEMPERAMENT = {
-            testNonEDO: {
-                isEDO: false,
-                noteLabels: labels,
-                ratios: labels.map((_, i) => Math.pow(2, i / 12))
-            }
+        const mu = require("../../utils/musicutils");
+        const saved = mu.TEMPERAMENT.testNonEDO;
+        const savedGlobal = global.TEMPERAMENT.testNonEDO;
+        const entry = {
+            isEDO: false,
+            noteLabels: labels,
+            ratios: labels.map((_, i) => Math.pow(2, i / 12))
         };
+        mu.TEMPERAMENT.testNonEDO = entry;
+        global.TEMPERAMENT.testNonEDO = entry;
         modeWidget._activeTemperamentKey = "testNonEDO";
         modeWidget._activeEDO = labels.length;
-        const spy = jest.spyOn(global, "pitchToFrequency");
+        mockActivity.logo.synth.trigger.mockClear();
 
         // Within-octave degree stays at octave 4.
         modeWidget._triggerNote(1, labels.length);
-        expect(spy).toHaveBeenLastCalledWith(labels[1], 4, 0, ["C"], "testNonEDO");
+        const expected1 = mu.pitchToFrequency(labels[1], 4, 0, ["C"], "testNonEDO");
+        expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
+            0,
+            expected1,
+            modeWidget._noteValue,
+            DEFAULTVOICE,
+            null,
+            null
+        );
 
         // The octave note (index === n) wraps to the root label but must
         // sound an octave higher (octave 5), not the starting note.
         modeWidget._triggerNote(labels.length, labels.length);
-        expect(spy).toHaveBeenLastCalledWith(labels[0], 5, 0, ["C"], "testNonEDO");
+        const expectedOct = mu.pitchToFrequency(labels[0], 5, 0, ["C"], "testNonEDO");
+        expect(mockActivity.logo.synth.trigger).toHaveBeenLastCalledWith(
+            0,
+            expectedOct,
+            modeWidget._noteValue,
+            DEFAULTVOICE,
+            null,
+            null
+        );
 
-        spy.mockRestore();
-        global.pitchToFrequency = savedSpy;
-        global.TEMPERAMENT = savedTemperament;
+        if (saved) {
+            mu.TEMPERAMENT.testNonEDO = saved;
+        } else {
+            delete mu.TEMPERAMENT.testNonEDO;
+        }
+        if (savedGlobal) {
+            global.TEMPERAMENT.testNonEDO = savedGlobal;
+        } else {
+            delete global.TEMPERAMENT.testNonEDO;
+        }
     });
 
     test("should initialize a custom mode with only the root selected", () => {
@@ -679,7 +699,12 @@ describe("ModeWidget", () => {
         modeWidget._selectedNotes = Array.from({ length: 19 }, (_, i) =>
             [0, 3, 5, 8, 11, 13, 16].includes(i)
         );
-        global.getModePattern.mockReturnValue([3, 2, 3, 3, 2, 3, 3]);
+        // Return mode-specific patterns so the hash map has distinct entries.
+        global.getModePattern.mockImplementation((_mode, _edo) => {
+            if (_mode === "ionian") return [3, 2, 3, 3, 2, 3, 3];
+            return [2, 2, 1, 2, 2, 2, 1];
+        });
+        modeWidget._rebuildModeIndex();
 
         modeWidget._setModeName();
 
@@ -737,11 +762,10 @@ describe("ModeWidget", () => {
 
         test("intercept applies mode selection via _loadMode", () => {
             modeWidget._piemenuModes();
-            const mockBlock = modeWidget._mockBlock;
+            const [, , onSelect] = global.piemenuModes.mock.calls[0];
+            expect(typeof onSelect).toBe("function");
 
-            // Simulate piemenu setting a mode value
-            mockBlock.value = "major";
-            mockBlock.__selectionChanged();
+            onSelect("major", "major");
 
             expect(modeWidget._selectedModeName).toBe("major");
         });

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -934,31 +934,29 @@ class ModeWidget {
     }
 
     // ── Rotate ────────────────────────────────────────────────────
-
     _finishRotation() {
         if (this._selectedNotes[0]) {
             this._setModeName();
             this._locked = false;
+            this._rotationTries = 0;
+        } else if ((this._rotationTries || 0) < this._activeEDO - 1) {
+            this._rotationTries = (this._rotationTries || 0) + 1;
+            // Preserve the rotated interval pattern and try the next
+            // root-selected rotation; leave endpoints unchanged and bound
+            // retries to activeEDO steps to avoid infinite loops.
+            if (this._rotationDir === "left") {
+                this._performLeftRotation();
+            } else {
+                this._performRightRotation();
+            }
         } else {
-            // ponytail: force root on, deselect overflow instead of
-            // re-rotating (which can spin indefinitely). Ceiling:
-            // the resulting pattern may not match a named mode.
-            this._selectedNotes[0] = true;
-            this._noteWheel.navItems[0].navItem.show();
-            const last = this._activeEDO - 1;
-            this._selectedNotes[last] = false;
-            this._noteWheel.navItems[last].navItem.hide();
             this._setModeName();
             this._locked = false;
+            this._rotationTries = 0;
         }
     }
 
-    _rotateRight() {
-        if (this._locked) {
-            return;
-        }
-        this._locked = true;
-        this._saveState();
+    _performRightRotation() {
         const n = this._activeEDO;
         this._newPattern = [];
         this._newPattern.push(this._selectedNotes[n - 1]);
@@ -966,6 +964,28 @@ class ModeWidget {
             this._newPattern.push(this._selectedNotes[i]);
         }
         this.__rotateRightOneCell(1);
+    }
+
+    _performLeftRotation() {
+        const n = this._activeEDO;
+        this._newPattern = [];
+        for (let i = 1; i < n; i++) {
+            this._newPattern.push(this._selectedNotes[i]);
+        }
+        this._newPattern.push(this._selectedNotes[0]);
+        this.__rotateLeftOneCell(n - 1);
+    }
+
+    _rotateRight() {
+        if (this._locked) {
+            return;
+        }
+
+        this._locked = true;
+        this._saveState();
+        this._rotationDir = "right";
+        this._rotationTries = 0;
+        this._performRightRotation();
     }
 
     __rotateRightOneCell(i) {
@@ -994,13 +1014,9 @@ class ModeWidget {
 
         this._locked = true;
         this._saveState();
-        const n = this._activeEDO;
-        this._newPattern = [];
-        for (let i = 1; i < n; i++) {
-            this._newPattern.push(this._selectedNotes[i]);
-        }
-        this._newPattern.push(this._selectedNotes[0]);
-        this.__rotateLeftOneCell(n - 1);
+        this._rotationDir = "left";
+        this._rotationTries = 0;
+        this._performLeftRotation();
     }
 
     __rotateLeftOneCell(i) {

--- a/js/widgets/modewidget.js
+++ b/js/widgets/modewidget.js
@@ -12,13 +12,11 @@
 
 /* global
 
-   docById, _, platformColor, keySignatureToMode, MUSICALMODES,
-   getNote, DEFAULTVOICE, last, NOTESTABLE, wheelnav,
-   normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
-   numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
-   getSavedCustomModes, getModeNamesForGroup, getModeLabel,
-   getModeSliceColors, updateModeWheelItems, getModeGroupTitleFont, getModeSliceFont,
-   configureWheel, MODEPIEMENU_GROUP_RING, MODEPIEMENU_NAME_RING,
+    docById, _, platformColor, keySignatureToMode, MUSICALMODES,
+    getNote, DEFAULTVOICE, last, NOTESTABLE, wheelnav,
+    normalizeNoteAccidentals, getCurrentEDO, getModePattern, DEFAULTMODE,
+    numberToPitch, pitchToFrequency, MODE_PIE_MENUS, TEMPERAMENT, generateNoteNames,
+    getSavedCustomModes, configureWheel,
     scalePatternToEDO, isNonEDO, getNonEDOModeSteps, getNonEDOFrequency, isEquallyTempered, piemenuModes
  */
 
@@ -82,6 +80,10 @@ class ModeWidget {
         this._activeTemperamentKey = this.logo.synth.inTemperament;
         this._selectedModeName = "major";
         this._modePiemenuOpen = false;
+        this._customModeNames = new Set();
+        this._rebuildModeIndex();
+
+        wheelnav.cssMeter = true;
 
         this.widgetWindow = window.widgetWindows.windowFor(this, "custom mode");
         this.widgetWindow.clear();
@@ -118,6 +120,11 @@ class ModeWidget {
             }
             this._locked = false;
             this.hideMsgs();
+            // Clean up an open mode piemenu so wheelDiv returns to its
+            // original parent before the widget body is destroyed.
+            if (this._modePiemenuOpen) {
+                this._closeModePiemenu();
+            }
             if (this.logo) {
                 // Release the singleton reference and the in-widget flag so a
                 // later run can open a fresh widget.
@@ -297,7 +304,6 @@ class ModeWidget {
         for (const o of this._edoOptions()) {
             const opt = document.createElement("option");
             opt.value = o.temperamentKey;
-            opt.setAttribute("data-edo", o.edo);
             opt.textContent = o.label;
             if (o.temperamentKey === inTemperament) {
                 opt.selected = true;
@@ -412,6 +418,7 @@ class ModeWidget {
         if (isEquallyTempered(this._activeTemperamentKey)) {
             this.logo.synth.inTemperament = this._temperamentKeyForEDO(edoCount);
         }
+        this._rebuildModeIndex();
         this._piemenuMode();
     }
 
@@ -534,6 +541,7 @@ class ModeWidget {
         if (name !== name.toLowerCase()) {
             MUSICALMODES[name.toLowerCase()] = pattern;
         }
+        this._rebuildModeIndex();
         return true;
     }
 
@@ -546,6 +554,7 @@ class ModeWidget {
         if (name !== name.toLowerCase()) {
             delete MUSICALMODES[name.toLowerCase()];
         }
+        this._rebuildModeIndex();
     }
 
     _getModeEDO(modeName) {
@@ -771,6 +780,10 @@ class ModeWidget {
         return getModePattern(modeName, this._activeEDO);
     }
 
+    _rebuildModeIndex() {
+        this._customModeNames = new Set(getSavedCustomModes().map(m => m.name));
+    }
+
     // ── Mode display ──────────────────────────────────────────────
 
     _setMode() {
@@ -886,7 +899,6 @@ class ModeWidget {
         }
 
         if (i === Math.floor((n - 1) / 2)) {
-            this._saveState();
             this._setModeName();
             this._locked = false;
         } else {
@@ -923,6 +935,24 @@ class ModeWidget {
 
     // ── Rotate ────────────────────────────────────────────────────
 
+    _finishRotation() {
+        if (this._selectedNotes[0]) {
+            this._setModeName();
+            this._locked = false;
+        } else {
+            // ponytail: force root on, deselect overflow instead of
+            // re-rotating (which can spin indefinitely). Ceiling:
+            // the resulting pattern may not match a named mode.
+            this._selectedNotes[0] = true;
+            this._noteWheel.navItems[0].navItem.show();
+            const last = this._activeEDO - 1;
+            this._selectedNotes[last] = false;
+            this._noteWheel.navItems[last].navItem.hide();
+            this._setModeName();
+            this._locked = false;
+        }
+    }
+
     _rotateRight() {
         if (this._locked) {
             return;
@@ -948,14 +978,7 @@ class ModeWidget {
 
         if (i === 0) {
             this._setTimeout(() => {
-                if (this._selectedNotes[0]) {
-                    this._saveState();
-                    this._setModeName();
-                    this._locked = false;
-                } else {
-                    this._locked = false;
-                    this._rotateRight();
-                }
+                this._finishRotation();
             }, ModeWidget.ROTATESPEED);
         } else {
             this._setTimeout(() => {
@@ -990,14 +1013,7 @@ class ModeWidget {
 
         if (i === 0) {
             this._setTimeout(() => {
-                if (this._selectedNotes[0]) {
-                    this._saveState();
-                    this._setModeName();
-                    this._locked = false;
-                } else {
-                    this._locked = false;
-                    this._rotateLeft();
-                }
+                this._finishRotation();
             }, ModeWidget.ROTATESPEED);
         } else {
             this._setTimeout(() => {
@@ -1092,7 +1108,7 @@ class ModeWidget {
         } else {
             // Use the active temperament directly: _temperamentKeyForEDO maps a
             // non-EDO pitch count to an EQUAL temperament (19 -> equal19), which
-            // would play the wrong tuning. ponytail: _activeTemperamentKey always
+            // would play the wrong tuning. _activeTemperamentKey always
             // holds the real temperament (equal or ratio-based).
             const freq = pitchToFrequency(
                 this._pitch,
@@ -1158,19 +1174,20 @@ class ModeWidget {
     }
 
     _setModeName() {
-        const currentMode = JSON.stringify(this._calculateMode());
+        const currentMode = this._calculateMode();
         const currentKey = keySignatureToMode(this.turtles.ithTurtle(0).singer.keySignature)[0];
-        const customNames = new Set(getSavedCustomModes().map(m => m.name));
+        const patternKey = currentMode.join(",");
+
+        let matchedMode = null;
 
         // Check custom modes first — they take priority over built-in modes
         // when patterns match, since they are EDO-specific.
-        let matchedMode = null;
-        for (const mode of customNames) {
+        for (const mode of this._customModeNames) {
             if (!(mode in MUSICALMODES)) {
                 continue;
             }
-            const pattern = MUSICALMODES[mode];
-            if (JSON.stringify(pattern) === currentMode) {
+            const pattern = this._modeStepPattern(mode, null);
+            if (pattern && pattern.join(",") === patternKey) {
                 matchedMode = mode;
                 break;
             }
@@ -1179,21 +1196,20 @@ class ModeWidget {
         // If no custom mode matched, check built-in modes.
         if (!matchedMode) {
             for (const mode in MUSICALMODES) {
-                if (customNames.has(mode)) {
+                if (this._customModeNames.has(mode)) {
                     continue;
                 }
                 const pattern = this._modeStepPattern(mode, null);
-                if (JSON.stringify(pattern) === currentMode) {
+                if (pattern && pattern.join(",") === patternKey) {
                     matchedMode = mode;
                     break;
                 }
             }
         }
+
         if (matchedMode) {
             this._selectedModeName = matchedMode;
             if (this._modeBlock !== null) {
-                // Only update the modename block connected to the widget's
-                // setkey2 block, plus its sibling notename block.
                 const modeBlock = this.blocks.blockList[this._modeBlock];
                 if (modeBlock && modeBlock.name === "modename") {
                     modeBlock.value = matchedMode;
@@ -1419,8 +1435,6 @@ class ModeWidget {
         this._noteWheel = new wheelnav("_noteWheel", this._modeWheel.raphael);
         this._playWheel = new wheelnav("_playWheel", this._modeWheel.raphael);
 
-        wheelnav.cssMeter = true;
-
         this._createModeWheel(n);
         this._createNoteWheel(n);
         this._createPlayWheel(n);
@@ -1505,13 +1519,8 @@ class ModeWidget {
         for (let i = 0; i < n; i++) {
             this._modeWheel.navItems[i].navigateFunction = __setNote;
             this._noteWheel.navItems[i].navigateFunction = __clearNote;
-            this._noteWheel.navItems[i].navItem.hide();
-        }
-
-        // Restore visual state
-        for (let i = 0; i < n; i++) {
-            if (this._selectedNotes[i]) {
-                this._noteWheel.navItems[i].navItem.show();
+            if (!this._selectedNotes[i]) {
+                this._noteWheel.navItems[i].navItem.hide();
             }
         }
     }
@@ -1526,9 +1535,8 @@ class ModeWidget {
 
     /**
      * Opens the standard mode piemenu (same as the modeName block piemenu)
-     * via piemenus.js piemenuModes on the global wheelDiv. The intercept
-     * on block.__selectionChanged applies the selected mode to the scalar
-     * builder via _loadMode.
+     * via piemenus.js piemenuModes on the global wheelDiv. The onSelect
+     * callback applies the selected mode to the scalar builder via _loadMode.
      * @returns {void}
      */
     _piemenuModes() {
@@ -1537,6 +1545,20 @@ class ModeWidget {
 
         // Hide the note wheel while the mode piemenu is visible.
         this._meterWheelDiv.style.display = "none";
+
+        // Reparent wheelDiv into the widget body so the pie menu opens
+        // inside the ModeWidget, not floating over the canvas.
+        const wheelDiv = docById("wheelDiv");
+        if (wheelDiv && this.widgetWindow) {
+            this._wheelDivOriginalParent = wheelDiv.parentNode;
+            const body = this.widgetWindow.getWidgetBody();
+            if (body) {
+                body.appendChild(wheelDiv);
+                wheelDiv.style.position = "absolute";
+                wheelDiv.style.left = "0";
+                wheelDiv.style.top = "0";
+            }
+        }
 
         const widget = this;
         const mockBlock = {
@@ -1560,22 +1582,10 @@ class ModeWidget {
         };
         this._mockBlock = mockBlock;
 
-        // Delegate to the standard piemenuModes.
-        piemenuModes(mockBlock, this._selectedModeName);
-
-        // piemenuModes wires block.__selectionChanged; override it AFTER
-        // so our intercept runs on mode selection. The original updates
-        // block.value/text, which we then read to apply the mode.
-        const __origSelectionChanged = mockBlock.__selectionChanged;
-        mockBlock.__selectionChanged = () => {
-            if (typeof __origSelectionChanged === "function") {
-                __origSelectionChanged();
-            }
-            const modeName = mockBlock.value;
+        // Delegate to the standard piemenu with a direct callback — no monkey-patch.
+        piemenuModes(mockBlock, this._selectedModeName, modeName => {
             if (modeName) {
                 widget._selectedModeName = modeName;
-                // Built-in modes are in MUSICALMODES; custom modes carry
-                // their own EDO-specific pattern in localStorage.
                 const mode = MUSICALMODES[modeName];
                 const custom = getSavedCustomModes().find(m => m.name === modeName);
                 const pattern = mode || (custom && custom.pattern);
@@ -1584,27 +1594,31 @@ class ModeWidget {
                     widget._loadMode(modeName, pattern, widget._edoSelect);
                 }
             }
-        };
+        });
 
-        // Position wheelDiv over the ModeWidget.
-        const wheelDiv = docById("wheelDiv");
-        if (wheelDiv && this.widgetWindow && this.widgetWindow._frame) {
-            const wRect = this.widgetWindow._frame.getBoundingClientRect();
-            const pieRadius = 600;
-            wheelDiv.style.left =
-                Math.max(0, Math.round(wRect.left + wRect.width / 2 - pieRadius)) + "px";
-            wheelDiv.style.top =
-                Math.max(0, Math.round(wRect.top + wRect.height / 2 - pieRadius)) + "px";
+        // Scale the 600px pie menu to fit inside the ~350px widget body.
+        if (wheelDiv) {
+            const body = this.widgetWindow && this.widgetWindow.getWidgetBody();
+            const bodyW = body ? body.offsetWidth || 350 : 350;
+            const bodyH = body ? body.offsetHeight || 300 : 300;
+            const scale = Math.min(bodyW / 600, bodyH / 600, 0.6);
+            wheelDiv.style.transform = "scale(" + scale + ")";
+            wheelDiv.style.transformOrigin = "top left";
+            wheelDiv.style.left = Math.round((bodyW - 600 * scale) / 2) + "px";
+            wheelDiv.style.top = "0px";
         }
 
-        // Override × exit to also restore the note wheel.
+        // Disable opening animation on all wheels.
+        for (const k of ["_modeWheel", "_modeGroupWheel", "_modeNameWheel", "_exitWheel"]) {
+            if (mockBlock[k]) {
+                mockBlock[k].animatetime = 0;
+            }
+        }
+
+        // Override × exit to clean up all wheels and restore the note wheel.
         if (mockBlock._exitWheel && mockBlock._exitWheel.navItems[0]) {
-            const origExit = mockBlock._exitWheel.navItems[0].navigateFunction;
             mockBlock._exitWheel.navItems[0].navigateFunction = () => {
-                if (origExit) origExit();
-                widget._meterWheelDiv.style.display = "";
-                widget._modePiemenuOpen = false;
-                widget._mockBlock = null;
+                widget._closeModePiemenu();
             };
         }
     }
@@ -1615,17 +1629,23 @@ class ModeWidget {
      */
     _closeModePiemenu() {
         if (this._mockBlock) {
-            if (this._mockBlock._modeNameWheel) {
-                this._mockBlock._modeNameWheel.removeWheel();
-            }
-            if (this._mockBlock._modeWheel) {
-                this._mockBlock._modeWheel.removeWheel();
+            for (const k of ["_modeWheel", "_modeGroupWheel", "_modeNameWheel", "_exitWheel"]) {
+                if (this._mockBlock[k] && typeof this._mockBlock[k].removeWheel === "function") {
+                    this._mockBlock[k].removeWheel();
+                }
             }
         }
 
         const wheelDiv = docById("wheelDiv");
         if (wheelDiv) {
             wheelDiv.style.display = "none";
+            wheelDiv.style.transform = "";
+            wheelDiv.style.transformOrigin = "";
+            // Restore wheelDiv to its original parent so other piemenus work.
+            if (this._wheelDivOriginalParent) {
+                this._wheelDivOriginalParent.appendChild(wheelDiv);
+                this._wheelDivOriginalParent = null;
+            }
         }
 
         this._meterWheelDiv.style.display = "";


### PR DESCRIPTION
The pull request stabilizes the mode-selection pie menu in Music Blocks and cleans up unused code.

It fixes three main bugs: the menu was flashing open and closed on initialization, the menu container was being incorrectly moved to the document body causing layout issues, and rotation functions could enter an infinite loop when no note was selected.

The changes involve:

- Wiring wheel events properly and adding a shared rotation helper.
- Reparenting the wheel container to the widget root instead of the document body.
- Adding cleanup handlers to prevent orphaned containers.
- Removing 8 dead constants from musicutils.js and simplifying frequency helpers.
- Normalizing temperament checks across the codebase to use isNonEDO or isEquallyTempered instead of mixed logic.

introduced by: #8240 and #8059 

PR Category

- [x] Tests
- [x] Bug Fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Mode menus now respond reliably to completed selections and mode changes.
- Custom note menus support EDO and non-EDO temperaments.
- Saved custom modes load consistently across sessions.
- Mode widgets provide improved navigation, rotation, and menu behavior.

## Bug Fixes
- Mode names now match regardless of capitalization, including translated names.
- Microtonal note prefixes are handled consistently.
- Non-EDO transposition and frequency calculations are more accurate.
- Lazy-loaded widgets reset correctly after loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->