### PR TITLE
fix: initialize translation helper before splash text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,7 +1128,6 @@
         <!-- Loading Dialog Script -->
         <script>
             document.addEventListener("DOMContentLoaded", function () {
-                window._ = window._ || (x => x);
                 const readStorage = key => {
                     try {
                         return localStorage.getItem(key);
@@ -1171,6 +1170,7 @@
 
                 loadL10nSplashScreen();
 
+                requirejs(["utils/utils"], function (_) {
                 setTimeout(function () {
                     const loadingText = document.getElementById("loadingText");
                     const texts = [
@@ -1185,6 +1185,7 @@
                         index = (index + 1) % texts.length;
                     }, 1500);
                 }, 3000);
+            });
 
                 const languageDropdown = document.getElementById("languagedropdown");
                 if (languageDropdown) {


### PR DESCRIPTION
\## Summary

Fixes the intermittent `ReferenceError: _ is not defined` during Music Blocks page initialization.

The loading splash text now waits for the translation helper from `utils/utils` before calling `_()`.

## UI Reference

<img width="1470" height="956" alt="Screenshot 2026-09-12 at 8 17 21 AM" src="https://github.com/user-attachments/assets/e34ce16b-1184-49a0-b456-26f4016b2b6e" />

> The UI screenshots are included to make the initialization behavior easier to review.

## Testing

- `npm test`
- 235 test suites passed
- 9237 tests passed

## Issue

Closes #7067

## PR Category
- [x] Bug Fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD
- [ ] Chore
- [ ] UI/UX
- [ ] i18n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loading dialog text now uses the application’s translation system, improving localized loading messages.
  * Removed the global fallback translation function to ensure consistent translation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->