### PR TITLE
perf(loader): drop a 5-second startup wait for a global nothing sets

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -495,18 +495,19 @@ requirejs(["i18next", "i18nextHttpBackend"], function (i18next, i18nextHttpBacke
 
             i18next.on("languageChanged", updateContent);
 
-            // Two-phase bootstrap: load core modules first, then application modules
-            const waitForGlobals = async (retryCount = 0) => {
-                if (typeof window.createjs === "undefined" && retryCount < 50) {
-                    await new Promise(resolve => setTimeout(resolve, 100));
-                    return waitForGlobals(retryCount + 1);
-                }
-            };
+            // Two-phase bootstrap: load core modules first, then application modules.
+            //
+            // Nothing is awaited here for createjs. index.html has no easeljs or
+            // tweenjs script tag, so window.createjs is not set before this point;
+            // it appears only once RequireJS resolves easeljs.min, which happens
+            // below as part of CORE_BOOTSTRAP_MODULES. Polling for it first meant
+            // every page load sat through the full retry budget before starting
+            // the work that actually defines it.
 
-            await waitForGlobals();
-
-            // Only pre-define modules that are loaded via script tags in index.html
-            // These modules are already available as globals before RequireJS loads them
+            // Pre-define anything that a script tag did happen to put on window,
+            // so RequireJS reuses the global instead of fetching it again. Each
+            // entry is skipped when its global is absent, and the module is then
+            // loaded normally from its configured path.
             const PRELOADED_SCRIPTS = [
                 { name: "easeljs.min", export: () => window.createjs },
                 { name: "tweenjs.min", export: () => window.createjs },


### PR DESCRIPTION
Music Blocks takes about 5.2 seconds to boot, and almost all of it is a wait for something that nothing sets.

`loader.js` polls for `window.createjs` before starting the core bootstrap:

```js
const waitForGlobals = async (retryCount = 0) => {
    if (typeof window.createjs === "undefined" && retryCount < 50) {
        await new Promise(resolve => setTimeout(resolve, 100));
        return waitForGlobals(retryCount + 1);
    }
};
await waitForGlobals();
```

The comment just below it says the `PRELOADED_SCRIPTS` entries are "loaded via script tags in index.html". For createjs that isn't true any more — `index.html` has no easeljs or tweenjs script tag. So `window.createjs` is undefined the whole time, the poll runs out all 50 retries, and only then does the loader start the step that actually produces createjs: `easeljs.min` and `tweenjs.min` are both in `CORE_BOOTSTRAP_MODULES`, so RequireJS fetches them immediately after.

The wait is for something only the work after it can produce.

### Measurements

The loader already has a perfTracker behind `?mbPerf=1`, so these are its own numbers. Headless Chromium, page served from `npm run serve:dev`, median of 7 loads each, same harness on both sides:

|                                       | before             | after            |
| ------------------------------------- | ------------------ | ---------------- |
| `loader.i18n_to_core_modules_ready`   | 5084.7 ms          | 26.1 ms          |
| `loader.total_bootstrap`              | 5165.5 ms          | 101.4 ms         |
| `core_modules_to_activity_module_ready` | 76.7 ms          | 73.6 ms          |

What convinced me it was a fixed sleep rather than slow work was the spread: before, `loader.total_bootstrap` ranged over 5134–5186 ms across runs — 52 ms of variation on a 5.2 second operation. Work doesn't behave like that; a timeout does. 50 × 100 ms is 5000 ms.

Two more checks:

- Instrumenting `window.createjs` shows it first becomes defined at ~5450 ms, i.e. after the poll has already given up. It is never there while the poll is looking for it.
- Defining `window.createjs` before the page scripts run collapses that same phase from 5252 ms to 30 ms, which pins the delay on this poll specifically.

The last row is the point of the table: the phase after the wait is unchanged, so this removes idle time rather than moving work around.

### What is kept

`PRELOADED_SCRIPTS` is untouched and still adopts any global a script tag does provide — each entry is already guarded by `mod.export()` and skipped when the global is absent, so it degrades to a normal RequireJS load. The `FATAL: createjs ... not found` check after the bootstrap is also untouched, and it's the better place for the invariant anyway: it runs at the point where createjs genuinely should exist.

### Verification

- `npx eslint js/loader.js` — clean
- `npx jest` — 234 of 235 suites pass, 9213 of 9214 tests. The one failure is `js/utils/__tests__/synthutils.test.js:3352` (`_getFrequency` with `19-EDO`), which fails the same way on master and is unrelated to this change.
- Across 7 loads on the branch: no page errors, no console errors, `createjs.Stage` is a real constructor, and the canvas is present — so RequireJS is supplying the genuine EaselJS, not a stub.

---

## Category

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [x] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Testing Performed

- `npx eslint js/loader.js` — clean
- `npx jest` — 234 of 235 suites pass, 9213 of 9214 tests. The one failure,
  `js/utils/__tests__/synthutils.test.js:3352` (`_getFrequency` with `19-EDO`),
  fails identically on master and is unrelated to this change.
- 7 headless Chromium loads on this branch: no page errors, no console errors,
  `createjs.EaselJS.version` reports `1.0.0` and `createjs.Stage` is a real
  constructor, so RequireJS is supplying the genuine library.
- Screenshots of master and this branch, taken after a 6 second settle at
  1400x900, are byte-identical (108,205 bytes, `cmp` reports no difference).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup by removing an unnecessary initialization wait when required libraries are already available.
  - The loader now proceeds directly with setup, helping reduce delays during page loading and provide a more responsive launch experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->