### PR TITLE
chore: patch npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "jquery": "3.7.1",
                 "jquery-ui-dist": "1.12.1",
                 "materialize-css": "0.100.2",
-                "postcss": "8.5.18",
+                "postcss": "8.5.28",
                 "sass": "1.101.0",
                 "tone": "^15.1.22"
             },
@@ -45,7 +45,7 @@
                 "cross-env": "^7.0.3",
                 "cypress": "^15.15.0",
                 "electron": "41.10.3",
-                "electron-builder": "26.8.1",
+                "electron-builder": "26.15.3",
                 "eslint": "^9.0.0",
                 "eslint-config-prettier": "^9.0.0",
                 "fake-indexeddb": "6.2.5",
@@ -2253,22 +2253,6 @@
                 "ms": "^2.1.1"
             }
         },
-        "node_modules/@develar/schema-utils": {
-            "version": "2.6.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.12.0",
-                "ajv-keywords": "^3.4.1"
-            },
-            "engines": {
-                "node": ">= 8.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/@electron-internal/extract-zip": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
@@ -2281,6 +2265,8 @@
         },
         "node_modules/@electron/asar": {
             "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+            "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2297,6 +2283,8 @@
         },
         "node_modules/@electron/asar/node_modules/commander": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2305,6 +2293,8 @@
         },
         "node_modules/@electron/asar/node_modules/minimatch": {
             "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2316,6 +2306,8 @@
         },
         "node_modules/@electron/fuses": {
             "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+            "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2399,13 +2391,6 @@
                 "node": ">=12.13.0"
             }
         },
-        "node_modules/@electron/node-gyp/node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/@electron/node-gyp/node_modules/glob": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -2440,32 +2425,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@electron/node-gyp/node_modules/nopt": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^1.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@electron/node-gyp/node_modules/proc-log": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
-            "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/@electron/node-gyp/node_modules/semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -2481,6 +2440,8 @@
         },
         "node_modules/@electron/notarize": {
             "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+            "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2494,6 +2455,8 @@
         },
         "node_modules/@electron/osx-sign": {
             "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+            "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2514,6 +2477,8 @@
         },
         "node_modules/@electron/osx-sign/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2527,6 +2492,8 @@
         },
         "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
             "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+            "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2536,8 +2503,67 @@
                 "url": "https://github.com/sponsors/gjtorikian/"
             }
         },
+        "node_modules/@electron/rebuild": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
+            "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
+                "@malept/cross-spawn-promise": "^2.0.0",
+                "chalk": "^4.0.0",
+                "debug": "^4.1.1",
+                "detect-libc": "^2.0.1",
+                "fs-extra": "^10.0.0",
+                "got": "^11.7.0",
+                "node-abi": "^3.45.0",
+                "node-api-version": "^0.2.0",
+                "ora": "^5.1.0",
+                "read-binary-file-arch": "^1.0.6",
+                "semver": "^7.3.5",
+                "tar": "^6.0.5",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "electron-rebuild": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=12.13.0"
+            }
+        },
+        "node_modules/@electron/rebuild/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@electron/rebuild/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@electron/universal": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+            "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2554,7 +2580,9 @@
             }
         },
         "node_modules/@electron/universal/node_modules/fs-extra": {
-            "version": "11.3.5",
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+            "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2568,6 +2596,8 @@
         },
         "node_modules/@electron/universal/node_modules/minimatch": {
             "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3861,6 +3891,8 @@
         },
         "node_modules/@malept/cross-spawn-promise": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+            "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
             "dev": true,
             "funding": [
                 {
@@ -3882,6 +3914,8 @@
         },
         "node_modules/@malept/flatpak-bundler": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+            "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3900,6 +3934,19 @@
             "license": "MIT",
             "dependencies": {
                 "eslint-scope": "5.1.1"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+            "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@npmcli/fs": {
@@ -4241,6 +4288,89 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+            "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/json-schema": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+            "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@peculiar/json-schema/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/webcrypto": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+            "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/json-schema": "^1.1.12",
+                "@peculiar/utils": "^2.0.2",
+                "tslib": "^2.8.1",
+                "webcrypto-core": "^1.9.2"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -4255,6 +4385,8 @@
         },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4669,6 +4801,8 @@
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4735,6 +4869,8 @@
         },
         "node_modules/@types/cacheable-request": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4754,6 +4890,8 @@
         },
         "node_modules/@types/debug": {
             "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4771,6 +4909,8 @@
         },
         "node_modules/@types/fs-extra": {
             "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4787,6 +4927,8 @@
         },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -4828,6 +4970,8 @@
         },
         "node_modules/@types/keyv": {
             "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4836,6 +4980,8 @@
         },
         "node_modules/@types/ms": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4846,20 +4992,10 @@
                 "undici-types": "~7.16.0"
             }
         },
