### PR TITLE
fix(widgets): ignore stale blockMap entries during arpeggio octave shift

### DIFF
--- a/js/widgets/__tests__/arpeggio.test.js
+++ b/js/widgets/__tests__/arpeggio.test.js
@@ -753,6 +753,17 @@ describe("Arpeggio Widget", () => {
             }
         });
 
+        test("ignores stale blockMap entries when shifting octave", () => {
+            arpeggio._blockMap = [
+                [999, 1],
+                [1, 999]
+            ];
+
+            arpeggio._shiftOctave(1);
+
+            expect(arpeggio._blockMap).toEqual([]);
+        });
+
         test("widgetWindow.onclose restores Singer.masterVolume if present", () => {
             global.Singer = { masterVolume: [0.8] };
             activityMock.logo.synth.setMasterVolume = jest.fn();

--- a/js/widgets/arpeggio.js
+++ b/js/widgets/arpeggio.js
@@ -720,12 +720,13 @@ class Arpeggio {
             if (obj && obj[0] !== -1) {
                 const oldRow = this._rowBlocks.indexOf(obj[0]);
                 const oldCol = this._colBlocks.indexOf(obj[1]);
-                if (oldRow >= 0 && oldCol >= 0) {
-                    const table = docById("arpeggioCellTable" + oldRow);
-                    if (table && table.rows && table.rows[0] && table.rows[0].cells[oldCol]) {
-                        table.rows[0].cells[oldCol].style.backgroundColor =
-                            this._getBackgroundColor(oldRow);
-                    }
+                if (oldRow < 0 || oldCol < 0) {
+                    continue;
+                }
+                const table = docById("arpeggioCellTable" + oldRow);
+                if (table && table.rows && table.rows[0] && table.rows[0].cells[oldCol]) {
+                    table.rows[0].cells[oldCol].style.backgroundColor =
+                        this._getBackgroundColor(oldRow);
                 }
 
                 const numRows = this._rowBlocks.length;


### PR DESCRIPTION
## Description

Fixes an issue in `Arpeggio._shiftOctave()` where stale or unmapped `_blockMap` entries (where `indexOf` returns `-1`) were unintentionally mapped to row `0` when shifting octaves up or down.

In `_shiftOctave()`, the modulo arithmetic `(oldRow + deltaRow + numRows) % numRows` evaluated `-1 + 1 = 0` when `deltaRow = 1`. This converted an invalid/out-of-range pitch into a valid note at row 0, activating unintended cells in the matrix.

## Related Issue

**Fixes:** N/A (Direct bug fix with regression test)

---

## Category

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **`js/widgets/arpeggio.js`**: Added an early guard (`if (oldRow < 0 || oldCol < 0) continue;`) inside `_shiftOctave()` loop to ignore entries whose pitch or time step does not exist in the current `_rowBlocks` or `_colBlocks`. Removed the now-redundant conditional check on the unhighlighting logic.
- **`js/widgets/__tests__/arpeggio.test.js`**: Added a regression test `ignores stale blockMap entries when shifting octave` to verify that stale entries are dropped and do not shift into valid rows.

---

## Steps to Reproduce

1. Open the Arpeggio widget.
2. If `_blockMap` contains stale entries from previously removed notes/blocks (where pitch is not in `_rowBlocks`, i.e., `oldRow === -1`).
3. Click the "Move up" toolbar button to trigger `_shiftOctave(1)`.
4. Observe that the stale note gets calculated as `(-1 + 1 + numRows) % numRows = 0` and resurrects as an active cell in row 0.

---

## Testing Performed

- **Jest Unit Tests:** Ran `npm test -- js/widgets/__tests__/arpeggio.test.js` (48/48 passed, including the new regression test).
- **ESLint:** Ran `npm run lint` with 0 errors / warnings.
- **Prettier:** Ran `npx prettier --check js/widgets/arpeggio.js js/widgets/__tests__/arpeggio.test.js` (passed).
- **Git Diff:** Ran `git diff --check` with no whitespace issues.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved arpeggio playback when shifting octaves by safely handling invalid row or column mappings.
  - Prevented stale playback mappings from causing errors when their corresponding cells no longer exist.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->