### PR TITLE
perf: eliminate redundant RAF callback after clean render frames

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -594,6 +594,7 @@ class Activity {
                         this.selectionController.isDragging || this.selectionController.isSelecting;
 
                     if (this.stageDirty || hasActiveTweens || hasActiveGifs || isInteracting) {
+                        let frameErrored = false;
                         try {
                             // Recompute culling when container moved.
                             if (
@@ -613,11 +614,28 @@ class Activity {
                             // with no frame queued, and _startRenderLoop() refuses to
                             // restart on that flag, so the canvas stopped repainting for
                             // the rest of the session. Report the frame and keep going.
+                            frameErrored = true;
                             console.error("Music Blocks: render frame failed", err);
                         } finally {
                             this.stageDirty = false;
-                            // Continue the loop if there's work or ongoing interaction
+                        }
+
+                        // On error: always keep the loop alive (prevents canvas freeze).
+                        // On success: continue only if there is still outstanding work.
+                        // Re-reading stageDirty after clearing it catches the edge case
+                        // where stage.update() itself synchronously re-dirtied the stage.
+                        if (
+                            frameErrored ||
+                            this.stageDirty ||
+                            hasActiveTweens ||
+                            hasActiveGifs ||
+                            isInteracting
+                        ) {
                             this._renderLoopRafId = requestAnimationFrame(renderLoop);
+                        } else {
+                            // Nothing to render — let the loop go idle
+                            this._renderLoopRunning = false;
+                            this._renderLoopRafId = null;
                         }
                     } else {
                         // Nothing to render — let the loop go idle


### PR DESCRIPTION
## Description

While looking into how the render loop handles dirty canvas updates, I noticed that whenever `stageDirty` is set, such as when a note plays or the turtle moves, the render loop calls `stage.update()` and then always schedules another `requestAnimationFrame` through the `finally` block.

That second frame usually has nothing left to render and only checks that the canvas is already clean before stopping. So, every visual update currently triggers **2 RAF callbacks**: one that renders the changes and another empty frame right after it.

This PR optimizes that flow by checking if any work is still pending after `stage.update()`. If there are no active tweens, GIFs, user interactions, or new dirty flags, the loop stops immediately instead of scheduling an unnecessary extra frame.

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [ ] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [x] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation


---

## Changes Made

  * Removed the unconditional RAF re-queue from the `finally` block.
  * Added a check after `stage.update()` to see if another frame is actually needed because of `stageDirty`, active tweens/GIFs, dragging/selection, or a frame error.
  * If there is no work left, the loop now immediately sets `_renderLoopRunning = false` and resets `_renderLoopRafId` to idle.
  * Handled cases where `stage.update()` re-dirties the canvas or throws an error, so the loop continues when needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas rendering recovery after a frame update error.
  * Rendering now continues when work remains pending, including animations, GIFs, dragging, or selection interactions.
  * The render loop now correctly returns to an idle state only when no further updates are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->