### PR TITLE
fix(logo): replace embeddedGraphicsFinished boolean with a per-turtle pending count

### DIFF
--- a/js/__tests__/embedded-graphics-scheduler.test.js
+++ b/js/__tests__/embedded-graphics-scheduler.test.js
@@ -52,6 +52,7 @@ const buildTurtle = () => ({
         embeddedGraphics: {}
     },
     embeddedGraphicsPending: 0,
+    embeddedGraphicsGeneration: 0,
     painter: buildPainter()
 });
 
@@ -299,6 +300,56 @@ describe("EmbeddedGraphicsScheduler", () => {
         // Only once note N+1's own call resolves does the count return to 0.
         resolveSecond();
         await secondCall;
+        expect(turtle0.embeddedGraphicsPending).toBe(0);
+    });
+
+    test("a stale call's completion does not corrupt the count after a turtle/run reset (#8639 follow-up)", async () => {
+        // runLogoCommands()/Turtle.initTurtle() reset embeddedGraphicsPending
+        // to 0 (Stop button, or a "run" block restarting this turtle), but a
+        // schedule() call already in flight at that moment does not know
+        // about the reset. Without tracking a generation, that stale call's
+        // eventual decrement would corrupt the fresh generation's count
+        // instead of being ignored.
+        turtle0.singer.suppressOutput = false;
+        mockLogo.parseArg = jest.fn(() => 5);
+        mockLogo.blockList = [null, { name: "setcolor", connections: [null, 1] }];
+        turtle0.singer.embeddedGraphics = { 9: [1], 10: [1] };
+
+        let resolveStale;
+        let resolveFresh;
+        const delays = [
+            new Promise(resolve => {
+                resolveStale = resolve;
+            }),
+            new Promise(resolve => {
+                resolveFresh = resolve;
+            })
+        ];
+        let callIndex = 0;
+        mockLogo.deps.utils.delayExecution = jest.fn(() => delays[callIndex++]);
+
+        // Note N's call starts and is still pending when a reset happens.
+        const staleCall = scheduler.schedule(0, 0.5, 9, 0);
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+
+        // Simulate the reset performed by runLogoCommands()/initTurtle().
+        turtle0.embeddedGraphicsPending = 0;
+        turtle0.embeddedGraphicsGeneration += 1;
+
+        // A genuinely new call starts in the new generation. It sees no
+        // pending work (the reset cleared it), so no compensating delay.
+        const freshCall = scheduler.schedule(0, 0.5, 10, 0);
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+
+        // The stale call from before the reset finally resolves. It must
+        // not touch the new generation's count.
+        resolveStale();
+        await staleCall;
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+
+        // The fresh call resolving does decrement its own generation's count.
+        resolveFresh();
+        await freshCall;
         expect(turtle0.embeddedGraphicsPending).toBe(0);
     });
 });

--- a/js/__tests__/embedded-graphics-scheduler.test.js
+++ b/js/__tests__/embedded-graphics-scheduler.test.js
@@ -51,7 +51,7 @@ const buildTurtle = () => ({
         dispatchFactor: 1,
         embeddedGraphics: {}
     },
-    embeddedGraphicsFinished: true,
+    embeddedGraphicsPending: 0,
     painter: buildPainter()
 });
 