-        "node_modules/@types/plist": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
-            "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/node": "*",
-                "xmlbuilder": ">=11.0.1"
-            }
-        },
         "node_modules/@types/responselike": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4890,14 +5026,6 @@
             "version": "4.0.5",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/verror": {
-            "version": "1.10.11",
-            "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
-            "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/vinyl": {
             "version": "2.0.12",
@@ -4930,17 +5058,21 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.13",
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+            "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/7zip-bin": {
-            "version": "5.2.0",
+        "node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "ISC"
         },
         "node_modules/abcjs": {
             "version": "6.3.0",
@@ -5051,14 +5183,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
-            }
-        },
         "node_modules/angular-html-parser": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
@@ -5143,36 +5267,36 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/app-builder-bin": {
-            "version": "5.0.0-alpha.12",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/app-builder-lib": {
-            "version": "26.8.1",
+            "version": "26.15.3",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+            "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@develar/schema-utils": "~2.6.5",
                 "@electron/asar": "3.4.1",
                 "@electron/fuses": "^1.8.0",
                 "@electron/get": "^3.0.0",
                 "@electron/notarize": "2.5.0",
                 "@electron/osx-sign": "1.3.3",
-                "@electron/rebuild": "^4.0.3",
+                "@electron/rebuild": "^4.0.4",
                 "@electron/universal": "2.0.3",
                 "@malept/flatpak-bundler": "^0.4.0",
+                "@noble/hashes": "^2.2.0",
+                "@peculiar/webcrypto": "^1.7.1",
                 "@types/fs-extra": "9.0.13",
+                "ajv": "^8.18.0",
+                "asn1js": "^3.0.10",
                 "async-exit-hook": "^2.0.1",
-                "builder-util": "26.8.1",
-                "builder-util-runtime": "9.5.1",
+                "builder-util": "26.15.3",
+                "builder-util-runtime": "9.7.0",
                 "chromium-pickle-js": "^0.2.0",
                 "ci-info": "4.3.1",
                 "debug": "^4.3.4",
                 "dotenv": "^16.4.5",
                 "dotenv-expand": "^11.0.6",
                 "ejs": "^3.1.8",
-                "electron-publish": "26.8.1",
+                "electron-publish": "26.15.3",
                 "fs-extra": "^10.1.0",
                 "hosted-git-info": "^4.1.0",
                 "isbinaryfile": "^5.0.0",
@@ -5180,7 +5304,8 @@
                 "js-yaml": "^4.1.0",
                 "json5": "^2.2.3",
                 "lazy-val": "^1.0.5",
-                "minimatch": "^10.0.3",
+                "minimatch": "^10.2.5",
+                "pkijs": "^3.4.0",
                 "plist": "3.1.0",
                 "proper-lockfile": "^4.1.2",
                 "resedit": "^1.7.0",
@@ -5188,18 +5313,21 @@
                 "tar": "^7.5.7",
                 "temp-file": "^3.4.0",
                 "tiny-async-pool": "1.3.0",
+                "unzipper": "^0.12.3",
                 "which": "^5.0.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "dmg-builder": "26.8.1",
