### PR TITLE
fix: pop increscendo array in docrescendo listener

### DIFF
--- a/js/turtleactions/VolumeActions.js
+++ b/js/turtleactions/VolumeActions.js
@@ -98,6 +98,7 @@ function setupVolumeActions(activity) {
                     );
                     tur.singer.crescendoInitialVolume[synth].pop();
                 }
+                tur.singer.inCrescendo.pop();
             };
 
             activity.logo.setTurtleListener(turtle, listenerName, __listener);

--- a/js/turtleactions/__tests__/VolumeActions.test.js
+++ b/js/turtleactions/__tests__/VolumeActions.test.js
@@ -202,8 +202,10 @@ describe("setupVolumeActions", () => {
         ])("listener execution with justCounting %p", (justCounting, noCall) => {
             targetTurtle.singer.justCounting = justCounting;
             Singer.VolumeActions.doCrescendo("crescendo", 10, 0, 1);
+            expect(targetTurtle.singer.inCrescendo.length).toBe(1);
             const listener = activity.logo.setTurtleListener.mock.calls.pop()[2];
             listener();
+            expect(targetTurtle.singer.inCrescendo.length).toBe(0);
             if (!noCall) {
                 expect(crescendoEndSpy).toHaveBeenCalledWith(0, 10);
             } else {


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes a memory leak and state bug in the `doCrescendo` turtle action (`js/turtleactions/VolumeActions.js`). Previously, `tur.singer.inCrescendo` was never popped in the crescendo listener, causing the crescendo logic to incorrectly apply delta adjustments to subsequent notes outside the block. This adds the missing `.pop()` call.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- Added `tur.singer.inCrescendo.pop();` at the end of the `__listener` callback in `Singer.VolumeActions.doCrescendo`.
- Updated `VolumeActions.test.js` to assert that `targetTurtle.singer.inCrescendo.length` is `0` after the listener completes.

---

## Steps to Reproduce

1. Create a project with two consecutive crescendo clamps, each containing notes.
2. Notice that after the first crescendo ends, the subsequent notes are still treated as if they are inside a crescendo block because the state was never cleared.

## Visual Changes

<!-- If this PR introduces visual or UI changes, please provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- Added automated Jest tests in `VolumeActions.test.js` to strictly enforce the length of `inCrescendo` before and after the listener fires.
- Verified `npm test` passes successfully.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Crescendo and decrescendo completion now correctly resets the active crescendo state, preventing lingering volume-control state.

- **Tests**
  - Added coverage confirming the crescendo state is cleared after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->