### PR TITLE
fix(abc): import rest notes without crashing

### DIFF
--- a/js/activity/__tests__/abc-parser.test.js
+++ b/js/activity/__tests__/abc-parser.test.js
@@ -447,6 +447,23 @@ describe("Test 5: Key signature accidentals (F major)", () => {
 // Test 6 — Empty-voice / degenerate input guard (issue: actionBlock[0] crash)
 // ---------------------------------------------------------------------------
 describe("Test 6: Empty-voice and degenerate input guard", () => {
+    test("ABC rest creates a rest block inside a note", async () => {
+        const tune = makeTune({
+            staves: [
+                {
+                    meter: { value: [{ num: 4, den: 4 }] },
+                    key: { root: "C", mode: "major", accidentals: [] },
+                    voices: [[{ el_type: "note", rest: { type: "rest" }, duration: 0.25 }]]
+                }
+            ]
+        });
+        const blocks = await parseAndCapture(tune);
+
+        expect(blocksOfType(blocks, "newnote")).toHaveLength(1);
+        expect(blocksOfType(blocks, "rest2")).toHaveLength(1);
+        expect(blocksOfType(blocks, "pitch")).toHaveLength(0);
+    });
+
     test("tune with no lines resolves without throwing and passes empty array to loadNewBlocks", async () => {
         const activity = makeActivity();
         const emptyTune = { metaText: { title: "Empty" }, lines: [] };

--- a/js/activity/__tests__/abc-parser.test.js
+++ b/js/activity/__tests__/abc-parser.test.js
@@ -464,6 +464,28 @@ describe("Test 6: Empty-voice and degenerate input guard", () => {
         expect(blocksOfType(blocks, "pitch")).toHaveLength(0);
     });
 
+    test("ABC rest keeps block ids contiguous for following notes", async () => {
+        const tune = makeTune({
+            staves: [
+                {
+                    meter: { value: [{ num: 4, den: 4 }] },
+                    key: { root: "C", mode: "major", accidentals: [] },
+                    voices: [
+                        [
+                            { el_type: "note", rest: { type: "rest" }, duration: 0.25 },
+                            makeNote("D", 1)
+                        ]
+                    ]
+                }
+            ]
+        });
+        const blocks = await parseAndCapture(tune);
+
+        expect(blocks.map(block => block[0])).toEqual(
+            Array.from({ length: blocks.length }, (_, index) => index)
+        );
+    });
+
     test("tune with no lines resolves without throwing and passes empty array to loadNewBlocks", async () => {
         const activity = makeActivity();
         const emptyTune = { metaText: { title: "Empty" }, lines: [] };

--- a/js/activity/abc-parser.js
+++ b/js/activity/abc-parser.js
@@ -49,12 +49,11 @@ function _createPitchBlocks(
     meterDen
 ) {
     const duration = toFraction(pitchDuration);
-    const adjustedNote = _adjustPitch(pitches.name, keySignature).toUpperCase();
     if (triplet !== null) {
         duration[1] = meterDen * triplet;
     }
 
-    actionBlock.push(
+    const noteBlocks = [
         [
             blockId,
             ["newnote", { collapsed: true }],
@@ -65,18 +64,28 @@ function _createPitchBlocks(
         [blockId + 1, "divide", 0, 0, [blockId, blockId + 2, blockId + 3]],
         [blockId + 2, ["number", { value: duration[0] }], 0, 0, [blockId + 1]],
         [blockId + 3, ["number", { value: duration[1] }], 0, 0, [blockId + 1]],
-        [blockId + 4, "vspace", 0, 0, [blockId, blockId + 5]],
-        [blockId + 5, "pitch", 0, 0, [blockId + 4, blockId + 6, blockId + 7, null]],
-        [blockId + 6, ["notename", { value: adjustedNote }], 0, 0, [blockId + 5]],
-        [
-            blockId + 7,
-            ["number", { value: _abcToStandardValue(pitches.pitch) }],
-            0,
-            0,
-            [blockId + 5]
-        ],
-        [blockId + 8, "hidden", 0, 0, [blockId, blockId + 9]]
-    );
+        [blockId + 4, "vspace", 0, 0, [blockId, blockId + 5]]
+    ];
+
+    if (pitches) {
+        const adjustedNote = _adjustPitch(pitches.name, keySignature).toUpperCase();
+        noteBlocks.push(
+            [blockId + 5, "pitch", 0, 0, [blockId + 4, blockId + 6, blockId + 7, null]],
+            [blockId + 6, ["notename", { value: adjustedNote }], 0, 0, [blockId + 5]],
+            [
+                blockId + 7,
+                ["number", { value: _abcToStandardValue(pitches.pitch) }],
+                0,
+                0,
+                [blockId + 5]
+            ]
+        );
+    } else {
+        noteBlocks.push([blockId + 5, "rest2", 0, 0, [blockId + 4, null]]);
+    }
+
+    noteBlocks.push([blockId + 8, "hidden", 0, 0, [blockId, blockId + 9]]);
+    actionBlock.push(...noteBlocks);
 }
 
 // Function to search index for particular type of block
@@ -212,7 +221,7 @@ function _processVoice(voice, blockId, staff, staffIdx, staffRecord) {
             }
 
             _createPitchBlocks(
-                element.pitches[0],
+                element.pitches?.[0],
                 blockId,
                 element.duration,
                 staff.key,

--- a/js/activity/abc-parser.js
+++ b/js/activity/abc-parser.js
@@ -49,6 +49,7 @@ function _createPitchBlocks(
     meterDen
 ) {
     const duration = toFraction(pitchDuration);
+    const hiddenBlockId = blockId + (pitches ? 8 : 6);
     if (triplet !== null) {
         duration[1] = meterDen * triplet;
     }
@@ -59,7 +60,7 @@ function _createPitchBlocks(
             ["newnote", { collapsed: true }],
             0,
             0,
-            [blockId - 1, blockId + 1, blockId + 4, blockId + 8]
+            [blockId - 1, blockId + 1, blockId + 4, hiddenBlockId]
         ],
         [blockId + 1, "divide", 0, 0, [blockId, blockId + 2, blockId + 3]],
         [blockId + 2, ["number", { value: duration[0] }], 0, 0, [blockId + 1]],
@@ -84,8 +85,9 @@ function _createPitchBlocks(
         noteBlocks.push([blockId + 5, "rest2", 0, 0, [blockId + 4, null]]);
     }
 
-    noteBlocks.push([blockId + 8, "hidden", 0, 0, [blockId, blockId + 9]]);
+    noteBlocks.push([hiddenBlockId, "hidden", 0, 0, [blockId, hiddenBlockId + 1]]);
     actionBlock.push(...noteBlocks);
+    return noteBlocks.length;
 }
 
 // Function to search index for particular type of block
@@ -220,7 +222,7 @@ function _processVoice(voice, blockId, staff, staffIdx, staffRecord) {
                 tripletFinder = element.startTriplet;
             }
 
-            _createPitchBlocks(
+            blockId += _createPitchBlocks(
                 element.pitches?.[0],
                 blockId,
                 element.duration,
@@ -234,7 +236,6 @@ function _processVoice(voice, blockId, staff, staffIdx, staffRecord) {
             if (element?.endTriplet !== null && element?.endTriplet !== undefined) {
                 tripletFinder = null;
             }
-            blockId = blockId + 9;
         } else if (element.el_type === "bar") {
             _handleBarElement(element, staffRecord.repeatArray, staffRecord.baseBlocks.length);
         }


### PR DESCRIPTION
## Description

  ABC files containing valid rest notes failed to import because the ABC parser assumed every note element had a `pitches` array. This change imports rest notes as Music Blocks rest blocks instead of throwing a `TypeError`.

  ## Related Issue

  **Fixes:** #8660

  ---

  ## Category

  - [x] Bug Fix — Fixes a bug or incorrect behavior
  - [x] Tests — Adds or updates test coverage

  ---

  ## Changes Made

  - Handle ABCJS note elements that contain rests instead of pitches.
  - Create the existing `rest2` block for imported rest notes.
  - Preserve note duration and triplet handling for regular notes.
  - Add a regression test covering ABC rest imports.

  ---

  ## Steps to Reproduce

  1. Create a file named `rest-import.abc` with this content:

  ```abc
  X:1
  T:Rest import
  M:4/4
  L:1/4
  K:C
  C z2 D
  ```

  2. Open Music Blocks.
  3. Use the project file chooser to import `rest-import.abc`.
  4. Confirm that the file imports successfully and the rest is represented by a rest block.

  Before this fix, the import failed with:

  ```text
  TypeError: Cannot read properties of undefined (reading '0')
  at js/activity/abc-parser.js:215
  ```

  ---

  ## Testing Performed

  - Focused ABC parser tests: `26/26` passed.
  - Full Jest suite: `235` suites and `9,238` tests passed.
  - ESLint checks passed for the modified files.
  - Prettier checks passed for the modified files.
  - `git diff --check` passed.

  ---

  ## Checklist

  - [x] I have tested these changes locally and they work as expected.
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [ ] I have updated the documentation to reflect these changes, if applicable.
  - [x] I have followed the project's coding style guidelines.
  - [ ] I have run `npm run lint` and `npx prettier --check .` with no errors.
  - [ ] I have addressed the code review feedback from the previous submission, if applicable.
  - [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

  ---

  ## Additional Notes

  No visual changes are included. The fix uses the existing `rest2` block and changes only the ABC parser and its regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ABC notation parsing for notes containing rests.
  * Ensured rest elements produce the correct note and rest blocks without generating invalid pitch blocks.
  * Improved handling of optional pitches and note sequencing in voice parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->