-                "electron-builder-squirrel-windows": "26.8.1"
+                "dmg-builder": "26.15.3",
+                "electron-builder-squirrel-windows": "26.15.3"
             }
         },
         "node_modules/app-builder-lib/node_modules/@electron/get": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+            "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5220,6 +5348,8 @@
         },
         "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
             "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5233,6 +5363,8 @@
         },
         "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/jsonfile": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {
@@ -5241,6 +5373,8 @@
         },
         "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5249,43 +5383,18 @@
         },
         "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/universalify": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
-            "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-                "@malept/cross-spawn-promise": "^2.0.0",
-                "chalk": "^4.0.0",
-                "debug": "^4.1.1",
-                "detect-libc": "^2.0.1",
-                "fs-extra": "^10.0.0",
-                "got": "^11.7.0",
-                "node-abi": "^3.45.0",
-                "node-api-version": "^0.2.0",
-                "ora": "^5.1.0",
-                "read-binary-file-arch": "^1.0.6",
-                "semver": "^7.3.5",
-                "tar": "^6.0.5",
-                "yargs": "^17.0.1"
-            },
-            "bin": {
-                "electron-rebuild": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
         "node_modules/app-builder-lib/node_modules/ci-info": {
             "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+            "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
             "dev": true,
             "funding": [
                 {
@@ -5300,6 +5409,8 @@
         },
         "node_modules/app-builder-lib/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5313,27 +5424,18 @@
         },
         "node_modules/app-builder-lib/node_modules/isexe": {
             "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/app-builder-lib/node_modules/node-abi": {
-            "version": "3.94.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-            "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/app-builder-lib/node_modules/semver": {
             "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5345,6 +5447,8 @@
         },
         "node_modules/app-builder-lib/node_modules/which": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5428,6 +5532,28 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "dev": true,
@@ -5441,17 +5567,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/astral-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/async": {
@@ -5473,6 +5588,8 @@
         },
         "node_modules/async-exit-hook": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5781,9 +5898,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.20",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-            "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+            "version": "2.11.22",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.22.tgz",
+            "integrity": "sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -5942,34 +6059,25 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "es-define-property": "^1.0.1",
-                "side-channel": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "license": "ISC"
         },
         "node_modules/boolean": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "dev": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.3",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5988,9 +6096,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+            "version": "4.28.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+            "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6007,11 +6115,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.11.12",
-                "caniuse-lite": "^1.0.30001809",
-                "electron-to-chromium": "^1.5.402",
-                "node-releases": "^2.0.53",
-                "update-browserslist-db": "^1.3.0"
+                "baseline-browser-mapping": "^2.11.20",
+                "caniuse-lite": "^1.0.30001810",
+                "electron-to-chromium": "^1.5.420",
+                "node-releases": "^2.0.54",
+                "update-browserslist-db": "^1.3.2"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -6065,14 +6173,14 @@
             "license": "MIT"
         },
         "node_modules/builder-util": {
-            "version": "26.8.1",
+            "version": "26.15.3",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+            "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/debug": "^4.1.6",
-                "7zip-bin": "~5.2.0",
-                "app-builder-bin": "5.0.0-alpha.12",
-                "builder-util-runtime": "9.5.1",
+                "builder-util-runtime": "9.7.0",
                 "chalk": "^4.1.2",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.4",
@@ -6085,10 +6193,15 @@
                 "stat-mode": "^1.0.0",
                 "temp-file": "^3.4.0",
                 "tiny-async-pool": "1.3.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/builder-util-runtime": {
-            "version": "9.5.1",
+            "version": "9.7.0",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6101,6 +6214,8 @@
         },
         "node_modules/builder-util/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6117,6 +6232,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/cacache": {
@@ -6225,6 +6350,8 @@
         },
         "node_modules/cacheable-lookup": {
             "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6233,6 +6360,8 @@
         },
         "node_modules/cacheable-request": {
             "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6417,6 +6546,8 @@
         },
         "node_modules/chromium-pickle-js": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+            "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
             "dev": true,
             "license": "MIT"
         },
@@ -6501,24 +6632,6 @@
                 "colors": "1.4.0"
             }
         },
