### PR TITLE
feat(tempo): add keyboard shortcuts and ±1 BPM fine-tuning (#8601)

### DIFF
--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -958,6 +958,208 @@ describe("Tempo Widget", () => {
             );
         });
     });
+
+    describe("Keyboard shortcuts and fine-tuning (#8601)", () => {
+        test("speedUp() should support custom step for ±1 fine-tuning", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.BPMInputs = [{ value: 120 }];
+            tempoWidget._intervals = [500];
+
+            tempoWidget.speedUp(0, 1);
+            expect(tempoWidget.BPMs[0]).toBe(121);
+            expect(tempoWidget.BPMInputs[0].value).toBe(121);
+        });
+
+        test("slowDown() should support custom step for ±1 fine-tuning", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.BPMInputs = [{ value: 120 }];
+            tempoWidget._intervals = [500];
+
+            tempoWidget.slowDown(0, 1);
+            expect(tempoWidget.BPMs[0]).toBe(119);
+            expect(tempoWidget.BPMInputs[0].value).toBe(119);
+        });
+
+        test("togglePlayPause() should invoke pauseBtn.onclick when present", () => {
+            const mockClick = jest.fn();
+            tempoWidget.pauseBtn = { onclick: mockClick };
+
+            tempoWidget.togglePlayPause();
+            expect(mockClick).toHaveBeenCalledTimes(1);
+        });
+
+        test("togglePlayPause() should toggle moving state when pauseBtn is absent", () => {
+            tempoWidget.pauseBtn = null;
+            tempoWidget.isMoving = true;
+            const pauseSpy = jest.spyOn(tempoWidget, "pause").mockImplementation(() => {});
+            const resumeSpy = jest.spyOn(tempoWidget, "resume").mockImplementation(() => {});
+
+            tempoWidget.togglePlayPause();
+            expect(pauseSpy).toHaveBeenCalledTimes(1);
+            expect(tempoWidget.isMoving).toBe(false);
+
+            tempoWidget.togglePlayPause();
+            expect(resumeSpy).toHaveBeenCalledTimes(1);
+            expect(tempoWidget.isMoving).toBe(true);
+
+            pauseSpy.mockRestore();
+            resumeSpy.mockRestore();
+        });
+
+        test("init registers keydown listener on document and responds to fine/coarse shortcuts", () => {
+            const addEventSpy = jest.spyOn(document, "addEventListener");
+            const removeEventSpy = jest.spyOn(document, "removeEventListener");
+
+            tempoWidget.BPMs = [120];
+            tempoWidget.init(mockActivity);
+
+            expect(addEventSpy).toHaveBeenCalledWith("keydown", expect.any(Function), true);
+            expect(tempoWidget._keyHandler).toBeDefined();
+
+            const handler = tempoWidget._keyHandler;
+
+            // Fine speedUp with ArrowUp and ArrowRight (+1 BPM)
+            const upEvent = {
+                key: "ArrowUp",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEvent);
+            expect(upEvent.preventDefault).toHaveBeenCalled();
+            expect(upEvent.stopPropagation).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
+
+            const rightEvent = {
+                key: "ArrowRight",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(rightEvent);
+            expect(rightEvent.preventDefault).toHaveBeenCalled();
+            expect(rightEvent.stopPropagation).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(122);
+
+            // Fine slowDown with ArrowDown and ArrowLeft (-1 BPM)
+            const downEvent = {
+                key: "ArrowDown",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(downEvent);
+            expect(downEvent.preventDefault).toHaveBeenCalled();
+            expect(downEvent.stopPropagation).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
+
+            const leftEvent = {
+                key: "ArrowLeft",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(leftEvent);
+            expect(leftEvent.preventDefault).toHaveBeenCalled();
+            expect(leftEvent.stopPropagation).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            // Coarse speedUp with Shift + ArrowUp (+10%)
+            // 120 + round(0.1 * 120) = 120 + 12 = 132
+            const shiftUpEvent = {
+                key: "ArrowUp",
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(shiftUpEvent);
+            expect(tempoWidget.BPMs[0]).toBe(132);
+
+            // Coarse slowDown with Shift + ArrowDown (-10%)
+            // 132 - round(0.1 * 132) = 132 - 13 = 119
+            const shiftDownEvent = {
+                key: "ArrowDown",
+                shiftKey: true,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(shiftDownEvent);
+            expect(tempoWidget.BPMs[0]).toBe(119);
+
+            // Spacebar toggles playback
+            const toggleSpy = jest
+                .spyOn(tempoWidget, "togglePlayPause")
+                .mockImplementation(() => {});
+            const spaceEvent = {
+                key: " ",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(spaceEvent);
+            expect(spaceEvent.preventDefault).toHaveBeenCalled();
+            expect(spaceEvent.stopPropagation).toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
+            toggleSpy.mockRestore();
+
+            // Closing window cleans up keydown listener
+            tempoWidget.widgetWindow.onclose();
+            expect(removeEventSpy).toHaveBeenCalledWith("keydown", handler, true);
+            expect(tempoWidget._keyHandler).toBeNull();
+
+            addEventSpy.mockRestore();
+            removeEventSpy.mockRestore();
+        });
+
+        test("keydown listener ignores events when an input element is focused", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.init(mockActivity);
+
+            const handler = tempoWidget._keyHandler;
+            const inputEl = document.createElement("input");
+            document.body.appendChild(inputEl);
+            inputEl.focus();
+
+            const upEvent = {
+                key: "ArrowUp",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+
+            handler(upEvent);
+            expect(upEvent.preventDefault).not.toHaveBeenCalled();
+            expect(upEvent.stopPropagation).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            document.body.removeChild(inputEl);
+            tempoWidget.widgetWindow.onclose();
+        });
+
+        test("tracks activeBPMIndex on input and canvas interactions", () => {
+            tempoWidget.BPMs = [100, 200];
+            tempoWidget.BPMBlocks = [null, null];
+            tempoWidget.init(mockActivity);
+
+            expect(tempoWidget.activeBPMIndex).toBe(0);
+
+            // Simulate clicking second canvas
+            tempoWidget.tempoCanvases[1].onclick();
+            expect(tempoWidget.activeBPMIndex).toBe(1);
+
+            // Now shortcut should target index 1
+            const upEvent = {
+                key: "ArrowUp",
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            tempoWidget._keyHandler(upEvent);
+            expect(tempoWidget.BPMs[1]).toBe(201);
+            expect(tempoWidget.BPMs[0]).toBe(100);
+
+            tempoWidget.widgetWindow.onclose();
+        });
+    });
 });
 
 describe("Tempo widget cleanup on block deletion", () => {

--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -1159,6 +1159,197 @@ describe("Tempo Widget", () => {
 
             tempoWidget.widgetWindow.onclose();
         });
+
+        test("keydown listener supports keyCode fallbacks and code === 'Space'", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.init(mockActivity);
+            const handler = tempoWidget._keyHandler;
+
+            // keyCode 38 (Up)
+            const upKeyCodeEvent = {
+                keyCode: 38,
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upKeyCodeEvent);
+            expect(upKeyCodeEvent.preventDefault).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
+
+            // keyCode 39 (Right)
+            const rightKeyCodeEvent = {
+                keyCode: 39,
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(rightKeyCodeEvent);
+            expect(rightKeyCodeEvent.preventDefault).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(122);
+
+            // keyCode 40 (Down)
+            const downKeyCodeEvent = {
+                keyCode: 40,
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(downKeyCodeEvent);
+            expect(downKeyCodeEvent.preventDefault).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
+
+            // keyCode 37 (Left)
+            const leftKeyCodeEvent = {
+                keyCode: 37,
+                shiftKey: false,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(leftKeyCodeEvent);
+            expect(leftKeyCodeEvent.preventDefault).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            // code === "Space"
+            const toggleSpy = jest
+                .spyOn(tempoWidget, "togglePlayPause")
+                .mockImplementation(() => {});
+            const codeSpaceEvent = {
+                code: "Space",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(codeSpaceEvent);
+            expect(codeSpaceEvent.preventDefault).toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
+
+            // keyCode === 32
+            const keyCodeSpaceEvent = {
+                keyCode: 32,
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(keyCodeSpaceEvent);
+            expect(keyCodeSpaceEvent.preventDefault).toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(2);
+
+            toggleSpy.mockRestore();
+            tempoWidget.widgetWindow.onclose();
+        });
+
+        test("keydown listener ignores Space when a button or select element is focused", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.init(mockActivity);
+            const handler = tempoWidget._keyHandler;
+            const toggleSpy = jest
+                .spyOn(tempoWidget, "togglePlayPause")
+                .mockImplementation(() => {});
+
+            // Button focused
+            const buttonEl = document.createElement("button");
+            document.body.appendChild(buttonEl);
+            buttonEl.focus();
+
+            const spaceEvent1 = {
+                key: " ",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(spaceEvent1);
+            expect(spaceEvent1.preventDefault).not.toHaveBeenCalled();
+            expect(toggleSpy).not.toHaveBeenCalled();
+
+            document.body.removeChild(buttonEl);
+
+            // Select focused
+            const selectEl = document.createElement("select");
+            document.body.appendChild(selectEl);
+            selectEl.focus();
+
+            const spaceEvent2 = {
+                key: " ",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(spaceEvent2);
+            expect(spaceEvent2.preventDefault).not.toHaveBeenCalled();
+            expect(toggleSpy).not.toHaveBeenCalled();
+
+            // ArrowUp on select should also be ignored
+            const upEvent = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEvent);
+            expect(upEvent.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            document.body.removeChild(selectEl);
+            toggleSpy.mockRestore();
+            tempoWidget.widgetWindow.onclose();
+        });
+
+        test("keydown listener ignores events when another widget is focused or activeBlock exists", () => {
+            tempoWidget.BPMs = [120];
+            tempoWidget.init(mockActivity);
+            const handler = tempoWidget._keyHandler;
+
+            // Another widget focused
+            const otherWin = { _frame: document.createElement("div") };
+            window.widgetWindows.focused = otherWin;
+
+            const upEvent1 = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEvent1);
+            expect(upEvent1.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            window.widgetWindows.focused = tempoWidget.widgetWindow;
+
+            // Active workspace block
+            mockActivity.blocks.activeBlock = 5;
+            const upEvent2 = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEvent2);
+            expect(upEvent2.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+            mockActivity.blocks.activeBlock = null;
+
+            // Empty BPMs guard
+            tempoWidget.BPMs = [];
+            handler(upEvent2);
+            expect(upEvent2.preventDefault).not.toHaveBeenCalled();
+
+            tempoWidget.widgetWindow.onclose();
+        });
+
+        test("speedUp and slowDown with custom step respect 1000 and 30 boundaries", () => {
+            tempoWidget.BPMs = [1000];
+            tempoWidget.BPMInputs = [{ value: 1000 }];
+            tempoWidget.BPMBlocks = [null];
+            mockActivity.errorMsg = jest.fn();
+
+            tempoWidget.speedUp(0, 1);
+            expect(tempoWidget.BPMs[0]).toBe(1000);
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                "The beats per minute must be below 1000.",
+                3000
+            );
+
+            tempoWidget.BPMs[0] = 30;
+            tempoWidget.slowDown(0, 1);
+            expect(tempoWidget.BPMs[0]).toBe(30);
+            expect(mockActivity.errorMsg).toHaveBeenCalledWith(
+                "The beats per minute must be above 30",
+                3000
+            );
+        });
     });
 });
 

--- a/js/widgets/__tests__/tempo.test.js
+++ b/js/widgets/__tests__/tempo.test.js
@@ -26,35 +26,43 @@ const Tempo = require("../tempo.js");
 global._ = msg => msg; // Mock translation function
 global.getDrumSynthName = jest.fn();
 
-// Mock the Window Manager
-window.widgetWindows = {
-    windowFor: jest.fn().mockReturnValue({
-        clear: jest.fn(),
-        show: jest.fn(),
-        timerManager: {
-            setInterval: jest.fn().mockImplementation((cb, t) => setInterval(cb, t)),
-            clearInterval: jest.fn().mockImplementation(id => clearInterval(id)),
-            setTimeout: jest.fn().mockImplementation((cb, t) => setTimeout(cb, t)),
-            clearTimeout: jest.fn().mockImplementation(id => clearTimeout(id)),
-            clearAll: jest.fn()
-        },
-        addButton: jest.fn().mockReturnValue({ onclick: () => {} }),
-        addInputButton: jest.fn().mockImplementation(val => ({
-            value: val,
-            addEventListener: jest.fn()
-        })),
-        getWidgetBody: jest.fn().mockReturnValue({
-            appendChild: jest.fn(),
-            insertRow: jest.fn().mockReturnValue({
-                insertCell: jest.fn().mockReturnValue({
-                    appendChild: jest.fn(),
-                    setAttribute: jest.fn()
-                })
+const mockWidgetWindowInstance = {
+    clear: jest.fn(),
+    show: jest.fn(),
+    takeFocus: jest.fn().mockImplementation(function () {
+        window.widgetWindows.focused = mockWidgetWindowInstance;
+    }),
+    timerManager: {
+        setInterval: jest.fn().mockImplementation((cb, t) => setInterval(cb, t)),
+        clearInterval: jest.fn().mockImplementation(id => clearInterval(id)),
+        setTimeout: jest.fn().mockImplementation((cb, t) => setTimeout(cb, t)),
+        clearTimeout: jest.fn().mockImplementation(id => clearTimeout(id)),
+        clearAll: jest.fn()
+    },
+    addButton: jest.fn().mockReturnValue({ onclick: () => {} }),
+    addInputButton: jest.fn().mockImplementation(val => ({
+        value: val,
+        addEventListener: jest.fn()
+    })),
+    getWidgetBody: jest.fn().mockReturnValue({
+        appendChild: jest.fn(),
+        insertRow: jest.fn().mockReturnValue({
+            insertCell: jest.fn().mockReturnValue({
+                appendChild: jest.fn(),
+                setAttribute: jest.fn()
             })
-        }),
-        sendToCenter: jest.fn(),
-        onclose: jest.fn(),
-        destroy: jest.fn()
+        })
+    }),
+    sendToCenter: jest.fn(),
+    onclose: jest.fn(),
+    destroy: jest.fn()
+};
+
+window.widgetWindows = {
+    focused: mockWidgetWindowInstance,
+    windowFor: jest.fn().mockImplementation(() => {
+        window.widgetWindows.focused = mockWidgetWindowInstance;
+        return mockWidgetWindowInstance;
     })
 };
 // Mock Document (for creating the canvas)
@@ -73,6 +81,7 @@ describe("Tempo Widget", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         jest.useFakeTimers();
+        window.widgetWindows.focused = mockWidgetWindowInstance;
         tempoWidget = new Tempo();
 
         // Mock the Music Blocks Activity object
@@ -1018,7 +1027,7 @@ describe("Tempo Widget", () => {
 
             const handler = tempoWidget._keyHandler;
 
-            // Fine speedUp with ArrowUp and ArrowRight (+1 BPM)
+            // Fine speedUp with ArrowUp (+1 BPM)
             const upEvent = {
                 key: "ArrowUp",
                 shiftKey: false,
@@ -1030,6 +1039,7 @@ describe("Tempo Widget", () => {
             expect(upEvent.stopPropagation).toHaveBeenCalled();
             expect(tempoWidget.BPMs[0]).toBe(121);
 
+            // ArrowRight should NOT adjust tempo (left/right disabled per review)
             const rightEvent = {
                 key: "ArrowRight",
                 shiftKey: false,
@@ -1037,11 +1047,11 @@ describe("Tempo Widget", () => {
                 stopPropagation: jest.fn()
             };
             handler(rightEvent);
-            expect(rightEvent.preventDefault).toHaveBeenCalled();
-            expect(rightEvent.stopPropagation).toHaveBeenCalled();
-            expect(tempoWidget.BPMs[0]).toBe(122);
+            expect(rightEvent.preventDefault).not.toHaveBeenCalled();
+            expect(rightEvent.stopPropagation).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
 
-            // Fine slowDown with ArrowDown and ArrowLeft (-1 BPM)
+            // Fine slowDown with ArrowDown (-1 BPM)
             const downEvent = {
                 key: "ArrowDown",
                 shiftKey: false,
@@ -1051,8 +1061,9 @@ describe("Tempo Widget", () => {
             handler(downEvent);
             expect(downEvent.preventDefault).toHaveBeenCalled();
             expect(downEvent.stopPropagation).toHaveBeenCalled();
-            expect(tempoWidget.BPMs[0]).toBe(121);
+            expect(tempoWidget.BPMs[0]).toBe(120);
 
+            // ArrowLeft should NOT adjust tempo (left/right disabled per review)
             const leftEvent = {
                 key: "ArrowLeft",
                 shiftKey: false,
@@ -1060,8 +1071,8 @@ describe("Tempo Widget", () => {
                 stopPropagation: jest.fn()
             };
             handler(leftEvent);
-            expect(leftEvent.preventDefault).toHaveBeenCalled();
-            expect(leftEvent.stopPropagation).toHaveBeenCalled();
+            expect(leftEvent.preventDefault).not.toHaveBeenCalled();
+            expect(leftEvent.stopPropagation).not.toHaveBeenCalled();
             expect(tempoWidget.BPMs[0]).toBe(120);
 
             // Coarse speedUp with Shift + ArrowUp (+10%)
@@ -1160,7 +1171,7 @@ describe("Tempo Widget", () => {
             tempoWidget.widgetWindow.onclose();
         });
 
-        test("keydown listener supports keyCode fallbacks and code === 'Space'", () => {
+        test("keydown listener supports keyCode fallbacks, event.code, and code === 'Space'", () => {
             tempoWidget.BPMs = [120];
             tempoWidget.init(mockActivity);
             const handler = tempoWidget._keyHandler;
@@ -1176,7 +1187,7 @@ describe("Tempo Widget", () => {
             expect(upKeyCodeEvent.preventDefault).toHaveBeenCalled();
             expect(tempoWidget.BPMs[0]).toBe(121);
 
-            // keyCode 39 (Right)
+            // keyCode 39 (Right) should not be handled
             const rightKeyCodeEvent = {
                 keyCode: 39,
                 shiftKey: false,
@@ -1184,8 +1195,8 @@ describe("Tempo Widget", () => {
                 stopPropagation: jest.fn()
             };
             handler(rightKeyCodeEvent);
-            expect(rightKeyCodeEvent.preventDefault).toHaveBeenCalled();
-            expect(tempoWidget.BPMs[0]).toBe(122);
+            expect(rightKeyCodeEvent.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
 
             // keyCode 40 (Down)
             const downKeyCodeEvent = {
@@ -1196,9 +1207,9 @@ describe("Tempo Widget", () => {
             };
             handler(downKeyCodeEvent);
             expect(downKeyCodeEvent.preventDefault).toHaveBeenCalled();
-            expect(tempoWidget.BPMs[0]).toBe(121);
+            expect(tempoWidget.BPMs[0]).toBe(120);
 
-            // keyCode 37 (Left)
+            // keyCode 37 (Left) should not be handled
             const leftKeyCodeEvent = {
                 keyCode: 37,
                 shiftKey: false,
@@ -1206,7 +1217,26 @@ describe("Tempo Widget", () => {
                 stopPropagation: jest.fn()
             };
             handler(leftKeyCodeEvent);
-            expect(leftKeyCodeEvent.preventDefault).toHaveBeenCalled();
+            expect(leftKeyCodeEvent.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
+            // code === "ArrowUp" and code === "ArrowDown"
+            const codeUpEvent = {
+                code: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(codeUpEvent);
+            expect(codeUpEvent.preventDefault).toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(121);
+
+            const codeDownEvent = {
+                code: "ArrowDown",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(codeDownEvent);
+            expect(codeDownEvent.preventDefault).toHaveBeenCalled();
             expect(tempoWidget.BPMs[0]).toBe(120);
 
             // code === "Space"
@@ -1236,7 +1266,7 @@ describe("Tempo Widget", () => {
             tempoWidget.widgetWindow.onclose();
         });
 
-        test("keydown listener ignores Space when a button or select element is focused", () => {
+        test("keydown listener ignores Space and Arrow keys when a button or select element is focused", () => {
             tempoWidget.BPMs = [120];
             tempoWidget.init(mockActivity);
             const handler = tempoWidget._keyHandler;
@@ -1244,7 +1274,7 @@ describe("Tempo Widget", () => {
                 .spyOn(tempoWidget, "togglePlayPause")
                 .mockImplementation(() => {});
 
-            // Button focused
+            // Button focused: neither Space nor ArrowUp should trigger
             const buttonEl = document.createElement("button");
             document.body.appendChild(buttonEl);
             buttonEl.focus();
@@ -1258,9 +1288,18 @@ describe("Tempo Widget", () => {
             expect(spaceEvent1.preventDefault).not.toHaveBeenCalled();
             expect(toggleSpy).not.toHaveBeenCalled();
 
+            const upEventButton = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEventButton);
+            expect(upEventButton.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
+
             document.body.removeChild(buttonEl);
 
-            // Select focused
+            // Select focused: neither Space nor ArrowUp should trigger
             const selectEl = document.createElement("select");
             document.body.appendChild(selectEl);
             selectEl.focus();
@@ -1274,14 +1313,13 @@ describe("Tempo Widget", () => {
             expect(spaceEvent2.preventDefault).not.toHaveBeenCalled();
             expect(toggleSpy).not.toHaveBeenCalled();
 
-            // ArrowUp on select should also be ignored
-            const upEvent = {
+            const upEventSelect = {
                 key: "ArrowUp",
                 preventDefault: jest.fn(),
                 stopPropagation: jest.fn()
             };
-            handler(upEvent);
-            expect(upEvent.preventDefault).not.toHaveBeenCalled();
+            handler(upEventSelect);
+            expect(upEventSelect.preventDefault).not.toHaveBeenCalled();
             expect(tempoWidget.BPMs[0]).toBe(120);
 
             document.body.removeChild(selectEl);
@@ -1289,10 +1327,21 @@ describe("Tempo Widget", () => {
             tempoWidget.widgetWindow.onclose();
         });
 
-        test("keydown listener ignores events when another widget is focused or activeBlock exists", () => {
+        test("keydown listener ignores events when focus is null, another widget is focused, or activeBlock exists", () => {
             tempoWidget.BPMs = [120];
             tempoWidget.init(mockActivity);
             const handler = tempoWidget._keyHandler;
+
+            // Focus is null (e.g. user clicked on canvas or workspace)
+            window.widgetWindows.focused = null;
+            const upEvent0 = {
+                key: "ArrowUp",
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn()
+            };
+            handler(upEvent0);
+            expect(upEvent0.preventDefault).not.toHaveBeenCalled();
+            expect(tempoWidget.BPMs[0]).toBe(120);
 
             // Another widget focused
             const otherWin = { _frame: document.createElement("div") };
@@ -1342,6 +1391,10 @@ describe("Tempo Widget", () => {
                 3000
             );
 
+            // Default 10% coarse speedUp at boundary
+            tempoWidget.speedUp(0);
+            expect(tempoWidget.BPMs[0]).toBe(1000);
+
             tempoWidget.BPMs[0] = 30;
             tempoWidget.slowDown(0, 1);
             expect(tempoWidget.BPMs[0]).toBe(30);
@@ -1349,6 +1402,10 @@ describe("Tempo Widget", () => {
                 "The beats per minute must be above 30",
                 3000
             );
+
+            // Default 10% coarse slowDown at boundary
+            tempoWidget.slowDown(0);
+            expect(tempoWidget.BPMs[0]).toBe(30);
         });
     });
 });

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -49,6 +49,9 @@ class Tempo {
         this.BPMInputs = [];
         this.BPMBlocks = [];
         this.tempoCanvases = [];
+        this.activeBPMIndex = 0;
+        this._keyHandler = null;
+        this.pauseBtn = null;
     }
 
     init(activity) {
@@ -78,12 +81,21 @@ class Tempo {
             }
         }
 
+        if (this._keyHandler) {
+            document.removeEventListener("keydown", this._keyHandler, true);
+            this._keyHandler = null;
+        }
+
         const widgetWindow = window.widgetWindows.windowFor(this, "tempo", "tempo", true);
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
 
         widgetWindow.onclose = () => {
+            if (this._keyHandler) {
+                document.removeEventListener("keydown", this._keyHandler, true);
+                this._keyHandler = null;
+            }
             if (this._intervalID !== null) {
                 widgetWindow.timerManager.clearInterval(this._intervalID);
             }
@@ -91,6 +103,7 @@ class Tempo {
         };
 
         const pauseBtn = widgetWindow.addButton("pause-button.svg", Tempo.ICONSIZE, _("Pause"));
+        this.pauseBtn = pauseBtn;
         pauseBtn.onclick = () => {
             if (this.isMoving) {
                 this.pause();
@@ -176,6 +189,9 @@ class Tempo {
             )(i);
 
             this.BPMInputs[i] = widgetWindow.addInputButton(this.BPMs[i], r3.insertCell());
+            this.BPMInputs[i].addEventListener("focus", () => {
+                this.activeBPMIndex = i;
+            });
             this.tempoCanvases[i] = document.createElement("canvas");
             this.tempoCanvases[i].style.width = Tempo.TEMPOWIDTH + "px";
             this.tempoCanvases[i].style.height = Tempo.TEMPOHEIGHT + "px";
@@ -187,6 +203,7 @@ class Tempo {
 
             // The tempo can be set from the interval between successive clicks on the canvas.
             this.tempoCanvases[i].onclick = (id => () => {
+                this.activeBPMIndex = id;
                 const d = new Date();
                 let newBPM, BPMInput;
                 if (this._firstClickTime === null) {
@@ -208,12 +225,74 @@ class Tempo {
             this.BPMInputs[i].addEventListener(
                 "keyup",
                 (id => e => {
+                    this.activeBPMIndex = id;
                     if (e.key === "Enter") {
                         this._useBPM(id);
                     }
                 })(i)
             );
         }
+
+        this._keyHandler = event => {
+            const activeElement = document.activeElement;
+            if (
+                activeElement &&
+                (activeElement.tagName === "INPUT" ||
+                    activeElement.tagName === "TEXTAREA" ||
+                    activeElement.isContentEditable)
+            ) {
+                return;
+            }
+
+            if (!this.BPMs || this.BPMs.length === 0) {
+                return;
+            }
+
+            const id =
+                this.activeBPMIndex >= 0 && this.activeBPMIndex < this.BPMs.length
+                    ? this.activeBPMIndex
+                    : 0;
+
+            if (
+                event.key === "ArrowUp" ||
+                event.key === "ArrowRight" ||
+                event.keyCode === 38 ||
+                event.keyCode === 39
+            ) {
+                event.preventDefault();
+                event.stopPropagation();
+                if (event.shiftKey) {
+                    this.speedUp(id);
+                } else {
+                    this.speedUp(id, 1);
+                }
+                return;
+            }
+
+            if (
+                event.key === "ArrowDown" ||
+                event.key === "ArrowLeft" ||
+                event.keyCode === 40 ||
+                event.keyCode === 37
+            ) {
+                event.preventDefault();
+                event.stopPropagation();
+                if (event.shiftKey) {
+                    this.slowDown(id);
+                } else {
+                    this.slowDown(id, 1);
+                }
+                return;
+            }
+
+            if (event.key === " " || event.code === "Space" || event.keyCode === 32) {
+                event.preventDefault();
+                event.stopPropagation();
+                this.togglePlayPause();
+            }
+        };
+
+        document.addEventListener("keydown", this._keyHandler, true);
 
         this.activity.textMsg(_("Adjust the tempo with the buttons."), 3000);
         this.resume();
@@ -229,9 +308,12 @@ class Tempo {
     _updateBPM(i) {
         this._intervals[i] = (60 / this.BPMs[i]) * 1000;
 
-        if (this.BPMBlocks[i] === null) return;
+        if (!this.BPMBlocks || this.BPMBlocks[i] === null || this.BPMBlocks[i] === undefined) {
+            return;
+        }
 
         const bpmBlock = this.activity.blocks.blockList[this.BPMBlocks[i]];
+        if (!bpmBlock) return;
         const blockNumber = bpmBlock.connections[1];
         if (blockNumber !== null) {
             this.activity.blocks.blockList[blockNumber].value = parseFloat(this.BPMs[i]);
@@ -327,11 +409,29 @@ class Tempo {
 
     /**
      * @public
-     * @param {number} i
      * @returns {void}
      */
-    speedUp(i) {
-        this.BPMs[i] = parseFloat(this.BPMs[i]) + Math.round(0.1 * this.BPMs[i]);
+    togglePlayPause() {
+        if (this.pauseBtn && typeof this.pauseBtn.onclick === "function") {
+            this.pauseBtn.onclick();
+        } else if (this.isMoving) {
+            this.pause();
+            this.isMoving = false;
+        } else {
+            this.resume();
+            this.isMoving = true;
+        }
+    }
+
+    /**
+     * @public
+     * @param {number} i
+     * @param {number} [step]
+     * @returns {void}
+     */
+    speedUp(i, step) {
+        const delta = step !== undefined ? step : Math.round(0.1 * this.BPMs[i]);
+        this.BPMs[i] = parseFloat(this.BPMs[i]) + delta;
 
         if (this.BPMs[i] > 1000) {
             this.activity.errorMsg(_("The beats per minute must be below 1000."), 3000);
@@ -345,10 +445,12 @@ class Tempo {
     /**
      * @public
      * @param {number} i
+     * @param {number} [step]
      * @returns {void}
      */
-    slowDown(i) {
-        this.BPMs[i] = parseFloat(this.BPMs[i]) - Math.round(0.1 * this.BPMs[i]);
+    slowDown(i, step) {
+        const delta = step !== undefined ? step : Math.round(0.1 * this.BPMs[i]);
+        this.BPMs[i] = parseFloat(this.BPMs[i]) - delta;
         if (this.BPMs[i] < 30) {
             this.activity.errorMsg(_("The beats per minute must be above 30"), 3000);
             this.BPMs[i] = 30;

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -90,6 +90,9 @@ class Tempo {
         this.widgetWindow = widgetWindow;
         widgetWindow.clear();
         widgetWindow.show();
+        if (typeof widgetWindow.takeFocus === "function") {
+            widgetWindow.takeFocus();
+        }
 
         widgetWindow.onclose = () => {
             if (this._keyHandler) {
@@ -235,9 +238,8 @@ class Tempo {
 
         this._keyHandler = event => {
             if (
-                typeof window !== "undefined" &&
-                window.widgetWindows &&
-                window.widgetWindows.focused &&
+                typeof window === "undefined" ||
+                !window.widgetWindows ||
                 window.widgetWindows.focused !== widgetWindow
             ) {
                 return;
@@ -264,23 +266,7 @@ class Tempo {
 
             if (
                 activeElement &&
-                (activeElement.tagName === "BUTTON" || activeElement.tagName === "SELECT") &&
-                (event.key === " " || event.code === "Space" || event.keyCode === 32)
-            ) {
-                return;
-            }
-
-            if (
-                activeElement &&
-                activeElement.tagName === "SELECT" &&
-                (event.key === "ArrowUp" ||
-                    event.key === "ArrowDown" ||
-                    event.key === "ArrowLeft" ||
-                    event.key === "ArrowRight" ||
-                    event.keyCode === 38 ||
-                    event.keyCode === 40 ||
-                    event.keyCode === 37 ||
-                    event.keyCode === 39)
+                (activeElement.tagName === "BUTTON" || activeElement.tagName === "SELECT")
             ) {
                 return;
             }
@@ -294,12 +280,7 @@ class Tempo {
                     ? this.activeBPMIndex
                     : 0;
 
-            if (
-                event.key === "ArrowUp" ||
-                event.key === "ArrowRight" ||
-                event.keyCode === 38 ||
-                event.keyCode === 39
-            ) {
+            if (event.key === "ArrowUp" || event.code === "ArrowUp" || event.keyCode === 38) {
                 event.preventDefault();
                 event.stopPropagation();
                 if (event.shiftKey) {
@@ -310,12 +291,7 @@ class Tempo {
                 return;
             }
 
-            if (
-                event.key === "ArrowDown" ||
-                event.key === "ArrowLeft" ||
-                event.keyCode === 40 ||
-                event.keyCode === 37
-            ) {
+            if (event.key === "ArrowDown" || event.code === "ArrowDown" || event.keyCode === 40) {
                 event.preventDefault();
                 event.stopPropagation();
                 if (event.shiftKey) {

--- a/js/widgets/tempo.js
+++ b/js/widgets/tempo.js
@@ -234,12 +234,53 @@ class Tempo {
         }
 
         this._keyHandler = event => {
+            if (
+                typeof window !== "undefined" &&
+                window.widgetWindows &&
+                window.widgetWindows.focused &&
+                window.widgetWindows.focused !== widgetWindow
+            ) {
+                return;
+            }
+
+            if (
+                this.activity &&
+                this.activity.blocks &&
+                this.activity.blocks.activeBlock !== null &&
+                this.activity.blocks.activeBlock !== undefined
+            ) {
+                return;
+            }
+
             const activeElement = document.activeElement;
             if (
                 activeElement &&
                 (activeElement.tagName === "INPUT" ||
                     activeElement.tagName === "TEXTAREA" ||
                     activeElement.isContentEditable)
+            ) {
+                return;
+            }
+
+            if (
+                activeElement &&
+                (activeElement.tagName === "BUTTON" || activeElement.tagName === "SELECT") &&
+                (event.key === " " || event.code === "Space" || event.keyCode === 32)
+            ) {
+                return;
+            }
+
+            if (
+                activeElement &&
+                activeElement.tagName === "SELECT" &&
+                (event.key === "ArrowUp" ||
+                    event.key === "ArrowDown" ||
+                    event.key === "ArrowLeft" ||
+                    event.key === "ArrowRight" ||
+                    event.keyCode === 38 ||
+                    event.keyCode === 40 ||
+                    event.keyCode === 37 ||
+                    event.keyCode === 39)
             ) {
                 return;
             }


### PR DESCRIPTION
## Description

Addresses and fixes #8601.
Following up on keyboard accessibility improvements across widgets (such as PitchSlider #8518 and MusicKeyboard #8375), this PR adds an encapsulated keyboard listener and fine-tuning controls to the Tempo (metronome) widget:
- Up and down buttons previously only jumped by coarse 10% steps (`Math.round(0.1 * BPM)`). Users wanting exact increments (e.g. 120 -> 121 BPM) had to click and type into the input field manually.
- The metronome play/pause button lacked a keyboard shortcut.
- The widget now encapsulates its own keyboard listener adhering to the pattern used in modern widgets.

## Related Issue

**Fixes:** #8601

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [x] Feature — Adds new functionality
- [x] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **Fine-Tuning Controls (`speedUp` & `slowDown` in `js/widgets/tempo.js`):**
  - Updated `speedUp(i, step)` and `slowDown(i, step)` to take an optional `step` parameter.
  - When `step` is provided (e.g. `1`), it applies the exact BPM delta.
  - When `step` is omitted, it retains the existing `Math.round(0.1 * this.BPMs[i])` (+10% / -10%) behavior for 100% backward compatibility.
- **Encapsulated `keydown` Listener:**
  - `ArrowUp` / `ArrowRight` (without Shift): Fine-tune BPM (+1 BPM).
  - `ArrowDown` / `ArrowLeft` (without Shift): Fine-tune BPM (-1 BPM).
  - `Shift + ArrowUp` / `Shift + ArrowRight`: Coarse-tune BPM (+10%).
  - `Shift + ArrowDown` / `Shift + ArrowLeft`: Coarse-tune BPM (-10%).
  - `Space`: Toggle Pause / Resume playback via `togglePlayPause()`.
- **Accessibility & Safety:**
  - **Typing Safety:** Ignored when `document.activeElement` is an `<input>`, `<textarea>`, or contenteditable element so typing numbers or navigating within the BPM text input is uninterrupted.
  - **Multi-BPM Support:** Automatically tracks `activeBPMIndex` across input focus and canvas interactions.
  - **Lifecycle Cleanup:** Keydown listener is cleanly removed on `widgetWindow.onclose` via `document.removeEventListener("keydown", this._keyHandler, true)`.
  - **Defensive Null-Safety:** Added null/undefined checks in `_updateBPM(i)` for `BPMBlocks` array and block lookup.
- **Unit Testing (`js/widgets/__tests__/tempo.test.js`):**
  - Added comprehensive test suite with 7 dedicated test cases covering ±1 BPM fine-tuning, coarse-tuning, spacebar playback toggle, input typing safety, active index tracking, and `onclose` cleanup.

---

## Testing Performed

- **Unit Tests:** `npx jest js/widgets/__tests__/tempo.test.js` (all 80 tests passed).
- **Integration Tests:** `npx jest js/activity/__tests__/keyboard-controller.test.js` (all 32 tests passed).
- **Linter:** `npx eslint js/widgets/tempo.js js/widgets/__tests__/tempo.test.js` (0 errors, 0 warnings).
- **Formatter:** `npx prettier --check js/widgets/tempo.js js/widgets/__tests__/tempo.test.js` (100% compliant).

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Encapsulating the listener inside `tempo.js` in capture phase (`useCapture: true`) and cleaning it up on `widgetWindow.onclose` mirrors the implementation in `PitchSlider` (PR #8518), preventing memory leaks and avoiding side effects on global workspace block movement.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard controls to adjust BPM with ArrowUp and ArrowDown.
  - Added Space bar support to toggle play and pause.
  - Added single-step BPM adjustments for finer control.

- **Bug Fixes**
  - Keyboard shortcuts now respond only when the Tempo widget is focused.
  - Shortcuts are ignored while buttons, selectors, or active blocks are focused.
  - BPM adjustments remain within valid minimum and maximum limits.
  - Improved handling when no BPM block is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->