### PR TITLE
fix(test): use real equal19 key instead of broken global mock in syntax

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -3341,14 +3341,8 @@ describe("Use-after-dispose race in Synth.trigger async path", () => {
             expect(Array.isArray(freqs)).toBe(true);
             expect(freqs).toHaveLength(3);
 
-            // EDO temperament (e.g. 19-EDO or 31-EDO)
-            const edoTemp = { isEDO: true, pitchNumber: 19 };
-            const origGetTemp = global.getTemperament;
-            global.getTemperament = jest.fn(name =>
-                name === "19-EDO" ? edoTemp : origGetTemp(name)
-            );
-
-            synth.inTemperament = "19-EDO";
+            // EDO temperament (equal19 is a real key in the TEMPERAMENT table)
+            synth.inTemperament = "equal19";
             expect(typeof synth._getFrequency("C4", false)).toBe("number");
             expect(synth._getFrequency(440, false)).toBe(440);
             expect(Array.isArray(synth._getFrequency(["C4", 440], false))).toBe(true);
@@ -3368,8 +3362,6 @@ describe("Use-after-dispose race in Synth.trigger async path", () => {
             synth._getFrequency("C4", true);
             synth._getFrequency("C4", true, "just intonation");
             expect(synth.changeInTemperament).toBe(false);
-
-            global.getTemperament = origGetTemp;
         });
 
         test("getCustomFrequency for custom temperament notes", () => {


### PR DESCRIPTION
The test was broken because it incorrectly mocked global.getTemperament instead of targeting the actual module-scope getTemperament imported from musicutils.js. Since the code doesn’t use a global function but rather an imported one, the mock had no effect.

The real key for 19-EDO in the TEMPERAMENT table is "equal19", not "19-EDO". When isEquallyTempered("19-EDO") is called without a real mock, it returns false because "19-EDO" isn’t a valid key in the dictionary. This causes the code to fall through to the _getFrequency fallback, which returns undefined since the noteFrequencies map is empty.

Fix:
Replace "19-EDO" with "equal19" - the actual key used in the TEMPERAMENT table - and remove the unnecessary global mock. Now isEquallyTempered("equal19") will correctly resolve via the module-scope getTemperament and return true.

This aligns with how the code is structured in musicutils.js, where TEMPERAMENT is defined with keys like "equal19" for 19-EDO 

PR Category
 - [x] Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated frequency tests to use the supported 19-tone equal temperament configuration.
  * Simplified test setup and cleanup by removing unnecessary temperament mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->