-        "node_modules/cli-truncate": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "slice-ansi": "^3.0.0",
-                "string-width": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cli-width": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -6574,6 +6687,8 @@
         },
         "node_modules/clone-response": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6683,6 +6798,8 @@
         },
         "node_modules/compare-version": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+            "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6893,17 +7010,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/crc": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "buffer": "^5.1.0"
-            }
-        },
         "node_modules/create-jest": {
             "version": "29.7.0",
             "dev": true,
@@ -6981,14 +7087,16 @@
             }
         },
         "node_modules/css-select": {
-            "version": "5.2.2",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+            "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
+                "css-what": "^7.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "nth-check": "^2.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
@@ -7006,7 +7114,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "6.2.2",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+            "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
@@ -7275,14 +7385,18 @@
             "license": "MIT"
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.2",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+            "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
             "license": "MIT",
             "engines": {
-                "node": ">=0.10"
+                "node": ">=14.16"
             }
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7297,6 +7411,8 @@
         },
         "node_modules/decompress-response/node_modules/mimic-response": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7357,6 +7473,8 @@
         },
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7365,6 +7483,8 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -7382,6 +7502,8 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -7448,6 +7570,8 @@
         },
         "node_modules/detect-node": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true,
             "license": "MIT",
             "optional": true
@@ -7469,6 +7593,8 @@
         },
         "node_modules/dir-compare": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+            "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7478,6 +7604,8 @@
         },
         "node_modules/dir-compare/node_modules/minimatch": {
             "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7488,22 +7616,22 @@
             }
         },
         "node_modules/dmg-builder": {
-            "version": "26.8.1",
+            "version": "26.15.3",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+            "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.8.1",
-                "builder-util": "26.8.1",
+                "app-builder-lib": "26.15.3",
+                "builder-util": "26.15.3",
                 "fs-extra": "^10.1.0",
-                "iconv-lite": "^0.6.2",
                 "js-yaml": "^4.1.0"
-            },
-            "optionalDependencies": {
-                "dmg-license": "^1.0.11"
             }
         },
         "node_modules/dmg-builder/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7515,35 +7643,10 @@
                 "node": ">=12"
             }
         },
-        "node_modules/dmg-license": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
-            "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "@types/plist": "^3.0.1",
-                "@types/verror": "^1.10.3",
-                "ajv": "^6.10.0",
-                "crc": "^3.8.0",
-                "iconv-corefoundation": "^1.1.7",
-                "plist": "^3.0.4",
-                "smart-buffer": "^4.0.2",
-                "verror": "^1.10.0"
-            },
-            "bin": {
-                "dmg-license": "bin/dmg-license.js"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
@@ -7556,6 +7659,8 @@
         },
         "node_modules/dom-serializer/node_modules/entities": {
             "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -7566,6 +7671,8 @@
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "funding": [
                 {
                     "type": "github",
@@ -7576,6 +7683,8 @@
         },
         "node_modules/domhandler": {
             "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
@@ -7589,6 +7698,8 @@
         },
         "node_modules/domutils": {
             "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
@@ -7612,6 +7723,8 @@
         },
         "node_modules/dotenv": {
             "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -7623,6 +7736,8 @@
         },
         "node_modules/dotenv-expand": {
             "version": "11.0.7",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+            "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -7645,6 +7760,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "readable-stream": "^2.0.2"
             }
         },
         "node_modules/each-props": {
@@ -7674,6 +7799,8 @@
         },
         "node_modules/ejs": {
             "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -7706,16 +7833,18 @@
             }
         },
         "node_modules/electron-builder": {
-            "version": "26.8.1",
+            "version": "26.15.3",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
+            "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.8.1",
-                "builder-util": "26.8.1",
-                "builder-util-runtime": "9.5.1",
+                "app-builder-lib": "26.15.3",
+                "builder-util": "26.15.3",
+                "builder-util-runtime": "9.7.0",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
-                "dmg-builder": "26.8.1",
+                "dmg-builder": "26.15.3",
                 "fs-extra": "^10.1.0",
                 "lazy-val": "^1.0.5",
                 "simple-update-notifier": "2.0.0",
@@ -7743,13 +7872,16 @@
             }
         },
         "node_modules/electron-publish": {
-            "version": "26.8.1",
+            "version": "26.15.3",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+            "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "^9.0.11",
-                "builder-util": "26.8.1",
-                "builder-util-runtime": "9.5.1",
+                "aws4": "^1.13.2",
+                "builder-util": "26.15.3",
+                "builder-util-runtime": "9.7.0",
                 "chalk": "^4.1.2",
                 "form-data": "^4.0.5",
                 "fs-extra": "^10.1.0",
@@ -7759,6 +7891,8 @@
         },
         "node_modules/electron-publish/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7771,9 +7905,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.419",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
