### PR TITLE
fix(blocks): remove disposed block from spatial grid to prevent stale-index crash

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -1726,6 +1726,47 @@ describe("Blocks Foundation", () => {
             expect(blocks.blockList[0].connections[1]).toBeNull();
         });
 
+        it("does not throw when the spatial grid holds a stale index for a disposed block (#8610)", async () => {
+            blocks.blockList = [
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 0,
+                    docks: [
+                        [0, 0, "in"],
+                        [0, 20, "out"]
+                    ],
+                    connections: [null, null],
+                    name: "target"
+                }),
+                makeRealFlowBlock({
+                    x: 0,
+                    y: 15,
+                    docks: [[0, 0, "in"]],
+                    connections: [null],
+                    name: "moving"
+                })
+            ];
+            blocks._rebuildSpatialGrid();
+
+            // Simulate a grid left out of sync with blockList by some path other
+            // than disposeBlock (which is now fixed to clean up after itself) --
+            // this is the defense-in-depth guard's own regression case.
+            blocks.blockList[2] = null;
+            let cellSet = blocks._spatialGrid.get("0,0");
+            if (!cellSet) {
+                cellSet = new Set();
+                blocks._spatialGrid.set("0,0", cellSet);
+            }
+            cellSet.add(2);
+
+            // Would throw TypeError: Cannot read properties of null (reading
+            // 'inCollapsed') without the guard in block-drag-controller.js.
+            await blocks.blockMoved(1);
+
+            // The real, live target block should still be found and connected to.
+            expect(blocks.blockList[1].connections[0]).toBe(0);
+        });
+
         it("exposes the same BlockDragController instance to every delegated method", () => {
             expect(blocks.blockDragController).toBeDefined();
             expect(blocks.findDragGroup).not.toBe(blocks.blockDragController.findDragGroup);
@@ -2287,6 +2328,43 @@ describe("Spatial grid indexing", () => {
         expect(cellsHolding(1)).toEqual(["100,100"]);
         expect(blocks._getNearbyBlocks(0, 0)).not.toContain(1);
         expect(blocks._getNearbyBlocks(5000, 5000)).toContain(1);
+    });
+
+    describe("disposeBlock (#8610)", () => {
+        it("removes the disposed block from the spatial grid, not just blockList", () => {
+            blocks.blockList[1].dispose = jest.fn();
+
+            // Sanity check: before disposal, both blocks share the (0,0) cell.
+            expect(blocks._getNearbyBlocks(0, 0)).toEqual(expect.arrayContaining([0, 1]));
+
+            blocks.disposeBlock(1);
+
+            expect(blocks.blockList[1]).toBeNull();
+            expect(cellsHolding(1)).toEqual([]);
+            expect(blocks._blockGridCell.has(1)).toBe(false);
+            expect(blocks._getNearbyBlocks(0, 0)).not.toContain(1);
+        });
+
+        it("leaves the grid alone when the target has already been disposed", () => {
+            blocks.blockList[1].dispose = jest.fn();
+            blocks.disposeBlock(1);
+            const gridSizeAfterFirstDispose = blocks._spatialGrid.size;
+
+            // A second call on the same (now-null) index must be a no-op --
+            // it should not throw and should not touch the other block's entry.
+            expect(() => blocks.disposeBlock(1)).not.toThrow();
+            expect(blocks._spatialGrid.size).toBe(gridSizeAfterFirstDispose);
+            expect(cellsHolding(0)).toEqual(["0,0"]);
+        });
+
+        it("does not disturb the grid entry of a block left in the same cell", () => {
+            blocks.blockList[1].dispose = jest.fn();
+
+            blocks.disposeBlock(1);
+
+            expect(cellsHolding(0)).toEqual(["0,0"]);
+            expect(blocks._getNearbyBlocks(0, 0)).toEqual([0]);
+        });
     });
 
     describe("when the index arrives as a string", () => {

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -2365,6 +2365,17 @@ describe("Spatial grid indexing", () => {
             expect(cellsHolding(0)).toEqual(["0,0"]);
             expect(blocks._getNearbyBlocks(0, 0)).toEqual([0]);
         });
+
+        it("empty-grid fallback also skips an undefined slot, not just a disposed (null) one", () => {
+            // The fallback used to test `!== null`, which would still return
+            // a hole/undefined slot -- only disposeBlock's exact `null`
+            // assignment happened to be caught. Use a truthiness check
+            // instead so any missing entry is excluded.
+            blocks._spatialGrid.clear();
+            blocks.blockList[1] = undefined;
+
+            expect(blocks._getNearbyBlocks(0, 0)).toEqual([0]);
+        });
     });
 
     describe("when the index arrives as a string", () => {

--- a/js/activity/block-drag-controller.js
+++ b/js/activity/block-drag-controller.js
@@ -422,6 +422,14 @@ class BlockDragController {
                 continue;
             }
 
+            /** Skip an index the spatial grid returned for a block that no
+             *  longer exists (defense in depth alongside the fix for #8610:
+             *  disposeBlock keeps the grid in sync, but this guard protects
+             *  against any future path that forgets to). */
+            if (!blocks.blockList[b]) {
+                continue;
+            }
+
             /** Don't connect to a collapsed block. */
             if (blocks.blockList[b].inCollapsed) {
                 continue;

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -315,6 +315,27 @@ class Blocks {
         };
 
         /**
+         * Removes a block index from every spatial-grid cell it currently
+         * occupies, per _blockGridCell. Leaves the _blockGridCell entry
+         * itself untouched; callers that are relocating the block overwrite
+         * it with the new cells right after, callers that are removing the
+         * block for good (e.g. disposeBlock) delete it explicitly.
+         * @param {number} idx - Block index, already normalized to a number
+         * @returns {void}
+         */
+        this._removeFromSpatialGrid = idx => {
+            const oldKeys = this._blockGridCell.get(idx);
+            if (!oldKeys) return;
+            for (const oldKey of oldKeys) {
+                const oldSet = this._spatialGrid.get(oldKey);
+                if (oldSet) {
+                    oldSet.delete(idx);
+                    if (oldSet.size === 0) this._spatialGrid.delete(oldKey);
+                }
+            }
+        };
+
+        /**
          * Updates the spatial grid position for a given block index.
          * Registers the block in every cell that any of its dock
          * positions falls into, so that nearby-dock searches always
@@ -362,16 +383,7 @@ class Blocks {
                 if (same) return;
             }
 
-            // Remove from all old cells
-            if (oldKeys) {
-                for (const oldKey of oldKeys) {
-                    const oldSet = this._spatialGrid.get(oldKey);
-                    if (oldSet) {
-                        oldSet.delete(idx);
-                        if (oldSet.size === 0) this._spatialGrid.delete(oldKey);
-                    }
-                }
-            }
+            this._removeFromSpatialGrid(idx);
 
             // Add to all new cells
             for (const key of newKeys) {
@@ -6823,6 +6835,12 @@ class Blocks {
             if (this.blockCollapseArt && this.blockCollapseArt[blkIdx]) {
                 delete this.blockCollapseArt[blkIdx];
             }
+            // The block is gone for good, so drop it from the spatial grid too --
+            // otherwise _getNearbyBlocks keeps handing out this index after
+            // blockList[blkIdx] has been nulled out below (issue #8610).
+            const idx = Number(blkIdx);
+            this._removeFromSpatialGrid(idx);
+            this._blockGridCell.delete(idx);
             this.blockList[blkIdx] = null;
         };
 

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -409,7 +409,9 @@ class Blocks {
             if (this._spatialGrid.size === 0) {
                 const all = [];
                 for (let i = 0; i < this.blockList.length; i++) {
-                    all.push(i);
+                    if (this.blockList[i] !== null) {
+                        all.push(i);
+                    }
                 }
                 return all;
             }

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -409,7 +409,7 @@ class Blocks {
             if (this._spatialGrid.size === 0) {
                 const all = [];
                 for (let i = 0; i < this.blockList.length; i++) {
-                    if (this.blockList[i] !== null) {
+                    if (this.blockList[i]) {
                         all.push(i);
                     }
                 }


### PR DESCRIPTION
## Description

`disposeBlock()` nulls out `blockList[blkIdx]` but never touches the spatial grid (`_spatialGrid`/`_blockGridCell`) that backs `_getNearbyBlocks`, the O(1) nearest-dock lookup added in #7207. Every other block-relocation path in `js/blocks.js` keeps the grid in sync; `disposeBlock` was the one that got missed. This means the grid can keep handing out an index whose `blockList` slot is `null`, and `block-drag-controller.js` dereferences that index with no null check, so dragging a block near a disposed block's old position throws a `TypeError` mid-drag.

## Related Issue

**Fixes:** #8610

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [x] Tests — Adds or updates test coverage

## Changes Made

- Extracted the "remove from all old cells" logic already in `_updateSpatialGrid` into a small `_removeFromSpatialGrid(idx)` helper, so it's not duplicated.
- `disposeBlock` now calls `_removeFromSpatialGrid` and deletes the `_blockGridCell` entry before nulling `blockList[blkIdx]`, so a disposed block's index stops showing up in `_getNearbyBlocks` results.
- Added a defensive `if (!blocks.blockList[b]) continue;` check in `block-drag-controller.js`'s dock-search loop, as belt-and-suspenders in case a future mutation path forgets to keep the grid in sync the way `disposeBlock` now does.

## Steps to Reproduce

1. Two blocks sharing a spatial-grid cell, e.g. both with `container: { x: 0, y: 0 }`.
2. Call `disposeBlock` on one of them (this is what `sendStackToTrash` does automatically once `trashStacks.length` exceeds `MAX_TRASH_UNDO`, 100 trashed stacks in one session).
3. Call `_getNearbyBlocks(0, 0)` again. Before this fix it still returns the disposed index, and dereferencing `blockList[thatIndex]` throws.

## Testing Performed

- Added a `disposeBlock (#8610)` test group in `js/__tests__/blocks.test.js` covering: the index is removed from both `_spatialGrid` and `_blockGridCell` on disposal, a second `disposeBlock` call on an already-disposed index is a safe no-op, and a still-live block in the same cell is left untouched.
- Added an end-to-end regression test in the existing "Block dragging via the real BlockDragController" suite that manually desyncs the grid (simulating some other path forgetting to clean up) and drives a real `blockMoved()` call through it, asserting it no longer throws and still finds the correct, live dock.
- Full suite runs, both green:
  - `js/__tests__/blocks.test.js`: 106/106 passed
  - `js/activity/__tests__/block-drag-controller.test.js`: 61/61 passed
- `npx eslint js/blocks.js js/activity/block-drag-controller.js js/__tests__/blocks.test.js`: clean
- `npx prettier --check` on the same files: clean

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

## Additional Notes

This is scoped to the disposal path only. `_updateSpatialGrid`'s string-vs-number key handling (#8475/#8476) and the unrelated `meterwidget.js` disposal guard (#8281/#8283) are separate, already-fixed bugs and aren't touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block-dragging stability when spatial data contains outdated references.
  * Fixed disposed blocks remaining discoverable during nearby-block checks.
  * Prevented errors when interacting with blocks after disposal.
  * Repeatedly disposing a block is now handled safely.
  * Preserved the correct behavior of neighboring blocks when another block is disposed.
  * Excluded missing or disposed blocks from empty-grid fallback results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->