### PR TITLE
fix: allow string values in heap entry block

### DIFF
--- a/js/blocks/HeapBlocks.js
+++ b/js/blocks/HeapBlocks.js
@@ -79,6 +79,7 @@ function setupHeapBlocks(activity) {
                     "print"
             ) {
                 logo.statusFields.push([blk, "heap"]);
+                return JSON.stringify([]);
             } else {
                 return JSON.stringify(logo.turtleHeaps[turtle]);
             }
@@ -220,6 +221,7 @@ function setupHeapBlocks(activity) {
                     "print"
             ) {
                 logo.statusFields.push([blk, "heapLength"]);
+                return 0;
             } else {
                 // Return the length of the heap
                 return logo.turtleHeaps[turtle].length;
@@ -566,7 +568,7 @@ function setupHeapBlocks(activity) {
                 return;
             }
 
-            if (typeof args[0] !== "number" || typeof args[1] !== "number") {
+            if (typeof args[0] !== "number") {
                 activity.errorMsg(NANERRORMSG, blk);
                 return;
             }

--- a/js/blocks/__tests__/HeapBlocks.test.js
+++ b/js/blocks/__tests__/HeapBlocks.test.js
@@ -151,7 +151,7 @@ describe("setupHeapBlocks", () => {
             logo.inStatusMatrix = true;
             const blk = 10;
             const result = heapBlock.arg(logo, turtle, blk);
-            expect(result).toBeUndefined();
+            expect(result).toBe("[]");
             expect(logo.statusFields).toContainEqual([blk, "heap"]);
         });
 
@@ -202,7 +202,7 @@ describe("setupHeapBlocks", () => {
             logo.inStatusMatrix = true;
             const blk = 10;
             const result = heapLengthBlock.arg(logo, turtle, blk);
-            expect(result).toBeUndefined();
+            expect(result).toBe(0);
             expect(logo.statusFields).toContainEqual([blk, "heapLength"]);
         });
     });
@@ -335,9 +335,14 @@ describe("setupHeapBlocks", () => {
             expect(activity.errorMsg).toHaveBeenCalledWith("No input provided", blk);
         });
 
-        it("should call errorMsg if arguments are not numbers", () => {
+        it("should call errorMsg if index is not a number", () => {
             setHeapEntryBlock.flow(["a", 99], logo, 0, blk);
             expect(activity.errorMsg).toHaveBeenCalledWith("Not a number", blk);
+        });
+
+        it("should allow string values", () => {
+            setHeapEntryBlock.flow([2, "test"], logo, 0, blk);
+            expect(logo.turtleHeaps[0][1]).toEqual("test");
         });
 
         it("should adjust index < 1 and set the value at index 1", () => {

--- a/js/js-export/__tests__/export.test.js
+++ b/js/js-export/__tests__/export.test.js
@@ -289,6 +289,13 @@ describe("MusicBlocks Class", () => {
             globalActivity.logo.turtleHeaps[musicBlocks.turIndex] = [];
             musicBlocks.setHeapEntry(2, 5);
             expect(globalActivity.logo.turtleHeaps[musicBlocks.turIndex]).toEqual([0, 5]);
+
+            musicBlocks.setHeapEntry(3, "testString");
+            expect(globalActivity.logo.turtleHeaps[musicBlocks.turIndex]).toEqual([
+                0,
+                5,
+                "testString"
+            ]);
         });
 
         test("should push to heap", () => {

--- a/js/js-export/export.js
+++ b/js/js-export/export.js
@@ -434,8 +434,8 @@ class MusicBlocks {
             return;
         }
 
-        if (typeof index !== "number" || typeof value !== "number") {
-            JSEditor.logConsole("Heap index and value must be numbers.", "maroon");
+        if (typeof index !== "number") {
+            JSEditor.logConsole("Heap index must be a number.", "maroon");
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes two separate bugs within `js/blocks/HeapBlocks.js` related to the Heap functionality:

1. **`SetHeapEntryBlock` String Storage Bug:** `SetHeapEntryBlock` was incorrectly rejecting string values. Its type guard checked both the heap index (`args[0]`) and the value to store (`args[1]`) for numeric types, despite the heap design (and `argTypes`) allowing `anyin` values. 
2. **`HeapBlock`/`HeapLengthBlock` Status Matrix Return Bug:** `HeapBlock.arg()` and `HeapLengthBlock.arg()` were silently returning `undefined` when operating in a status-matrix context, which violates the contract for `ValueBlock` implementations.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`HeapBlocks.js`:**
  - Modified the type check in `SetHeapEntryBlock.flow()` to only enforce `typeof args[0] !== "number"` (the heap index), allowing strings to be successfully stored.
  - Added `return JSON.stringify([]);` inside the `inStatusMatrix` branch of `HeapBlock.arg()`.
  - Added `return 0;` inside the `inStatusMatrix` branch of `HeapLengthBlock.arg()`.
- **`HeapBlocks.test.js`:**
  - Added focused Jest test cases to verify string storage is allowed in `SetHeapEntryBlock`.

---

## Steps to Reproduce

**Bug 1 (Set Heap Entry):**
1. Create a project with a `Set Heap` block.
2. Attempt to store a text string at any index. 
3. Observe that prior to this fix, it would erroneously throw a "Not a number" error.

**Bug 2 (Heap / Heap Length in Status Matrix):**
1. Open the Status widget.
2. Connect a `Heap` or `Heap Length` block to a `Print` block inside the `Status` block.
3. Play the project and verify it rendered "undefined".

## Visual Changes

<!-- If this PR introduces visual or UI changes, please provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- Added automated Jest tests to verify `SetHeapEntryBlock` handles strings successfully.
- Verified `npm test` passes successfully.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heap-related blocks now return stable values when used in status-matrix evaluations with print blocks.
  * Heap entries can now store non-numeric values while still requiring numeric indices.
* **Tests**
  * Updated coverage for status-matrix results and validation of heap entry indices and values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->