-            "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
+            "version": "1.5.427",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.427.tgz",
+            "integrity": "sha512-n14zb3FdsChZ2BNobqNHAJMcP3ifFv4paox2LvCrfVAQcqGiSURgbJl+PfMpHVCNFkStnNc+RRVtPBTVW5PDgw==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -7850,6 +7984,8 @@
         },
         "node_modules/err-code": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
             "dev": true,
             "license": "MIT"
         },
@@ -7915,6 +8051,8 @@
         },
         "node_modules/es6-error": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
             "dev": true,
             "license": "MIT",
             "optional": true
@@ -8311,6 +8449,8 @@
         },
         "node_modules/exponential-backoff": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -8475,9 +8615,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "dev": true,
             "funding": [
                 {
@@ -8575,6 +8715,8 @@
         },
         "node_modules/filelist": {
             "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+            "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -8583,6 +8725,8 @@
         },
         "node_modules/filelist/node_modules/minimatch": {
             "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9043,6 +9187,8 @@
         },
         "node_modules/global-agent": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
@@ -9059,7 +9205,9 @@
             }
         },
         "node_modules/global-agent/node_modules/semver": {
-            "version": "7.8.1",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "optional": true,
@@ -9163,6 +9311,8 @@
         },
         "node_modules/globalthis": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -9200,6 +9350,8 @@
         },
         "node_modules/got": {
             "version": "11.8.6",
+            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9592,6 +9744,8 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -9673,6 +9827,8 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9684,6 +9840,8 @@
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9695,6 +9853,8 @@
         },
         "node_modules/hosted-git-info/node_modules/yallist": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true,
             "license": "ISC"
         },
@@ -9719,6 +9879,8 @@
         },
         "node_modules/http-cache-semantics": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
@@ -9814,6 +9976,8 @@
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9902,24 +10066,6 @@
             "license": "MIT",
             "dependencies": {
                 "cross-fetch": "4.1.0"
-            }
-        },
-        "node_modules/iconv-corefoundation": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
-            "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "cli-truncate": "^2.1.0",
-                "node-addon-api": "^1.6.3"
-            },
-            "engines": {
-                "node": "^8.11.2 || >=10"
             }
         },
         "node_modules/iconv-lite": {
@@ -10067,9 +10213,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+            "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10356,6 +10502,8 @@
         },
         "node_modules/isbinaryfile": {
             "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+            "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10481,6 +10629,8 @@
         },
         "node_modules/jake": {
             "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -11273,6 +11423,8 @@
         },
         "node_modules/jiti": {
             "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -11526,6 +11678,8 @@
         },
         "node_modules/lazy-val": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+            "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -12195,6 +12349,8 @@
         },
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12372,6 +12528,8 @@
         },
         "node_modules/matcher": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -12469,6 +12627,8 @@
         },
         "node_modules/mime": {
             "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -12525,6 +12685,8 @@
         },
         "node_modules/mimic-response": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12891,16 +13053,36 @@
             "version": "1.1.0",
             "license": "ISC"
         },
-        "node_modules/node-addon-api": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+        "node_modules/node-abi": {
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-abi/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/node-api-version": {
             "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+            "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12908,7 +13090,9 @@
             }
         },
         "node_modules/node-api-version/node_modules/semver": {
-            "version": "7.8.1",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -12958,9 +13142,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.54",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
-            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+            "version": "2.0.55",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+            "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -13023,6 +13207,22 @@
                 "node": ">=4"
             }
         },
