### PR TITLE
fix: use textContent.trim() instead of innerHTML for title comparison in closeBlkWidgets

### DIFF
--- a/js/widgets/__tests__/widgetWindows.test.js
+++ b/js/widgets/__tests__/widgetWindows.test.js
@@ -649,7 +649,7 @@ describe("widgetWindows", () => {
     });
 
     describe("updateTitle", () => {
-        test("updates the title element innerHTML", () => {
+        test("updates the title element textContent", () => {
             const win = createTestWindow("Old Title");
             const key = win._key;
             const titleEl = document.getElementById(key + "WidgetID");
@@ -657,7 +657,7 @@ describe("widgetWindows", () => {
 
             win.updateTitle("New Title");
 
-            expect(titleEl.innerHTML).toBe("New Title");
+            expect(titleEl.textContent).toBe("New Title");
         });
 
         test("keeps the frame's aria-label in sync with the new title", () => {
@@ -1182,7 +1182,7 @@ describe("widgetWindows", () => {
         });
 
         it("closes matching widget by name", () => {
-            const mockElement = { innerHTML: "TestWidget" };
+            const mockElement = { textContent: "TestWidget", id: "" };
 
             document.getElementsByClassName = jest.fn(() => [mockElement]);
 
@@ -1213,7 +1213,7 @@ describe("widgetWindows", () => {
 
         it("closes widget by matching element ID when display title changes", () => {
             const mockElement = {
-                innerHTML: "C MAJOR",
+                textContent: "C MAJOR",
                 id: "custom modeWidgetID"
             };
 
@@ -1225,7 +1225,9 @@ describe("widgetWindows", () => {
         });
 
         it("does nothing if no match found", () => {
-            document.getElementsByClassName = jest.fn(() => [{ innerHTML: "OtherWidget" }]);
+            document.getElementsByClassName = jest.fn(() => [
+                { textContent: "OtherWidget", id: "" }
+            ]);
 
             window.widgetWindows.closeBlkWidgets("TestWidget");
 

--- a/js/widgets/widgetWindows.js
+++ b/js/widgets/widgetWindows.js
@@ -78,8 +78,8 @@ window.widgetWindows = {
         for (let i = 0; i < widgetTitle.length; i++) {
             const titleEl = widgetTitle[i];
             if (
-                titleEl.innerHTML === name ||
-                titleEl.innerHTML === searchKey ||
+                titleEl.textContent.trim() === name ||
+                titleEl.textContent.trim() === searchKey ||
                 titleEl.id === `${searchKey}WidgetID`
             ) {
                 const winKey =


### PR DESCRIPTION
## Description

`closeBlkWidgets()` in `js/widgets/widgetWindows.js` uses `innerHTML` to compare widget
title elements against a plain-text name. This is fragile because `innerHTML` returns
serialized HTML, which breaks the match when titles contain child elements (e.g. a `<span>`
added by an i18n layer) or HTML entities, even when the visible text is correct.

Replaced both `innerHTML` comparisons with `textContent.trim()`, which is consistent with
how titles are written via `_createUIelements` and `updateTitle`.


## Related Issue

**Fixes:** #8668 

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [x] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- `js/widgets/widgetWindows.js`: replaced `titleEl.innerHTML === name` and
  `titleEl.innerHTML === searchKey` with `titleEl.textContent.trim() === name`
  and `titleEl.textContent.trim() === searchKey` in the DOM-scan fallback of
  `closeBlkWidgets()`.

- `js/widgets/__tests__/widgetWindows.test.js`: updated mock objects and
  assertions to use `textContent` instead of `innerHTML`, matching real DOM
  behavior.

---

## Steps to Reproduce

1. Open any widget whose title is wrapped in a child element by an i18n layer
   (e.g. `<span>Temperament</span>`).
2. Call `window.widgetWindows.closeBlkWidgets("temperament")` from the browser console.
3. Observe: window is NOT closed because `innerHTML` ≠ plain-text name.

## Testing Performed

- npm test          → 115/115 tests pass
- npm run lint      → 0 warnings, 0 errors
- npx prettier --check js/widgets/widgetWindows.js js/widgets/__tests__/widgetWindows.test.js → clean

---

## Checklist

<!-- Please check the boxes that apply. Add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

<!-- Provide any additional context for the reviewers (e.g., design decisions, potential concerns). -->

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget closing so titles with extra whitespace or rendered text differences are matched more reliably.
  * Improved keyboard shortcut handling for widget actions, including Escape, maximize/restore, repeated key events, editable fields, and fullscreen restrictions.
  * Fixed dragging behavior so restoring a maximized widget during a drag maintains the correct position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->