### PR TITLE
test(js-export): catch the three ast2blocks copies drifting apart

### DIFF
--- a/js/js-export/__tests__/config-sync.test.js
+++ b/js/js-export/__tests__/config-sync.test.js
@@ -1,0 +1,104 @@
+/**
+ * MusicBlocks v3.7.1
+ *
+ * @copyright 2026 Kunal Kumar
+ *
+ * @license
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * `ast2blocks.json` is the source of truth for the AST-to-block mappings, but
+ * it is not what runs. The JS editor loads `ast2blocks.config.js`
+ * (js/loader.js:230, js/widgets/jseditor.js:998), and `ast2blocks.min.json`
+ * is a third copy.
+ *
+ * Nothing currently checks that the three agree. `minify.test.js` mocks `fs`
+ * and only asserts that minify.js calls readFileSync/writeFileSync with the
+ * right arguments, and `ast2blocklist.test.js` reads `ast2blocks.json`
+ * directly. So a mapping added to the JSON alone passes every test while the
+ * editor keeps using the old table.
+ *
+ * These tests compare the parsed values rather than the file text, because
+ * `ast2blocks.config.js` is pretty-printed by hand and is deliberately not
+ * byte-identical to minify.js's output.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DIR = path.join(__dirname, "..");
+const readJSON = name => JSON.parse(fs.readFileSync(path.join(DIR, name), "utf8"));
+
+/** Evaluate ast2blocks.config.js the way a browser would and hand back the object. */
+const loadConfigJS = () => {
+    const text = fs.readFileSync(path.join(DIR, "ast2blocks.config.js"), "utf8");
+    const sandbox = {};
+    new Function("window", text)(sandbox);
+    return sandbox.ast2blocklist_config;
+};
+
+/** Every leaf path where two objects disagree, so a failure names the mapping. */
+const diffPaths = (a, b, prefix = "") => {
+    const out = [];
+    const isObj = v => typeof v === "object" && v !== null;
+    if (!isObj(a) || !isObj(b)) {
+        if (JSON.stringify(a) !== JSON.stringify(b)) {
+            out.push(`${prefix || "<root>"}: json=${JSON.stringify(a)} other=${JSON.stringify(b)}`);
+        }
+        return out;
+    }
+    for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        out.push(...diffPaths(a[key], b[key], prefix ? `${prefix}.${key}` : key));
+    }
+    return out;
+};
+
+describe("ast2blocks config copies stay in sync", () => {
+    const source = readJSON("ast2blocks.json");
+
+    test("ast2blocks.config.js holds the same mappings as ast2blocks.json", () => {
+        const config = loadConfigJS();
+        expect(config).toBeDefined();
+        expect(diffPaths(source, config)).toEqual([]);
+    });
+
+    test("ast2blocks.min.json holds the same mappings as ast2blocks.json", () => {
+        expect(diffPaths(source, readJSON("ast2blocks.min.json"))).toEqual([]);
+    });
+
+    test("ast2blocks.min.json is exactly what minify.js would write", () => {
+        // This one may be byte-compared: minify.js writes JSON.stringify output
+        // and nothing hand-edits the .min.json.
+        const expected = JSON.stringify(source);
+        const actual = fs.readFileSync(path.join(DIR, "ast2blocks.min.json"), "utf8").trim();
+        expect(actual).toBe(expected);
+    });
+
+    test("every name in the getter tables maps to a non-empty block name", () => {
+        const bad = [];
+        const walk = (node, trail) => {
+            if (Array.isArray(node)) {
+                node.forEach((v, i) => walk(v, `${trail}[${i}]`));
+            } else if (node && typeof node === "object") {
+                for (const [k, v] of Object.entries(node)) {
+                    if (typeof v === "string") {
+                        if (/^[A-Z][A-Z0-9_]*$/.test(k) && v.trim() === "") {
+                            bad.push(`${trail}.${k}`);
+                        }
+                    } else {
+                        walk(v, `${trail}.${k}`);
+                    }
+                }
+            }
+        };
+        walk(source, "");
+        expect(bad).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Description

`js/js-export/ast2blocks.json` is the source of truth for the AST-to-block
mappings, but it is not the file that runs. The JS editor loads
**`ast2blocks.config.js`**:

```
js/loader.js:230            "activity/js-export/ast2blocks.config": { ... }
js/widgets/jseditor.js:998  ["activity/js-export/ast2blocks.config"]
```

and `ast2blocks.min.json` is a third copy. All three agree today. Nothing
checks that they keep agreeing.

Neither existing test can notice a drift:

- `__tests__/ast2blocklist.test.js:33` reads `ast2blocks.json` directly.
- `__tests__/minify.test.js` opens with `jest.mock("fs")`, so it only asserts
  that `minify.js` calls `readFileSync`/`writeFileSync` with the right
  arguments. It never compares the committed artifacts against the source.

So a mapping added to the JSON alone passes the entire suite while the editor
carries on using the old table.

## Related Issue

**Fixes:** _n/a — found while reading how the js-export config is loaded._

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

One new file, `js/js-export/__tests__/config-sync.test.js`, with four tests:

1. `ast2blocks.config.js` holds the same parsed mappings as `ast2blocks.json`.
2. `ast2blocks.min.json` holds the same parsed mappings as `ast2blocks.json`.
3. `ast2blocks.min.json` is byte-for-byte what `minify.js` would write.
4. No `SHOUTY_CASE` getter name maps to an empty block name.

The first two compare **parsed values, not file text**, and that is deliberate.
`ast2blocks.config.js` is pretty-printed with unquoted keys — 96,984 characters
against the 63,387 `minify.js` would emit — so it is not byte-identical to the
generator's output even though its content matches exactly. A textual
comparison would fail today and would push people towards reformatting the file
rather than fixing the mapping.

Test 3 may safely be byte-compared, since nothing hand-edits `.min.json`.

A failure names the offending mapping rather than dumping the whole object:

```
argument_blocks.10.name_map.CURRENTKEY: json="key" other="currentkey"
argument_blocks.10.name_map.HEADING: json="heading" other=undefined
argument_blocks.10.name_map.MASTERVOLUME: json="notevolumefactor" other=undefined
```

---

## Testing Performed

`npx jest` — 236 suites, 9130 tests, all passing.
`npm run lint` and `npx prettier --check` — both clean.

Verified against a real case rather than a synthetic one. Applying only the
`ast2blocks.json` half of a pending mapping change leaves
`ast2blocklist.test.js` at **24 passed** and `minify.test.js` at **2 passed**,
while these four fail with the diagnostic above. Reverting restores all four.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This adds no mappings and changes no behaviour — it only pins the invariant that
the three copies agree, so the next person to edit one of them finds out before
review rather than after merge.

Claude was used to help investigate and write this. Every claim above was
checked against the source, and the suite was run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure MusicBlocks mapping files remain consistent.
  * Added validation that minified mapping data matches the generated source exactly.
  * Added coverage to verify getter-table entries map to valid, non-empty block names.
  * Added checks to detect missing mapping entries and confirm differences are reported accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->