+        "node_modules/nopt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^1.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "license": "MIT",
@@ -13032,6 +13232,8 @@
         },
         "node_modules/normalize-url": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13065,6 +13267,8 @@
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
@@ -13099,6 +13303,8 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -13277,6 +13483,8 @@
         },
         "node_modules/p-cancelable": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13473,6 +13681,8 @@
         },
         "node_modules/pe-library": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+            "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13595,8 +13805,48 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/pkijs/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/pkijs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/plist": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+            "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13633,9 +13883,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.18",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-            "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13652,7 +13902,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -14030,7 +14280,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+            "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14146,6 +14398,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/proc-log": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+            "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "dev": true,
@@ -14175,6 +14437,8 @@
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14199,6 +14463,8 @@
         },
         "node_modules/proper-lockfile": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+            "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14260,10 +14526,37 @@
             ],
             "license": "MIT"
         },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/pvutils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+            "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "es-define-property": "^1.0.1",
@@ -14278,6 +14571,8 @@
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14340,6 +14635,8 @@
         },
         "node_modules/read-binary-file-arch": {
             "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+            "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14501,6 +14798,8 @@
         },
         "node_modules/resedit": {
             "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+            "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14537,6 +14836,8 @@
         },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
             "dev": true,
             "license": "MIT"
         },
@@ -14600,6 +14901,8 @@
         },
         "node_modules/responselike": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14651,6 +14954,8 @@
         },
         "node_modules/retry": {
             "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14690,6 +14995,8 @@
         },
         "node_modules/roarr": {
             "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
@@ -14769,6 +15076,8 @@
         },
         "node_modules/sanitize-filename": {
             "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+            "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
             "dev": true,
             "license": "WTFPL OR ISC",
             "dependencies": {
@@ -14820,7 +15129,9 @@
             }
         },
         "node_modules/sax": {
-            "version": "1.6.0",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -14851,6 +15162,8 @@
         },
         "node_modules/semver-compare": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "dev": true,
             "license": "MIT",
             "optional": true
@@ -14906,6 +15219,8 @@
         },
         "node_modules/serialize-error": {
             "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -14921,6 +15236,8 @@
         },
         "node_modules/serialize-error/node_modules/type-fest": {
             "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "optional": true,
@@ -15083,22 +15400,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slice-ansi": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -15111,9 +15412,9 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+            "version": "2.8.10",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+            "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15177,6 +15478,8 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15202,6 +15505,8 @@
         },
         "node_modules/sprintf-js": {
             "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true
@@ -15297,6 +15602,8 @@
         },
         "node_modules/stat-mode": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+            "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -15486,12 +15793,12 @@
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",
-                "css-select": "^5.1.0",
+                "css-select": "^6.0.0",
                 "css-tree": "^3.0.1",
-                "css-what": "^6.1.0",
+                "css-what": "^7.0.0",
                 "csso": "^5.0.5",
                 "picocolors": "^1.1.1",
-                "sax": "^1.5.0"
+                "sax": "1.6.1"
             },
             "bin": {
                 "svgo": "bin/svgo.js"
@@ -15544,9 +15851,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -15578,6 +15885,8 @@
         },
         "node_modules/temp-file": {
             "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+            "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15587,6 +15896,8 @@
         },
         "node_modules/temp-file/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15685,6 +15996,8 @@
         },
         "node_modules/tiny-async-pool": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+            "integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15693,6 +16006,8 @@
         },
         "node_modules/tiny-async-pool/node_modules/semver": {
             "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -15733,6 +16048,8 @@
         },
         "node_modules/tmp-promise": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15825,6 +16142,8 @@
         },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
             "dev": true,
             "license": "WTFPL",
             "dependencies": {
@@ -16142,10 +16461,39 @@
                 "node": ">=8"
             }
         },
