### PR TITLE
fix(lilypond): place staccato after the duration in tuplet export

### DIFF
--- a/js/__tests__/lilypond.test.js
+++ b/js/__tests__/lilypond.test.js
@@ -161,6 +161,18 @@ describe("processLilypondNotes", () => {
         expect(logo.notationNotes[turtle]).not.toContain("\\staccato");
     });
 
+    test("should place staccato after the duration on a note inside a tuplet", () => {
+        logo.notation.notationStaging[turtle] = [[["G4"], 4, 8, [3, 2], 8, -1, true]];
+        processLilypondNotes(lilypond, logo, turtle);
+        expect(logo.notationNotes[turtle]).toContain("g' 8 \\staccato ");
+    });
+
+    test("should place staccato after the chord on notes inside a tuplet", () => {
+        logo.notation.notationStaging[turtle] = [[["C4", "E4"], 4, 8, [3, 2], 8, -1, true]];
+        processLilypondNotes(lilypond, logo, turtle);
+        expect(logo.notationNotes[turtle]).toContain("<c' e'>8 \\staccato ");
+    });
+
     test("should process a markup command correctly", () => {
         logo.notation.notationStaging[turtle] = ["markup", "Test Markup"];
         processLilypondNotes(lilypond, logo, turtle);

--- a/js/lilypond.js
+++ b/js/lilypond.js
@@ -121,16 +121,17 @@ const processLilypondNotes = (lilypond, logo, turtle) => {
                     }
                 }
 
-                if (logo.notation.notationStaging[turtle][i + j][NOTATIONSTACCATO]) {
-                    logo.notationNotes[turtle] += " \\staccato ";
-                }
-
                 if (notes.length > 1) {
                     logo.notationNotes[turtle] += ">";
                 }
 
                 logo.notationNotes[turtle] +=
                     logo.notation.notationStaging[turtle][i + j][NOTATIONROUNDDOWN];
+
+                if (logo.notation.notationStaging[turtle][i + j][NOTATIONSTACCATO]) {
+                    logo.notationNotes[turtle] += " \\staccato ";
+                }
+
                 j++; // Jump to next note.
                 k++; // Increment notes in tuplet.
             } else if (logo.notation.notationStaging[turtle][i + j] === "tie") {


### PR DESCRIPTION
## Description

Moves `\staccato` after the note's duration in `__processTuplet`, so the tuplet path writes notes the same way the rest of `js/lilypond.js` does.

Why it matters is in #8629.

## Related Issue

**Fixes:** #8629

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

One block moved. The condition and the string it writes are untouched.

```
\tuplet 3/2 { g'  \staccato 2}   ->  \tuplet 3/2 { g' 2 \staccato }
\tuplet 3/2 { <c' e' \staccato >8}  ->  \tuplet 3/2 { <c' e'>8 \staccato }
```

The chord now carries the staccato instead of its last pitch.

---

## Steps to Reproduce

In #8629. Before and after engravings are there too.

---

## Testing Performed

Two tests in `js/__tests__/lilypond.test.js`, one note and one chord. Both fail on master, both pass here.

Full suite: 9143 tests, one failure, `js/utils/__tests__/synthutils.test.js`. That one also fails on a clean master checkout and varies between runs.

`eslint` and `prettier --check` clean on both files.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The existing tuplet staccato test only checks that `\staccato` appears somewhere, which is how this got through. It still passes.

`js/__tests__/lilypond.test.js` has `NOTATIONDOTCOUNT` and `NOTATIONROUNDDOWN` swapped against `js/logoconstants.js`. I left it alone to keep this to one thing. The new fixtures put the same value in both slots so they hold either way. Say the word and I will fix the header separately.

#8221 is still open. Its original defect was fixed by #8222 and only the placement was left. Whether to close it is your call.
