### PR TITLE
fix(deps): update svgo override to resolve security audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15480,9 +15480,9 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+            "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         },
         "@isaacs/brace-expansion": "^5.0.1",
         "immutable": "5.1.9",
-        "svgo": "4.0.2",
+        "svgo": "^4.1.0",
         "@xmldom/xmldom": "^0.8.13",
         "@gulp-sourcemaps/identity-map": {
             "postcss": "^8.4.31"


### PR DESCRIPTION
## Description

Resolves the failing GitHub Actions `security` audit CI step by updating the `svgo` dependency override from `4.0.2` to `^4.1.0`. Pinned version `4.0.2` triggered high-severity security advisories GHSA-w27v-7q3p-w38r and GHSA-4vpr-x523-8j87, causing `npm audit --omit=dev --audit-level=high` to exit with failure.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [x] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [x] CI/CD — Changes to workflows and automation

---

## Changes Made

- Updated `overrides.svgo` in `package.json` from `4.0.2` to `^4.1.0`.
- Synchronized `package-lock.json` with `svgo@4.1.0`.
- Verified that `npm audit --omit=dev --audit-level=high` passes with 0 high vulnerabilities and exit code `0`.

---

## Testing Performed

- Ran `npm audit --omit=dev --audit-level=high` locally; exited with code 0 (no high/critical vulnerabilities).
- Ran unit test suite (`npm test`); all suites passed.
- Pre-commit hooks (`lint-staged`, `commitlint`, DCO sign-off) passed.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.

- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SVG optimization tooling version range to allow compatible 4.x updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->