+        "node_modules/unzipper": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+            "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bluebird": "~3.7.2",
+                "duplexer2": "~0.1.4",
+                "fs-extra": "11.3.1",
+                "graceful-fs": "^4.2.2",
+                "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/unzipper/node_modules/fs-extra": {
+            "version": "11.3.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+            "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/update-browserslist-db": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
-            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.3.tgz",
+            "integrity": "sha512-pJ2sYawQS0R/WI928Gj5GlPhTGzbMelq0+4INtSYNDV9ErKJcX6xjGWkoG/VnB3dpUm00zALaqkrUD77pO5TDQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -16186,6 +16534,8 @@
         },
         "node_modules/utf8-byte-length": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
             "dev": true,
             "license": "(WTFPL OR MIT)"
         },
@@ -16228,30 +16578,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/verror": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
-        "node_modules/verror/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/vinyl": {
             "version": "2.2.1",
@@ -16436,6 +16762,27 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/webcrypto-core": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+            "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/json-schema": "^1.1.12",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/webcrypto-core/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
             "dev": true,
@@ -16476,6 +16823,8 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -16615,6 +16964,8 @@
         },
         "node_modules/xmlbuilder": {
             "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "cross-env": "^7.0.3",
         "cypress": "^15.15.0",
         "electron": "41.10.3",
-        "electron-builder": "26.8.1",
+        "electron-builder": "26.15.3",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
         "fake-indexeddb": "6.2.5",
@@ -79,7 +79,7 @@
         "jquery": "3.7.1",
         "jquery-ui-dist": "1.12.1",
         "materialize-css": "0.100.2",
-        "postcss": "8.5.18",
+        "postcss": "8.5.28",
         "sass": "1.101.0",
         "tone": "^15.1.22"
     },
@@ -103,11 +103,11 @@
         "electron": "41.10.3",
         "flatted": "3.4.2",
         "lodash": "4.18.1",
-        "brace-expansion": "2.0.3",
+        "brace-expansion": "2.1.4",
         "minimatch@^10.0.0": {
             "brace-expansion": "^5.0.5"
         },
-        "tar": "^7.5.10",
+        "tar": "7.5.22",
         "path-to-regexp": "^8.4.0",
         "picomatch": "^4.0.4",
         "yaml": "^2.8.3",
@@ -123,13 +123,18 @@
         },
         "@isaacs/brace-expansion": "^5.0.1",
         "immutable": "5.1.9",
-        "svgo": "^4.1.0",
-        "@xmldom/xmldom": "^0.8.13",
+        "svgo": "4.1.0",
+        "@xmldom/xmldom": "0.8.15",
         "@gulp-sourcemaps/identity-map": {
-            "postcss": "^8.4.31"
+            "postcss": "8.5.28"
         },
         "body-parser": "2.3.0",
-        "qs": "6.15.3"
+        "qs": "6.16.0",
+        "browserslist": "4.28.9",
+        "baseline-browser-mapping": "2.11.22",
+        "decode-uri-component": "0.5.0",
+        "postcss-selector-parser": "7.1.6",
+        "fast-uri": "3.1.7"
     },
     "lint-staged": {
         "*.{js,mjs}": [


### PR DESCRIPTION
## What does this PR do?

- Updates npm dependencies to address reported security vulnerabilities.
- Updates `package.json` and `package-lock.json` to keep the dependency tree consistent.

## Why is this needed?

The repository's dependency audit reported vulnerabilities in transitive npm dependencies. This change updates the dependency resolution to use the available patched versions where possible.

## Testing Performed

- Ran `npm audit --audit-level=moderate`
- Verified the updated dependency tree locally.
- Verified that only `package.json` and `package-lock.json` are included in this change.

## Checklist

- [x] I have tested these changes locally and the work is as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run the relevant npm validation commands locally.

## Additional Notes

`npm audit` still reports `materialize-css` as a moderate vulnerability for which npm currently reports no available fix. The remaining dependency findings should be reviewed separately if required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and styling tool versions.
  * Refreshed dependency version overrides and transitive dependency pins.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## PR Category
- [x] Chore
- [ ] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] UI/UX
- [ ] i18n