### PR TITLE
test(jseditor): cover the syntax error highlighting path

### DIFF
--- a/js/widgets/__tests__/jseditor.test.js
+++ b/js/widgets/__tests__/jseditor.test.js
@@ -854,4 +854,168 @@ describe("JSEditor", () => {
             expect(editor._currentStyle).toBe(0);
         });
     });
+    // -----------------------------------------------------------------------
+    // Syntax error highlighting
+    //
+    // _highlightErrors runs the buffer through acorn and, when it throws,
+    // widens the reported character position out to the whole token so the
+    // marker covers something the user can see rather than one character.
+    // -----------------------------------------------------------------------
+
+    describe("syntax error highlighting", () => {
+        /** An editor element whose textContent is `code`. */
+        const editorWith = code => {
+            const el = document.createElement("div");
+            el.textContent = code;
+            document.body.appendChild(el);
+            return el;
+        };
+
+        /** Run _markErrorAtPosition and report the span it asked for. */
+        const spanFor = (editor, code, position) => {
+            const el = editorWith(code);
+            const spy = jest.spyOn(editor, "_markErrorSpan").mockImplementation(() => {});
+            editor._markErrorAtPosition(el, position, "boom");
+            const call = spy.mock.calls[0];
+            spy.mockRestore();
+            return { start: call[1], end: call[2], text: code.slice(call[1], call[2]) };
+        };
+
+        beforeEach(() => {
+            // The outer beforeEach rebuilds document.body (including the
+            // overlayCanvas the constructor reads), so only the injected
+            // stylesheet needs clearing here.
+            const existing = document.getElementById("js-error-styles");
+            if (existing) existing.remove();
+        });
+
+        describe("_addErrorStyles", () => {
+            test("injects the stylesheet once", () => {
+                const editor = createEditor();
+
+                editor._addErrorStyles();
+                const first = document.getElementById("js-error-styles");
+                expect(first).not.toBeNull();
+                expect(first.tagName).toBe("STYLE");
+
+                editor._addErrorStyles();
+                expect(document.querySelectorAll("#js-error-styles")).toHaveLength(1);
+                expect(document.getElementById("js-error-styles")).toBe(first);
+            });
+
+            test("defines the .error rule the markers rely on", () => {
+                const editor = createEditor();
+                editor._addErrorStyles();
+
+                expect(document.getElementById("js-error-styles").textContent).toContain(".error");
+            });
+        });
+
+        describe("_markErrorAtPosition widens to the whole token", () => {
+            test("expands both ways from inside a word", () => {
+                const editor = createEditor();
+                // position 8 is the "r" of "varx"; the marker should cover the word.
+                expect(spanFor(editor, "let a = varx;", 10).text).toBe("varx");
+            });
+
+            test("stops at the start of the string", () => {
+                const editor = createEditor();
+                const span = spanFor(editor, "banana", 3);
+                expect(span.start).toBe(0);
+                expect(span.end).toBe(6);
+            });
+
+            test.each([
+                [" ", "space"],
+                ["\n", "newline"],
+                ["\t", "tab"],
+                [";", "semicolon"],
+                ["{", "open brace"],
+                ["}", "close brace"],
+                ["(", "open paren"],
+                [")", "close paren"],
+                [",", "comma"]
+            ])("treats %s as a token boundary (%s)", delimiter => {
+                const editor = createEditor();
+                const code = `aa${delimiter}target${delimiter}bb`;
+                // Start inside "target" and check the delimiters bound it.
+                expect(spanFor(editor, code, 5).text).toBe("target");
+            });
+
+            test("falls back to a single character when the position is on a delimiter", () => {
+                const editor = createEditor();
+                // Delimiters on both sides: the left scan sees ";" before the
+                // position and the right scan sees ";" at it, so both stop
+                // immediately and the span would be zero width. It is widened
+                // to one character instead.
+                const span = spanFor(editor, "a;;b", 2);
+                expect(span.start).toBe(2);
+                expect(span.end).toBe(3);
+            });
+
+            test("does not run past the end of the buffer", () => {
+                const editor = createEditor();
+                // The delimiter is the last character, so the one-character
+                // fallback has nothing to widen into.
+                const span = spanFor(editor, "ab;", 3);
+                expect(span.end).toBeLessThanOrEqual(3);
+            });
+        });
+
+        describe("_highlightErrors", () => {
+            test("clears markers from a previous run before re-parsing", () => {
+                const editor = createEditor();
+                const el = editorWith("");
+                el.innerHTML = 'ok <span class="error">bad</span> tail';
+                acorn.parse.mockImplementation(() => {});
+
+                editor._highlightErrors(el);
+
+                expect(el.querySelectorAll(".error")).toHaveLength(0);
+                // The text survives; only the wrapper goes.
+                expect(el.textContent).toContain("bad");
+            });
+
+            test("marks the token when acorn reports a position", () => {
+                const editor = createEditor();
+                const el = editorWith("let a = ;");
+                const spy = jest.spyOn(editor, "_markErrorAtPosition").mockImplementation(() => {});
+                acorn.parse.mockImplementation(() => {
+                    const e = new Error("Unexpected token");
+                    e.pos = 8;
+                    throw e;
+                });
+
+                editor._highlightErrors(el);
+
+                expect(spy).toHaveBeenCalledWith(el, 8, "Unexpected token");
+                spy.mockRestore();
+            });
+
+            test("marks nothing when the error carries no position", () => {
+                const editor = createEditor();
+                const el = editorWith("let a = ;");
+                const spy = jest.spyOn(editor, "_markErrorAtPosition").mockImplementation(() => {});
+                acorn.parse.mockImplementation(() => {
+                    throw new Error("no position on this one");
+                });
+
+                expect(() => editor._highlightErrors(el)).not.toThrow();
+                expect(spy).not.toHaveBeenCalled();
+                spy.mockRestore();
+            });
+
+            test("leaves a clean buffer alone", () => {
+                const editor = createEditor();
+                const el = editorWith("let a = 1;");
+                const spy = jest.spyOn(editor, "_markErrorAtPosition").mockImplementation(() => {});
+                acorn.parse.mockImplementation(() => {});
+
+                editor._highlightErrors(el);
+
+                expect(spy).not.toHaveBeenCalled();
+                spy.mockRestore();
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Description

`js/widgets/jseditor.js` sat at **41.84% of branches** with 30 of its 59
functions never executed. The whole syntax-error path was part of that —
`_addErrorStyles`, `_highlightErrors` and `_markErrorAtPosition` had no tests
at all.

No production code changes.

## Related Issue

**Fixes:** _n/a — coverage work, no issue filed._

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`_markErrorAtPosition`** is the interesting one. acorn reports a single
character offset, and this walks outwards from it to the surrounding token so
the marker covers something the user can actually see. Covered:

- expands both ways from inside a word
- stops at each of the **nine** delimiters (space, newline, tab, `;`, `{`, `}`,
  `(`, `)`, `,`) — one parameterised case per delimiter
- clamps at the start and the end of the buffer
- widens a zero-width span to one character when the position has delimiters on
  both sides

**`_highlightErrors`** — clears markers left by the previous run (keeping the
text, dropping only the wrapper), marks when acorn supplies `error.pos`, and
marks nothing when it doesn't.

**`_addErrorStyles`** — injects its stylesheet exactly once, and defines the
`.error` rule the markers depend on.

## Testing Performed

| | before | after |
|---|---|---|
| Statements | 72.85% (502/689) | **76.63%** (528/689) |
| Branches | 41.84% (77/184) | **55.97%** (103/184) |
| Functions | 49.15% (29/59) | **54.23%** (32/59) |
| Lines | 74.24% | 78.16% |

Checked against mutations rather than only run — each fails only the tests
that assert that behaviour:

| mutation | tests that catch it |
|---|---|
| drop the one-character widening | falls back to a single character… |
| make `_addErrorStyles` non-idempotent | injects the stylesheet once |
| invert the `error.pos` guard | both `_highlightErrors` position cases |

One note on the zero-width case, since the obvious test for it is wrong:
`"a;b"` at position 1 still expands left over `"a"`, because the left scan
reads the character *before* the position rather than at it. The real case
needs delimiters on both sides, so the test uses `"a;;b"` at position 2.

Full suite **235 suites, 9137 tests, all passing**. ESLint and Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for JavaScript editor syntax-error highlighting.
  * Verified error styling, token selection, delimiter handling, and behavior for errors with or without positions.
  * Confirmed existing error markers are cleared and clean editor content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->