### PR TITLE
fix(musicutils): add missing named interval ratios to equal17

### DIFF
--- a/js/utils/__tests__/musicutils.test.js
+++ b/js/utils/__tests__/musicutils.test.js
@@ -321,9 +321,42 @@ describe("Temperament Functions", () => {
             expect(equal5Temperament).toHaveProperty("pitchNumber", 5);
         });
 
+        it("should return the correct temperament for equal17 key", () => {
+            const equal17Temperament = getTemperament("equal17");
+            expect(equal17Temperament).toHaveProperty("perfect 1");
+            expect(equal17Temperament).toHaveProperty("minor 2");
+            expect(equal17Temperament).toHaveProperty("pitchNumber", 17);
+        });
+
         it("should return undefined for an invalid key", () => {
             const invalidTemperament = getTemperament("invalid");
             expect(invalidTemperament).toBeUndefined();
+        });
+    });
+
+    describe("named interval lookups", () => {
+        // The temperament widget fills its ratio, cents, and frequency columns
+        // with getTemperamentRatio(t[t.interval[i]]). When a temperament omits
+        // the named interval keys, every lookup is undefined and the widget
+        // silently falls back to a ratio of 1 for every pitch.
+        const widgetRatios = key => {
+            const t = getTemperament(key);
+            return t.interval.map(name => getTemperamentRatio(t[name]));
+        };
+
+        it.each(["equal", "equal5", "equal7", "equal17", "equal19", "equal31"])(
+            "%s resolves every name in its interval array to a distinct ratio",
+            key => {
+                const ratios = widgetRatios(key);
+                expect(new Set(ratios).size).toBe(ratios.length);
+            }
+        );
+
+        it("equal17 named intervals match its ratios table and close the octave", () => {
+            const t = getTemperament("equal17");
+            const ratios = widgetRatios("equal17");
+            expect(ratios.slice(0, t.ratios.length)).toEqual(t.ratios);
+            expect(ratios[ratios.length - 1]).toBe(2);
         });
     });
 

