### PR TITLE
feat: add keyboard navigation and ARIA to temperament widget

### DIFF
--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1,3 +1,6 @@
+const { makeKeyboardAccessible } = require("../../utils/dom-helpers");
+global.makeKeyboardAccessible = makeKeyboardAccessible;
+
 const TemperamentWidget = require("../temperament");
 describe("TemperamentWidget basic tests", () => {
     let widget;
@@ -7,6 +10,12 @@ describe("TemperamentWidget basic tests", () => {
         textContent: "",
         appendChild: jest.fn(),
         setAttribute: jest.fn(),
+        getAttribute: jest.fn(() => ""),
+        classList: {
+            add: jest.fn(),
+            remove: jest.fn(),
+            contains: jest.fn()
+        },
         style: {},
         width: 100,
         height: 100,
@@ -1862,6 +1871,228 @@ describe("TemperamentWidget basic tests", () => {
             expect(mockEditBtn1.removeEventListener).toHaveBeenCalledWith("click", handler3);
             expect(widget._editBtn).toBeNull();
             expect(widget._editClickHandler).toBeNull();
+        });
+    });
+
+    describe("TemperamentWidget keyboard accessibility and ARIA support", () => {
+        beforeEach(() => {
+            global.docById = jest.fn(id => document.getElementById(id) || createMockElement(id));
+        });
+
+        test("_addButton sets role, tabindex, and aria-label", () => {
+            const mockRow = {
+                insertCell: jest.fn(() => document.createElement("td"))
+            };
+            const cell = widget._addButton(mockRow, "play-button.svg", 32, "Play");
+            expect(cell.getAttribute("role")).toBe("button");
+            expect(cell.getAttribute("tabindex")).toBe("0");
+            expect(cell.getAttribute("aria-label")).toBe("Play");
+        });
+
+        test("edit() sets keyboard accessibility on all navigation tabs", () => {
+            global.window.widgetWindows = {
+                windowFor: jest.fn(() => ({
+                    clear: jest.fn(),
+                    show: jest.fn(),
+                    getWidgetBody: jest.fn(() => document.body),
+                    addButton: jest.fn(() => ({
+                        onclick: null,
+                        getElementsByTagName: jest.fn(() => [{}])
+                    })),
+                    sendToCenter: jest.fn()
+                }))
+            };
+            global.buildScale = jest.fn(() => [["C"], []]);
+            global.getNoteFromInterval = jest.fn(() => ["C", 4]);
+            global.getTemperament = jest.fn(() => ({
+                interval: [],
+                pitchNumber: 1,
+                0: 1,
+                1: 2
+            }));
+
+            widget.inTemperament = "equal";
+            widget.scale = ["C", "Major"];
+            widget.init({
+                errorMsg: jest.fn(),
+                logo: {
+                    synth: {
+                        startingPitch: "C4",
+                        _getFrequency: jest.fn(() => 440),
+                        setMasterVolume: jest.fn(),
+                        stop: jest.fn()
+                    }
+                }
+            });
+
+            widget.notesCircle = { removeWheel: jest.fn() };
+            widget.equalEdit = jest.fn();
+            widget.edit();
+
+            const menuTr = document.getElementById("menu");
+            expect(menuTr).not.toBeNull();
+            const tabs = menuTr.querySelectorAll("td.editMenus");
+            expect(tabs.length).toBe(4);
+
+            const expectedLabels = ["equal", "ratios", "arbitrary", "octave space"];
+            tabs.forEach((tab, index) => {
+                expect(tab.getAttribute("role")).toBe("button");
+                expect(tab.getAttribute("tabindex")).toBe("0");
+                expect(tab.getAttribute("aria-label")).toBe(expectedLabels[index]);
+            });
+        });
+
+        test("equalEdit() assigns aria-label to numeric inputs and accessibility to preview/done buttons", () => {
+            widget.ratios = [1, 2];
+            widget.equalEdit();
+
+            const octaveIn = document.getElementById("octaveIn");
+            const octaveOut = document.getElementById("octaveOut");
+            const divisions = document.getElementById("divisions");
+            expect(octaveIn.getAttribute("aria-label")).toBe("pitch number");
+            expect(octaveOut.getAttribute("aria-label")).toBe("to");
+            expect(divisions.getAttribute("aria-label")).toBe("number of divisions");
+
+            const preview = document.getElementById("preview");
+            const done = document.getElementById("done_");
+            expect(preview.getAttribute("role")).toBe("button");
+            expect(preview.getAttribute("tabindex")).toBe("0");
+            expect(done.getAttribute("role")).toBe("button");
+            expect(done.getAttribute("tabindex")).toBe("0");
+        });
+
+        test("ratioEdit() assigns aria-label to ratio inputs and recursion", () => {
+            widget.ratioEdit();
+
+            const ratioIn = document.getElementById("ratioIn");
+            const ratioOut = document.getElementById("ratioOut");
+            const recursion = document.getElementById("recursion");
+            expect(ratioIn.getAttribute("aria-label")).toBe("ratio numerator");
+            expect(ratioOut.getAttribute("aria-label")).toBe("ratio denominator");
+            expect(recursion.getAttribute("aria-label")).toBe("recursion");
+        });
+
+        test("octaveSpaceEdit() assigns aria-label to octave inputs and accessibility to done button", () => {
+            widget.ratios = [1, 2];
+            widget.octaveSpaceEdit();
+
+            const startNote = document.getElementById("startNote");
+            const endNote = document.getElementById("endNote");
+            expect(startNote.getAttribute("aria-label")).toBe("octave space start");
+            expect(endNote.getAttribute("aria-label")).toBe("octave space end");
+
+            const doneBtn = document.getElementById("divAppend");
+            expect(doneBtn.getAttribute("role")).toBe("button");
+            expect(doneBtn.getAttribute("tabindex")).toBe("0");
+            expect(doneBtn.getAttribute("aria-label")).toBe("done");
+        });
+
+        test("editFrequency() assigns aria-label to inputs and accessibility to done button", () => {
+            const noteInfo = document.createElement("div");
+            noteInfo.id = "noteInfo";
+            document.body.appendChild(noteInfo);
+
+            widget.frequencies = ["261.63", "293.66", "329.63"];
+            widget.ratios = [1, 1.12, 1.25];
+
+            widget.editFrequency({ target: { dataset: { message: "1" } } });
+
+            const slider = document.getElementById("frequencySlider1");
+            const centsInput = document.getElementById("centsInput1");
+            const done = document.getElementById("done");
+
+            expect(slider.getAttribute("aria-label")).toBe("frequency");
+            expect(centsInput.getAttribute("aria-label")).toBe("cents");
+            expect(done.getAttribute("role")).toBe("button");
+            expect(done.getAttribute("tabindex")).toBe("0");
+            expect(done.getAttribute("aria-label")).toBe("done");
+        });
+
+        test("_graphOfNotes() sets keyboard accessibility on note play buttons", () => {
+            const origQuerySelectorAll = document.querySelectorAll.bind(document);
+            document.querySelectorAll = jest.fn(selector => {
+                if (selector === "#menuLabels") {
+                    return Array.from({ length: 7 }, () => ({ style: {} }));
+                }
+                return origQuerySelectorAll(selector);
+            });
+
+            global.window.widgetWindows = {
+                windowFor: jest.fn(() => ({
+                    clear: jest.fn(),
+                    show: jest.fn(),
+                    getWidgetBody: jest.fn(() => document.body),
+                    addButton: jest.fn(() => ({
+                        onclick: null,
+                        getElementsByTagName: jest.fn(() => [{}])
+                    })),
+                    sendToCenter: jest.fn()
+                }))
+            };
+            global.buildScale = jest.fn(() => [["C"], []]);
+            global.getNoteFromInterval = jest.fn(() => ["C", 4]);
+            global.getTemperament = jest.fn(() => ({
+                interval: [],
+                pitchNumber: 1,
+                0: 1,
+                1: 2
+            }));
+
+            widget.inTemperament = "equal";
+            widget.scale = ["C", "Major"];
+            widget.init({
+                errorMsg: jest.fn(),
+                logo: {
+                    synth: {
+                        startingPitch: "C4",
+                        _getFrequency: jest.fn(() => 440)
+                    }
+                }
+            });
+
+            widget.toggleNotesButton = jest.fn();
+            widget.notesCircle = { removeWheel: jest.fn() };
+            widget.pitchNumber = 1;
+            widget.ratios = [1, 2];
+            widget.frequencies = [440, 880];
+            widget.intervals = ["0", "1"];
+            widget.notes = [
+                ["C", 4],
+                ["C", 5]
+            ];
+            widget.scaleNotes = ["C"];
+            widget.circleIsVisible = false;
+
+            widget._graphOfNotes();
+
+            for (let i = 0; i <= 1; i++) {
+                const playBtn = document.getElementById("play_" + i);
+                expect(playBtn).not.toBeNull();
+                expect(playBtn.getAttribute("role")).toBe("button");
+                expect(playBtn.getAttribute("tabindex")).toBe("0");
+                expect(playBtn.getAttribute("aria-label")).toContain("play");
+            }
+
+            document.querySelectorAll = origQuerySelectorAll;
+        });
+
+        test("keyboard activation via Enter and Space triggers click handler", () => {
+            const mockRow = {
+                insertCell: jest.fn(() => document.createElement("td"))
+            };
+            const cell = widget._addButton(mockRow, "play-button.svg", 32, "Play");
+            const clickSpy = jest.fn();
+            cell.addEventListener("click", clickSpy);
+
+            cell.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            expect(clickSpy).toHaveBeenCalledTimes(1);
+
+            cell.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+            expect(clickSpy).toHaveBeenCalledTimes(2);
+
+            // Other keys should not activate
+            cell.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+            expect(clickSpy).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/js/widgets/__tests__/temperament.test.js
+++ b/js/widgets/__tests__/temperament.test.js
@@ -1902,6 +1902,10 @@ describe("TemperamentWidget basic tests", () => {
                     sendToCenter: jest.fn()
                 }))
             };
+            const origGetTemperament = global.getTemperament;
+            const origBuildScale = global.buildScale;
+            const origGetNoteFromInterval = global.getNoteFromInterval;
+
             global.buildScale = jest.fn(() => [["C"], []]);
             global.getNoteFromInterval = jest.fn(() => ["C", 4]);
             global.getTemperament = jest.fn(() => ({
@@ -1940,6 +1944,10 @@ describe("TemperamentWidget basic tests", () => {
                 expect(tab.getAttribute("tabindex")).toBe("0");
                 expect(tab.getAttribute("aria-label")).toBe(expectedLabels[index]);
             });
+
+            global.getTemperament = origGetTemperament;
+            global.buildScale = origBuildScale;
+            global.getNoteFromInterval = origGetNoteFromInterval;
         });
 
         test("equalEdit() assigns aria-label to numeric inputs and accessibility to preview/done buttons", () => {
@@ -1949,8 +1957,8 @@ describe("TemperamentWidget basic tests", () => {
             const octaveIn = document.getElementById("octaveIn");
             const octaveOut = document.getElementById("octaveOut");
             const divisions = document.getElementById("divisions");
-            expect(octaveIn.getAttribute("aria-label")).toBe("pitch number");
-            expect(octaveOut.getAttribute("aria-label")).toBe("to");
+            expect(octaveIn.getAttribute("aria-label")).toBe("starting pitch number");
+            expect(octaveOut.getAttribute("aria-label")).toBe("ending pitch number");
             expect(divisions.getAttribute("aria-label")).toBe("number of divisions");
 
             const preview = document.getElementById("preview");
@@ -2029,6 +2037,10 @@ describe("TemperamentWidget basic tests", () => {
                     sendToCenter: jest.fn()
                 }))
             };
+            const origGetTemperament = global.getTemperament;
+            const origBuildScale = global.buildScale;
+            const origGetNoteFromInterval = global.getNoteFromInterval;
+
             global.buildScale = jest.fn(() => [["C"], []]);
             global.getNoteFromInterval = jest.fn(() => ["C", 4]);
             global.getTemperament = jest.fn(() => ({
@@ -2074,6 +2086,9 @@ describe("TemperamentWidget basic tests", () => {
             }
 
             document.querySelectorAll = origQuerySelectorAll;
+            global.getTemperament = origGetTemperament;
+            global.buildScale = origBuildScale;
+            global.getNoteFromInterval = origGetNoteFromInterval;
         });
 
         test("keyboard activation via Enter and Space triggers click handler", () => {

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -797,9 +797,7 @@ function TemperamentWidget() {
         const el = docById(divId);
         if (el !== null) {
             el.style.display = "none";
-            if (wheel && typeof wheel.removeWheel === "function") {
-                wheel.removeWheel();
-            }
+            wheel.removeWheel();
         }
     };
 
@@ -1108,7 +1106,7 @@ function TemperamentWidget() {
         octaveIn.type = "text";
         octaveIn.id = "octaveIn";
         octaveIn.value = "0";
-        octaveIn.setAttribute("aria-label", _("pitch number"));
+        octaveIn.setAttribute("aria-label", _("starting pitch number"));
         equalEdit.appendChild(octaveIn);
         equalEdit.appendChild(
             document.createTextNode(" \u00A0\u00A0 " + _("to") + "\u00A0\u00A0 ")
@@ -1117,7 +1115,7 @@ function TemperamentWidget() {
         octaveOut.type = "text";
         octaveOut.id = "octaveOut";
         octaveOut.value = "0";
-        octaveOut.setAttribute("aria-label", _("to"));
+        octaveOut.setAttribute("aria-label", _("ending pitch number"));
         equalEdit.appendChild(octaveOut);
         equalEdit.appendChild(document.createElement("br"));
         equalEdit.appendChild(document.createElement("br"));

--- a/js/widgets/temperament.js
+++ b/js/widgets/temperament.js
@@ -23,8 +23,8 @@
    deleteTemperamentFromList, docById, FLAT, getNoteFromInterval,
    getOctaveRatio, getTemperament, getTemperamentKeys, getTemperamentRatio,
    isCustomTemperament, last, normalizeNoteAccidentals, parseNoteString, pitchToFrequency, platformColor,
-   PREVIEWVOLUME, ratioToWheelAngle, rationalToFraction, setOctaveRatio, setOctaveRatio, SHARP, Singer,
-   slicePath, updateTemperaments, wheelnav, frequencyToPitch, clampNumber
+   PREVIEWVOLUME, ratioToWheelAngle, rationalToFraction, setOctaveRatio, SHARP, Singer,
+   slicePath, updateTemperaments, wheelnav, frequencyToPitch, clampNumber, makeKeyboardAccessible
  */
 
 /* exported TemperamentWidget */
@@ -172,6 +172,8 @@ function TemperamentWidget() {
         doneDiv.id = "done_";
         doneDiv.style.cssFloat = "right";
         doneDiv.textContent = _("done");
+        makeKeyboardAccessible(previewDiv, preview ? _("back") : _("preview"));
+        makeKeyboardAccessible(doneDiv, _("done"));
         divAppend.appendChild(previewDiv);
         divAppend.appendChild(doneDiv);
         divAppend.style.textAlign = "center";
@@ -223,6 +225,8 @@ function TemperamentWidget() {
         cell.style.minHeight = cell.style.height;
         cell.style.maxHeight = cell.style.height;
         cell.classList.add("temperament-selector-cell");
+
+        makeKeyboardAccessible(cell, label);
 
         cell.onmouseover = function () {
             this.classList.add("temperament-selector-hover");
@@ -389,6 +393,8 @@ function TemperamentWidget() {
             standardOctaveDiv.id = "standardOctave";
             standardOctaveDiv.style.cssFloat = "right";
             standardOctaveDiv.textContent = _("back to 2:1 octave space");
+            makeKeyboardAccessible(clearNotesDiv, _("Clear"));
+            makeKeyboardAccessible(standardOctaveDiv, _("back to 2:1 octave space"));
             divAppend.appendChild(clearNotesDiv);
             divAppend.appendChild(standardOctaveDiv);
             divAppend.style.textAlign = "center";
@@ -406,16 +412,19 @@ function TemperamentWidget() {
             divAppend1.style.marginLeft = "3px";
             divAppend1.style.backgroundColor = platformColor.selectorBackground;
             divAppend1.style.width = "212px";
+            divAppend1.style.cursor = "pointer";
 
             divAppend2 = docById("standardOctave");
             divAppend2.style.height = "30px";
             divAppend2.style.marginRight = "3px";
             divAppend2.style.backgroundColor = platformColor.selectorBackground;
             divAppend2.style.width = BUTTONDIVWIDTH / 2 - 8 + "px";
+            divAppend2.style.cursor = "pointer";
         } else {
             divAppend1 = document.createElement("div");
             divAppend1.id = "divAppend";
             divAppend1.textContent = _("Clear");
+            makeKeyboardAccessible(divAppend1, _("Clear"));
             divAppend1.style.textAlign = "center";
             divAppend1.style.position = "absolute";
             divAppend1.style.zIndex = 2;
@@ -425,6 +434,7 @@ function TemperamentWidget() {
             divAppend1.style.width = docById("wheelDiv2").style.width;
             divAppend1.style.marginTop = docById("wheelDiv2").style.height;
             divAppend1.style.overflow = "auto";
+            divAppend1.style.cursor = "pointer";
             docById("temperamentTable").append(divAppend1);
         }
 
@@ -536,6 +546,8 @@ function TemperamentWidget() {
                     editImg.setAttribute("height", "20px");
                     editImg.setAttribute("width", "20px");
                     editImg.setAttribute("data-message", i);
+                    editImg.style.cursor = "pointer";
+                    makeKeyboardAccessible(editImg, _("edit"));
                     noteInfoDiv.appendChild(editImg);
                 }
 
@@ -547,6 +559,8 @@ function TemperamentWidget() {
                 closeImg.setAttribute("height", "20px");
                 closeImg.setAttribute("width", "20px");
                 closeImg.setAttribute("align", "right");
+                closeImg.style.cursor = "pointer";
+                makeKeyboardAccessible(closeImg, _("Close"));
                 noteInfoDiv.appendChild(closeImg);
 
                 noteInfoDiv.appendChild(document.createElement("br"));
@@ -648,6 +662,7 @@ function TemperamentWidget() {
         slider.style.border = "0";
         slider.setAttribute("min", this.frequencies[i - 1]);
         slider.setAttribute("max", this.frequencies[i + 1]);
+        slider.setAttribute("aria-label", _("frequency"));
         center.appendChild(slider);
         noteInfo.appendChild(center);
 
@@ -669,6 +684,7 @@ function TemperamentWidget() {
         centsInput.id = "centsInput1";
         centsInput.value = "0";
         centsInput.step = "1";
+        centsInput.setAttribute("aria-label", _("cents"));
         // Match the frequency display styling: blue text on grey rounded pill.
         centsInput.className = "rangeslidervalue";
         centsInput.style.width = "60px";
@@ -685,6 +701,7 @@ function TemperamentWidget() {
         doneDiv.style.marginTop = "8px";
         doneDiv.style.borderRadius = "4px";
         doneDiv.style.cursor = "pointer";
+        makeKeyboardAccessible(doneDiv, _("done"));
         const doneCenter = document.createElement("center");
         doneCenter.textContent = _("done");
         doneCenter.style.color = "white";
@@ -780,7 +797,9 @@ function TemperamentWidget() {
         const el = docById(divId);
         if (el !== null) {
             el.style.display = "none";
-            wheel.removeWheel();
+            if (wheel && typeof wheel.removeWheel === "function") {
+                wheel.removeWheel();
+            }
         }
     };
 
@@ -882,12 +901,14 @@ function TemperamentWidget() {
             notesCell[i][0].textContent = "\u00A0\u00A0";
             const playImg = document.createElement("img");
             playImg.src = "header-icons/play-button.svg";
-            playImg.title = _("Play");
-            playImg.alt = _("Play");
+            playImg.id = "play_" + i;
+            playImg.title = _("play");
+            playImg.alt = "play";
             playImg.setAttribute("height", "20px");
             playImg.setAttribute("width", "20px");
-            playImg.id = "play_" + i;
             playImg.setAttribute("data-id", i);
+            playImg.style.cursor = "pointer";
+            makeKeyboardAccessible(playImg, `${_("play")} ${this.notes[i] || i}`);
             notesCell[i][0].appendChild(playImg);
             notesCell[i][0].appendChild(document.createTextNode("\u00A0\u00A0"));
             notesCell[i][0].style.width = 40 + "px";
@@ -1013,6 +1034,8 @@ function TemperamentWidget() {
             td.style.height = 30 + "px";
             td.style.textAlign = "center";
             td.style.fontWeight = "bold";
+            td.style.cursor = "pointer";
+            makeKeyboardAccessible(td, editMenus[i]);
             menuItems.push(td);
             editOctaveTr.appendChild(td);
         }
@@ -1085,6 +1108,7 @@ function TemperamentWidget() {
         octaveIn.type = "text";
         octaveIn.id = "octaveIn";
         octaveIn.value = "0";
+        octaveIn.setAttribute("aria-label", _("pitch number"));
         equalEdit.appendChild(octaveIn);
         equalEdit.appendChild(
             document.createTextNode(" \u00A0\u00A0 " + _("to") + "\u00A0\u00A0 ")
@@ -1093,6 +1117,7 @@ function TemperamentWidget() {
         octaveOut.type = "text";
         octaveOut.id = "octaveOut";
         octaveOut.value = "0";
+        octaveOut.setAttribute("aria-label", _("to"));
         equalEdit.appendChild(octaveOut);
         equalEdit.appendChild(document.createElement("br"));
         equalEdit.appendChild(document.createElement("br"));
@@ -1103,6 +1128,7 @@ function TemperamentWidget() {
         divisions.type = "text";
         divisions.id = "divisions";
         divisions.value = this.pitchNumber;
+        divisions.setAttribute("aria-label", _("number of divisions"));
         equalEdit.appendChild(divisions);
         equalEdit.style.paddingLeft = "80px";
         const that = this;
@@ -1257,12 +1283,14 @@ function TemperamentWidget() {
         ratioIn.type = "text";
         ratioIn.id = "ratioIn";
         ratioIn.value = "1";
+        ratioIn.setAttribute("aria-label", _("ratio numerator"));
         ratioEdit.appendChild(ratioIn);
         ratioEdit.appendChild(document.createTextNode(" \u00A0\u00A0 : \u00A0\u00A0 "));
         const ratioOut = document.createElement("input");
         ratioOut.type = "text";
         ratioOut.id = "ratioOut";
         ratioOut.value = "1";
+        ratioOut.setAttribute("aria-label", _("ratio denominator"));
         ratioEdit.appendChild(ratioOut);
         ratioEdit.appendChild(document.createElement("br"));
         ratioEdit.appendChild(document.createElement("br"));
@@ -1273,6 +1301,7 @@ function TemperamentWidget() {
         recursion.type = "text";
         recursion.id = "recursion";
         recursion.value = "1";
+        recursion.setAttribute("aria-label", _("recursion"));
         ratioEdit.appendChild(recursion);
         ratioEdit.style.paddingLeft = "100px";
         const that = this;
@@ -1628,6 +1657,8 @@ function TemperamentWidget() {
         divAppend.style.height = "25px";
         divAppend.style.marginTop = "40px";
         divAppend.style.overflow = "auto";
+        divAppend.style.cursor = "pointer";
+        makeKeyboardAccessible(divAppend, _("done"));
         arbitraryEdit.append(divAppend);
 
         divAppend.onmouseover = function () {
@@ -1688,6 +1719,8 @@ function TemperamentWidget() {
                 closeImg.setAttribute("height", "20px");
                 closeImg.setAttribute("width", "20px");
                 closeImg.setAttribute("align", "right");
+                closeImg.style.cursor = "pointer";
+                makeKeyboardAccessible(closeImg, _("Close"));
                 noteInfo1.appendChild(closeImg);
 
                 noteInfo1.appendChild(document.createElement("br"));
@@ -1702,6 +1735,7 @@ function TemperamentWidget() {
                 slider.setAttribute("min", frequencies[i]);
                 slider.setAttribute("max", frequencies[i + 1]);
                 slider.setAttribute("value", "30");
+                slider.setAttribute("aria-label", _("frequency"));
                 centerNode.appendChild(slider);
                 noteInfo1.appendChild(centerNode);
 
@@ -1717,6 +1751,8 @@ function TemperamentWidget() {
                 const doneDiv = document.createElement("div");
                 doneDiv.id = "done";
                 doneDiv.style.background = "rgb(196, 196, 196)";
+                doneDiv.style.cursor = "pointer";
+                makeKeyboardAccessible(doneDiv, _("done"));
                 const doneCenter = document.createElement("center");
                 doneCenter.textContent = _("done");
                 doneDiv.appendChild(doneCenter);
@@ -1803,6 +1839,7 @@ function TemperamentWidget() {
         startNote.id = "startNote";
         startNote.value = octaveRatio;
         startNote.style.width = "50px";
+        startNote.setAttribute("aria-label", _("octave space start"));
         octaveSpaceEdit.appendChild(startNote);
         octaveSpaceEdit.appendChild(document.createTextNode(" \u00A0\u00A0 : \u00A0\u00A0 "));
         const endNote = document.createElement("input");
@@ -1810,6 +1847,7 @@ function TemperamentWidget() {
         endNote.id = "endNote";
         endNote.value = "1";
         endNote.style.width = "50px";
+        endNote.setAttribute("aria-label", _("octave space end"));
         octaveSpaceEdit.appendChild(endNote);
         octaveSpaceEdit.appendChild(document.createElement("br"));
         octaveSpaceEdit.appendChild(document.createElement("br"));
@@ -1826,6 +1864,8 @@ function TemperamentWidget() {
         divAppend.style.height = "25px";
         divAppend.style.marginTop = "40px";
         divAppend.style.overflow = "auto";
+        divAppend.style.cursor = "pointer";
+        makeKeyboardAccessible(divAppend, _("done"));
         octaveSpaceEdit.append(divAppend);
 
         divAppend.onmouseover = function () {


### PR DESCRIPTION
## Description

Adds full keyboard navigation (<kbd>Tab</kbd> focus, <kbd>Enter</kbd> / <kbd>Space</kbd> key activation) and ARIA accessibility (roles, labels) to interactive controls within the Temperament widget (`js/widgets/temperament.js`). Previously, the widget relied entirely on mouse-only click handlers and lacked keyboard accessibility or screen-reader accessible names (WCAG 2.1 compliance).

## Related Issue

**Fixes:** #8648

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [x] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **Keyboard navigation & activation**: Applied `makeKeyboardAccessible(element, label)` from `js/utils/dom-helpers.js` to internal non-standard interactive button elements (`<div>`, `<td>`, `<img>`), setting `role="button"`, `tabindex="0"`, `aria-label`, and handling <kbd>Enter</kbd> / <kbd>Space</kbd> activation:
  - Buttons created via `this._addButton` helper
  - Edit view mode navigation tabs (`menuItems`: Equal, Pitch Ratio, Arbitrary, Octave Space)
  - Preview and Done button pairs (`addPreviewDoneButtonPair`, `done_`, `preview`, `divAppend`)
  - Clear notes & Standard octave buttons in `_circleOfNotes`
  - Note row play buttons in `_graphOfNotes`
  - Note Info and Frequency edit popup buttons (Edit, Close, Done)
- **Screen reader labels**: Added descriptive `aria-label` attributes to text, number, and slider inputs:
  - Equal temperament inputs (`octaveIn` as starting pitch number, `octaveOut` as ending pitch number, `divisions` as number of divisions)
  - Pitch ratio inputs (`ratioIn`, `ratioOut`, `recursion`)
  - Octave space inputs (`startNote`, `endNote`)
  - Frequency & cents popup editor (`slider`, `centsInput`)
- **Unit Tests**: Added comprehensive test suite in `js/widgets/__tests__/temperament.test.js` verifying that:
  - Elements receive `tabindex="0"` and `role="button"`
  - Descriptive `aria-label` attributes are set on all buttons, tabs, and inputs
  - <kbd>Enter</kbd> and <kbd>Space</kbd> keydown events trigger button click handlers
  - Test isolation is maintained by restoring all mocked globals

---

## Steps to Reproduce

1. Open Music Blocks and open the Temperament widget.
2. Attempt to navigate to internal controls (Clear, Done, Preview, Edit mode tabs, Note table play buttons) using only the <kbd>Tab</kbd> key.
3. Observe that these controls cannot receive keyboard focus and cannot be triggered with <kbd>Enter</kbd> or <kbd>Space</kbd>.

---

## Visual Changes

N/A (Accessibility enhancement; interactive controls now display the browser focus outline when focused via keyboard and have pointer cursors).

---

## Testing Performed

- ✅ **Unit Tests**: `npm test js/widgets/__tests__/temperament.test.js` — **73/73 tests pass** (8 new a11y tests)
- ✅ **Code Style**: `npx prettier --check js/widgets/temperament.js js/widgets/__tests__/temperament.test.js` — Clean
- ✅ **Linter**: `npm run lint` (`eslint .`) — 0 errors, 0 warnings
- ✅ **Pre-commit Hooks**: Husky `lint-staged` and `commitlint` passed on commit

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

- Reuses the existing `makeKeyboardAccessible` helper from `js/utils/dom-helpers.js`.
- Preserves existing mouse click behavior and full backward compatibility.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added keyboard activation support for widget controls, navigation tabs, forms, editing menus, preview and completion actions, and note playback.
  * Added descriptive ARIA labels to sliders and input fields, including starting and ending pitch fields.
* **Usability**
  * Added pointer-cursor styling to interactive buttons, images, menus, and playback controls.
* **Testing**
  * Expanded accessibility tests covering keyboard interactions and Enter/Space activation across the temperament widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->