### PR TITLE
fix(blockfactory): include the porch in the basicClamp cache key

### DIFF
--- a/js/__tests__/blockfactory.test.js
+++ b/js/__tests__/blockfactory.test.js
@@ -239,6 +239,54 @@ describe("SVG Class", () => {
         });
     });
 
+    // -----------------------------------------------------------------------
+    // Cache key completeness
+    //
+    // basicClamp() memoises its SVG against a key built from the properties
+    // that change the drawing. A property that alters the output but is absent
+    // from the key makes the first variant rendered win for every later one.
+    // -----------------------------------------------------------------------
+
+    describe("basicClamp cache key", () => {
+        /** A clamp with the given porch setting, everything else equal. */
+        const clampWithPorch = porch => {
+            const s = new SVG();
+            s.setInnies([true, true]);
+            if (porch) {
+                s.setPorch(true);
+            }
+            return s.basicClamp();
+        };
+
+        it("draws a porched clamp differently from an unporched one", () => {
+            // _style() at line 1547 emits a porch only when this._porch is set,
+            // so the two must not be byte-identical whichever order they are
+            // generated in.
+            jest.resetModules();
+            const porched = clampWithPorch(true);
+            const plain = clampWithPorch(false);
+
+            expect(porched).not.toBe(plain);
+        });
+
+        it("does not serve an unporched clamp from a porched cache entry", () => {
+            jest.resetModules();
+            const porchedFirst = clampWithPorch(true);
+            const plainSecond = clampWithPorch(false);
+
+            expect(plainSecond).not.toBe(porchedFirst);
+        });
+
+        it("keeps memoising when the porch setting is unchanged", () => {
+            // The fix must not defeat the cache for identical inputs.
+            jest.resetModules();
+            const first = clampWithPorch(true);
+            const second = clampWithPorch(true);
+
+            expect(second).toBe(first);
+        });
+    });
+
     describe("Dock Coordinate Rounding (Regression Tests)", () => {
         const BLOCKSCALES = [
             0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 3.25, 3.5, 3.75, 4.0

--- a/js/blockfactory.js
+++ b/js/blockfactory.js
@@ -1505,6 +1505,8 @@ class SVG {
             "|" +
             (this._bool ? 1 : 0) +
             "|" +
+            (this._porch ? 1 : 0) +
+            "|" +
             this._clampCount +
             "|" +
             JSON.stringify(this._clampSlots) +


### PR DESCRIPTION
## Description

`basicClamp()` memoises its generated SVG against a cache key built from the
properties that change the drawing — but the key omits `this._porch`, even
though the drawing reads it:

```js
if (i === 0 && this._porch) {
    svg += this._doPorch(false);
}
```

So two clamps that are identical in every keyed property but differ in porch
share one cache entry, and **whichever is drawn first supplies the artwork for
both**.

## Related Issue

**Fixes:** _n/a — found by comparing each cache key against the properties its
method actually reads._

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Steps to Reproduce

1. Build a clamp block with `_porch` unset and render it through `basicClamp()`.
2. Build a second clamp identical in every property the cache key covers, but
   with `_porch` set.
3. Render the second and compare the two SVG strings.

```
unporched drawn first, then porched   ->  byte-identical, 1876 chars
porched drawn first, then unporched   ->  byte-identical, 1923 chars
```

4. Both orderings collapse to a single output — whichever is drawn first
   supplies the artwork for both. The 47-character difference between the two
   runs is the porch itself, so a real difference in the drawing is being lost,
   not a no-op.

## Changes Made

Adds `(this._porch ? 1 : 0)` to the key, in the same style as the `_slot`,
`_tab`, `_outie` and `_bool` entries beside it.

I checked the other three cached methods in this file for the same fault, by
comparing each key against the properties its body reads:

| method | key prefix | verdict |
|---|---|---|
| `_style()` | `bb` | no state property missing |
| `booleanCompare()` | `boolcmp` | no state property missing |
| `argClamp()` | `ac` | omits `_cap`, but its output is **verified to differ correctly either ordering**, so `_cap` is already captured through another keyed value — left alone |
| `basicClamp()` | `bc` | omits `_porch` — **this fix** |

## Testing Performed

Three tests in `js/__tests__/blockfactory.test.js`. Restoring `blockfactory.js`
from `master`, **two fail**:

```
✕ draws a porched clamp differently from an unporched one
✕ does not serve an unporched clamp from a porched cache entry
```

The third — `keeps memoising when the porch setting is unchanged` — passes on
both, and is there so the fix cannot be "fixed" by simply defeating the cache.

Full suite **235 suites, 9129 tests, all passing**. ESLint and Prettier clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed clamp rendering so cached results correctly distinguish between porched and unporched configurations.
  - Ensured identical porch settings continue to reuse cached renderings while different settings produce the correct SVG output.

- **Tests**
  - Added coverage verifying clamp cache behavior across generation order and porch configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->