--- a/js/utils/musicutils.js
+++ b/js/utils/musicutils.js
@@ -2509,11 +2509,11 @@ const TEMPERAMENT = {
         ]
     },
     "equal17": {
-        isEDO: true,
-        edo: 17,
-        name: "Equal (17EDO)",
-        description: "17 Equal Divisions of the Octave",
-        ratios: [
+        "isEDO": true,
+        "edo": 17,
+        "name": "Equal (17EDO)",
+        "description": "17 Equal Divisions of the Octave",
+        "ratios": [
             1,
             Math.pow(2, 1 / 17),
             Math.pow(2, 2 / 17),
@@ -2532,9 +2532,27 @@ const TEMPERAMENT = {
             Math.pow(2, 15 / 17),
             Math.pow(2, 16 / 17)
         ],
-        octaveRatio: 2,
-        pitchNumber: 17,
-        interval: [
+        "octaveRatio": 2,
+        "pitchNumber": 17,
+        "perfect 1": Math.pow(2, 0 / 17),
+        "minor 2": Math.pow(2, 1 / 17),
+        "augmented 1": Math.pow(2, 2 / 17),
+        "minor 3": Math.pow(2, 3 / 17),
+        "major 2": Math.pow(2, 4 / 17),
+        "augmented 2": Math.pow(2, 5 / 17),
+        "major 3": Math.pow(2, 6 / 17),
+        "perfect 4": Math.pow(2, 7 / 17),
+        "augmented 4": Math.pow(2, 8 / 17),
+        "diminished 5": Math.pow(2, 9 / 17),
+        "perfect 5": Math.pow(2, 10 / 17),
+        "augmented 5": Math.pow(2, 11 / 17),
+        "minor 6": Math.pow(2, 12 / 17),
+        "major 6": Math.pow(2, 13 / 17),
+        "augmented 6": Math.pow(2, 14 / 17),
+        "minor 7": Math.pow(2, 15 / 17),
+        "major 7": Math.pow(2, 16 / 17),
+        "perfect 8": Math.pow(2, 17 / 17),
+        "interval": [
             "perfect 1",
             "minor 2",
             "augmented 1",


### PR DESCRIPTION
## Description

`equal17` is the only entry in `TEMPERAMENT` (`js/utils/musicutils.js`) that defines no named interval keys (`"perfect 1"`, `"minor 2"`, ...). Every other temperament including `equal19` and `equal31` provides all of them.

The Temperament widget fills its ratio, cents and frequency columns by looking those names up:

```js
// js/widgets/temperament.js:2674
this.ratios[i] = getTemperamentRatio(t[this.intervals[i]]);
```

Because `equal17` has no such keys, every lookup is `undefined`, and `getTemperamentRatio` silently falls back to `return 1`. Opening the Temperament widget on **Equal (17EDO)** therefore renders 18 unisons — every row shows ratio `1.00`, `0` cents and the same frequency.

Note playback is **not** affected: `equal17` sets `isEDO: true`, so `pitchToFrequency` derives frequencies from `pitchNumber` and never consults these keys. The bug is confined to the widget.

## Related Issue

No existing issue found while auditing the temperament tables. Happy to open one first if maintainers prefer that order.

**Fixes:** N/A

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

**`js/utils/musicutils.js`**

Added the 18 named intervals referenced by `equal17`'s own `interval` array, mapping each to its consecutive 17-EDO step (`Math.pow(2, n / 17)`) exactly how `equal19` and `equal31` are already defined.

The property-name quoting churn in this file is required rather than cosmetic: adding keys that contain spaces makes prettier's `"quoteProps": "consistent"` rule demand quotes on every key in the object. That is why all the other temperaments already use quoted names, and it brings `equal17` in line with them.

Deliberately **not** changed: the ordering of names inside `equal17`'s `interval` array. `equal19` shows the same kind of deviation from strict chain-of-fifths naming while still producing correct widget output, so "names map to consecutive steps in `interval[]` order" is the established convention here. Following it keeps this fix surgical, and the resulting ratios are correct either way.

**`js/utils/__tests__/musicutils.test.js`**

- an `equal17` case alongside the existing `equal` / `equal5` `getTemperament` assertions
- a `named interval lookups` block that replays the widget's own lookup across all six EDO temperaments and asserts each resolves to a distinct ratio

---

## Steps to Reproduce

1. `npm run serve:dev` and open `http://127.0.0.1:3000`
2. Drag out a **temperament** block (Widgets palette) and set its name argument to **Equal (17EDO)**
3. Press **Play** to open the Temperament widget
4. Click the **table** icon in the widget toolbar to switch to the Table of Notes

**Before:** all 18 rows show ratio `1.00`, `0` cents and an identical frequency.
**After:** ratios ascend `1.00 → 2.00` with rising cents and frequencies.

The same collapse is visible without the UI:

```
equal:   13 entries, 13 distinct   1.000 1.059 1.122 ... 2.000   OK
equal17: 18 entries,  1 distinct   1.000 1.000 1.000 ... 1.000   BUG
equal19: 20 entries, 20 distinct                                 OK
equal31: 32 entries, 32 distinct                                 OK
```

## Visual Changes

### Before

<!-- Paste/drop before screenshot here -->

### After

<!-- Paste/drop after screenshot here -->

---

## Testing Performed

- `npm run lint` — clean
- `npx prettier --check` on both changed files — clean
- `npm test` — 234/235 suites, 9148/9149 tests pass

Confirmed the new test actually catches the bug rather than merely passing: with the source change reverted, exactly one test fails (`equal17`, `Expected: 18, Received: 1`) while the other five EDO temperaments still pass.

The single remaining suite failure is **pre-existing on `master` and unrelated** to this change: `synthutils.test.js` › `_getFrequency across various temperaments and input types` sets `synth.inTemperament = "19-EDO"`, which is not a valid `TEMPERAMENT` key (the real key is `equal19`), so `_getFrequency` returns `undefined`. Verified identical with and without this change by stashing.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

`equal17` was introduced in #7807 as a side addition to an unrelated accidentals fix. It appears to have been written fresh rather than copied from a sibling temperament — its property names were unquoted where every neighbouring entry uses quoted names — which is likely how the named interval keys came to be omitted.

While auditing the temperament tables I noticed two further issues that are **out of scope here** and would be better as separate PRs:

1. The 1/4-comma meantone `noteLabels` array drifts out of alignment with its `ratios` from index 7 onward (the perfect fifth reads 631 ¢ instead of 702 ¢), and contains a duplicate `"C"` that breaks `indexOf` lookups.
2. Both meantone tables list `D♭` before `C♯`, contradicting their own `interval` arrays and meantone theory.

Happy to open issues for those if useful.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Equal17 temperament intervals now provide accurate ratio values for perfect 1 through perfect 8.
  - Named interval lookups for equal temperaments now resolve consistently to distinct ratios.
  - Equal17 interval ratios now align with its ratio table and correctly reach the octave at 2:1.

- **Tests**
  - Added coverage validating Equal17 pitch configuration and named interval ratio lookups across equal temperaments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->