### PR TITLE
fix(blocks): guard the empty denominator slot in noteValueValue

### DIFF
--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -2537,6 +2537,23 @@ describe("noteValueValue", () => {
         ];
     }
 
+    /**
+     * Builds the same fraction under a block that holds its note value in the
+     * second slot, the way meter and the rhythm family do.
+     * @param {string} parentName - the block the divide hangs from
+     * @param {number|null} denominator - index of the denominator block, or
+     *     null for the empty slot left behind when it is dragged out
+     * @returns {void}
+     */
+    function buildMeterStyleNote(parentName, denominator) {
+        blocks.blockList = [
+            { name: parentName, connections: [null, null, 1] },
+            { name: "divide", connections: [0, 2, denominator] },
+            { name: "number", value: 1, connections: [1] },
+            { name: "number", value: 4, connections: [1] }
+        ];
+    }
+
     it("reads the denominator of a complete fraction", () => {
         buildNote("newnote", 3);
 
@@ -2550,9 +2567,27 @@ describe("noteValueValue", () => {
         expect(blocks.noteValueValue(2)).toBe(1);
     });
 
-    it("falls back to the default for the other note value blocks too", () => {
-        buildNote("rhythm2", null);
-        blocks.blockList[0].connections = [null, 1, 1];
+    it("reads the denominator under meter, which carries the fraction in its second slot", () => {
+        buildMeterStyleNote("meter", 3);
+
+        expect(blocks.noteValueValue(2)).toBe(4);
+    });
+
+    it("falls back to the default when meter's denominator slot is empty", () => {
+        buildMeterStyleNote("meter", null);
+
+        expect(() => blocks.noteValueValue(2)).not.toThrow();
+        expect(blocks.noteValueValue(2)).toBe(1);
+    });
+
+    it("reads the denominator under rhythm, which carries the fraction the same way", () => {
+        buildMeterStyleNote("rhythm2", 3);
+
+        expect(blocks.noteValueValue(2)).toBe(4);
+    });
+
+    it("falls back to the default when rhythm's denominator slot is empty", () => {
+        buildMeterStyleNote("rhythm2", null);
 
         expect(() => blocks.noteValueValue(2)).not.toThrow();
         expect(blocks.noteValueValue(2)).toBe(1);

--- a/js/__tests__/blocks.test.js
+++ b/js/__tests__/blocks.test.js
@@ -2491,3 +2491,70 @@ describe("Spatial grid indexing", () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// noteValueValue — the number in a note's fraction
+// ---------------------------------------------------------------------------
+
+describe("noteValueValue", () => {
+    let blocks;
+
+    beforeEach(() => {
+        const mockActivity = {
+            storage: {},
+            trashcan: {},
+            turtles: {},
+            boundary: {},
+            macroDict: {},
+            palettes: { dict: {}, show: jest.fn() },
+            logo: { synth: { loadSynth: jest.fn() } },
+            blocksContainer: { x: 0, y: 0 },
+            canvas: { width: 800, height: 600 },
+            refreshCanvas: jest.fn(),
+            errorMsg: jest.fn(),
+            setSelectionMode: jest.fn(),
+            stopLoadAnimation: jest.fn(),
+            setHomeContainers: jest.fn(),
+            __tick: jest.fn()
+        };
+        blocks = new Blocks(mockActivity);
+    });
+
+    /**
+     * Builds "note 1 / 4", the shape the default project ships with.
+     * Block 2 is the numerator, which is the one the user clicks.
+     * @param {string} parentName - the block the divide hangs from
+     * @param {number|null} denominator - index of the denominator block, or
+     *     null for the empty slot left behind when it is dragged out
+     * @returns {void}
+     */
+    function buildNote(parentName, denominator) {
+        blocks.blockList = [
+            { name: parentName, connections: [null, 1, null] },
+            { name: "divide", connections: [0, 2, denominator] },
+            { name: "number", value: 1, connections: [1] },
+            { name: "number", value: 4, connections: [1] }
+        ];
+    }
+
+    it("reads the denominator of a complete fraction", () => {
+        buildNote("newnote", 3);
+
+        expect(blocks.noteValueValue(2)).toBe(4);
+    });
+
+    it("falls back to the default when the denominator slot is empty", () => {
+        buildNote("newnote", null);
+
+        expect(() => blocks.noteValueValue(2)).not.toThrow();
+        expect(blocks.noteValueValue(2)).toBe(1);
+    });
+
+    it("falls back to the default for the other note value blocks too", () => {
+        buildNote("rhythm2", null);
+        blocks.blockList[0].connections = [null, 1, 1];
+
+        expect(() => blocks.noteValueValue(2)).not.toThrow();
+        expect(blocks.noteValueValue(2)).toBe(1);
+    });
+});

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4429,10 +4429,7 @@ class Blocks {
                     case "meter":
                         this.blockList[blk]._check_meter_block = cblk;
                         if (this.blockList[cblk].connections[2] === dblk) {
-                            if (this.blockList[cblk].connections[1] === dblk) {
-                                return denominatorValue();
-                            }
-                            return 1;
+                            return denominatorValue();
                         }
                         return 1;
                     case "setbpm3":
@@ -4445,10 +4442,7 @@ class Blocks {
                     case "neighbor":
                     case "neighbor2":
                         if (this.blockList[cblk].connections[2] === dblk) {
-                            if (this.blockList[cblk].connections[1] === dblk) {
-                                return denominatorValue();
-                            }
-                            return 1;
+                            return denominatorValue();
                         }
                         return 1;
                     default:

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -4395,6 +4395,21 @@ class Blocks {
 
             const myBlock = this.blockList[blk];
             const dblk = myBlock.connections[0];
+
+            /**
+             * Read the number in the divide block's denominator slot. The
+             * slot is empty whenever the user pulls that block out, so fall
+             * back to the same default the rest of this function returns.
+             */
+            const denominatorValue = () => {
+                const nblk = this.blockList[dblk].connections[2];
+                if (nblk === null || nblk === undefined || !this.blockList[nblk]) {
+                    return 1;
+                }
+
+                return this.blockList[nblk].value;
+            };
+
             /** We are connected to a divide block. */
             /** Is the divide block connected to a note value block? */
             let cblk = this.blockList[dblk].connections[0];
@@ -4408,16 +4423,14 @@ class Blocks {
                     case "newslur":
                     case "elapsednotes2":
                         if (this.blockList[cblk].connections[1] === dblk) {
-                            cblk = this.blockList[dblk].connections[2];
-                            return this.blockList[cblk].value;
+                            return denominatorValue();
                         }
                         return 1;
                     case "meter":
                         this.blockList[blk]._check_meter_block = cblk;
                         if (this.blockList[cblk].connections[2] === dblk) {
                             if (this.blockList[cblk].connections[1] === dblk) {
-                                cblk = this.blockList[dblk].connections[2];
-                                return this.blockList[cblk].value;
+                                return denominatorValue();
                             }
                             return 1;
                         }
@@ -4433,8 +4446,7 @@ class Blocks {
                     case "neighbor2":
                         if (this.blockList[cblk].connections[2] === dblk) {
                             if (this.blockList[cblk].connections[1] === dblk) {
-                                cblk = this.blockList[dblk].connections[2];
-                                return this.blockList[cblk].value;
+                                return denominatorValue();
                             }
                             return 1;
                         }


### PR DESCRIPTION
- [x] Bug Fix
- [x] Tests

## What's wrong

Two things in `noteValueValue`, the function that decides how many entries the note value pie menu needs.

**1. An empty denominator slot crashes the click handler.**

Drag the bottom number out of a note's `1 / 4` fraction and it leaves an empty socket behind. Click the number still sitting in that fraction and nothing happens. The pie menu never opens, and that number cannot be edited again until something is plugged back into the empty socket.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'value')
    at Blocks.noteValueValue (blocks.js:4412)
```

**2. The meter and rhythm branches never read the fraction at all.**

Those two branches of the switch nest a second check inside the first:

```js
if (connections[2] === dblk) {
    if (connections[1] === dblk) {
        ... read the denominator ...
    }
    return 1;
}
```

The inner test can never pass, since a divide block cannot sit in two of its parent's sockets at once. So both branches always returned the `1` fallback. The sibling function `noteValueNumber` has the same switch with a single check in each of those cases, which is the shape they were meant to have.

## Steps to reproduce

The crash:

1. Open Music Blocks with the default project.
2. In the first **note** block, drag the **4** out of the `1 / 4` fraction and drop it on empty canvas. Don't drop it on the trash, because deleting it makes Music Blocks refill the socket and the bug won't show.
3. The fraction now reads 1 over an empty socket.
4. Click the **1** that is still in the fraction. Nothing opens, and the console shows the TypeError above.

For contrast, click the **1** in the second note, whose fraction is still whole, and the pie menu opens as normal.

The wrong pie menu:

1. Drag a **meter** block onto the canvas. It reads "4 beats of 1 / 4 note".
2. Click the **1** in that `1 / 4`.
3. The pie menu offers 8, 7, 6, 5, 4, 3, 2, 1 instead of the 1, 2, 3, 4 you get from a note block's own fraction.

## The fix

The three places that read the denominator now go through a small helper that returns 1 when the slot is empty, which is the same default every other branch already returns.

The meter and rhythm branches drop the unreachable inner check, so they read the fraction like the note branch does. The beats-per-measure number sits in a different socket and is unaffected. This also makes the empty-slot guard reachable for those blocks.

## Testing

Six tests in `js/__tests__/blocks.test.js` cover both parent shapes with a filled and an empty denominator slot. The empty-socket ones throw the TypeError above on master, and the meter and rhythm ones return 1 instead of 4.

Full suite, `npm run lint` and `npx prettier --check` are clean. In the running app I confirmed the pie menu opens again after pulling the denominator out, and that a meter's `1 / 4` now offers 1, 2, 3, 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of incomplete or unexpected note-value configurations.
  - Note, meter, and rhythm values now safely fall back to a default denominator when no valid denominator is available.
  - Prevented errors when working with empty fraction slots or alternate note-value structures.
  - Ensured complete fractions return the correct denominator across supported note-value layouts.

- **Tests**
  - Added coverage for complete fractions, missing denominators, and alternate parent structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->