### PR TITLE
fix(synthutils): restore linting for the second half of the file

### DIFF
--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -1798,7 +1798,6 @@ function Synth() {
      * @returns {Tone.Instrument|null} - The loaded synth or null if not loaded.
      */
     this.loadSynth = async (turtle, sourceName) => {
-        /* eslint-disable */
         sourceName = this.resolveInstrumentName(sourceName);
         if (sourceName.substring(0, 13) === "customsample_") {
             console.debug("loading custom " + sourceName);
@@ -1863,13 +1862,11 @@ function Synth() {
         }
 
         if (needsFreqConversion()) {
-            if (typeof notes === "number") {
-                notes = notes;
-            } else {
+            if (typeof notes !== "number") {
                 const notes1 = notes;
                 notes = this._getFrequency(notes, this.changeInTemperament);
                 if (notes === undefined) {
-                    if (notes1.substring(1, notes1.length - 1) == DOUBLEFLAT) {
+                    if (notes1.substring(1, notes1.length - 1) === DOUBLEFLAT) {
                         notes = notes1.substring(0, 1) + "bb" + notes1.substring(notes1.length - 1);
                     } else if (notes1.substring(1, notes1.length - 1) === DOUBLESHARP) {
                         notes = notes1.substring(0, 1) + "x" + notes1.substring(notes1.length - 1);
@@ -2471,6 +2468,7 @@ function Synth() {
                 instruments[turtle][instrumentName].stop();
                 break;
             default:
+                // eslint-disable-next-line eqeqeq -- loose on purpose, catches null and undefined
                 if (note == undefined) {
                     instruments[turtle][instrumentName].triggerRelease();
                 } else {
@@ -2487,6 +2485,7 @@ function Synth() {
         const flag = instrumentsSource[instrumentName][0];
         const now = Tone.now();
         const loopA = new Tone.Loop(time => {
+            // eslint-disable-next-line eqeqeq -- flag comes from instrumentsSource and may be "1"
             if (flag == 1) {
                 this.setVolume(turtle, instrumentName, velocity * 100);
                 instruments[turtle][instrumentName].start();
@@ -3145,10 +3144,6 @@ function Synth() {
                                 activityProxy.logo = logo;
 
                                 const tempBlock = {
-                                    container: {
-                                        x: targetNoteSelector.offsetLeft,
-                                        y: targetNoteSelector.offsetTop
-                                    },
                                     activity: activityProxy,
                                     blocks: {
                                         blockList: [


### PR DESCRIPTION
## Description

`loadSynth` opens with a bare `/* eslint-disable */` and **nothing re-enables
it**, so every rule is off from line 1801 to the end of the file — **2258 lines,
55% of `synthutils.js`**.

Removing it surfaces five problems, two of them errors:

```
no-self-assign  1866  `notes` is assigned to itself
no-dupe-keys    3189  duplicate key 'container'
eqeqeq          1871, 2473, 2489
```

## Related Issue

**Fixes:** _n/a — found by auditing the file-level eslint-disable directives._

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Steps to Reproduce

1. Run `npx eslint js/utils/synthutils.js` on master — it reports 0 problems.
2. Delete the bare `/* eslint-disable */` on line 1801.
3. Run eslint again. Five problems appear, two of them errors:

```
no-self-assign  1866  `notes` is assigned to itself
no-dupe-keys    3189  duplicate key 'container'
eqeqeq          1871, 2473, 2489
```

4. Every one of them sits between line 1801 and the end of the file — 2258
   lines, 55% of `synthutils.js` — which is the span the directive had been
   silencing, because nothing re-enables it.

---

## Changes Made

Each finding is addressed on its own terms rather than blanket-fixed:

**`notes = notes`** sat alone in the `typeof notes === "number"` branch, which
did nothing else. The branch is dropped and the condition inverted, so the code
now reads the way it always behaved.

**The duplicate `container` key** on `tempBlock` declared `{x, y}` first and
`{x, y, setChildIndex}` second. A later key wins, so the surviving value already
carried `setChildIndex` and behaviour does not change. The dead first
declaration is removed — and leaving it is the actual hazard, because the
natural way to resolve a duplicate is to keep the *first* one, which would drop
`setChildIndex` and break `container.setChildIndex()`.

**`notes1.substring(...) == DOUBLEFLAT`** compares two strings, so `==` and
`===` agree — and the very next branch already uses `===` for `DOUBLESHARP`.
Tightened so the pair is consistent.

**The other two comparisons are deliberate** and keep `==`, with a targeted
`eslint-disable-next-line eqeqeq` and a stated reason: `note == undefined` is
the loose-null idiom, and `flag` comes from `instrumentsSource` where it may be
the string `"1"`.

## Testing Performed

- `npx eslint js/utils/synthutils.js` is **clean with the blanket disable gone**,
  so the file is covered by linting again rather than exempt.
- Verified the surviving `container` object is identical to what the duplicate
  resolved to, including `setChildIndex`.
- Full suite **235 suites, 9126 tests, all passing**. Prettier clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric note values during frequency conversion.
  * Ensured stricter matching when identifying double-flat notes.

* **Maintenance**
  * Clarified intentional comparison behavior in sound playback controls.
  * Removed redundant tuner menu configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->