### PR TITLE
fix(turtle): let media follow the turtle instead of a property that is never set

### DIFF
--- a/js/__tests__/turtle-painter.test.js
+++ b/js/__tests__/turtle-painter.test.js
@@ -501,11 +501,15 @@ describe("Drawing - doForward", () => {
         expect(mockTurtle.container.x).toBe(startX + 20);
     });
 
-    test("doForward should trigger view media position updates if view exists", () => {
-        const mockView = { _updateMediaPositions: jest.fn() };
-        mockTurtle._view = mockView;
+    test("doForward repositions the turtle's media", () => {
+        mockTurtle._updateMediaPositions = jest.fn();
         painter.doForward(10);
-        expect(mockView._updateMediaPositions).toHaveBeenCalled();
+        expect(mockTurtle._updateMediaPositions).toHaveBeenCalled();
+    });
+
+    test("doForward does not throw when the turtle has no media hook", () => {
+        delete mockTurtle._updateMediaPositions;
+        expect(() => painter.doForward(10)).not.toThrow();
     });
 });
 
@@ -964,11 +968,15 @@ describe("doSetXY operations", () => {
         expect(mockTurtle.ctx.beginPath).not.toHaveBeenCalled();
     });
 
-    test("doSetXY should trigger view update if view exists", () => {
-        const mockView = { _updateMediaPositions: jest.fn() };
-        mockTurtle._view = mockView;
+    test("doSetXY repositions the turtle's media", () => {
+        mockTurtle._updateMediaPositions = jest.fn();
         painter.doSetXY(100, 200);
-        expect(mockView._updateMediaPositions).toHaveBeenCalled();
+        expect(mockTurtle._updateMediaPositions).toHaveBeenCalled();
+    });
+
+    test("doSetXY does not throw when the turtle has no media hook", () => {
+        delete mockTurtle._updateMediaPositions;
+        expect(() => painter.doSetXY(100, 200)).not.toThrow();
     });
 
     test("doSetXY should handle NaN or Infinity gracefully", () => {

--- a/js/turtle-painter.js
+++ b/js/turtle-painter.js
@@ -920,9 +920,8 @@ class Painter {
             this._scheduleCanvasUpdate();
         }
         // Update media positions
-        const view = this.turtle._view;
-        if (view && typeof view._updateMediaPositions === "function") {
-            view._updateMediaPositions();
+        if (typeof this.turtle._updateMediaPositions === "function") {
+            this.turtle._updateMediaPositions();
         }
     }
 
@@ -989,9 +988,8 @@ class Painter {
 
         this._move(ox, oy, nx, ny, true);
         this._scheduleCanvasUpdate();
-        const view = this.turtle._view;
-        if (view && typeof view._updateMediaPositions === "function") {
-            view._updateMediaPositions();
+        if (typeof this.turtle._updateMediaPositions === "function") {
+            this.turtle._updateMediaPositions();
         }
     }
 


### PR DESCRIPTION
## Description

`doForward` and `doSetXY` both end by trying to reposition the turtle's media:

```js
const view = this.turtle._view;
if (view && typeof view._updateMediaPositions === "function") {
    view._updateMediaPositions();
}
```

Nothing in the repository ever assigns `_view`. `grep -rn "\._view\b" js` returns
exactly two lines, and both are these reads. So `view` is always `undefined`, the
guard is always false, and `_updateMediaPositions` is never called.

`_updateMediaPositions` is a real method on `Turtle` (`js/turtle.js:810`). It walks
`this._media` and moves each GIF and `createjs.Bitmap` to the turtle's current
position and orientation. `_media` is genuinely populated — `js/turtle.js:772`
pushes GIF entries, `:793` pushes bitmaps, `:979` pushes text — so the work it
does is wanted.

The user-visible effect: media placed with the Media block stays where it was put
while the turtle moves away from it. `doForward` and `doSetXY` are the two main
ways a turtle moves, so this covers ordinary movement.

Both `_view` and `_updateMediaPositions` were added in the same commit, b5e49f24e
*"Add animated GIF support to Media Block (Fixes #4560) (#4859)"*, so this has not
worked since the feature landed.

## Related Issue

**Fixes:** #

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

`this.turtle` is the `Turtle` itself (`Painter` constructor, line 78), so it already
carries the method — the hop through `_view` was never needed:

```js
if (typeof this.turtle._updateMediaPositions === "function") {
    this.turtle._updateMediaPositions();
}
```

The `typeof` guard is kept because the painter's unit tests construct turtle mocks
that do not define it.

## Steps to Reproduce

1. Place a Media block with an image or animated GIF.
2. Move the turtle with Forward, or with Set XY.
3. The media stays at its original position instead of travelling with the turtle.

---

## Testing Performed

`npx jest` — 235 suites, 9128 tests, all passing.
`npm run lint` and `npx prettier --check` — both clean.

The two existing tests for this path passed only because each one first did
`mockTurtle._view = { _updateMediaPositions: jest.fn() }`, creating the property
that production never creates, and then asserted against that object. They now
drive the turtle's own method, and two added cases cover a turtle without the hook.

Both call sites were mutation-checked: restoring the `_view` indirection fails
`doForward repositions the turtle's media` and `doSetXY repositions the turtle's
media`, and nothing else.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The dead branch was found with a script that lists properties compared against but
never assigned anywhere in `js/`; `_view` was the only project-internal one that
survived filtering, and checking it by hand turned up the missing assignment.

Claude was used to help investigate and write this change. Every claim above was
checked against the source, and the test suite was run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media positioning after moving or repositioning a turtle.
  * Prevented errors when media-position update support is unavailable.
  * Added coverage to verify media positions update correctly after movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->