### PR TITLE
fix(temperament): keep the table of notes working after saving

### DIFF
--- a/cypress/e2e/temperament-widget.cy.js
+++ b/cypress/e2e/temperament-widget.cy.js
@@ -102,6 +102,39 @@ describe("Temperament widget", () => {
         cy.get('[aria-label="temperament"]').find('img[title="table"]').should("exist");
     });
 
+    it("keeps the table of notes intact after saving the temperament", () => {
+        // Regression: _save() used to clear this.notes for every temperament
+        // while only refilling it for a custom one, so the table of notes threw
+        // reading this.notes[i][0] and rendered no rows at all.
+        loadFixtureProject("temperament-widget-minimal.tb");
+        cy.get("#play").click();
+
+        cy.get('[aria-label="temperament"]', { timeout: 30000 }).should("be.visible");
+
+        // Record how many rows the table holds before anything is saved, so the
+        // check after saving compares against the widget's own baseline rather
+        // than a hard coded count.
+        cy.get('[aria-label="temperament"]').find('img[title="table"]').click({ force: true });
+        cy.get("#tableOfNotes tr")
+            .then($rows => $rows.length)
+            .as("rowCount");
+        cy.get('[aria-label="temperament"]').find('img[title="circle"]').click({ force: true });
+
+        // Save the temperament, which is the step that used to empty the notes.
+        cy.get('[aria-label="temperament"]').find('img[title="Save"]').click({ force: true });
+
+        // The table must still render, and every row must still be populated.
+        cy.get('[aria-label="temperament"]').find('img[title="table"]').click({ force: true });
+        cy.get("#tableOfNotes").should("exist").and("be.visible");
+
+        cy.get("@rowCount").then(rowCount => {
+            cy.get("#tableOfNotes tr").should("have.length", rowCount);
+            cy.get("#tableOfNotes tr").each($row => {
+                expect($row[0].cells.length).to.be.greaterThan(0);
+            });
+        });
+    });
+
     it("closes the Temperament widget and cleans up the DOM", () => {
         loadFixtureProject("temperament-widget-minimal.tb");
         cy.get("#play").click();

--- a/cypress/e2e/temperament-widget.cy.js
+++ b/cypress/e2e/temperament-widget.cy.js
@@ -130,7 +130,12 @@ describe("Temperament widget", () => {
         cy.get("@rowCount").then(rowCount => {
             cy.get("#tableOfNotes tr").should("have.length", rowCount);
             cy.get("#tableOfNotes tr").each($row => {
-                expect($row[0].cells.length).to.be.greaterThan(0);
+                // Cell 4 is the note name, the column fed by this.notes. A row
+                // that kept its cells but lost that text would still be the
+                // regression, so assert the note itself rather than the count.
+                const cells = $row[0].cells;
+                expect(cells.length).to.be.greaterThan(4);
+                expect(cells[4].textContent.trim()).to.not.equal("");
             });
         });
     });

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -1921,9 +1921,12 @@ function TemperamentWidget() {
      * @returns {void}
      */
     this._save = function () {
-        this.notes = [];
-
         if (isCustomTemperament(this.inTemperament)) {
+            // Only a custom temperament rebuilds this.notes below. Clearing it
+            // for the other temperaments would leave the table of notes with
+            // nothing to read, so it is reset inside this branch alone.
+            this.notes = [];
+
             const startingPitch = this._logo.synth.startingPitch;
             const startPitchParsed = parseNoteString(startingPitch);
             const startPitch = pitchToFrequency(


### PR DESCRIPTION
## Category

- [x] Bug Fix
- [x] Tests

## What the problem is

In the Temperament widget, hitting Save breaks the table of notes.

Open the widget and the table view works fine, it lists every note with its ratio, interval, note name and frequency. Click Save, then switch to the table again, and the table comes up blank apart from one half drawn row. The console throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at TemperamentWidget._graphOfNotes (temperament.js:949)
    at noteCell.onclick (temperament.js:2715)
```

It stays broken for the rest of that widget session. Toggling back to the circle works, but every attempt to get to the table throws again. You have to close the window and run the block again to get the table back.

The cause is in `_save()`. It clears the list of note names first, then only refills it when the temperament is a custom one. The temperament block ships with `equal` selected, so for the default case and for every other built in tuning the list is emptied and never rebuilt. `_graphOfNotes()` then walks the notes and reads `this.notes[i][0]`, which is undefined, and the row building stops there.

## How I solved it

Moved the reset inside the branch that actually refills it. A custom temperament still gets a clean list before it is rebuilt, and the other tunings keep the note names they were given when the widget opened.

Also added a Cypress regression test to the existing temperament spec. It records how many rows the table has, saves the temperament, opens the table again and checks every row is still there and populated. The test fails on master with the same TypeError and passes with this change.

## Steps to reproduce

1. Open Music Blocks with the browser console visible.
2. Switch to advanced mode, the temperament block is hidden in beginner mode.
3. Drag the `temperament` block from the Widgets palette onto the canvas and leave its tuning on the default `equal`.
4. Click the block to run it. The Temperament widget opens on the circle of notes.
5. Click the table icon in the widget toolbar. The table renders with all 13 rows. Click it again to go back to the circle.
6. Click Save, the music note icon with the down arrow.
7. Click the table icon again.

The table is blank apart from one partial row and the console shows the TypeError above.

### before: 


https://github.com/user-attachments/assets/bc80449d-a5a6-42fc-b007-0c4cbfccee50

### after:


https://github.com/user-attachments/assets/b2f180a3-833e-4930-b5da-644ae5072f91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Saving a non-custom temperament now preserves the existing notes table and its populated rows.
* Saving a custom temperament continues to reset its notes as expected.

## Tests

* Added regression coverage to verify that notes-table row counts, note names, and cell contents remain unchanged after saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->