### PR TITLE
fix(a11y): add missing accessible names for axe-flagged elements (#6608)

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,6 +397,7 @@
                     <iframe
                         src="planet/index.html"
                         id="planet-iframe"
+                        title="Music Blocks Planet — save, load, and share projects"
                         style="display: none"
                     ></iframe>
 

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -778,6 +778,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/synth2.svg";
+                img.title = this._(this.rowLabels[i]);
+                img.alt = this._(this.rowLabels[i]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");
@@ -2054,6 +2056,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/synth2.svg";
+                img.title = this._(this.rowLabels[blockIndex]);
+                img.alt = this._(this.rowLabels[blockIndex]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -405,6 +405,8 @@ class PhraseMaker {
                 cell.textContent = "";
                 const img = document.createElement("img");
                 img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
+                img.title = this._("bell") + " " + noteName;
+                img.alt = this._("bell") + " " + noteName;
                 img.setAttribute("width", cell.style.width);
                 img.setAttribute("vertical-align", "middle");
                 cell.appendChild(img);
@@ -412,6 +414,8 @@ class PhraseMaker {
                 cell.textContent = "";
                 const img = document.createElement("img");
                 img.src = "images/8_bellset_key_8.svg";
+                img.title = this._("bell") + " C";
+                img.alt = this._("bell") + " C";
                 img.setAttribute("width", cell.style.width);
                 img.setAttribute("vertical-align", "middle");
                 cell.appendChild(img);
@@ -783,6 +787,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/mouse.svg";
+                img.title = this._(this.rowLabels[i]);
+                img.alt = this._(this.rowLabels[i]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");
@@ -792,6 +798,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/mouse.svg";
+                img.title = this._(this.rowLabels[i]);
+                img.alt = this._(this.rowLabels[i]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");
@@ -819,12 +827,16 @@ class PhraseMaker {
                 if (noteName in BELLSETIDX && this.rowArgs[i] === 4) {
                     const img = document.createElement("img");
                     img.src = `images/8_bellset_key_${BELLSETIDX[noteName]}.svg`;
+                    img.title = this._("bell") + " " + noteName;
+                    img.alt = this._("bell") + " " + noteName;
                     img.setAttribute("width", cell.style.width);
                     img.setAttribute("vertical-align", "middle");
                     cell.appendChild(img);
                 } else if (["C", "do"].includes(noteName) && this.rowArgs[i] === 5) {
                     const img = document.createElement("img");
                     img.src = "images/8_bellset_key_8.svg";
+                    img.title = this._("bell") + " C";
+                    img.alt = this._("bell") + " C";
                     img.setAttribute("width", cell.style.width);
                     img.setAttribute("vertical-align", "middle");
                     cell.appendChild(img);
@@ -1740,6 +1752,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/mouse.svg";
+                img.title = this._(this.rowLabels[blockIndex]);
+                img.alt = this._(this.rowLabels[blockIndex]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");
@@ -2044,6 +2058,8 @@ class PhraseMaker {
                 cell.textContent = "\u00A0\u00A0";
                 const img = document.createElement("img");
                 img.src = "images/mouse.svg";
+                img.title = this._(this.rowLabels[blockIndex]);
+                img.alt = this._(this.rowLabels[blockIndex]);
                 img.setAttribute("height", iconSize);
                 img.setAttribute("width", iconSize);
                 img.setAttribute("vertical-align", "middle");

--- a/js/widgets/phrasemaker.js
+++ b/js/widgets/phrasemaker.js
@@ -835,8 +835,13 @@ class PhraseMaker {
                 } else if (["C", "do"].includes(noteName) && this.rowArgs[i] === 5) {
                     const img = document.createElement("img");
                     img.src = "images/8_bellset_key_8.svg";
-                    img.title = this._("bell") + " C";
-                    img.alt = this._("bell") + " C";
+                    const displayNote =
+                        this._deps.noteIsSolfege(noteName) &&
+                        !this._deps.isCustomTemperament(this.activity.logo.synth.inTemperament)
+                            ? this._deps.i18nSolfege(noteName)
+                            : noteName;
+                    img.title = this._("bell") + " " + displayNote;
+                    img.alt = this._("bell") + " " + displayNote;
                     img.setAttribute("width", cell.style.width);
                     img.setAttribute("vertical-align", "middle");
                     cell.appendChild(img);

--- a/planet/js/GlobalCard.js
+++ b/planet/js/GlobalCard.js
@@ -36,7 +36,9 @@ class GlobalCard {
                 <div class="card" style="height:95%;"> 
                 
                     <div class="card-image"> 
-                        <img class="project-image project-card-image" id="global-project-image-{ID}" src="images/planetgraphic.png"> 
+                        <img class="project-image project-card-image" alt="${_(
+                            "Project thumbnail"
+                        )}" id="global-project-image-{ID}" src="images/planetgraphic.png"> 
                     </div> 
 
                     <div class="card-content"> 

--- a/planet/js/LocalCard.js
+++ b/planet/js/LocalCard.js
@@ -40,14 +40,18 @@ class LocalCard {
                     </a>
                         
                         <div class="card-image"> 
-                            <img class="project-image project-card-image" id="local-project-image-{ID}"> 
+                            <img class="project-image project-card-image" alt="${_(
+                                "Project thumbnail"
+                            )}" id="local-project-image-{ID}"> 
                             <a class="btn-floating halfway-fab waves-effect waves-light orange tooltipped" data-position="top" data-delay="50" data-tooltip="${_(
                                 "Publish project"
                             )}" id="local-project-publish-{ID}"><i class="material-icons">cloud_upload</i></a> 
                         </div> 
                             
                         <div class="card-content"> 
-                            <input class="card-title grey-text text-darken-4" id="local-project-input-{ID}" /> 
+                            <input class="card-title grey-text text-darken-4" aria-label="${_(
+                                "Project name"
+                            )}" id="local-project-input-{ID}" /> 
                         </div> 
                             
                         <div class="card-action"> 


### PR DESCRIPTION
## Description

Fixes several axe-core-flagged accessibility violations found while auditing Phrase Maker and the Planet (save/load) dialogs against WCAG 2.1 AA. All of these are missing accessible names on `<img>`, `<iframe>`, and `<input>` elements — screen readers had no way to announce what these elements were.

## Related Issue

**Fixes:** part of #6608

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/widgets/phrasemaker.js`: added `alt`/`title` to the bellset-key note icons (5 call sites across the initial table build and per-row update paths) and to the mouse-graphics row icons (3 call sites, `MATRIXGRAPHICS`/`MATRIXGRAPHICS2` branches) — all previously rendered as bare `<img>` tags with no accessible name.
- `index.html`: added a `title` attribute to the hidden `#planet-iframe`, which had no accessible name (`aria-label`/`title`/frame name were all missing).
- `planet/js/LocalCard.js`: added `alt` text to the local-project thumbnail `<img>` and an `aria-label` to the project-name `<input>` on each project card.
- `planet/js/GlobalCard.js`: added `alt` text to the equivalent thumbnail `<img>` on the global/published project card.

---

## Steps to Reproduce

1. Run an axe-core scan (axe DevTools extension, WCAG 2.1 AA ruleset) on the base page — 3 issues on the Planet "My Projects" modal (iframe name, image alt, form label).
2. Open the Phrase Maker widget and add a few pitch/drum/mouse-graphics blocks, then scan again — 7 "Images must have alternative text" violations on the note/action icon images.

## Visual Changes

N/A — these are accessibility-tree-only changes (alt text, titles, aria-labels); no visible UI change.

---

## Testing Performed

- Ran the full `phrasemaker` Jest suite locally (`npx jest js/widgets/__tests__/phrasemaker --coverage=false`) — 345/345 passing, no regressions.
- `npx eslint` and `npx prettier --check` clean on all changed files.
- Re-ran the axe-core scan after the fix: total issues on Phrase Maker dropped from 8 to 1 (the 1 remaining is a separate color-contrast issue on the same widget's row labels, being tracked/fixed separately since it needs a different, more involved change).
- Verified the fix was actually served via `npm run serve:dev` (the default `serve` script caches JS; `serve:dev` disables caching for local iteration).

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

The color-contrast violation on the same `.labelcol` cells (drum/pitch/graphics row label text) is being handled as a follow-up — no single fixed text color passes WCAG AA against all three category background colors, so it needs a small per-category color mapping rather than a one-line fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader support for the embedded Planet workspace with a descriptive label.
  * Added localized alternative text and descriptive labels to PhraseMaker bell and instrument controls, including octave-5 note names.
  * Added accessible labels for project thumbnails and project-name fields in local and shared project cards.
  * Improved localization support for accessibility text across project cards and musical controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->