### PR TITLE
fix(synthutils): restore t.isEDO check for custom EDO temperaments (Related to #8590)

### DIFF
--- a/js/utils/__tests__/synthutils.test.js
+++ b/js/utils/__tests__/synthutils.test.js
@@ -642,6 +642,24 @@ describe("Utility Functions (logic-only)", () => {
             delete global.TEMPERAMENT[customTempName];
             Synth.inTemperament = originalInTemp;
         });
+
+        it("should early-return and reset changeInTemperament for custom EDO temperaments (t.isEDO)", () => {
+            const customEdoName = "custom19EDO";
+            global.TEMPERAMENT[customEdoName] = {
+                isEDO: true,
+                pitchNumber: 19
+            };
+            const originalInTemp = Synth.inTemperament;
+            Synth.inTemperament = customEdoName;
+            Synth.changeInTemperament = true;
+
+            expect(() => temperamentChanged(customEdoName, "C4")).not.toThrow();
+            expect(Synth.changeInTemperament).toBe(false);
+            expect(whichTemperament()).toBe(customEdoName);
+
+            delete global.TEMPERAMENT[customEdoName];
+            Synth.inTemperament = originalInTemp;
+        });
     });
 
     describe("resume", () => {
@@ -1241,6 +1259,23 @@ describe("Utility Functions (logic-only)", () => {
             expect(_getFrequency("Bb2", false, "equal")).toBe(116.54094037952261);
             expect(_getFrequency("Bb3", false, "equal")).toBe(233.0818807590453);
             expect(_getFrequency("A4", false, "equal")).toBe(440.00000000000085);
+        });
+
+        it("should return frequency for custom EDO temperament via t.isEDO", () => {
+            const customEdoName = "custom19EDO";
+            global.TEMPERAMENT[customEdoName] = {
+                isEDO: true,
+                pitchNumber: 19
+            };
+            const originalInTemp = Synth.inTemperament;
+            Synth.inTemperament = customEdoName;
+
+            const freq = _getFrequency("C4", false, customEdoName);
+            expect(typeof freq).toBe("number");
+            expect(freq).toBeGreaterThan(0);
+
+            delete global.TEMPERAMENT[customEdoName];
+            Synth.inTemperament = originalInTemp;
         });
     });
     describe("getCustomFrequency", () => {
@@ -3328,6 +3363,19 @@ describe("Use-after-dispose race in Synth.trigger async path", () => {
 
             synth.temperamentChanged("just intonation", "C4");
             expect(Object.keys(synth.noteFrequencies).length).toBeGreaterThan(0);
+
+            // Custom EDO temperament (t.isEDO path)
+            const customEdoTemp = { isEDO: true, pitchNumber: 19 };
+            const origGetTemp = global.getTemperament;
+            global.getTemperament = jest.fn(name =>
+                name === "custom-19-edo" ? customEdoTemp : origGetTemp(name)
+            );
+            synth.inTemperament = "custom-19-edo";
+            synth.changeInTemperament = true;
+            synth.temperamentChanged("custom-19-edo", "C4");
+            expect(synth.inTemperament).toBe("custom-19-edo");
+            expect(synth.changeInTemperament).toBe(false);
+            global.getTemperament = origGetTemp;
         });
 
         test("_getFrequency across various temperaments and input types", () => {

--- a/js/utils/synthutils.js
+++ b/js/utils/synthutils.js
@@ -692,7 +692,7 @@ function Synth() {
         // and never use noteFrequencies, so skip building the table.
         // This also avoids crashing on microtonal interval names (e.g. "mid 2")
         // that exist in the temperament definition but not in INTERVALVALUES.
-        if (isEquallyTempered(temperament)) {
+        if (t && (t.isEDO || isEquallyTempered(temperament))) {
             this.changeInTemperament = false;
             return;
         }
@@ -808,7 +808,8 @@ function Synth() {
             }
         }
 
-        if (isEquallyTempered(this.inTemperament)) {
+        const t = getTemperament(this.inTemperament);
+        if (t && (t.isEDO || isEquallyTempered(this.inTemperament))) {
             if (typeof notes === "string") {
                 const parsed = parseNoteString(notes);
                 return pitchToFrequency(parsed[0], parsed[1], 0, "c major", this.inTemperament);


### PR DESCRIPTION



## Description

Restores the `t && (t.isEDO || isEquallyTempered(...))` check in `temperamentChanged` and `_getFrequency` in `js/utils/synthutils.js`.
In commit `dfb7c72de` (#8590), this check was simplified to `isEquallyTempered(...)`. This caused an upstream regression on `master` for mocked or custom EDO temperaments in tests and runtime: `isEquallyTempered` only checks the internal `TEMPERAMENT` table in `musicutils.js`. When a custom or mocked EDO temperament with `isEDO: true` is passed (such as `"19-EDO"` in `synthutils.test.js`), `isEquallyTempered` returns `false`, causing `_getFrequency` to fall through to `this.noteFrequencies` and return `undefined`.

## Related Issue

Related to #8590

---

## Category



- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`js/utils/synthutils.js` (`temperamentChanged`)**: Restored `if (t && (t.isEDO || isEquallyTempered(temperament)))` to preserve `t.isEDO` detection.
- **`js/utils/synthutils.js` (`_getFrequency`)**: Restored `const t = getTemperament(this.inTemperament); if (t && (t.isEDO || isEquallyTempered(this.inTemperament)))` so custom/mocked EDO temperaments are correctly routed to `pitchToFrequency`.
---

## Steps to Reproduce

1. Run `npx jest js/utils/__tests__/synthutils.test.js -t "_getFrequency across various temperaments and input types"`.
2. Observe test failure at line 3352:
   ```text
   Expected: "number"
   Received: "undefined"
3.With this patch, synth._getFrequency("C4", false) under "19-EDO" correctly identifies isEDO: true and returns the frequency as expected.



---

## Testing Performed

Executed npx jest js/utils/__tests__/synthutils.test.js: All 191/191 tests pass cleanly.
Executed npm run lint: Passes with 0 errors / 0 warnings.
Executed npx prettier --check js/utils/synthutils.js: Verified style compliance.

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

This regression on master is currently causing the CI / Jest tests & coverage check to fail across freshly rebased pull requests (such as #8611). Merging this fix will unblock CI for those branches.
---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for EDO (equal division of the octave) temperaments when calculating note frequencies.
  - Prevented errors caused by microtonal interval names during temperament changes.
  - Improved performance by avoiding unnecessary frequency-table generation for supported temperaments.
  - Ensured EDO temperament changes retain the selected temperament and produce valid frequencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->