### PR TITLE
fix: prevent TypeError on detached blocks in NumberBlocks helpers

### DIFF
--- a/js/blocks/NumberBlocks.js
+++ b/js/blocks/NumberBlocks.js
@@ -24,10 +24,12 @@ function setupNumberBlocks(activity) {
      * Check if block is in status matrix print context
      */
     const isInStatusMatrix = (logo, blk, fieldName) => {
+        const parentId = activity.blocks.blockList[blk].connections[0];
         if (
             logo.inStatusMatrix &&
-            activity.blocks.blockList[activity.blocks.blockList[blk].connections[0]].name ===
-                "print"
+            parentId !== null &&
+            activity.blocks.blockList[parentId] &&
+            activity.blocks.blockList[parentId].name === "print"
         ) {
             logo.statusFields.push([blk, fieldName]);
             return true;
@@ -77,11 +79,17 @@ function setupNumberBlocks(activity) {
         if (cblk0 === null) return undefined;
         let par = activity.blocks.blockList[cblk0];
         while (par.name === "hspace") {
+            if (par.connections[0] === null) return undefined;
             par = activity.blocks.blockList[par.connections[0]];
         }
-        return par.name === "pitch"
-            ? activity.blocks.blockList[par.connections[2]].value
-            : undefined;
+        if (
+            par.name === "pitch" &&
+            par.connections[2] !== null &&
+            par.connections[2] !== undefined
+        ) {
+            return activity.blocks.blockList[par.connections[2]].value;
+        }
+        return undefined;
     };
 
     /**

--- a/js/blocks/__tests__/NumberBlocks.test.js
+++ b/js/blocks/__tests__/NumberBlocks.test.js
@@ -241,6 +241,19 @@ describe("setupNumberBlocks", () => {
             logo.inStatusMatrix = false;
         });
 
+        it("should return safely when status-matrix parent is missing (isInStatusMatrix safety)", () => {
+            activity.blocks.blockList[300] = {
+                connections: [null, 302],
+                name: "int"
+            };
+            logo.inStatusMatrix = true;
+            logo.statusFields = [];
+            const intBlock = createdBlocks["int"];
+            intBlock.arg(logo, 0, 300, null);
+            expect(logo.statusFields.length).toBe(0);
+            logo.inStatusMatrix = false;
+        });
+
         it("should call errorMsg and return 0 when MathUtility.doInt throws", () => {
             activity.blocks.blockList[100] = { connections: [null, "c1"] };
             logo.parseArg = jest.fn(() => "not-a-number");
@@ -692,6 +705,44 @@ describe("setupNumberBlocks", () => {
             const randomBlock = createdBlocks["random"];
             const result = randomBlock.arg(logo, 0, 220, null);
             expect(result).toEqual(5);
+            global.MathUtility.doRandom = (a, b, octave) => a;
+        });
+
+        it("should handle hspace block with missing parent connection (null hspace parent)", () => {
+            activity.blocks.blockList[220] = {
+                connections: ["hspace_blk", "c1", "c2"]
+            };
+            activity.blocks.blockList["hspace_blk"] = {
+                name: "hspace",
+                connections: [null]
+            };
+            logo.parseArg = jest.fn((l, t, c) => {
+                if (c === "c1") return 0;
+                if (c === "c2") return 12;
+            });
+            global.MathUtility.doRandom = (a, b, octave) => (octave !== undefined ? octave : a);
+            const randomBlock = createdBlocks["random"];
+            const result = randomBlock.arg(logo, 0, 220, null);
+            expect(result).toEqual(0);
+            global.MathUtility.doRandom = (a, b, octave) => a;
+        });
+
+        it("should handle pitch block with no octave connection", () => {
+            activity.blocks.blockList[220] = {
+                connections: ["pitch_blk", "c1", "c2"]
+            };
+            activity.blocks.blockList["pitch_blk"] = {
+                name: "pitch",
+                connections: [null, null, null]
+            };
+            logo.parseArg = jest.fn((l, t, c) => {
+                if (c === "c1") return 0;
+                if (c === "c2") return 12;
+            });
+            global.MathUtility.doRandom = (a, b, octave) => (octave !== undefined ? octave : a);
+            const randomBlock = createdBlocks["random"];
+            const result = randomBlock.arg(logo, 0, 220, null);
+            expect(result).toEqual(0);
             global.MathUtility.doRandom = (a, b, octave) => a;
         });
 


### PR DESCRIPTION
<!--
Thank you for contributing to our project!
Please complete the sections below to help us review your changes efficiently.
-->

## Description

This PR fixes two pervasive `TypeError` crashes located in the helper functions of `NumberBlocks.js`. Because these helpers (`isInStatusMatrix` and `getOctaveFromParent`) are invoked by roughly 13 different number-related block types, fixing them resolves a whole class of detached-block crashes.

## Related Issue

**Fixes:** # <!-- Add issue number here if you created one! -->

---

## Category

<!-- NOTE: CI ENFORCED. You MUST check at least ONE category below or the CI will fail. -->

- [x] Bug Fix — Fixes a bug or incorrect behavior
- [ ] Feature — Adds new functionality
- [ ] UI/UX — Changes to the user interface or user experience
- [ ] Performance — Improves load time, memory, rendering, etc.
- [ ] Tests — Adds or updates test coverage
- [ ] Documentation — Updates to docs, comments, or README
- [ ] Chore / Refactor — Maintenance, cleanup, or refactoring with no behavior change
- [ ] CI/CD — Changes to workflows and automation

---

## Changes Made

- **NumberBlocks.js (`isInStatusMatrix`)**: Added a null check for `connections[0]`. Previously, evaluating a detached `NumberBlock` caused a crash because looking up `connections[0]` resulted in `null`, which crashed when attempting to evaluate `.name`.
- **NumberBlocks.js (`getOctaveFromParent`)**: Guarded the `hspace` traversal loop to check for null parent connections. Additionally, added a guard to ensure `connections[2]` exists before accessing `.value`. 

---

## Steps to Reproduce

1. Drag a `Pitch` block onto the workspace (inside a start block or action block).
2. Inside the note input of the `Pitch` block, attach a `Random` block.
3. Leave the `octave` input of the `Pitch` block completely empty (detached).
4. Click "Play" to execute the blocks.
5. On the `master` branch (without this fix), the app will crash and throw a `TypeError: Cannot read properties of undefined (reading 'name')` because the `Random` block attempts to read the missing octave connection.
6. With this fix applied, the app successfully plays using a default fallback without crashing.


## Testing Performed

- Evaluated standalone number blocks locally; verified they no longer throw `TypeErrors` on evaluation.
- Executed the full `npm test` suite which passed successfully.
- Verified changes pass `npm run lint` and `npx prettier --check .`.

---

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have run `npm run lint` and `npx prettier --check .` with no errors.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
- [x] I have enabled **"Allow edits from maintainers"** (required for auto-rebase; affects PR branch only).

---

## Additional Notes

Fixed an unrelated strict equality (`!==`) linter warning on line 85 of `NumberBlocks.js` in the process.

---

<details>
<summary><b>Contributor Resources</b></summary>
<br>

- **Guidelines:** [Music Blocks Contributing Guide](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
- **Chat:** [Community Matrix Server](https://matrix.to/#/#sugar:matrix.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when number blocks have missing parent blocks or disconnected inputs.
  * Prevented errors when octave information is unavailable or when pitch connections are invalid.
  * Ensured octave lookup stops safely when required input data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->