### PR TITLE
fix(rubrics): stop scoring two deprecated blocks in TACAT

### DIFF
--- a/js/rubrics.js
+++ b/js/rubrics.js
@@ -31,8 +31,6 @@ Globals location
    getStatsFromNotation
 */
 
-/* eslint-disable no-dupe-keys */
-
 /**
  * TACAT (Turtle Art Category)
  * Maps individual block names to their category bins.
@@ -91,7 +89,6 @@ const TACAT = {
     register: "transpose",
     settransposition: "transpose",
     setratio: "transpose",
-    interval: "pitch",
     accidental: "pitch",
     hertz: "pitch",
     pitchnumber: "pitch",
@@ -172,13 +169,11 @@ const TACAT = {
     phaser: "tone",
     chorus: "tone",
     vibrato: "tone",
-    setvoice: "tone",
     glide: "tone",
     slur: "tone",
     staccato: "tone",
     newslur: "tone",
     newstaccato: "tone",
-    synthname: "tone",
     voicename: "tone",
     settimbre: "tone",
     settemperament: "tone",
@@ -378,9 +373,6 @@ const TACAT = {
     runblock: "programming",
     dockblock: "programming",
     makeblock: "programming",
-    saveabc: "ignore",
-    savelilypond: "ignore",
-    savesvg: "ignore",
     nobackground: "ignore",
     showblocks: "ignore",
     hideblocks: "ignore",


### PR DESCRIPTION
> **Updated after review.** The first version of this PR removed the wrong
> duplicate. @rakshityadav1868 pointed out that five of the six blocks are
> deprecated, which inverts the conclusion — see below. Thanks for catching it.

## Description

`TACAT` maps a block name to the category the project analyser scores it under
(`js/rubrics.js:638`). Six names are listed twice, and the file carries an
`/* eslint-disable no-dupe-keys */` at the top, so the rule cannot report them.

A later key wins in an object literal — and for **two** of the six, the later
key is the wrong one:

| block | declared in | status |
|---|---|---|
| `setvoice` | `ToneBlocks.js:759` | `this.hidden = this.deprecated = true` |
| `synthname` | `ToneBlocks.js:834` | `this.hidden = this.deprecated = true` |

Both appear in the **"Deprecated blocks (no longer in use, mapped to `ignore`)"**
section as `"ignore"`, and again in the tone palette section as `"tone"`. The
tone entry is later, so both resolve to `"tone"` — and the analyser counts two
deprecated, hidden blocks toward a project's tone category. The section comment
says explicitly that these are meant to be excluded from scoring.

## Related Issue

**Fixes:** _n/a — found by scanning object literals for duplicate keys._

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

Removes the **later** duplicate in each case, so the deprecated `"ignore"`
survives. Two values change:

```
setvoice    tone -> ignore
synthname   tone -> ignore
```

The other four are removed with no change in resolved value:

- `saveabc`, `savelilypond`, `savesvg` — `"ignore"` in both places, and all
  three are `hidden = deprecated = true` (`ExtrasBlocks.js:84/120/156`), so the
  copy in the extras palette section is the one that goes.
- `interval` — the one genuinely live block of the six
  (`IntervalsBlocks.js:1067`, `setPalette("intervals")`, `beginnerBlock(true)`),
  so its intervals-palette `"pitchchord"` is correct and the stray `"pitch"`
  entry in the pitch palette section goes.

Also removes the `eslint-disable`, so `no-dupe-keys` guards the file again and
the next duplicate that resolves to the wrong category fails lint instead of
silently mis-scoring a project. That rule was doing nothing here precisely
because it had been switched off to accommodate these six.

## Steps to Reproduce

1. Open a project that uses the **set voice** and **synth name** blocks.
2. Run the rubric analyser over it.
3. Read the scoring category each block resolves to:

```js
TACAT.setvoice     // "tone"    — but ToneBlocks.js:759 sets hidden = deprecated = true
TACAT.synthname    // "tone"    — but ToneBlocks.js:834 sets hidden = deprecated = true
```

4. Both are listed as `"ignore"` earlier in the deprecated section of the same
   object literal. The later tone-palette entry silently overrides that, so two
   blocks the palette hides as deprecated are still scored as tone work.

## Testing Performed

- Resolved `TACAT` dumped and diffed before and after: **325 keys both ways**,
  and exactly two values differ — the two above. Nothing else moves.
- Each surviving value checked against the block's own `setPalette(...)` and its
  `hidden` / `deprecated` flags.
- `npx eslint js/rubrics.js` clean **with `no-dupe-keys` active**, confirming
  these six were the only reason the rule was disabled.
- `js/__tests__/rubrics.test.js`: 17 passing.
- Full suite **235 suites, 9118 tests, all passing**. Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined rubric categorization for voice, synthesis, interval, and save/export actions.
  - Improved consistency checks for rubric definitions to help prevent conflicting classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
