### PR TITLE
fix(munsell): parse rgba formatted candidates in searchColors

### DIFF
--- a/js/utils/__tests__/munsell.test.js
+++ b/js/utils/__tests__/munsell.test.js
@@ -99,6 +99,14 @@ describe("munsell", () => {
             const nearestColor = getcolor(color);
             expect(nearestColor[2]).toMatch(/^#[0-9a-fA-F]{6}$/);
         });
+
+        it("should correctly identify a color that uses rgba format", () => {
+            // Color 37 returns an rgba string from getcolor
+            const c = getcolor(37)[2];
+            const [, r, g, b] = c.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+            const color = searchColors(+r, +g, +b);
+            expect(color).toBe(37);
+        });
     });
 });
 

--- a/js/utils/munsell.js
+++ b/js/utils/munsell.js
@@ -6838,9 +6838,17 @@ let searchColors = (r, g, b) => {
     let distance = 10000000;
     for (let i = 0; i < 100; i++) {
         const color = getcolor(i);
-        const r1 = parseInt(color[2].substr(1, 2), 16);
-        const g1 = parseInt(color[2].substr(3, 2), 16);
-        const b1 = parseInt(color[2].substr(5, 2), 16);
+        let r1, g1, b1;
+        if (color[2].charAt(0) === "#") {
+            r1 = parseInt(color[2].substr(1, 2), 16);
+            g1 = parseInt(color[2].substr(3, 2), 16);
+            b1 = parseInt(color[2].substr(5, 2), 16);
+        } else {
+            const match = color[2].match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+            r1 = parseInt(match[1], 10);
+            g1 = parseInt(match[2], 10);
+            b1 = parseInt(match[3], 10);
+        }
         const distSquared = (r1 - r) * (r1 - r) + (g1 - g) * (g1 - g) + (b1 - b) * (b1 - b);
         if (distSquared < distance) {
             distance = distSquared;


### PR DESCRIPTION


 Description:

`searchColors` in `js/utils/munsell.js` previously assumed candidate colors were hex strings (`#rrggbb`). Intermediate values returned `rgba(...)` strings, causing `parseInt` to yield `NaN` and making 80 of the 100 candidate colors unreachable. This PR updates `searchColors` to support both `#` hex and `rgba(...)` string formats.


 Related Issue:

Fixes: #8422 

 Category:



- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation



 Changes Made:

`js/utils/munsell.js`: Updated `searchColors` to parse `rgba(...)` strings in addition to `#rrggbb` hex.
`js/utils/__tests__/munsell.test.js`: Added unit test for `rgba` candidate parsing.


 Steps to Reproduce:
```
const m = require("./js/utils/munsell.js");
const c = m.getColor(37)[2]; // returns rgba() string
const [, r, g, b] = c.match(/rgba?\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
console.log(m.searchColors(+r, +g, +b)); // Returns 37 (was 35)
```



Visual Changes:

i created a temporary test.js file for it, here are the outcomes for it.

Before:

<img width="647" height="202" alt="Screenshot 2026-09-09 004907" src="https://github.com/user-attachments/assets/985a48a7-7bef-48e8-85af-ec03caad02b4" />


After:

<img width="492" height="155" alt="Screenshot 2026-09-09 004852" src="https://github.com/user-attachments/assets/f2c06b5a-7b66-4e27-9cf4-77569ed8a83f" />


 Testing Performed:

Verified searchColors identifies rgba() candidates locally.
Added unit test in munsell.test.js.



Checklist:



- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).


Additional Notes:
None

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Color search now correctly matches colors returned in `rgb()` or `rgba()` format, in addition to hexadecimal values.

- **Tests**
  - Added coverage to verify color searches work with RGB-formatted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->