### PR TITLE
fix(logo): give each turtle its own infinite-loop iteration budget

### DIFF
--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2117,7 +2117,7 @@ describe("Logo runFromBlockNow", () => {
                 })
             };
 
-            logo._iterationBudget = 1;
+            turtle0.iterationBudget = 1;
             logo.blockList = [makeFlowBlock("noop")];
 
             logo.runFromBlockNow(logo, 0, 0, 0, null);
@@ -2158,14 +2158,16 @@ describe("Logo runFromBlockNow", () => {
     });
 
     describe("limits and plugin dispatch", () => {
-        test("stops execution and reports error when MAX_ITERATIONS exceeded", () => {
-            logo._iterationBudget = 1;
+        test("stops the offending turtle and reports error when its budget is exceeded", () => {
+            turtle0.iterationBudget = 1;
             logo.blockList = [makeFlowBlock("noop")];
 
             logo.runFromBlockNow(logo, 0, 0, 0, null);
 
             expect(mockActivity.errorMsg).toHaveBeenCalled();
-            expect(logo.stopTurtle).toBe(true);
+            expect(turtle0.running).toBe(false);
+            // The guard must not halt the whole run — only the exhausted turtle.
+            expect(logo.stopTurtle).toBe(false);
         });
 
         test("evalFlowDict plugin executes when block name matches", () => {
@@ -2381,6 +2383,138 @@ describe("Logo runFromBlockNow", () => {
 
         expect(mockActivity.blocks.updateParameterBlock).toHaveBeenCalledWith(logo, 0, 10);
         expect(mockActivity.refreshCanvas).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ─── Logo runFromBlockNow — per-turtle iteration budget (#8627) ──────────────
+// The infinite-loop guard used to share one _iterationBudget counter across
+// every turtle in the project, so one turtle's workload could exhaust the
+// budget and abort every other (well-behaved) turtle in the same run, with
+// the error blamed on whichever turtle happened to be executing at that
+// moment. These tests cover the fix: each turtle now has its own budget,
+// and exhausting it stops only that turtle.
+
+describe("Logo runFromBlockNow iteration budget is per turtle", () => {
+    let logo;
+    let mockActivity;
+    let turtle0;
+    let turtle1;
+
+    beforeEach(() => {
+        setupLogoEnv({ withFlute: true });
+        turtle0 = createMockTurtle();
+        turtle1 = createMockTurtle();
+        mockActivity = createTwoTurtleActivity(turtle0, turtle1);
+        mockActivity.turtles.running = jest.fn(() => turtle0.running || turtle1.running);
+        logo = new Logo(mockActivity);
+        mockActivity.logo = logo;
+        logo.blockList = [makeFlowBlock("noop")];
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("a turtle's first block execution lazily starts its own full budget", () => {
+        expect(turtle0.iterationBudget).toBeUndefined();
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(turtle0.iterationBudget).toBe(logo._MAX_ITERATIONS);
+        expect(turtle1.iterationBudget).toBeUndefined();
+    });
+
+    test("exhausting one turtle's budget does not decrement another turtle's budget", () => {
+        turtle0.iterationBudget = 1;
+        turtle1.iterationBudget = 5;
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(mockActivity.errorMsg).toHaveBeenCalled();
+        expect(turtle1.iterationBudget).toBe(5);
+    });
+
+    test("exhausting one turtle's budget stops only that turtle, not the whole run", () => {
+        turtle0.running = true;
+        turtle1.running = true;
+        turtle0.iterationBudget = 1;
+        turtle1.iterationBudget = 100;
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(mockActivity.errorMsg).toHaveBeenCalled();
+        expect(turtle0.running).toBe(false);
+        expect(turtle1.running).toBe(true);
+        // The old global stopTurtle flag halted every turtle; it must not
+        // be used for a single turtle's budget exhaustion any more.
+        expect(logo.stopTurtle).toBe(false);
+        // Turtle 1 is still running, so the "all turtles finished" callback
+        // must not fire yet.
+        expect(mockActivity.onStopTurtle).not.toHaveBeenCalled();
+    });
+
+    test("exhausting the budget clears only the offending turtle's queue", () => {
+        turtle0.queue = [{ blk: 1 }];
+        turtle1.queue = [{ blk: 2 }];
+        turtle0.iterationBudget = 1;
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(turtle0.queue).toEqual([]);
+        expect(turtle1.queue).toEqual([{ blk: 2 }]);
+    });
+
+    test("combined block executions across turtles do not trip either turtle's guard", () => {
+        // Under the old shared counter, these four combined calls against a
+        // budget of 3 would have tripped "Infinite loop detected" on the
+        // third call even though neither turtle individually reached 3.
+        turtle0.iterationBudget = 3;
+        turtle1.iterationBudget = 3;
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+        logo.runFromBlockNow(logo, 1, 0, 0, null);
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+        logo.runFromBlockNow(logo, 1, 0, 0, null);
+
+        expect(mockActivity.errorMsg).not.toHaveBeenCalled();
+        expect(turtle0.iterationBudget).toBe(1);
+        expect(turtle1.iterationBudget).toBe(1);
+    });
+});
+
+// ─── Logo runLogoCommands resets per-turtle budgets (#8627) ──────────────────
+
+describe("Logo runLogoCommands resets every turtle's iteration budget", () => {
+    let logo;
+    let mockActivity;
+    let turtle0;
+    let turtle1;
+
+    beforeEach(() => {
+        setupLogoEnv({ withFlute: true });
+        turtle0 = createMockTurtle();
+        turtle1 = createMockTurtle();
+        mockActivity = createTwoTurtleActivity(turtle0, turtle1);
+        logo = new Logo(mockActivity);
+        mockActivity.logo = logo;
+        logo.prepSynths = jest.fn();
+        logo.initTurtle = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("gives every existing turtle a fresh budget when a run starts", () => {
+        logo.blockList = [];
+        mockActivity.blocks.stackList = [];
+        turtle0.iterationBudget = 3;
+        turtle1.iterationBudget = logo._MAX_ITERATIONS + 1;
+
+        logo.runLogoCommands(null, null);
+
+        expect(turtle0.iterationBudget).toBe(logo._MAX_ITERATIONS + 1);
+        expect(turtle1.iterationBudget).toBe(logo._MAX_ITERATIONS + 1);
     });
 });
 

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2159,16 +2159,14 @@ describe("Logo runFromBlockNow", () => {
     });
 
     describe("limits and plugin dispatch", () => {
-        test("stops the offending turtle and reports error when its budget is exceeded", () => {
+        test("stops execution and reports error when MAX_ITERATIONS exceeded", () => {
             turtle0.iterationBudget = 1;
             logo.blockList = [makeFlowBlock("noop")];
 
             logo.runFromBlockNow(logo, 0, 0, 0, null);
 
             expect(mockActivity.errorMsg).toHaveBeenCalled();
-            expect(turtle0.running).toBe(false);
-            // The guard must not halt the whole run — only the exhausted turtle.
-            expect(logo.stopTurtle).toBe(false);
+            expect(logo.stopTurtle).toBe(true);
         });
 
         test("evalFlowDict plugin executes when block name matches", () => {
@@ -2390,10 +2388,12 @@ describe("Logo runFromBlockNow", () => {
 // ─── Logo runFromBlockNow — per-turtle iteration budget (#8627) ──────────────
 // The infinite-loop guard used to share one _iterationBudget counter across
 // every turtle in the project, so one turtle's workload could exhaust the
-// budget and abort every other (well-behaved) turtle in the same run, with
-// the error blamed on whichever turtle happened to be executing at that
-// moment. These tests cover the fix: each turtle now has its own budget,
-// and exhausting it stops only that turtle.
+// budget even though no single turtle was actually looping forever, and the
+// error was blamed on whichever turtle happened to be executing at that
+// moment. These tests cover the fix: each turtle now has its own budget, so
+// the guard only fires when a turtle's own work exhausts it. The guard still
+// stops the whole run when it fires -- an infinite loop is a whole-run
+// problem -- only the source of exhaustion changed, not the response to it.
 
 describe("Logo runFromBlockNow iteration budget is per turtle", () => {
     let logo;
@@ -2406,7 +2406,6 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
         turtle0 = createMockTurtle();
         turtle1 = createMockTurtle();
         mockActivity = createTwoTurtleActivity(turtle0, turtle1);
-        mockActivity.turtles.running = jest.fn(() => turtle0.running || turtle1.running);
         logo = new Logo(mockActivity);
         mockActivity.logo = logo;
         logo.blockList = [makeFlowBlock("noop")];
@@ -2435,51 +2434,14 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
         expect(turtle1.iterationBudget).toBe(5);
     });
 
-    test("exhausting one turtle's budget stops only that turtle, not the whole run", () => {
-        turtle0.running = true;
-        turtle1.running = true;
+    test("exhausting a turtle's own budget still stops the whole run", () => {
         turtle0.iterationBudget = 1;
         turtle1.iterationBudget = 100;
 
         logo.runFromBlockNow(logo, 0, 0, 0, null);
 
         expect(mockActivity.errorMsg).toHaveBeenCalled();
-        expect(turtle0.running).toBe(false);
-        expect(turtle1.running).toBe(true);
-        // The old global stopTurtle flag halted every turtle; it must not
-        // be used for a single turtle's budget exhaustion any more.
-        expect(logo.stopTurtle).toBe(false);
-        // Turtle 1 is still running, so the "all turtles finished" callback
-        // must not fire yet.
-        expect(mockActivity.onStopTurtle).not.toHaveBeenCalled();
-    });
-
-    test("exhausting the budget clears only the offending turtle's queue", () => {
-        turtle0.queue = [{ blk: 1 }];
-        turtle1.queue = [{ blk: 2 }];
-        turtle0.iterationBudget = 1;
-
-        logo.runFromBlockNow(logo, 0, 0, 0, null);
-
-        expect(turtle0.queue).toEqual([]);
-        expect(turtle1.queue).toEqual([{ blk: 2 }]);
-    });
-
-    test("tears down audio/transport/listeners when the exhausted turtle was the last one running", () => {
-        // Regression: an early version of this fix called onStopTurtle() but
-        // skipped _cleanupAfterCompletion(), which is what actually kills
-        // active audio voices, cancels the transport, and disposes
-        // instruments -- leaving zombie audio behind after an infinite-loop
-        // abort. doStopTurtles() (the Stop button) calls it synchronously
-        // for the same reason: this is an abort, not a graceful finish.
-        turtle1.running = false;
-        turtle0.iterationBudget = 1;
-        const cleanupSpy = jest.spyOn(logo, "_cleanupAfterCompletion");
-
-        logo.runFromBlockNow(logo, 0, 0, 0, null);
-
-        expect(mockActivity.onStopTurtle).toHaveBeenCalled();
-        expect(cleanupSpy).toHaveBeenCalled();
+        expect(logo.stopTurtle).toBe(true);
     });
 
     test("combined block executions across turtles do not trip either turtle's guard", () => {
@@ -2495,6 +2457,7 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
         logo.runFromBlockNow(logo, 1, 0, 0, null);
 
         expect(mockActivity.errorMsg).not.toHaveBeenCalled();
+        expect(logo.stopTurtle).toBe(false);
         expect(turtle0.iterationBudget).toBe(1);
         expect(turtle1.iterationBudget).toBe(1);
     });

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -246,6 +246,7 @@ function createMockTurtle(overrides = {}) {
         doWait: jest.fn(),
         delayTimeout: null,
         delayParameters: null,
+        iterationBudget: null,
         _transportTime: null,
         _transportEventId: null,
         container: { x: 0, y: 0 },
@@ -2416,12 +2417,12 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
     });
 
     test("a turtle's first block execution lazily starts its own full budget", () => {
-        expect(turtle0.iterationBudget).toBeUndefined();
+        expect(turtle0.iterationBudget).toBeNull();
 
         logo.runFromBlockNow(logo, 0, 0, 0, null);
 
         expect(turtle0.iterationBudget).toBe(logo._MAX_ITERATIONS);
-        expect(turtle1.iterationBudget).toBeUndefined();
+        expect(turtle1.iterationBudget).toBeNull();
     });
 
     test("exhausting one turtle's budget does not decrement another turtle's budget", () => {
@@ -2462,6 +2463,23 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
 
         expect(turtle0.queue).toEqual([]);
         expect(turtle1.queue).toEqual([{ blk: 2 }]);
+    });
+
+    test("tears down audio/transport/listeners when the exhausted turtle was the last one running", () => {
+        // Regression: an early version of this fix called onStopTurtle() but
+        // skipped _cleanupAfterCompletion(), which is what actually kills
+        // active audio voices, cancels the transport, and disposes
+        // instruments -- leaving zombie audio behind after an infinite-loop
+        // abort. doStopTurtles() (the Stop button) calls it synchronously
+        // for the same reason: this is an abort, not a graceful finish.
+        turtle1.running = false;
+        turtle0.iterationBudget = 1;
+        const cleanupSpy = jest.spyOn(logo, "_cleanupAfterCompletion");
+
+        logo.runFromBlockNow(logo, 0, 0, 0, null);
+
+        expect(mockActivity.onStopTurtle).toHaveBeenCalled();
+        expect(cleanupSpy).toHaveBeenCalled();
     });
 
     test("combined block executions across turtles do not trip either turtle's guard", () => {

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -2442,6 +2442,13 @@ describe("Logo runFromBlockNow iteration budget is per turtle", () => {
 
         expect(mockActivity.errorMsg).toHaveBeenCalled();
         expect(logo.stopTurtle).toBe(true);
+
+        // Observable outcome, not just the flag: runFromBlock() refuses to
+        // schedule anything while stopTurtle is set, so trying to queue
+        // turtle1's next block after this is a no-op -- its flow() is
+        // never reached.
+        logo.runFromBlock(logo, 1, 0, 0, null);
+        expect(logo.blockList[0].protoblock.flow).not.toHaveBeenCalled();
     });
 
     test("combined block executions across turtles do not trip either turtle's guard", () => {

--- a/js/logo.js
+++ b/js/logo.js
@@ -331,7 +331,7 @@ class Logo {
         this._syncCounter = 0;
         this._YIELD_AFTER_SYNC_RUNS = 1000;
         this._EXPORT_YIELD_AFTER_SYNC_RUNS = 100; // Sync yield threshold during exports.
-        this._iterationBudget = this._MAX_ITERATIONS + 1;
+        // Per-turtle infinite-loop guard budget; see Turtle#iterationBudget.
         this._MAX_ITERATIONS = 1000000;
 
         // When running in step-by-step mode, the next command to run
@@ -1477,7 +1477,11 @@ class Logo {
         this.stopTurtle = false;
 
         this._syncCounter = 0;
-        this._iterationBudget = this._MAX_ITERATIONS + 1;
+        // Give every turtle its own fresh infinite-loop budget for this run
+        // so one turtle's workload cannot exhaust another's (see #8627).
+        for (const turtle of this.turtles.turtleList) {
+            turtle.iterationBudget = this._MAX_ITERATIONS + 1;
+        }
 
         this.blocks.unhighlightAll();
         this.blocks.bringToTop(); // Draw under the blocks.
@@ -1906,15 +1910,33 @@ class Logo {
 
         this.receivedArg = receivedArg;
 
-        if (--logo._iterationBudget <= 0) {
+        // Sometimes we don't want to unwind the entire queue.
+        if (queueStart === undefined) queueStart = 0;
+
+        const tur = logo.turtles.ithTurtle(turtle);
+
+        // Lazily initialize so a turtle created mid-run (e.g. "new turtle")
+        // starts with a full budget instead of inheriting another turtle's.
+        // eslint-disable-next-line eqeqeq
+        if (tur.iterationBudget == null) {
+            tur.iterationBudget = logo._MAX_ITERATIONS + 1;
+        }
+
+        if (--tur.iterationBudget <= 0) {
             logo.deps.errorHandler(
                 _("Infinite loop detected. Execution stopped to prevent browser freeze."),
                 blk
             );
-            logo.stopTurtle = true;
+            // Halt only this turtle; other turtles in the project keep running.
+            tur.queue = [];
+            tur.parentFlowQueue = [];
+            tur.running = false;
+            tur.iterationBudget = logo._MAX_ITERATIONS + 1;
             logo._alreadyRunning = false;
             logo._syncCounter = 0;
-            logo._iterationBudget = logo._MAX_ITERATIONS + 1;
+            if (!logo.turtles.running() && queueStart === 0) {
+                logo.onStopTurtle();
+            }
             if (profilingEnabled) {
                 Logo._recordBlockTiming(logo, blk, profilingStart);
                 performanceTracker.exitBlock();
@@ -1922,8 +1944,6 @@ class Logo {
             return;
         }
 
-        // Sometimes we don't want to unwind the entire queue.
-        if (queueStart === undefined) queueStart = 0;
         const currentBlock = logo.blockList[blk];
         const blockName = currentBlock.name;
         const proto = currentBlock.protoblock;
@@ -1935,7 +1955,6 @@ class Logo {
 (1) Evaluate any arguments (beginning with connection[1]).
 ===========================================================================
 */
-        const tur = logo.turtles.ithTurtle(turtle);
         const args = [];
 
         if (proto.args > 0) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1910,9 +1910,6 @@ class Logo {
 
         this.receivedArg = receivedArg;
 
-        // Sometimes we don't want to unwind the entire queue.
-        if (queueStart === undefined) queueStart = 0;
-
         const tur = logo.turtles.ithTurtle(turtle);
 
         // Lazily initialize so a turtle created mid-run (e.g. "new turtle")
@@ -1927,21 +1924,15 @@ class Logo {
                 _("Infinite loop detected. Execution stopped to prevent browser freeze."),
                 blk
             );
-            // Halt only this turtle; other turtles in the project keep running.
-            tur.queue = [];
-            tur.parentFlowQueue = [];
-            tur.running = false;
-            tur.iterationBudget = logo._MAX_ITERATIONS + 1;
+            // A real infinite loop is a whole-run problem, not just this
+            // turtle's -- stop everything, same as before. What's fixed is
+            // *whose* budget triggered this: each turtle now has its own,
+            // so this only fires when this turtle itself did the looping,
+            // not because some other turtle's work used up a shared pool.
+            logo.stopTurtle = true;
             logo._alreadyRunning = false;
             logo._syncCounter = 0;
-            if (!logo.turtles.running() && queueStart === 0) {
-                logo.onStopTurtle();
-                // This is an abort, not a graceful finish, so tear down
-                // audio/transport/listeners immediately rather than waiting
-                // on the natural-completion path's "last note" timeout --
-                // the same pattern doStopTurtles() uses for the Stop button.
-                logo._cleanupAfterCompletion();
-            }
+            tur.iterationBudget = logo._MAX_ITERATIONS + 1;
             if (profilingEnabled) {
                 Logo._recordBlockTiming(logo, blk, profilingStart);
                 performanceTracker.exitBlock();
@@ -1949,6 +1940,8 @@ class Logo {
             return;
         }
 
+        // Sometimes we don't want to unwind the entire queue.
+        if (queueStart === undefined) queueStart = 0;
         const currentBlock = logo.blockList[blk];
         const blockName = currentBlock.name;
         const proto = currentBlock.protoblock;

--- a/js/logo.js
+++ b/js/logo.js
@@ -1936,6 +1936,11 @@ class Logo {
             logo._syncCounter = 0;
             if (!logo.turtles.running() && queueStart === 0) {
                 logo.onStopTurtle();
+                // This is an abort, not a graceful finish, so tear down
+                // audio/transport/listeners immediately rather than waiting
+                // on the natural-completion path's "last note" timeout --
+                // the same pattern doStopTurtles() uses for the Stop button.
+                logo._cleanupAfterCompletion();
             }
             if (profilingEnabled) {
                 Logo._recordBlockTiming(logo, blk, profilingStart);

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -657,6 +657,12 @@ Turtle.TurtleModel = class {
         this.delayTimeout = null;
         this.delayParameters = {};
 
+        // Remaining block-execution budget for this turtle's infinite-loop
+        // guard (see Logo.runFromBlockNow). Lazily set to Logo._MAX_ITERATIONS
+        // the first time this turtle executes a block, so each turtle is
+        // judged on its own work rather than sharing one project-wide budget.
+        this.iterationBudget = null;
+
         this._media = []; // media (text, images) we need to remove on clear
 
         this._x = 0; // x coordinate


### PR DESCRIPTION
## Description

`_iterationBudget`, the interpreter's infinite-loop guard, was a single counter on the `Logo` instance shared by every turtle in the project for the whole run. `runFromBlockNow()` — the interpreter entry point called for every block on every turtle — decremented this one counter no matter which turtle it was executing for, and `step()` interleaves execution across all turtles' queues against it. A project with several turtles each doing bounded but substantial work could exhaust the shared budget even though no single turtle was actually looping infinitely, and the error was blamed on whichever block happened to be executing at that moment.

**Fixes:** #8627

**Note on scope:** an earlier version of this PR also made the guard stop only the offending turtle instead of the whole run. walterbender pointed out that's not what we want — an infinite loop is a whole-run problem — so that part's been reverted. The guard still halts everything on exhaustion, exactly as before; the only change now is *whose* budget is being checked.

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

- `js/turtle.js` — added `Turtle.iterationBudget`, lazily initialized on a turtle's first block execution.
- `js/logo.js`:
  - Removed the shared `Logo._iterationBudget` field.
  - `runLogoCommands()` now resets every existing turtle's `iterationBudget` when a run starts, instead of resetting one global counter.
  - `runFromBlockNow()` now decrements and checks `tur.iterationBudget` for the specific turtle it's executing, lazily initializing it so a turtle created mid-run (`new turtle` block, `run [start block]` block) starts with its own full budget rather than inheriting another turtle's remaining count.
  - On exhaustion, the response is unchanged from before this PR: `logo.stopTurtle = true`, halting the whole run. What's fixed is that this can now only be triggered by a turtle actually exhausting its *own* budget, not by unrelated turtles' work depleting a shared pool — so the error is always attributed to the turtle that's actually responsible.
- `js/utils/__tests__/synthutils.test.js` — unrelated fix found while getting this branch's CI green: the "19-EDO" temperament case in `_getFrequency across various temperaments and input types` mocked `global.getTemperament`, but that mock can never be observed by `isEquallyTempered()`/`getTemperament()` (both defined in `musicutils.js`, calling each other through the bare identifier, which resolves lexically to that module's own top-level binding, not through `global`). Switched the test to use the real `equal19` temperament, which is already `isEDO`-flagged in `TEMPERAMENT`. This was failing identically on `master` before this branch existed.
- `js/__tests__/logo.test.js` — updated the two existing tests that drove the guard through the old global `logo._iterationBudget`, and added tests covering: per-turtle budget isolation (one turtle's exhaustion doesn't touch another turtle's budget), the guard still halting the whole run on exhaustion, the combined-executions scenario from the issue (four calls interleaved across two turtles against a budget of 3 each no longer trips the guard, where a shared counter of 3 would have tripped on the third call), and `runLogoCommands` resetting every existing turtle's budget at run start.

## Why

The root cause is a shared counter that should have been scoped per turtle from the start — that's what's fixed here. The response to exhaustion (halt everything) is deliberately left as-is: once a turtle really has exhausted its own budget, that's a genuine runaway loop, and per walterbender's feedback, the whole run stopping is the right, simpler behavior for that — not something this issue asked to change.

## Testing Performed

- `npx eslint js/` — 0 errors, 0 warnings.
- `npx prettier --check js/logo.js js/turtle.js js/__tests__/logo.test.js js/utils/__tests__/synthutils.test.js` — passes.
- `npx jest` (full suite) — 235/235 suites, 9145/9146 tests passing (1 pre-existing skip).
- `js/__tests__/logo.test.js` — 163/163 passing, including the tests for this fix.
- Also ran the turtle/turtles/turtle-singer suites and every other test file that touches `runFromBlockNow`/`stopTurtle` individually — all passing.

## Additional Notes

Scope of the fix is limited to where the iteration budget lives and is checked. It does not change what happens when the guard fires (still a full run stop), the scheduler's `!logo.stopTurtle` gating in `runFromBlock()`, or anything about how turtles are created/removed.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors on every file changed by this PR.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved infinite-loop protection by tracking execution limits independently for each turtle.
  - Runs now stop when a turtle exceeds its execution limit, preventing runaway execution.
  - Execution budgets reset when a new run begins.
  - Valid multi-turtle executions no longer incorrectly trigger loop protection.

- **Tests**
  - Updated coverage for per-turtle execution limits and run-stopping behavior.
  - Added validation for combined executions that remain within their limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->