### PR TITLE
fix: return zero from graphics blocks in status matrix

### DIFF
--- a/js/blocks/GraphicsBlocks.js
+++ b/js/blocks/GraphicsBlocks.js
@@ -106,6 +106,7 @@ function setupGraphicsBlocks(activity) {
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "heading"]);
+                return 0;
             } else {
                 return activity.turtles.getTurtle(activity.turtles.companionTurtle(turtle))
                     .orientation;
@@ -191,6 +192,7 @@ function setupGraphicsBlocks(activity) {
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "y"]);
+                return 0;
             } else {
                 return activity.turtles.screenY2turtleY(
                     activity.turtles.getTurtle(activity.turtles.companionTurtle(turtle)).container.y
@@ -277,6 +279,7 @@ function setupGraphicsBlocks(activity) {
                 activity.blocks.blockList[parentId]?.name === "print"
             ) {
                 logo.statusFields.push([blk, "x"]);
+                return 0;
             } else {
                 return activity.turtles.screenX2turtleX(
                     activity.turtles.getTurtle(activity.turtles.companionTurtle(turtle)).container.x

--- a/js/blocks/__tests__/GraphicsBlocks.test.js
+++ b/js/blocks/__tests__/GraphicsBlocks.test.js
@@ -553,8 +553,9 @@ describe("GraphicsBlocks", () => {
                 1: { name: "print" }
             };
             const block = new activity.blocks.heading();
-            block.arg(logo, turtle, 0);
+            const res = block.arg(logo, turtle, 0);
             expect(logo.statusFields).toContainEqual([0, "heading"]);
+            expect(res).toBe(0);
         });
 
         test("XBlock pushes statusField when parent is print in status matrix", () => {
@@ -564,8 +565,9 @@ describe("GraphicsBlocks", () => {
                 1: { name: "print" }
             };
             const block = new activity.blocks.x();
-            block.arg(logo, turtle, 0);
+            const res = block.arg(logo, turtle, 0);
             expect(logo.statusFields).toContainEqual([0, "x"]);
+            expect(res).toBe(0);
         });
 
         test("YBlock pushes statusField when parent is print in status matrix", () => {
@@ -575,8 +577,9 @@ describe("GraphicsBlocks", () => {
                 1: { name: "print" }
             };
             const block = new activity.blocks.y();
-            block.arg(logo, turtle, 0);
+            const res = block.arg(logo, turtle, 0);
             expect(logo.statusFields).toContainEqual([0, "y"]);
+            expect(res).toBe(0);
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes a bug in `js/blocks/GraphicsBlocks.js` where `HeadingBlock`, `XBlock`, and `YBlock` would silently return `undefined` when operating in a status-matrix context. Since these are implementations of `ValueBlock`, they must always return a value. Returning `undefined` caused issues when these blocks were nested inside other blocks (like `Print` or mathematical operators) while rendering the Status widget. 

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`GraphicsBlocks.js`:** Added `return 0;` inside the `inStatusMatrix` logic path for `HeadingBlock.arg()`, `XBlock.arg()`, and `YBlock.arg()`.
- **`GraphicsBlocks.test.js`:** Added tests to ensure that `HeadingBlock`, `XBlock`, and `YBlock` correctly return `0` when evaluated within a status matrix context.

---

## Steps to Reproduce

1. Open the Status widget.
2. Connect a `Heading`, `X`, or `Y` block to a `Print` block inside the `Status` block.
3. Play the project.
4. Verify that it printed "undefined" before this fix, and will print "0" after.

## Visual Changes

<!-- If this PR introduces visual or UI changes, please provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- Added automated Jest tests specifically asserting the `arg()` output of these blocks when `inStatusMatrix` is active.
- Verified `npm test` passes successfully.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graphics block argument handlers now consistently return `0` when used within print blocks.
* **Tests**
  * Updated status-matrix coverage to verify the returned value alongside associated status fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->