@@ -118,14 +118,14 @@ describe("EmbeddedGraphicsScheduler", () => {
         expect(turtle0.painter.doSetHeading).toHaveBeenCalledWith(0);
         expect(turtle0.painter.doSetXY).toHaveBeenCalledWith(0, 0);
         expect(mockLogo.deps.utils.delayExecution).toHaveBeenCalledWith(500);
-        expect(turtle0.embeddedGraphicsFinished).toBe(true);
+        expect(turtle0.embeddedGraphicsPending).toBe(0);
     });
 
     test("schedule covers broad graphics switch with deterministic timers", async () => {
         mockLogo.deps.utils.delayExecution = jest.fn(() => Promise.resolve());
 
         turtle0.singer.suppressOutput = false;
-        turtle0.embeddedGraphicsFinished = false;
+        turtle0.embeddedGraphicsPending = 1;
 
         mockLogo.blockList = [];
         const names = [
@@ -233,8 +233,8 @@ describe("EmbeddedGraphicsScheduler", () => {
     test("schedule adds 0.1s delay when previous graphics not yet finished", async () => {
         mockLogo.deps.utils.delayExecution = jest.fn(() => Promise.resolve());
         turtle0.singer.suppressOutput = false;
-        // Simulate prior note's graphics still in-flight.
-        turtle0.embeddedGraphicsFinished = false;
+        // Simulate a prior note's graphics still in-flight.
+        turtle0.embeddedGraphicsPending = 1;
         mockLogo.parseArg = jest.fn(() => 5);
         mockLogo.blockList = [null, { name: "setcolor", connections: [null, 1] }];
         turtle0.singer.embeddedGraphics = { 9: [1] };
@@ -247,6 +247,58 @@ describe("EmbeddedGraphicsScheduler", () => {
             100,
             expect.any(Function)
         );
-        expect(turtle0.embeddedGraphicsFinished).toBe(true);
+        // This call's own share of the count is cleared, but the prior
+        // note's pending call (simulated above) is still outstanding.
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+    });
+
+    test("an earlier call resolving does not clear a later, still-running call's pending count (#8639)", async () => {
+        // turtle-singer.js never awaits dispatchTurtleSignals(), so it is
+        // routine for one note's schedule() call to still be pending when
+        // the next note's call starts. Under the old shared boolean, the
+        // earlier call resolving would unconditionally mark all graphics as
+        // finished, even while the later call's were still running.
+        turtle0.singer.suppressOutput = false;
+        mockLogo.parseArg = jest.fn(() => 5);
+        mockLogo.blockList = [null, { name: "setcolor", connections: [null, 1] }];
+        turtle0.singer.embeddedGraphics = { 9: [1], 10: [1] };
+
+        let resolveFirst;
+        let resolveSecond;
+        const delays = [
+            new Promise(resolve => {
+                resolveFirst = resolve;
+            }),
+            new Promise(resolve => {
+                resolveSecond = resolve;
+            })
+        ];
+        let callIndex = 0;
+        mockLogo.deps.utils.delayExecution = jest.fn(() => delays[callIndex++]);
+
+        // Note N starts; nothing pending yet, so no compensating delay.
+        const firstCall = scheduler.schedule(0, 0.5, 9, 0);
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+
+        // Note N+1 starts while N is still pending, so it must see that
+        // and add the 0.1s compensating delay (delay 0 becomes waitTime 100ms).
+        const secondCall = scheduler.schedule(0, 0.5, 10, 0);
+        expect(turtle0.embeddedGraphicsPending).toBe(2);
+        expect(mockLogo._timerManager.setGuardedTimeout).toHaveBeenLastCalledWith(
+            expect.any(Function),
+            100,
+            expect.any(Function)
+        );
+
+        // Note N's call resolves first. This must not mark everything as
+        // finished, since note N+1's graphics are still in flight.
+        resolveFirst();
+        await firstCall;
+        expect(turtle0.embeddedGraphicsPending).toBe(1);
+
+        // Only once note N+1's own call resolves does the count return to 0.
+        resolveSecond();
+        await secondCall;
+        expect(turtle0.embeddedGraphicsPending).toBe(0);
     });
 });

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -239,7 +239,7 @@ function createMockTurtle(overrides = {}) {
         listeners: {},
         endOfClampSignals: {},
         butNotThese: {},
-        embeddedGraphicsFinished: true,
+        embeddedGraphicsPending: 0,
         running: false,
         inTrash: false,
         waitTime: 0,

--- a/js/__tests__/logo.test.js
+++ b/js/__tests__/logo.test.js
@@ -240,6 +240,7 @@ function createMockTurtle(overrides = {}) {
         endOfClampSignals: {},
         butNotThese: {},
         embeddedGraphicsPending: 0,
+        embeddedGraphicsGeneration: 0,
         running: false,
         inTrash: false,
         waitTime: 0,

--- a/js/__tests__/turtle.test.js
+++ b/js/__tests__/turtle.test.js
@@ -166,10 +166,10 @@ describe("Turtle", () => {
             expect(turtle._waitTime).toBe(0);
         });
 
-        it("should set embeddedGraphicsFinished to true", () => {
-            turtle.embeddedGraphicsFinished = false;
+        it("should reset embeddedGraphicsPending to 0", () => {
+            turtle.embeddedGraphicsPending = 2;
             turtle.initTurtle(false);
-            expect(turtle.embeddedGraphicsFinished).toBe(true);
+            expect(turtle.embeddedGraphicsPending).toBe(0);
         });
 
         it("should set inSetTimbre to false", () => {

--- a/js/__tests__/turtle.test.js
+++ b/js/__tests__/turtle.test.js
@@ -166,10 +166,12 @@ describe("Turtle", () => {
             expect(turtle._waitTime).toBe(0);
         });
 
-        it("should reset embeddedGraphicsPending to 0", () => {
+        it("should reset embeddedGraphicsPending to 0 and bump embeddedGraphicsGeneration", () => {
             turtle.embeddedGraphicsPending = 2;
+            const generationBefore = turtle.embeddedGraphicsGeneration;
             turtle.initTurtle(false);
             expect(turtle.embeddedGraphicsPending).toBe(0);
+            expect(turtle.embeddedGraphicsGeneration).toBe(generationBefore + 1);
         });
 
         it("should set inSetTimbre to false", () => {

--- a/js/embedded-graphics-scheduler.js
+++ b/js/embedded-graphics-scheduler.js
@@ -60,13 +60,16 @@ class EmbeddedGraphicsScheduler {
 
         if (tur.singer.embeddedGraphics[blk].length === 0) return;
 
-        // If the previous note's graphics are not complete, add a
-        // slight delay before drawing any new graphics.
-        if (!tur.embeddedGraphicsFinished) {
+        // If an earlier note's graphics are still in flight, add a slight
+        // delay before drawing any new graphics. schedule() is async and
+        // callers do not await it, so consecutive notes routinely overlap;
+        // a counter (rather than a boolean) ensures a call that finishes
+        // early cannot mark a still-running later call as done.
+        if (tur.embeddedGraphicsPending > 0) {
             delay += 0.1;
         }
 
-        tur.embeddedGraphicsFinished = false;
+        tur.embeddedGraphicsPending += 1;
 
         const suppressOutput = tur.singer.suppressOutput;
 
@@ -221,9 +224,11 @@ class EmbeddedGraphicsScheduler {
             }
         }
 
-        // Mark the end time of this note's graphics operations.
+        // Mark the end time of this note's graphics operations. Only
+        // decrement this call's own share of the count, rather than setting
+        // it back to zero outright, since another call may still be pending.
         await logo.deps.utils.delayExecution(beatValue * 1000);
-        tur.embeddedGraphicsFinished = true;
+        tur.embeddedGraphicsPending -= 1;
     }
 
     _pen(tur, suppressOutput, turtle, name, b, timeout) {

--- a/js/embedded-graphics-scheduler.js
+++ b/js/embedded-graphics-scheduler.js
@@ -69,6 +69,11 @@ class EmbeddedGraphicsScheduler {
             delay += 0.1;
         }
 
+        // Remember which generation this call belongs to, so that if a
+        // turtle/run reset happens before this call finishes, its eventual
+        // completion does not decrement a count that has moved on to a
+        // different generation of work (see #8639 follow-up).
+        const generation = tur.embeddedGraphicsGeneration;
         tur.embeddedGraphicsPending += 1;
 
         const suppressOutput = tur.singer.suppressOutput;
@@ -228,7 +233,12 @@ class EmbeddedGraphicsScheduler {
         // decrement this call's own share of the count, rather than setting
         // it back to zero outright, since another call may still be pending.
         await logo.deps.utils.delayExecution(beatValue * 1000);
-        tur.embeddedGraphicsPending -= 1;
+        if (tur.embeddedGraphicsGeneration === generation) {
+            tur.embeddedGraphicsPending -= 1;
+        }
+        // else: a turtle/run reset happened while this call was pending.
+        // The count already belongs to a new generation of work that this
+        // stale call knows nothing about, so leave it alone.
     }
 
     _pen(tur, suppressOutput, turtle, name, b, timeout) {

--- a/js/logo.js
+++ b/js/logo.js
@@ -1503,7 +1503,7 @@ class Logo {
         this._exportNotationFinished = false;
 
         for (const turtle of this.turtles.turtleList) {
-            turtle.embeddedGraphicsFinished = true;
+            turtle.embeddedGraphicsPending = 0;
         }
 
         this.prepSynths();

--- a/js/logo.js
+++ b/js/logo.js
@@ -1504,6 +1504,7 @@ class Logo {
 
         for (const turtle of this.turtles.turtleList) {
             turtle.embeddedGraphicsPending = 0;
+            turtle.embeddedGraphicsGeneration += 1;
         }
 
         this.prepSynths();

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -59,7 +59,9 @@ class Turtle {
         this.painter = new Painter(this); // for drawing logic
 
         this._waitTime = 0;
-        this.embeddedGraphicsFinished = true;
+        // Number of EmbeddedGraphicsScheduler.schedule() calls for this
+        // turtle that are still in flight (0 means none are pending).
+        this.embeddedGraphicsPending = 0;
 
         // Widget-related attributes
         this.inSetTimbre = false;
@@ -199,7 +201,7 @@ class Turtle {
         this.endOfClampSignals = {};
         this.butNotThese = {};
 
-        this.embeddedGraphicsFinished = true;
+        this.embeddedGraphicsPending = 0;
 
         this.inSetTimbre = false;
 

--- a/js/turtle.js
+++ b/js/turtle.js
@@ -62,6 +62,11 @@ class Turtle {
         // Number of EmbeddedGraphicsScheduler.schedule() calls for this
         // turtle that are still in flight (0 means none are pending).
         this.embeddedGraphicsPending = 0;
+        // Bumped whenever embeddedGraphicsPending is reset (turtle init,
+        // run start). A schedule() call started in an earlier generation
+        // that is still running when a reset happens must not decrement
+        // the new generation's count when it eventually finishes.
+        this.embeddedGraphicsGeneration = 0;
 
         // Widget-related attributes
         this.inSetTimbre = false;
@@ -202,6 +207,7 @@ class Turtle {
         this.butNotThese = {};
 
         this.embeddedGraphicsPending = 0;
+        this.embeddedGraphicsGeneration += 1;
 
         this.inSetTimbre = false;
 


### PR DESCRIPTION
## Description

`EmbeddedGraphicsScheduler.schedule()` uses a shared per-turtle boolean, `tur.embeddedGraphicsFinished`, to decide whether to add a small compensating delay before drawing a note's embedded turtle graphics. Since `schedule()` is `async` and `turtle-singer.js` never awaits `dispatchTurtleSignals()`, consecutive notes routinely have their `schedule()` calls in flight at the same time. Whichever call happened to finish first would unconditionally reset the shared flag to `true`, even while a later call's graphics were still running, so a subsequent note could skip the compensating delay it actually needed.

**Fixes:** #8639

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior

---

## Changes Made

- `js/embedded-graphics-scheduler.js` — `schedule()` now increments `tur.embeddedGraphicsPending` on entry and decrements its own share on completion, instead of unconditionally setting a boolean. The compensating-delay check becomes `pending > 0` instead of `!finished`.
- `js/turtle.js` — `Turtle.embeddedGraphicsFinished` (default `true`) replaced with `Turtle.embeddedGraphicsPending` (default `0`), both in the constructor and `initTurtle()`. Also adds `Turtle.embeddedGraphicsGeneration` (default `0`), bumped in `initTurtle()`.
- `js/logo.js` — the per-run reset in `runLogoCommands()` now zeroes `embeddedGraphicsPending` and bumps `embeddedGraphicsGeneration` for every turtle instead of setting the old boolean to `true`.
- Each `schedule()` call records the turtle's `embeddedGraphicsGeneration` at entry and only decrements `embeddedGraphicsPending` on completion if that generation is still current. This closes a follow-up gap CodeRabbit caught in review: `runLogoCommands()`/`initTurtle()` can reset the count while an earlier `schedule()` call is still pending (Stop button, or a "run" block restarting a turtle mid-note); without the generation check, that stale call's later decrement would corrupt the freshly reset count instead of being ignored.
- `js/__tests__/embedded-graphics-scheduler.test.js` — updated existing tests to the new field, and added two new tests: one driving two overlapping `schedule()` calls the way playback actually does (second call starts before the first's `delayExecution` resolves), and one simulating a reset happening while a call is still pending, followed by a genuinely new call, confirming the stale call's later completion doesn't touch the new generation's count.
- `js/__tests__/turtle.test.js`, `js/__tests__/logo.test.js` — updated the mock/reset tests referencing the old field, and added coverage for the generation bump.

## Why

A count is the natural fix once the root cause is identified as multiple concurrent calls sharing one mutable flag: each call only ever touches its own increment and its own decrement, so an early-finishing call cannot report "done" on behalf of a call that's still running. This was the alternative the issue itself suggested (a monotonic id would also work, but a pending count is simpler here since the only thing the flag was ever used for is "is anything still in flight").

## Testing Performed

- Verified both regression tests actually catch what they claim: temporarily reverted the count logic, then separately the generation guard, in `embedded-graphics-scheduler.js`, confirmed the corresponding new test fails against each reverted version, then restored the fix and confirmed everything passes.
- `npx eslint` on every changed file: 0 errors, 0 warnings.
- `npx prettier --check` on every changed file: passes.
- `npx jest js/__tests__/embedded-graphics-scheduler.test.js js/__tests__/turtle.test.js js/__tests__/logo.test.js js/__tests__/turtle-singer.test.js`: 190/190 passing.
- `npx jest` (full suite): 235/235 suites, 9234/9235 tests passing (1 pre-existing skip), 0 failures.

## Additional Notes

This PR has three commits:
1. The `embeddedGraphicsFinished` to `embeddedGraphicsPending` fix for #8639.
2. An unrelated test-only fix for `js/utils/__tests__/synthutils.test.js`, found while getting this branch's CI green. It was failing identically on `master` before this branch existed (a broken mock, see the commit for details), unrelated to embedded graphics, turtles, or logo. Happy to split it into its own PR if preferred.
3. The `embeddedGraphicsGeneration` follow-up from CodeRabbit's review, closing the reset/stale-call gap described above.

Scope of the actual fix is limited to this one flag, its generation companion, and their touch points (the scheduler, and the two places that reset them at turtle-init and run-start). No changes to the scheduling/timing logic inside `schedule()` itself, the `turtle-singer.js` call sites, or anything about how the embedded graphics commands are dispatched.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors on every file changed by this PR.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved embedded graphics scheduling when multiple drawing operations run concurrently.
  - Prevented completed operations from incorrectly clearing the status of later graphics work.
  - Preserved timing delays while graphics operations remain pending.
  - Prevented delayed results from previous runs from affecting newly started or reset runs.
  - Improved reliability when resetting graphics activity during turtle initialization and new runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->