### PR TITLE
fix: correct musicxml divisions for quarter-note resolution

### DIFF
--- a/js/__tests__/mxml.test.js
+++ b/js/__tests__/mxml.test.js
@@ -39,6 +39,22 @@ describe("saveMxmlOutput", () => {
         expect(output).toContain('<part id="P1">');
     });
 
+    it("should express a quarter note using divisions per quarter note", () => {
+        const logo = {
+            notation: {
+                notationStaging: {
+                    0: [[["C4"], 4, 0]]
+                }
+            }
+        };
+
+        const output = saveMxmlOutput(logo);
+        const divisions = Number(output.match(/<divisions>(\d+)<\/divisions>/)[1]);
+        const duration = Number(output.match(/<duration>(\d+)<\/duration>/)[1]);
+
+        expect(duration / divisions).toBe(1);
+    });
+
     it("should handle multiple voices", () => {
         const logo = {
             notation: {
@@ -97,19 +113,29 @@ describe("saveMxmlOutput", () => {
     });
 
     it("should handle meter changes", () => {
+        const quarterNote = [["C4"], 4, 0];
         const logo = {
             notation: {
                 notationStaging: {
-                    0: ["meter", 3, 4, [["C"], 4, 0]]
+                    0: [
+                        quarterNote,
+                        quarterNote,
+                        quarterNote,
+                        quarterNote,
+                        "meter",
+                        3,
+                        4,
+                        quarterNote
+                    ]
                 }
             }
         };
 
         const output = saveMxmlOutput(logo);
 
-        expect(output).toContain("<time>");
+        expect(output).toContain("<beats>3</beats>");
         expect(output).toContain("<beat-type>4</beat-type>");
-        expect(output).toContain("<step>C</step>");
+        expect(output.match(/<divisions>8<\/divisions>/g)).toHaveLength(2);
     });
 
     it("should handle crescendo and decrescendo markings", () => {
@@ -225,10 +251,9 @@ describe("saveMxmlOutput", () => {
         const output = saveMxmlOutput(logo);
 
         expect(output).not.toContain("<duration>32</duration>");
-        // A voice containing a 3:2 tuplet gets divisions scaled to 32 * 3 = 96 (see
-        // _resolveDivisionsPerWholeNote), so this eighth-note triplet's duration is
-        // exactly (96 / 8) * (2 / 3) = 8 -- not a rounded approximation.
-        expect(output).toContain("<divisions>96</divisions>");
+        // The internal divisions-per-whole-note resolution scales to 96, which MusicXML
+        // represents as 24 divisions per quarter note. The exact duration remains 8.
+        expect(output).toContain("<divisions>24</divisions>");
         expect(output).toContain("<duration>8</duration>");
         expect(output).toContain("<step>C</step>");
         expect(output).toContain("<octave>4</octave>");
@@ -272,7 +297,7 @@ describe("saveMxmlOutput", () => {
 
         const output = saveMxmlOutput(logo);
 
-        expect(output).toContain("<divisions>480</divisions>");
+        expect(output).toContain("<divisions>120</divisions>");
         // Triplet (3:2): (480 / 8) * (2 / 3) = 40. "Quintuplet" (5:2): (480 / 8) * (2 / 5) = 24.
         expect(output).toContain("<duration>40</duration>");
         expect(output).toContain("<duration>24</duration>");

--- a/js/mxml.js
+++ b/js/mxml.js
@@ -128,6 +128,7 @@ saveMxmlOutput = logo => {
         // instead of a rounded one; identical to DIVISIONS_PER_WHOLE_NOTE (32, this
         // file's long-standing resolution) when the voice has no tuplets at all.
         const divisionsPerWholeNote = _resolveDivisionsPerWholeNote(notes);
+        const divisionsPerQuarterNote = divisionsPerWholeNote / 4;
 
         let currMeasure = 1,
             divisions = divisionsPerWholeNote,
@@ -247,14 +248,24 @@ saveMxmlOutput = logo => {
                 if (!isChordNote) {
                     if (divisionsLeft === divisions) {
                         if (firstMeasure) {
-                            addMeasureAttributes(currMeasure, divisions, beats, beatType);
+                            addMeasureAttributes(
+                                currMeasure,
+                                divisionsPerQuarterNote,
+                                beats,
+                                beatType
+                            );
                             firstMeasure = false;
                         } else if (beatsChanged) {
                             beats = newBeats;
                             beatType = newBeatType;
                             divisions = newDivisions;
                             divisionsLeft = divisions;
-                            addMeasureAttributes(currMeasure, newDivisions, newBeats, newBeatType);
+                            addMeasureAttributes(
+                                currMeasure,
+                                divisionsPerQuarterNote,
+                                newBeats,
+                                newBeatType
+                            );
                             beatsChanged = false;
                         } else {
                             add(`<measure number="${currMeasure}">`);


### PR DESCRIPTION
## Description

Fixes incorrect note durations in MusicXML exports caused by a mismatch between Music Blocks' internal timing resolution and the MusicXML `<divisions>` definition.

Music Blocks internally uses divisions per whole note, while MusicXML defines `<divisions>` as divisions per quarter note. The internal value was previously exported directly, causing note durations to be interpreted as four times shorter than intended.

For example, a quarter note was exported as:

```xml id="0gw2wa"
<divisions>32</divisions>
<duration>8</duration>
```

In MusicXML, this represents `8 / 32 = 1/4` of a quarter note rather than one quarter note.

The exporter now converts the internal resolution before writing `<divisions>`, so the same note is correctly represented as:

```xml id="fnnv25"
<divisions>8</divisions>
<duration>8</duration>
```

## Related Issue

**Fixes:** #

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
* [ ] Feature — Adds new functionality
* [ ] UI/UX — Changes to the user interface or user experience
* [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
* [ ] Documentation — Updates to docs, comments, or README
* [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
* [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

* Convert the internal divisions-per-whole-note resolution to divisions-per-quarter-note when writing MusicXML measure attributes.
* Apply the conversion to both initial measure attributes and attributes emitted after meter changes.
* Keep internal note-duration and measure calculations unchanged.
* Update MusicXML tests to validate durations relative to the exported `<divisions>` value.
* Preserve exact integer durations for tuplets. For example, an internal resolution of `96` divisions per whole note is exported as `24` divisions per quarter note while the exact triplet duration remains `8`.

---

## Steps to Reproduce

1. Open Music Blocks.
2. Create a Start stack with four `1/4` Note blocks.
3. Add a Pitch block to each note.
4. Export the project using **Save sheet music as MusicXML**.
5. Open the generated XML file in a text editor.
6. Before this fix, the output contains:

```xml id="bpkvfh"
<divisions>32</divisions>
...
<duration>8</duration>
```

Since MusicXML defines `<divisions>` per quarter note, each intended quarter note is interpreted as `8 / 32 = 1/4` of a quarter note.

After this fix, the output contains:

```xml id="31z72s"
<divisions>8</divisions>
...
<duration>8</duration>
```

so `8 / 8 = 1`, correctly representing a quarter note.

---

## Testing Performed

Added/updated focused MusicXML tests covering:

* Quarter-note duration relative to `<divisions>`.
* Dotted-quarter duration.
* Exact triplet-eighth duration and time modification.
* Correct divisions after meter changes.
* Existing measure-boundary behavior.

---

## Checklist

* [ ] I have tested these changes locally and they work as expected.
* [x] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [ ] I have followed the project's coding style guidelines.
* [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.
* [ ] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MusicXML duration divisions to consistently represent divisions per quarter note.
  * Improved timing accuracy for quarter notes, meter changes, and tuplets in generated MusicXML.
  * Preserved correct handling of notes surrounding meter changes and repeated division declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->