### PR TITLE
fix: parse bpm input as float in tempo widget

### DIFF
--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -226,12 +226,13 @@ describe("Tempo Widget", () => {
             expect(mockActivity.errorMsg).toHaveBeenCalled();
         });
 
-        test("should accept valid BPM input", () => {
-            tempoWidget.BPMInputs[0].value = 120;
+        test("should accept valid BPM input and parse to a number", () => {
+            tempoWidget.BPMInputs[0].value = "120"; // DOM inputs return strings
 
             tempoWidget._useBPM(0);
 
             expect(tempoWidget.BPMs[0]).toBe(120);
+            expect(typeof tempoWidget.BPMs[0]).toBe("number");
             expect(tempoWidget._intervals[0]).toBe(500); // 60/120 * 1000 = 500ms
         });
 
@@ -241,6 +242,15 @@ describe("Tempo Widget", () => {
             tempoWidget._useBPM(0);
 
             expect(tempoWidget.BPMInputs[0].value).toBe(150);
+        });
+
+        test("should clamp empty string input to 30", () => {
+            tempoWidget.BPMInputs[0].value = "";
+
+            tempoWidget._useBPM(0);
+
+            expect(tempoWidget.BPMs[0]).toBe(30);
+            expect(mockActivity.errorMsg).toHaveBeenCalled();
         });
     });
 

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -312,7 +312,7 @@ class Tempo {
             return;
         }
 
-        this.BPMs[i] = this.BPMInputs[i].value;
+        this.BPMs[i] = Number(this.BPMInputs[i].value);
         if (this.BPMs[i] > 1000) {
             this.BPMs[i] = 1000;
             this.activity.errorMsg(_("The beats per minute must be between 30 and 1000."), 3000);


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes a bug in `js/widgets/tempo.js` where the user input for BPM was being read as a string. Because JavaScript's `+` operator performs string concatenation when one of the operands is a string, this caused subsequent calculations using the BPM value to produce incorrect results (e.g., `"120" + 10` resulting in `"12010"` instead of `130`). 

Following reviewer feedback, this fix ensures the input is properly coerced to a number using `Number()` (which correctly mirrors the semantics of the existing `isNaN()` guard and handles empty strings gracefully) before being passed to `_updateBPM`.

## Related Issue

<!-- Reference the specific issue using #issue_number (e.g., "Fixes #123"). -->

**Fixes:** #

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`tempo.js`:** Wrapped the input reading in `Number()` within the `_useBPM` function: `this.BPMs[i] = Number(this.BPMInputs[i].value);`. This fixes the string concatenation issue while ensuring `""` correctly coerces to `0` and clamps to `30`.
- **`tempo.test.js`:** Added tests to specifically verify that setting the BPM via the widget parses the input into a numeric type, including a regression test to ensure empty string inputs clamp to 30.

---

## Steps to Reproduce

1. Open the Tempo widget in the UI.
2. Enter a custom BPM value.
3. Use blocks that perform mathematical operations on the current tempo.
4. Notice that prior to this fix, the tempo might jump to unexpectedly huge numbers due to string concatenation.

## Visual Changes

<!-- If this PR introduces visual or UI changes, please provide before and after screenshots or videos. Remove this entire section if not applicable. -->

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- Added automated Jest tests to verify `_useBPM` successfully coerces string inputs to Numbers.
- Added a regression test specifically for `""` (empty string) to ensure it clamps safely to 30.
- Verified `npm test` passes successfully.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Updated in response to reviewer feedback replacing `parseFloat()` with `Number()` to eliminate the coercion gap that was causing `NaN` propagation on empty string inputs.
